### PR TITLE
Add optional clang-tidy build support

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+Checks: 'clang-analyzer-*,bugprone-*,modernize-*,performance-*,readability-*,misc-unused-parameters'
+WarningsAsErrors: ''
+HeaderFilterRegex: 'corvid/.*'
+FormatStyle: file

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ LLVM suite: For clang, clang-format, and lldb. https://releases.llvm.org/downloa
 
 CMake: For batch build files. https://cmake.org/download/
 
+## Building
+
+Run `./cleanbuild.sh` to build the tests. Pass `tidy` as an optional
+argument to enable clang-tidy analysis during the build. You can also
+specify `libstdcpp` or `libcxx` as the first argument to choose the
+standard library implementation.
+
 
 NOTICE
 

--- a/cleanbuild.sh
+++ b/cleanbuild.sh
@@ -3,15 +3,27 @@
 # Fail fast.
 set -e
 
-# Choose which standard library to use. Pass "libstdcpp" or "libcxx" as the
-# first argument to override the default. Outside of Codex, the default is
-# libc++.
-choice=$1
+# Choose which standard library to use. Pass "libstdcpp" or "libcxx" as the first
+# argument to override the default. Add "tidy" to run clang-tidy during the
+# build. Outside of Codex, the default is libc++.
 
-if [[ -n "$choice" && "$choice" != "libstdcpp" && "$choice" != "libcxx" ]]; then
-  echo "Usage: $0 [libstdcpp|libcxx]" >&2
-  exit 1
-fi
+choice=""
+use_tidy=false
+
+for arg in "$@"; do
+  case "$arg" in
+    libstdcpp|libcxx)
+      choice="$arg"
+      ;;
+    tidy|--tidy)
+      use_tidy=true
+      ;;
+    *)
+      echo "Usage: $0 [libstdcpp|libcxx] [tidy]" >&2
+      exit 1
+      ;;
+  esac
+done
 
 if [[ -z "$choice" ]]; then
   if [[ -n "$CODEX_PROXY_CERT" ]]; then
@@ -33,19 +45,18 @@ else
   LIBSTD_OPTION="-DUSE_LIBSTDCPP=OFF"
 fi
 
+if $use_tidy; then
+  TIDY_OPTION="-DUSE_CLANG_TIDY=ON"
+else
+  TIDY_OPTION=""
+fi
+
 # Define the build directory (assuming you're using an out-of-source build)
 buildRoot="tests/build"
 buildDir="$buildRoot/release_bin"
 
-rm -f "CMakeCache.txt"
-rm -f "cmake_install.cmake"
-rm -f "ClangExeProject.sln"
-rm -f "build.ninja"
-rm -f "CMakeFiles/*"
-rm -f ".ninja_deps"
-rm -f ".ninja_log"
-rm -f "build.ninja"
-rm -f "cmake_install.cmake"
+rm -f CMakeCache.txt cmake_install.cmake ClangExeProject.sln build.ninja
+rm -rf CMakeFiles .ninja_deps .ninja_log
 
 # If the release directory exists, delete it to clean the build
 if [ -d "$buildDir" ]; then
@@ -60,7 +71,7 @@ rm -rf "$buildRoot"
 mkdir -p "$buildRoot" "$buildDir"
 
 # Run cmake to configure the project with Ninja (or MinGW Makefiles) and clang
-cmake -S tests -B "$buildRoot" -G "Ninja" $LIBSTD_OPTION
+cmake -S tests -B "$buildRoot" -G "Ninja" $LIBSTD_OPTION $TIDY_OPTION
 
 # Run the build (this will compile everything from scratch)
 cmake --build "$buildRoot" --config Release

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ project(Corvid VERSION 1.0 LANGUAGES CXX)
 # force libstdc++. Otherwise, the default is libc++ unless we're running on
 # Codex, where libstdc++ is required.
 option(USE_LIBSTDCPP "Use GNU libstdc++ instead of libc++" OFF)
+option(USE_CLANG_TIDY "Run clang-tidy analysis" OFF)
 
 # Set the C++ standard to C++23
 set(CMAKE_CXX_STANDARD 23)
@@ -34,6 +35,16 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -Wextra -Werror -nostdinc++ -isystem /usr/include/c++/v1 -std=c++23")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ --rtlib=compiler-rt -fuse-ld=lld")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L/usr/lib/llvm-19/lib -lc++ -lc++abi")
+endif()
+
+if(USE_CLANG_TIDY)
+    find_program(CLANG_TIDY_EXE NAMES clang-tidy clang-tidy-19 clang-tidy-20)
+    if(CLANG_TIDY_EXE)
+        message(STATUS "clang-tidy enabled: ${CLANG_TIDY_EXE}")
+        set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+    else()
+        message(WARNING "clang-tidy requested but not found")
+    endif()
 endif()
 
 # Output directory

--- a/wsl-instructions.md
+++ b/wsl-instructions.md
@@ -39,3 +39,5 @@
     ninja-build
 ```
 8. In the repo, run `code .`, which brings up VSCode remotely.
+9. Run `./cleanbuild.sh tidy` to build the tests with clang-tidy enabled. You can specify `libstdcpp` or `libcxx` as the first argument to choose the standard library.
+


### PR DESCRIPTION
## Summary
- provide a `.clang-tidy` config enabling common checks
- allow running clang-tidy through a new `USE_CLANG_TIDY` option in CMake
- update `cleanbuild.sh` so passing `tidy` enables clang-tidy
- document clang-tidy usage

## Testing
- `./cleanbuild.sh libcxx`


------
https://chatgpt.com/codex/tasks/task_e_68670f505c0c8326b21182e398282d60