### PR TITLE
Remove dependency on Acutest

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ HISTORY
 
 This is a fork of the original Corvid library, which was written for C++17. It was initially called Corvid20, but now that it's moved past that, the version number has been removed.
 
-With the C++17 version, rather than try to update it in place, it made more sense to make a new project and move code over, bit by bit, cleaning and upgrading it as I went. This approach enabled me to switch from MSVC to clang, which has resulted in more-compliant code, and to use GitHub Copilot and ChatGPT to help with the more tedious parts of the process. I also got rid of Google Test, just to simplify things, switching to the header-only Acutest, which is referenced but not bundled.
+With the C++17 version, rather than try to update it in place, it made more sense to make a new project and move code over, bit by bit, cleaning and upgrading it as I went. This approach enabled me to switch from MSVC to clang, which has resulted in more-compliant code, and to use GitHub Copilot and ChatGPT to help with the more tedious parts of the process. I also got rid of Google Test, simplifying things with a tiny built-in framework.
 
 
 CONTENTS
@@ -36,7 +36,6 @@ EXTERNAL DEPENDENCIES
 
 LLVM suite: For clang, clang-format, and lldb. https://releases.llvm.org/download.html
 CMake: For batch build files. https://cmake.org/download/
-Acutest: For unit tests. https://github.com/mity/acutest
 
 
 NOTICE

--- a/tests/AcutestShim.h
+++ b/tests/AcutestShim.h
@@ -1,11 +1,23 @@
 #include <iostream>
 #include <sstream>
 #include <type_traits>
+#include <cstdio>
+#include <exception>
 
-// From: https://github.com/mity/acutest
-#include "../../acutest/include/acutest.h"
-
+// Minimal test utilities, replacing the external Acutest dependency.
 namespace acutest_shim {
+
+struct test {
+  const char* name;
+  void (*func)();
+};
+
+extern test TEST_LIST[];
+
+inline bool current_failed = false;
+inline int failed_tests = 0;
+
+inline void mark_failed() { current_failed = true; }
 
 template<typename T>
 concept OStreamable = requires(T t, std::ostream& os) { os << t; };
@@ -32,6 +44,46 @@ auto inline stream_to_text(const auto& v) {
 }
 
 } // namespace acutest_shim
+
+#define TEST_MSG(fmt, ...) std::printf(fmt "\n", ##__VA_ARGS__)
+
+#define TEST_CHECK_(cond, fmt, ...)                                           \
+  do {                                                                        \
+    if (!(cond)) {                                                             \
+      acutest_shim::mark_failed();                                             \
+      std::printf("Check failed at %s:%d: " fmt "\n", __FILE__, __LINE__,       \
+                  ##__VA_ARGS__);                                             \
+    }                                                                         \
+  } while (false)
+
+#define TEST_ASSERT_(cond, fmt, ...)                                          \
+  do {                                                                        \
+    if (!(cond)) {                                                             \
+      acutest_shim::mark_failed();                                             \
+      std::printf("Assertion failed at %s:%d: " fmt "\n", __FILE__, __LINE__,   \
+                  ##__VA_ARGS__);                                             \
+      return;                                                                  \
+    }                                                                         \
+  } while (false)
+
+#define TEST_EXCEPTION(call, exc)                                             \
+  do {                                                                        \
+    bool caught_ = false;                                                      \
+    try {                                                                     \
+      call;                                                                   \
+    } catch (const exc&) {                                                    \
+      caught_ = true;                                                         \
+    } catch (...) {                                                           \
+      acutest_shim::mark_failed();                                             \
+      std::printf("Unexpected exception at %s:%d\n", __FILE__, __LINE__);       \
+      caught_ = true;                                                         \
+    }                                                                         \
+    if (!caught_) {                                                           \
+      acutest_shim::mark_failed();                                             \
+      std::printf("Expected exception %s not thrown at %s:%d\n", #exc,         \
+                  __FILE__, __LINE__);                                        \
+    }                                                                         \
+  } while (false)
 
 #define VALUE_MSG(actual, expected)                                           \
   TEST_MSG("Actual:   `%s`", acutest_shim::stream_to_text(actual).c_str());   \
@@ -221,5 +273,34 @@ auto inline stream_to_text(const auto& v) {
 #define TEST_LIST_IMPL(N, ...) TEST_LIST_IMPL_N(N, __VA_ARGS__)
 
 #define MAKE_TEST_LIST(...)                                                   \
-  TEST_LIST = {                                                               \
+  acutest_shim::test TEST_LIST[] = {                                          \
       TEST_LIST_IMPL(VA_NARGS(__VA_ARGS__), __VA_ARGS__){nullptr, nullptr}};
+
+inline int main() {
+  using namespace acutest_shim;
+  for (const test* t = TEST_LIST; t->name; ++t) {
+    current_failed = false;
+    std::printf("Running %s\n", t->name);
+    try {
+      t->func();
+    } catch (const std::exception& e) {
+      mark_failed();
+      std::printf("Unexpected exception: %s\n", e.what());
+    } catch (...) {
+      mark_failed();
+      std::printf("Unknown exception occurred\n");
+    }
+    if (current_failed) {
+      std::printf("[FAIL] %s\n", t->name);
+      ++failed_tests;
+    } else {
+      std::printf("[PASS] %s\n", t->name);
+    }
+  }
+  if (failed_tests) {
+    std::printf("%d test(s) failed\n", failed_tests);
+    return 1;
+  }
+  std::printf("All tests passed\n");
+  return 0;
+}

--- a/wsl-instructions.md
+++ b/wsl-instructions.md
@@ -1,7 +1,7 @@
 1. Install WSL 2 with Jammy, and do the usual `apt update` and `apt upgrade`.
 2. Install VSCode on Windows, including [WSL support](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl).
 3. All steps below are in WSL. First, install `gh` and link it to your account.
-4. Clone the repo. Also, clone `mity/acutest`.
+4. Clone the repo.
 5. Run `git config --global user.name "user name"` and `git config --global user.email "user_name@gmail.com"`.
 6. Install the clang key.
 ```


### PR DESCRIPTION
## Summary
- drop external Acutest include
- implement a minimal test runner in `AcutestShim`
- adjust documentation to remove Acutest instructions

## Testing
- `bash cleanbuild.sh` *(fails: 'cstdint' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_686609c97e94832695235a63badd3872