### PR TITLE
Enable libstdc++ on Codex

### DIFF
--- a/cleanbuild.ps1
+++ b/cleanbuild.ps1
@@ -1,9 +1,19 @@
-# Set the environment variables to use clang
-$env:CC="c:/program files/llvm/bin/clang"
-$env:CXX="c:/program files/llvm/bin/clang++"
+# Set the environment variables to use clang. When running on Codex, use the
+# default clang and libstdc++.
+if ($Env:CODEX_PROXY_CERT) {
+    Write-Host "Codex environment detected: using libstdc++"
+    $env:CC = (Get-Command clang).Source
+    $env:CXX = (Get-Command clang++).Source
+    $env:RC = (Get-Command clang).Source
+    $libStdOption = "-DUSE_LIBSTDCPP=ON"
+} else {
+    $env:CC="c:/program files/llvm/bin/clang"
+    $env:CXX="c:/program files/llvm/bin/clang++"
 
-# This is a crude lie to shut it up about resource compilers.
-$env:RC="c:/program files/llvm/bin/clang"
+    # This is a crude lie to shut it up about resource compilers.
+    $env:RC="c:/program files/llvm/bin/clang"
+    $libStdOption = "-DUSE_LIBSTDCPP=OFF"
+}
 
 # Define the build directory (assuming you're using an out-of-source build)
 $buildDir = "build"
@@ -23,7 +33,7 @@ New-Item -ItemType Directory -Path $buildDir
 Set-Location $buildDir
 
 # Run cmake to configure the project with Ninja (or MinGW Makefiles) and clang
-cmake -G "Ninja" ..
+cmake -G "Ninja" .. $libStdOption
 
 # Run the build (this will compile everything from scratch)
 cmake --build . --config Release

--- a/cleanbuild.ps1
+++ b/cleanbuild.ps1
@@ -10,8 +10,12 @@ if ($StdLib -and $StdLib -ne 'libstdcpp' -and $StdLib -ne 'libcxx') {
     exit 1
 }
 
