### PR TITLE
Build script portability

### DIFF
--- a/cleanbuild.sh
+++ b/cleanbuild.sh
@@ -3,9 +3,14 @@
 # Fail fast.
 set -e
 
-# Set the environment variables to use clang
-export CC="/usr/bin/clang-19"
-export CXX="/usr/bin/clang++-19"
+# Prefer clang-19 if available, otherwise use the system default
+if command -v clang-19 >/dev/null 2>&1; then
+  export CC="$(command -v clang-19)"
+  export CXX="$(command -v clang++-19)"
+else
+  export CC="$(command -v clang)"
+  export CXX="$(command -v clang++)"
+fi
 
 # Define the build directory (assuming you're using an out-of-source build)
 buildDir="tests/release_bin"
@@ -38,7 +43,7 @@ cd "$buildDir" || exit
 cmake -G "Ninja" ..
 
 # Run the build (this will compile everything from scratch)
-cmake --build .. --config Release
+cmake --build . --config Release
 
 # Loop through each file in the current directory
 for file in *; do

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,14 +7,14 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Use Clang 19 and avoid pulling in GCC
-set(CMAKE_CXX_COMPILER "/usr/bin/clang++-19")
-set(CMAKE_CXX_COMPILER_TARGET "x86_64-pc-linux-gnu")
+# Prefer clang++, falling back to the compiler configured in the environment.
+find_program(CLANGXX clang++ clang++-19)
+if (CLANGXX)
+  set(CMAKE_CXX_COMPILER "${CLANGXX}" CACHE FILEPATH "C++ compiler" FORCE)
+endif()
 
 # Compilation and linking flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -Wextra -Werror -nostdinc++ -isystem /usr/include/c++/v1 -std=c++23")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ --rtlib=compiler-rt -fuse-ld=lld")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L/usr/lib/llvm-19/lib -lc++ -lc++abi")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -Wextra -Werror -std=c++23")
 
 # Output directory
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/release_bin")


### PR DESCRIPTION
## Summary
- improve portability by searching for an available `clang` compiler in the build scripts
- simplify compiler flags and linker setup
- fix path used for `cmake --build`

## Testing
- `bash cleanbuild.sh` *(fails: missing `acutest` and `std::forward_like` errors)*

------
https://chatgpt.com/codex/tasks/task_e_686606b6719883269464cd8d43692a21