-if (-not $StdLib -and $Env:CODEX_PROXY_CERT) {
-    $StdLib = 'libstdcpp'
+if (-not $StdLib) {
+    if ($Env:CODEX_PROXY_CERT) {
+        $StdLib = 'libstdcpp'
+    } else {
+        $StdLib = 'libcxx'
+    }
 }
 
 if ($StdLib -eq 'libstdcpp') {
@@ -32,6 +36,7 @@ if ($StdLib -eq 'libstdcpp') {
 
 # Define the build directory (assuming you're using an out-of-source build)
 $buildDir = "build"
+$buildRoot = "$buildDir/cmake"
 
 # If the build directory exists, delete it to clean the build
 if (Test-Path $buildDir) {
@@ -42,16 +47,11 @@ if (Test-Path $buildDir) {
 }
 
 # Create the build directory
-New-Item -ItemType Directory -Path $buildDir
+New-Item -ItemType Directory -Force -Path $buildRoot | Out-Null
+New-Item -ItemType Directory -Force -Path $buildDir | Out-Null
 
-# Navigate to the build directory
-Set-Location $buildDir
-
-# Run cmake to configure the project with Ninja (or MinGW Makefiles) and clang
-cmake -G "Ninja" .. $libStdOption
+# Run cmake to configure the project with Ninja and clang
+cmake -S tests -B $buildRoot -G "Ninja" $libStdOption
 
 # Run the build (this will compile everything from scratch)
-cmake --build . --config Release
-
-# Navigate back to the original directory after building
-Set-Location ..
+cmake --build $buildRoot --config Release

--- a/cleanbuild.ps1
+++ b/cleanbuild.ps1
@@ -1,12 +1,27 @@
-# Set the environment variables to use clang. When running on Codex, use the
-# default clang and libstdc++.
-if ($Env:CODEX_PROXY_CERT) {
-    Write-Host "Codex environment detected: using libstdc++"
+# Choose which standard library to use. Pass 'libstdcpp' or 'libcxx' as the
+# first argument to override the default. Outside of Codex, the default is
+# libc++.
+param(
+    [string]$StdLib
+)
+
+if ($StdLib -and $StdLib -ne 'libstdcpp' -and $StdLib -ne 'libcxx') {
+    Write-Host "Usage: cleanbuild.ps1 [libstdcpp|libcxx]" -ForegroundColor Red
+    exit 1
+}
+
+if (-not $StdLib -and $Env:CODEX_PROXY_CERT) {
+    $StdLib = 'libstdcpp'
+}
+
+if ($StdLib -eq 'libstdcpp') {
+    Write-Host "Using libstdc++"
     $env:CC = (Get-Command clang).Source
     $env:CXX = (Get-Command clang++).Source
     $env:RC = (Get-Command clang).Source
     $libStdOption = "-DUSE_LIBSTDCPP=ON"
 } else {
+    Write-Host "Using libc++"
     $env:CC="c:/program files/llvm/bin/clang"
     $env:CXX="c:/program files/llvm/bin/clang++"
 

--- a/cleanbuild.sh
+++ b/cleanbuild.sh
@@ -3,14 +3,26 @@
 # Fail fast.
 set -e
 
-# Set the environment variables to use clang. When running on Codex, fall back to
-# the default clang and build with libstdc++.
-if [[ -n "$CODEX_PROXY_CERT" ]]; then
-  echo "Codex environment detected: using libstdc++"
+# Choose which standard library to use. Pass "libstdcpp" or "libcxx" as the first
+# argument to override the default. Outside of Codex, the default is libc++.
+choice=$1
+
+if [[ -n "$choice" && "$choice" != "libstdcpp" && "$choice" != "libcxx" ]]; then
+  echo "Usage: $0 [libstdcpp|libcxx]" >&2
+  exit 1
+fi
+
+if [[ -n "$CODEX_PROXY_CERT" && -z "$choice" ]]; then
+  choice="libstdcpp"
+fi
+
+if [[ "$choice" == "libstdcpp" ]]; then
+  echo "Using libstdc++"
   export CC="$(command -v clang)"
   export CXX="$(command -v clang++)"
   LIBSTD_OPTION="-DUSE_LIBSTDCPP=ON"
 else
+  echo "Using libc++"
   export CC="/usr/bin/clang-19"
   export CXX="/usr/bin/clang++-19"
   LIBSTD_OPTION="-DUSE_LIBSTDCPP=OFF"

--- a/cleanbuild.sh
+++ b/cleanbuild.sh
@@ -34,8 +34,8 @@ else
 fi
 
 # Define the build directory (assuming you're using an out-of-source build)
-buildDir="tests/release_bin"
 buildRoot="tests/build"
+buildDir="$buildRoot/release_bin"
 
 rm -f "CMakeCache.txt"
 rm -f "cmake_install.cmake"

--- a/corvid/containers/strong_type.h
+++ b/corvid/containers/strong_type.h
@@ -113,7 +113,7 @@ public:
 
   // Access.
   [[nodiscard]] constexpr decltype(auto) value(this auto&& self) noexcept {
-    return std::forward_like<decltype(self)>(self.value_);
+    return forward_like<decltype(self)>(self.value_);
   }
 
 #pragma endregion access
@@ -123,12 +123,12 @@ public:
   // `std::unique_ptr`, there is no possibility of a null. Also, note that
   // mutable references allow changing or moving.
   [[nodiscard]] constexpr decltype(auto) operator*(this auto&& self) noexcept {
-    return std::forward_like<decltype(self)>(self.value_);
+    return forward_like<decltype(self)>(self.value_);
   }
 
   [[nodiscard]] constexpr decltype(auto) operator->(
       this auto&& self) noexcept {
-    return &std::forward_like<decltype(self)>(self.value_);
+    return &forward_like<decltype(self)>(self.value_);
   }
 
   // Note: There is no upside to overloading `operator->*`. At best, it would

--- a/corvid/meta.h
+++ b/corvid/meta.h
@@ -22,3 +22,4 @@
 #include "meta/enums.h"
 #include "meta/naming.h"
 #include "meta/containers.h"
+#include "meta/forward_like.h"

--- a/corvid/meta/forward_like.h
+++ b/corvid/meta/forward_like.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "./meta_shared.h"
+
+namespace corvid { inline namespace meta { inline namespace forwarding {
+
+#if defined(__GLIBCXX__) && !defined(__cpp_lib_forward_like)
+// Fallback implementation of std::forward_like for older libstdc++.
+ template<class T, class U>
+ [[nodiscard]] constexpr decltype(auto) forward_like(U&& u) noexcept {
+  using UT = std::remove_reference_t<U>;
+  using Base = std::conditional_t<std::is_const_v<std::remove_reference_t<T>>, std::add_const_t<UT>, UT>;
+  using CV = std::conditional_t<std::is_volatile_v<std::remove_reference_t<T>>, std::add_volatile_t<Base>, Base>;
+  if constexpr (std::is_lvalue_reference_v<T>)
+    return static_cast<CV&>(u);
+  else
+    return static_cast<CV&&>(std::forward<U>(u));
+ }
+#else
+ using std::forward_like;
+#endif
+
+}}} // namespace corvid::meta::forwarding

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,14 +7,27 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Use Clang 19 and avoid pulling in GCC
-set(CMAKE_CXX_COMPILER "/usr/bin/clang++-19")
-set(CMAKE_CXX_COMPILER_TARGET "x86_64-pc-linux-gnu")
+# Detect whether we're running on Codex. If so, use libstdc++; otherwise, use
+# clang 19 with libc++.
+if(DEFINED ENV{CODEX_PROXY_CERT})
+    message(STATUS "Codex environment detected: using libstdc++")
+    set(USE_LIBSTDCPP ON)
+else()
+    message(STATUS "Using libc++")
+    set(USE_LIBSTDCPP OFF)
+endif()
 
-# Compilation and linking flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -Wextra -Werror -nostdinc++ -isystem /usr/include/c++/v1 -std=c++23")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ --rtlib=compiler-rt -fuse-ld=lld")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L/usr/lib/llvm-19/lib -lc++ -lc++abi")
+if(USE_LIBSTDCPP)
+    # Rely on whichever clang is available and the default libstdc++ install.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -Wextra -Werror -std=c++23")
+else()
+    # Use Clang 19 and avoid pulling in GCC.
+    set(CMAKE_CXX_COMPILER "/usr/bin/clang++-19")
+    set(CMAKE_CXX_COMPILER_TARGET "x86_64-pc-linux-gnu")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -Wextra -Werror -nostdinc++ -isystem /usr/include/c++/v1 -std=c++23")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ --rtlib=compiler-rt -fuse-ld=lld")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L/usr/lib/llvm-19/lib -lc++ -lc++abi")
+endif()
 
 # Output directory
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/release_bin")
@@ -30,6 +43,8 @@ foreach(SOURCE_FILE ${SOURCES})
     # Add executable for each source file
     add_executable(${EXECUTABLE_NAME} ${SOURCE_FILE})
 
-    # Link libc++ and libc++abi explicitly
-    target_link_libraries(${EXECUTABLE_NAME} PRIVATE c++ c++abi)
+    if(NOT USE_LIBSTDCPP)
+        # Link libc++ and libc++abi explicitly
+        target_link_libraries(${EXECUTABLE_NAME} PRIVATE c++ c++abi)
+    endif()
 endforeach()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,19 +2,26 @@ cmake_minimum_required(VERSION 3.16)
 
 project(Corvid VERSION 1.0 LANGUAGES CXX)
 
+# Allow selecting the standard library. Passing -DUSE_LIBSTDCPP=ON to cmake will
+# force libstdc++. Otherwise, the default is libc++ unless we're running on
+# Codex, where libstdc++ is required.
+option(USE_LIBSTDCPP "Use GNU libstdc++ instead of libc++" OFF)
+
 # Set the C++ standard to C++23
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Detect whether we're running on Codex. If so, use libstdc++; otherwise, use
-# clang 19 with libc++.
-if(DEFINED ENV{CODEX_PROXY_CERT})
+# On Codex, default to libstdc++ unless explicitly overridden.
+if(DEFINED ENV{CODEX_PROXY_CERT} AND NOT USE_LIBSTDCPP)
     message(STATUS "Codex environment detected: using libstdc++")
-    set(USE_LIBSTDCPP ON)
+    set(USE_LIBSTDCPP ON CACHE BOOL "Use GNU libstdc++ instead of libc++" FORCE)
 else()
-    message(STATUS "Using libc++")
-    set(USE_LIBSTDCPP OFF)
+    if(USE_LIBSTDCPP)
+        message(STATUS "Using libstdc++ (manual override)")
+    else()
+        message(STATUS "Using libc++")
+    endif()
 endif()
 
 if(USE_LIBSTDCPP)


### PR DESCRIPTION
## Summary
- allow build scripts and CMake to automatically switch to libstdc++ when running on Codex
- default to libc++ on all other systems

## Testing
- `bash ./cleanbuild.sh` *(fails: subcommand failed)*

------
https://chatgpt.com/codex/tasks/task_e_6866819640608326b8724ba927fdb087