### PR TITLE
CorvidSim: browser-based tower defense over WebSocket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,5 @@ tidy.log
 # npm
 corvid/sim/web/assets/
 corvid/sim/web/node_modules/
+corvid/sim/web/dist/
 corvid/sim/web/**/*.js

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ tidy.log
 
 # Claude Code
 .claude/
+
+# npm
+corvid/sim/web/assets/
+corvid/sim/web/node_modules/
+corvid/sim/web/**/*.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 If the user's intent is ever unclear, always ask before proceeding.
 
-When asked to fix a bug, first write a unit test that reproduces the bug. Apply the fix only after the test is in place, then confirm the test passes. This ensures the fix is correct and the test serves as a regression guard going forward.
+When asked to fix a bug, first write a unit test that reproduces the bug. Apply the fix only after the test is in place, then confirm the test passes. This ensures the fix is correct and the test serves as a regression guard going forward. Exception: if the only way to reproduce the bug requires a full integration test (live server, real timers, network I/O), skip the test — integration tests can run for minutes, and the executables in the test suite must each complete in a second or two.
 
 When presented with a code review comment, first read the relevant code and determine whether the claim is actually valid. Do not immediately act on it. Review comments can be correct, partially correct, or wrong — treat them as hypotheses to verify, not instructions to execute.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 If the user's intent is ever unclear, always ask before proceeding.
 
-When asked to fix a bug, first write a unit test that reproduces the bug. Apply the fix only after the test is in place, then confirm the test passes. This ensures the fix is correct and the test serves as a regression guard going forward. Exception: if the only way to reproduce the bug requires a full integration test (live server, real timers, network I/O), skip the test — integration tests can run for minutes, and the executables in the test suite must each complete in a second or two.
+When asked to fix a bug, first write a unit test that reproduces the bug. Apply the fix only after the test is in place, then confirm the test passes. This ensures the fix is correct and the test serves as a regression guard going forward. Exception: if the only way to reproduce the bug requires a full integration test (live server, real timers, network I/O), skip the test -- integration tests can run for minutes, and the executables in the test suite must each complete in a second or two.
 
 When presented with a code review comment, first read the relevant code and determine whether the claim is actually valid. Do not immediately act on it. Review comments can be correct, partially correct, or wrong — treat them as hypotheses to verify, not instructions to execute.
 

--- a/cleanbuild.sh
+++ b/cleanbuild.sh
@@ -114,7 +114,7 @@ for file in "$buildDir"/*; do
   # Check if the file is an executable and a regular file (not a directory or symlink)
   if [[ -x "$file" && -f "$file" && "$file" != *"CMakeCXXCompilerId"* ]]; then
     echo "$file..."
-    "$file"
+    "$file" -testonly
     echo "."
   fi
 done

--- a/cleanbuild.sh
+++ b/cleanbuild.sh
@@ -6,7 +6,7 @@ set -e
 # Choose which standard library to use. Optionally pass a test source filename
 # first to build and run a matching unit test, then pass "libstdcpp" or
 # "libcxx" to override the default. Add "tidy" to run clang-tidy during the
-# build. Outside of Codex, the default is libc++.
+# build. The default is `libcxx`.
 
 choice=""
 use_tidy=false
@@ -40,11 +40,7 @@ for arg in "$@"; do
 done
 
 if [[ -z "$choice" ]]; then
-  if [[ -n "$CODEX_PROXY_CERT" ]]; then
-    choice="libstdcpp"
-  else
-    choice="libcxx"
-  fi
+  choice="libcxx"
 fi
 
 if [[ "$choice" == "libstdcpp" ]]; then

--- a/corvid/containers/enum_vector.h
+++ b/corvid/containers/enum_vector.h
@@ -16,6 +16,7 @@
 // limitations under the License.
 #pragma once
 
+#include <type_traits>
 #include <vector>
 
 #include "../enums/sequence_enum.h"
@@ -31,7 +32,7 @@ class enum_vector {
 public:
   using value_type = T;
   using allocator_type = Allocator;
-  using size_type = std::size_t;
+  using size_type = std::underlying_type_t<E>;
   using difference_type = std::ptrdiff_t;
   using reference = value_type&;
   using const_reference = const value_type&;
@@ -102,7 +103,7 @@ public:
   // Additional methods.
 
   [[nodiscard]] enum_t size_as_enum() const noexcept {
-    return enum_t{data_.size()};
+    return enum_t{static_cast<size_type>(data_.size())};
   }
 
   // Access underlying type.

--- a/corvid/ecs/archetype_scene.h
+++ b/corvid/ecs/archetype_scene.h
@@ -478,6 +478,33 @@ public:
     }(storage_indices());
   }
 
+  // Return a pointer to component `C` for entity `id`, or `nullptr` if the
+  // entity is invalid, in staging, or its archetype does not contain `C`.
+  // Deduces `const` from the scene: on a `const` scene returns `const C*`.
+  template<typename C>
+  [[nodiscard]] auto
+  try_get_component(this auto& self, id_t id) noexcept -> std::conditional_t<
+      std::is_const_v<std::remove_reference_t<decltype(self)>>, const C*, C*> {
+    using result_t = std::conditional_t<
+        std::is_const_v<std::remove_reference_t<decltype(self)>>, const C, C>;
+    if (!self.registry_.is_valid(id)) return nullptr;
+    auto loc = self.registry_.get_location(id);
+    result_t* found = nullptr;
+    [&]<size_t... Is>(std::index_sequence<Is...>) {
+      (
+          [&](auto& storage) {
+            if constexpr (has_all_components_v<
+                              std::remove_cvref_t<decltype(storage)>, C>)
+            {
+              if (*loc.store_id == Is)
+                found = &storage[id].template component<C>();
+            }
+          }(std::get<Is>(self.storages_)),
+          ...);
+    }(storage_indices());
+    return found;
+  }
+
   // Erase all entities in all storages and in staging. After this call the
   // registry and all storages are empty. When `policy` is release, uses the
   // fast path that drops storage vectors and resets the registry wholesale,

--- a/corvid/ecs/archetype_scene.h
+++ b/corvid/ecs/archetype_scene.h
@@ -505,6 +505,41 @@ public:
     return found;
   }
 
+  // Return a tuple of pointers to the components `Cs` for entity `id`, with
+  // the value being `nullptr` if the entity is invalid, in staging, or its
+  // archetype does not contain `C`. Deduces `const` from the scene: on a
+  // `const` scene returns `const C*`.
+  template<typename... Cs>
+  [[nodiscard]] auto try_get_components(this auto& self, id_t id) noexcept
+      -> std::tuple<std::conditional_t<
+          std::is_const_v<std::remove_reference_t<decltype(self)>>, const Cs*,
+          Cs*>...> {
+    using self_t = std::remove_reference_t<decltype(self)>;
+    using result_t = std::tuple<
+        std::conditional_t<std::is_const_v<self_t>, const Cs*, Cs*>...>;
+
+    const result_t missing{static_cast<
+        std::conditional_t<std::is_const_v<self_t>, const Cs*, Cs*>>(
+        nullptr)...};
+    if (!self.registry_.is_valid(id)) return missing;
+
+    auto loc = self.registry_.get_location(id);
+    result_t found = missing;
+    [&]<size_t... Is>(std::index_sequence<Is...>) {
+      (
+          [&](auto& storage) {
+            if constexpr (has_all_components_v<
+                              std::remove_cvref_t<decltype(storage)>, Cs...>)
+            {
+              if (*loc.store_id == Is)
+                found = std::tuple{&storage[id].template component<Cs>()...};
+            }
+          }(std::get<Is>(self.storages_)),
+          ...);
+    }(storage_indices());
+    return found;
+  }
+
   // Erase all entities in all storages and in staging. After this call the
   // registry and all storages are empty. When `policy` is release, uses the
   // fast path that drops storage vectors and resets the registry wholesale,

--- a/corvid/ecs/entity_registry.h
+++ b/corvid/ecs/entity_registry.h
@@ -568,7 +568,7 @@ public:
   // One particularly obvious use case is to erase all entries that aren't in
   // any valid store. The ID is passed so you can cascade deletion to the
   // appropriate storage(s).
-  size_type erase_if(auto pred) {
+  size_type erase_if(auto&& pred) {
     size_type cnt{};
     const auto id_end = records_.size_as_enum();
     for (id_t id{}; id < id_end; ++id) {
@@ -578,6 +578,21 @@ public:
         do_erase(id);
         ++cnt;
       }
+    }
+    return cnt;
+  }
+
+  // Call a function for each living record, as `func(id, rec)`, where `id` is
+  // the entity ID and `rec` is the `record_t&`. The callback may return
+  // `false` to stop iteration early. Returns count visited.
+  size_type for_each(auto&& func) const {
+    size_type cnt{};
+    const auto id_end = records_.size_as_enum();
+    for (id_t id{}; id < id_end; ++id) {
+      const auto& rec = records_[id];
+      if (!is_alive(id)) continue;
+      if (!func(id, rec)) break;
+      ++cnt;
     }
     return cnt;
   }

--- a/corvid/ecs/entity_registry.h
+++ b/corvid/ecs/entity_registry.h
@@ -581,8 +581,8 @@ public:
       auto& rec = records_[id];
       if (!is_alive(id)) continue;
       if (pred(id, rec)) {
-        do_erase(id);
         ++cnt;
+        do_erase(id);
       }
     }
     return cnt;
@@ -597,8 +597,8 @@ public:
     for (id_t id{}; id < id_end; ++id) {
       const auto& rec = records_[id];
       if (!is_alive(id)) continue;
-      if (!func(id, rec)) break;
       ++cnt;
+      if (!func(id, rec)) break;
     }
     return cnt;
   }

--- a/corvid/ecs/entity_registry.h
+++ b/corvid/ecs/entity_registry.h
@@ -589,7 +589,7 @@ public:
   }
 
   // Call a function for each living record, as `func(id, rec)`, where `id` is
-  // the entity ID and `rec` is the `record_t&`. The callback may return
+  // the entity ID and `rec` is the `const record_t&`. The callback may return
   // `false` to stop iteration early. Returns count visited.
   size_type for_each(auto&& func) const {
     size_type cnt{};

--- a/corvid/ecs/entity_registry.h
+++ b/corvid/ecs/entity_registry.h
@@ -434,6 +434,12 @@ public:
     return true;
   }
 
+  // Get ID from handle, but returns `id_t::invalid` if the handle is invalid.
+  [[nodiscard]] id_t id_from_handle(handle_t handle) const {
+    if (!is_valid(handle)) return id_t::invalid;
+    return handle.id();
+  }
+
   // Get location for ID. Must be valid.
   //
   // Returns `location_t` in archetype mode, and `store_id_set_t` in component

--- a/corvid/enums/bool_enums.h
+++ b/corvid/enums/bool_enums.h
@@ -76,4 +76,7 @@ enum class coordination_policy : bool { unilateral = false, bilateral = true };
 // Whether to allow exclusive or shared access to a resource.
 enum class exclusivity : bool { exclusive = false, shared = true };
 
+// Whether to perform a full update or an incremental update.
+enum class update_strategy : bool { full = false, incremental = true };
+
 }}} // namespace corvid::enums::bool_enums

--- a/corvid/enums/sequence_enum.h
+++ b/corvid/enums/sequence_enum.h
@@ -288,6 +288,12 @@ template<std::integral T>
   return static_cast<T>(v);
 }
 
+// Look up exact string_view for value, or "(unknown)" if not found or empty.
+template<SequentialEnum E>
+[[nodiscard]] constexpr std::string_view enum_as_view(E v) noexcept {
+  return registry::enum_spec_v<std::decay_t<E>>.as_view(v);
+}
+
 // Length of range.
 template<SequentialEnum E>
 [[nodiscard]] constexpr auto range_length() noexcept {
@@ -321,8 +327,15 @@ struct sequence_enum_names_spec
   constexpr sequence_enum_names_spec(std::array<std::string_view, N> name_list)
       : names(name_list) {}
 
-  auto& append(AppendTarget auto& target, E v) const {
+  constexpr auto& append(AppendTarget auto& target, E v) const {
     return do_seq_append(target, v, names);
+  }
+
+  std::string_view as_view(E v) const noexcept {
+    auto n = as_underlying(v);
+    size_t ofs = n - *min_value<E>();
+    if (ofs < names.size() && names[ofs].size()) return names[ofs];
+    return std::string_view{"(unknown)"};
   }
 
   bool lookup(E& v, std::string_view sv) const {

--- a/corvid/enums/sequence_enum.h
+++ b/corvid/enums/sequence_enum.h
@@ -331,14 +331,14 @@ struct sequence_enum_names_spec
     return do_seq_append(target, v, names);
   }
 
-  std::string_view as_view(E v) const noexcept {
+  [[nodiscard]] constexpr std::string_view as_view(E v) const noexcept {
     auto n = as_underlying(v);
     size_t ofs = n - *min_value<E>();
     if (ofs < names.size() && names[ofs].size()) return names[ofs];
     return std::string_view{"(unknown)"};
   }
 
-  bool lookup(E& v, std::string_view sv) const {
+  [[nodiscard]] bool lookup(E& v, std::string_view sv) const {
     if (sv.empty()) return false;
     if (registry::details::lookup_helper(v, sv)) {
       if constexpr (seq_actually_wrap_v<E>)

--- a/corvid/proto.h
+++ b/corvid/proto.h
@@ -31,6 +31,8 @@
 //  stream_async - per-call async wrappers: `stream_async_cb` (callback-based)
 //                and `stream_async_coro` (coroutine-based)
 //  loop_task   - fire-and-forget coroutine return type for `epoll_loop`
+//  json_parser - strict header-only JSON parser and writer with non-owning
+//                views
 //  terminated_text_parser - sentinel-terminated text frame parser for
 //                line-oriented protocols (HTTP, SMTP, POP3, etc.)
 //  http_header_block - HTTP/1.1 types: `http_version`/`http_method` enums,
@@ -48,6 +50,7 @@
 #include "proto/stream_conn.h"
 #include "proto/stream_async.h"
 #include "proto/loop_task.h"
+#include "proto/json_parser.h"
 #include "proto/terminated_text_parser.h"
 #include "proto/stream_sync.h"
 #include "proto/base-64.h"

--- a/corvid/proto.h
+++ b/corvid/proto.h
@@ -58,3 +58,4 @@
 #include "proto/http_websocket.h"
 #include "proto/http_websocket_transaction.h"
 #include "proto/http_server.h"
+#include "proto/http_file_transaction.h"

--- a/corvid/proto/endian.h
+++ b/corvid/proto/endian.h
@@ -33,6 +33,12 @@ namespace corvid { inline namespace proto {
 
 inline auto swap_always(auto v) noexcept { return std::byteswap(v); }
 
+inline __uint128_t swap_always(__uint128_t v) noexcept {
+  auto lo = static_cast<uint64_t>(v);
+  auto hi = static_cast<uint64_t>(v >> 64);
+  return (static_cast<__uint128_t>(std::byteswap(lo)) << 64) | std::byteswap(hi);
+}
+
 inline auto swap_not_big(auto v) noexcept {
   if constexpr (std::endian::native == std::endian::big) return v;
   return swap_always(v);

--- a/corvid/proto/endian.h
+++ b/corvid/proto/endian.h
@@ -36,7 +36,8 @@ inline auto swap_always(auto v) noexcept { return std::byteswap(v); }
 inline __uint128_t swap_always(__uint128_t v) noexcept {
   auto lo = static_cast<uint64_t>(v);
   auto hi = static_cast<uint64_t>(v >> 64);
-  return (static_cast<__uint128_t>(std::byteswap(lo)) << 64) | std::byteswap(hi);
+  return (static_cast<__uint128_t>(std::byteswap(lo)) << 64) |
+         std::byteswap(hi);
 }
 
 inline auto swap_not_big(auto v) noexcept {

--- a/corvid/proto/http_file_transaction.h
+++ b/corvid/proto/http_file_transaction.h
@@ -1,0 +1,159 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+// HTTP transaction for serving pre-cached static files.
+//
+// `static_file_cache`       -- loads and owns the in-memory file cache
+// `static_file_transaction` -- `http_transaction` subclass that serves
+//                              entries from a `static_file_cache`
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "../containers/opt_find.h"
+#include "../containers/transparent.h"
+#include "../strings/token_parser.h"
+#include "http_head_codec.h"
+#include "http_transaction.h"
+
+namespace corvid { inline namespace proto {
+
+// `static_file_cache` is an in-memory cache of static files, keyed by URL
+// path.
+//
+// Walks a directory tree at construction time, reads every regular file into
+// memory, and serves them by URL path. Also adds "/" as an alias for
+// "/index.html" when that file is present.
+//
+// Content types are derived from file extensions at load time, so
+// directory-style URLs (e.g., "/") inherit the correct type from the file they
+// alias rather than from the URL itself.
+class static_file_cache {
+public:
+  // A single cached file: its pre-read body and `Content-Type` string.
+  struct entry {
+    std::string body;
+    std::string content_type;
+  };
+
+  // Load all regular files under `web_root`. Filesystem errors per entry are
+  // silently ignored; an unreadable `web_root` produces an empty cache.
+  explicit static_file_cache(const std::filesystem::path& web_root) {
+    std::error_code ec;
+    for (auto& e : std::filesystem::recursive_directory_iterator(web_root, ec))
+    {
+      if (!e.is_regular_file()) continue;
+      auto rel = e.path().lexically_relative(web_root);
+      std::string url = "/" + rel.generic_string();
+      auto body = read_file(e.path());
+      if (!body) continue;
+      map_[url] = {std::move(*body), std::string{content_type_for(url)}};
+    }
+    if (auto index = find_opt(map_, "/index.html")) map_["/"] = *index;
+  }
+
+  static_file_cache(static_file_cache&&) noexcept = default;
+  static_file_cache(const static_file_cache&) = delete;
+
+  static_file_cache& operator=(const static_file_cache&) = delete;
+  static_file_cache& operator=(static_file_cache&&) noexcept = default;
+
+  // Number of cached entries (including aliases such as "/").
+  [[nodiscard]] std::size_t size() const noexcept { return map_.size(); }
+
+  // Look up `url`. Returns a pointer into the cache (valid for the lifetime
+  // of this object), or null if not found.
+  [[nodiscard]] const entry* find(std::string_view url) const {
+    return find_opt(map_, url);
+  }
+
+private:
+  // Return the `Content-Type` string for a URL or filename by extension.
+  // TODO: This should be a lookup table.
+  [[nodiscard]] static std::string_view content_type_for(
+      std::string_view name) noexcept {
+    if (name.ends_with(".html")) return "text/html";
+    if (name.ends_with(".js")) return "text/javascript";
+    if (name.ends_with(".css")) return "text/css";
+    return "application/octet-stream";
+  }
+
+  // Read `path` into a string. Returns empty optional on failure.
+  [[nodiscard]] static std::optional<std::string> read_file(
+      const std::filesystem::path& path) {
+    std::ifstream f{path, std::ios::binary};
+    if (!f) return std::nullopt;
+    return std::string{std::istreambuf_iterator<char>{f}, {}};
+  }
+
+  string_map<entry> map_;
+};
+
+// `static_file_transaction` serves pre-cached static files from a
+// `static_file_cache`.
+//
+// Holds a `shared_ptr` to the cache so the transaction keeps the cache alive
+// independently of the factory closure. Only "GET" is supported; other methods
+// return 405. Request targets not found in the cache return 404.
+struct static_file_transaction: public http_transaction {
+  static_file_transaction(request_head&& req,
+      std::shared_ptr<const static_file_cache> cache)
+      : http_transaction{std::move(req)}, cache_{std::move(cache)} {}
+
+  [[nodiscard]] stream_claim handle_drain(const send_fn& send_cb) override {
+    const auto& req = request_headers;
+
+    if (req.method != http_method::GET) {
+      close_after = after_response::close;
+      (void)send_cb(response_head::make_error_response(close_after,
+          req.version, http_status_code::METHOD_NOT_ALLOWED,
+          "Method Not Allowed"));
+      return stream_claim::release;
+    }
+
+    // Strip query string; only the path portion is used for lookup.
+    auto path = std::string_view{req.target};
+    path = strings::token_parser::next_delimited('?', path);
+
+    const auto* e = cache_->find(path);
+    if (!e) {
+      (void)send_cb(response_head::make_error_response(close_after,
+          req.version, http_status_code::NOT_FOUND, "Not Found"));
+      return stream_claim::release;
+    }
+
+    response_headers.version = req.version;
+    response_headers.status_code = http_status_code::OK;
+    response_headers.reason = "OK";
+    response_headers.options.content_length = e->body.size();
+    response_headers.options.connection = close_after;
+    (void)response_headers.headers.reset_raw("Content-Type", e->content_type);
+
+    (void)send_cb(response_headers.serialize());
+    (void)send_cb(std::string{e->body});
+    return stream_claim::release;
+  }
+
+private:
+  std::shared_ptr<const static_file_cache> cache_;
+};
+
+}} // namespace corvid::proto

--- a/corvid/proto/http_head_codec.h
+++ b/corvid/proto/http_head_codec.h
@@ -458,7 +458,7 @@ public:
   [[nodiscard]] bool add_line(std::string_view line) {
     if (line.empty()) return false;
     if (line.front() == ' ' || line.front() == '\t') return false;
-    auto found = strings::token_parser::next_terminated(":", line);
+    auto found = strings::token_parser::next_terminated(':', line);
     if (!found) return false;
     const auto name = *found;
     const auto value = strings::trim(line);

--- a/corvid/proto/http_server.h
+++ b/corvid/proto/http_server.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <variant>
 
 #include "epoll_loop.h"
 #include "http_head_codec.h"

--- a/corvid/proto/http_server.h
+++ b/corvid/proto/http_server.h
@@ -145,7 +145,7 @@ class http_server: public std::enable_shared_from_this<http_server> {
     // Note: Ordering was chosen to improve packing, not based on logic.
 
     // Send callback bound for use with transaction `handle_drain`.
-    http_transaction::send_fn send_fn;
+    http_transaction::send_fn send_cb;
 
     std::atomic_uint64_t read_seq;  // Identifies read timeout fuse.
     std::atomic_uint64_t write_seq; // Identifies write timeout fuse.
@@ -344,9 +344,10 @@ private:
     auto& state = conn_t::from(conn).state();
     if (state.parser_state) return true;
     state.parser_state = terminated_text_parser::state{"\r\n", 8192};
-    state.send_fn = [this, &conn](std::string&& buf) -> bool {
-      if (buf.empty() || !arm_write_timeout(conn) ||
-          !conn.send(std::move(buf)))
+    state.send_cb = [this, &conn](any_strings&& bufs) -> bool {
+      bool is_hangup = std::holds_alternative<std::monostate>(bufs);
+      if (is_hangup || !arm_write_timeout(conn) ||
+          !conn.send_any(std::move(bufs)))
       {
         (void)hangup(conn);
         return false;
@@ -504,7 +505,7 @@ private:
 
     // If active writer transaction claims the write stream, it is still
     // producing output.
-    if (writer->handle_drain(state.send_fn) == stream_claim::claim)
+    if (writer->handle_drain(state.send_cb) == stream_claim::claim)
       return true;
 
     // The transaction can decide to gently close the connection after its

--- a/corvid/proto/http_transaction.h
+++ b/corvid/proto/http_transaction.h
@@ -23,8 +23,11 @@
 #include "http_head_codec.h"
 #include "recv_buffer.h"
 #include "stream_conn.h"
+#include "../strings/any_strings.h"
 
 namespace corvid { inline namespace proto {
+
+using namespace corvid::strings::any_strings_types;
 
 // Whether a transaction retains its claim on a pipeline stream.
 //

--- a/corvid/proto/http_transaction.h
+++ b/corvid/proto/http_transaction.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "http_head_codec.h"
 #include "recv_buffer.h"
@@ -68,9 +69,9 @@ using transaction_ptr = std::shared_ptr<http_transaction>;
 // class for stateful behavior, or install callbacks for simple handlers.
 struct http_transaction
     : public std::enable_shared_from_this<http_transaction> {
-  // Callback to allow sends, resetting the write timer. Calling it with an
-  // empty string signals failure and hangs up the connection.
-  using send_fn = std::function<bool(std::string&&)>;
+  // Callback to allow sends, resetting the write timer. Calling it with
+  // `std::monostate` signals failure and hangs up the connection.
+  using send_fn = std::function<bool(any_strings&&)>;
 
   // Callback types for the optional `on_data` / `on_drain` hooks.
   //
@@ -135,8 +136,8 @@ struct http_transaction
   // until the entire response is sent, at which point it returns `release`.
   //
   // Default: invoke `on_drain` if set, else return `release`.
-  [[nodiscard]] virtual stream_claim handle_drain(const send_fn& send) {
-    if (on_drain) return on_drain(*this, send);
+  [[nodiscard]] virtual stream_claim handle_drain(const send_fn& send_cb) {
+    if (on_drain) return on_drain(*this, send_cb);
     close_after = after_response::close;
     return stream_claim::release;
   }

--- a/corvid/proto/http_websocket.h
+++ b/corvid/proto/http_websocket.h
@@ -732,6 +732,15 @@ public:
     return send_frame(ws_frame_control::fin | ws_frame_control::pong, payload);
   }
 
+  // True while the sender is mid-fragmented-message: a data frame without FIN
+  // has been sent but the final fragment has not yet been sent. Control frames
+  // (ping, pong, close) may be sent freely during this window; other data
+  // frames must not be until fragmentation is complete. This is relevant
+  // mostly to timed callbacks.
+  [[nodiscard]] bool is_send_in_fragment() const noexcept {
+    return send_in_fragment_;
+  }
+
   // Send a frame. `frame_control` encodes both the FIN flag and the opcode
   // nibble. Masking is applied automatically for client-side connections. To
   // use this for fragmented messages: omit `ws_frame_control::fin` on all but
@@ -747,6 +756,10 @@ public:
     // stops the user from building the payload on a header in a frame string,
     // at least so long as they know its length in advance.
     if (sent_close_) return false;
+    // Track outgoing fragment state. Control frames (opcode bit 0x08 set) are
+    // allowed mid-fragment per RFC 6455 and do not change fragment state.
+    if (!bitmask::has(frame_control, ws_frame_control::control))
+      send_in_fragment_ = !bitmask::has(frame_control, ws_frame_control::fin);
     std::optional<uint32_t> mask;
     if (!is_server_) mask.emplace(generate_random());
     std::string frame =
@@ -1061,6 +1074,10 @@ private:
 
   // Whether we've sent a close frame, which means we should stop sending.
   bool sent_close_{false};
+
+  // True while we are mid-fragmented-send: a data frame without FIN has been
+  // sent but the matching final fragment has not yet been sent.
+  bool send_in_fragment_{false};
 
   // Auto-incrementing counter for outgoing pings. Each call to `send_ping`
   // increments this and stores the new value in `pending_ping_`.

--- a/corvid/proto/http_websocket.h
+++ b/corvid/proto/http_websocket.h
@@ -580,9 +580,10 @@ public:
 
   // Construct with a `send_fn`, in either client or server mode. Then
   // configure using public fields.
-  explicit http_websocket(http_transaction::send_fn send,
+  explicit http_websocket(http_transaction::send_fn send_cb,
       connection_role role = connection_role::server)
-      : send_{std::move(send)}, is_server_{role == connection_role::server} {}
+      : send_cb_{std::move(send_cb)},
+        is_server_{role == connection_role::server} {}
 
   // Feed raw received bytes from `handle_data`. Accumulates fragmented
   // messages across frames into `message_` and fires callbacks, while handling
@@ -738,11 +739,13 @@ public:
   // first.
   [[nodiscard]] bool
   send_frame(ws_frame_control frame_control, std::string_view payload) {
-    // TODO: As an architectural optimization, consider building the frame
-    // header separately, and modifying `send_fn` to take a header and payload,
-    // so we can avoid an extra copy. This might not be worth it, though. And
-    // if the payload is big, then the caller could compose their own frame to
-    // avoid a copy.
+    // TODO: A version that took a `std::string&&` for the payload could mask
+    // in-place, build the headers in a local string, and then use
+    // `any_strings` to gather them without copying them into a single buffer,
+    // much less making multiple syscalls. Perhaps we should offer this as an
+    // option, as it might be worth it for large payloads. Then again, nothing
+    // stops the user from building the payload on a header in a frame string,
+    // at least so long as they know its length in advance.
     if (sent_close_) return false;
     std::optional<uint32_t> mask;
     if (!is_server_) mask.emplace(generate_random());
@@ -753,8 +756,8 @@ public:
 
   // Send a serialized frame.
   [[nodiscard]] bool send_frame(std::string&& frame) {
-    if (sent_close_ || !send_) return false;
-    return send_(std::move(frame));
+    if (sent_close_ || !send_cb_) return false;
+    return send_cb_(std::move(frame));
   }
 
   // Generate a WebSocket upgrade request for the given `path`, returning the
@@ -777,10 +780,10 @@ public:
     return req;
   }
 
-  // Signal an immediate RST by invoking the send function with an empty
-  // string, then return false so callers can propagate the error.
+  // Signal an immediate RST by invoking the send function with `monostate`,
+  // then return false so callers can propagate the error.
   [[nodiscard]] bool hangup() {
-    if (send_) (void)send_(std::string{});
+    if (send_cb_) (void)send_cb_(std::monostate{});
     return false;
   }
 
@@ -1033,7 +1036,7 @@ private:
   }
 
   // Callback for sending frames through provided mechanism.
-  http_transaction::send_fn send_;
+  http_transaction::send_fn send_cb_;
 
   // Whether acting as server or client.
   const bool is_server_{};

--- a/corvid/proto/http_websocket.h
+++ b/corvid/proto/http_websocket.h
@@ -768,7 +768,7 @@ public:
   }
 
   // Send a serialized frame.
-  [[nodiscard]] bool send_frame(std::string&& frame) {
+  [[nodiscard]] bool send_frame(any_strings&& frame) {
     if (sent_close_ || !send_cb_) return false;
     return send_cb_(std::move(frame));
   }

--- a/corvid/proto/http_websocket_transaction.h
+++ b/corvid/proto/http_websocket_transaction.h
@@ -147,6 +147,10 @@ public:
   // transaction in `configure` to handle subprotocol negotiation.
   [[nodiscard]] static transaction_factory make_factory(
       configure_fn configure = {}) {
+    // False positive: the analyzer sees libc++ allocate storage for the
+    // captured `std::function`, but misses that the route map later destroys
+    // the returned factory and frees that storage with the server.
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
     return [configure = std::move(configure)](
                request_head&& req) -> std::shared_ptr<http_transaction> {
       auto tx = std::make_shared<http_websocket_transaction>(std::move(req));

--- a/corvid/proto/http_websocket_transaction.h
+++ b/corvid/proto/http_websocket_transaction.h
@@ -57,7 +57,7 @@ using namespace std::chrono_literals;
 //             };
 //         return true;
 //       });
-class http_websocket_transaction final: public http_transaction {
+class http_websocket_transaction: public http_transaction {
 public:
   using duration_t = timing_wheel::duration_t;
   using configure_fn = std::function<bool(http_websocket_transaction&)>;
@@ -307,11 +307,15 @@ private:
   std::string pending_response_;
   bool upgraded_{};
 
-  std::weak_ptr<epoll_loop> keepalive_loop_;
-  std::weak_ptr<timing_wheel> keepalive_wheel_;
   duration_t ping_interval_{30s};
   duration_t pong_timeout_{10s};
   std::atomic_uint64_t ping_interval_seq_;
   std::atomic_uint64_t pong_wait_seq_;
+
+protected:
+  // Exposed as `protected` so derived classes can schedule their own timer
+  // callbacks on the same loop and wheel without storing redundant copies.
+  std::weak_ptr<epoll_loop> keepalive_loop_;
+  std::weak_ptr<timing_wheel> keepalive_wheel_;
 };
 }} // namespace corvid::proto

--- a/corvid/proto/http_websocket_transaction.h
+++ b/corvid/proto/http_websocket_transaction.h
@@ -97,10 +97,10 @@ public:
   // The WebSocket output never completes via send-queue drain; return
   // `claim` unconditionally. Calls `on_drain`, if set, in order to offer flow
   // control. Returns `release` once the close handshake is complete.
-  [[nodiscard]] stream_claim handle_drain(const send_fn& send) override {
-    if (!websocket_send_) websocket_send_ = send;
+  [[nodiscard]] stream_claim handle_drain(const send_fn& send_cb) override {
+    if (!websocket_send_cb_) websocket_send_cb_ = send_cb;
     if (!pending_response_.empty()) {
-      if (!send(std::move(pending_response_))) return stream_claim::release;
+      if (!send_cb(std::move(pending_response_))) return stream_claim::release;
       pending_response_.clear();
       // Start keepalive cycle after the upgrade response is sent.
       if (!do_arm_ping_interval()) return stream_claim::release;
@@ -110,7 +110,7 @@ public:
       close_after = after_response::close;
       return stream_claim::release;
     }
-    if (on_drain) return on_drain(*this, send);
+    if (on_drain) return on_drain(*this, send_cb);
     return upgraded_ ? stream_claim::claim : stream_claim::release;
   }
 
@@ -171,8 +171,7 @@ private:
 
     const auto version_hdr =
         request_headers.headers.get("Sec-Websocket-Version");
-    if (!version_hdr || *version_hdr != "13")
-      return send_upgrade_required();
+    if (!version_hdr || *version_hdr != "13") return send_upgrade_required();
     const auto key_hdr = request_headers.headers.get("Sec-Websocket-Key");
     if (!key_hdr || key_hdr->empty()) return send_bad_request(view);
 
@@ -239,7 +238,7 @@ private:
   // Used during the upgrade handshake when we may not have a send function
   // yet.
   [[nodiscard]] stream_claim do_fail_badly() {
-    if (websocket_send_) (void)websocket_send_(std::string{});
+    if (websocket_send_cb_) (void)websocket_send_cb_(std::monostate{});
     close_after = after_response::close;
     return stream_claim::release;
   }
@@ -300,10 +299,10 @@ private:
     return websocket_.send_close(1001, "Keepalive pong not received.");
   }
 
-  http_transaction::send_fn websocket_send_;
-  http_websocket websocket_{[this](std::string&& frame) {
-    if (!websocket_send_) return false;
-    return websocket_send_(std::move(frame));
+  http_transaction::send_fn websocket_send_cb_;
+  http_websocket websocket_{[this](any_strings&& frame) {
+    if (!websocket_send_cb_) return false;
+    return websocket_send_cb_(std::move(frame));
   }};
   std::string pending_response_;
   bool upgraded_{};

--- a/corvid/proto/json_parser.h
+++ b/corvid/proto/json_parser.h
@@ -184,7 +184,7 @@ public:
     if (!is_number()) return std::nullopt;
     T value{};
     // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
-    auto [ptr, ec] = strings::std_from_chars(source_.data(),
+    auto [ptr, ec] = std::from_chars(source_.data(),
         source_.data() + source_.size(), value);
     if (ec != std::errc{} || ptr != source_.data() + source_.size())
       return std::nullopt;
@@ -632,9 +632,7 @@ constexpr bool parse_literal(json_cursor& c, std::string_view literal,
 
 constexpr bool consume_digits(json_cursor& c) {
   if (c.at_end() || !is_digit(*c)) return false;
-  do {
-    ++c;
-  } while (!c.at_end() && is_digit(*c));
+  do { ++c; } while (!c.at_end() && is_digit(*c));
   return true;
 }
 

--- a/corvid/proto/json_parser.h
+++ b/corvid/proto/json_parser.h
@@ -171,6 +171,7 @@ public:
   [[nodiscard]] std::optional<T> as_number() const noexcept {
     if (!is_number()) return std::nullopt;
     T value{};
+    // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
     auto [ptr, ec] = std::from_chars(source_.data(),
         source_.data() + source_.size(), value);
     if (ec != std::errc{} || ptr != source_.data() + source_.size())
@@ -179,9 +180,10 @@ public:
   }
 
   template<std::floating_point T>
-  [[nodiscard]] std::optional<T> as_number() const noexcept {
+  [[nodiscard]] std::optional<T> as_number() const {
     if (!is_number()) return std::nullopt;
     T value{};
+    // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
     auto [ptr, ec] = strings::std_from_chars(source_.data(),
         source_.data() + source_.size(), value);
     if (ec != std::errc{} || ptr != source_.data() + source_.size())
@@ -192,8 +194,7 @@ public:
   // If this is a plain JSON string (properly quoted and containing no escape
   // sequences), returns the inner `std::string_view`, which may be empty.
   // Otherwise, returns `std::nullopt`.
-  [[nodiscard]] std::optional<std::string_view>
-  string_view_if_plain() const noexcept {
+  [[nodiscard]] std::optional<std::string_view> string_view_if_plain() const {
     if (!is_string() || source_.size() < 2) return std::nullopt;
     auto inner = source_.substr(1, source_.size() - 2);
     if (inner.contains('\\')) return std::nullopt;
@@ -249,8 +250,7 @@ public:
   private:
     friend class json_array_view;
 
-    constexpr explicit iterator(const json_array_view* owner,
-        size_t pos) noexcept
+    constexpr explicit iterator(const json_array_view* owner, size_t pos)
         : owner_{owner}, pos_{pos} {
       load_current();
     }
@@ -326,8 +326,7 @@ public:
   private:
     friend class json_object_view;
 
-    constexpr explicit iterator(const json_object_view* owner,
-        size_t pos) noexcept
+    constexpr explicit iterator(const json_object_view* owner, size_t pos)
         : owner_{owner}, pos_{pos} {
       load_current();
     }
@@ -469,8 +468,7 @@ struct json_cursor {
 
   constexpr char next() noexcept { return input[pos++]; }
 
-  [[nodiscard]] constexpr auto
-  substr(size_t pos, size_t count = npos) const noexcept {
+  [[nodiscard]] constexpr auto substr(size_t pos, size_t count = npos) const {
     return input.substr(pos, count);
   }
 
@@ -1043,8 +1041,7 @@ class json_writer {
   template<typename Begin, typename End>
   class scoped_writer {
   public:
-    constexpr scoped_writer(json_writer& writer, Begin&& begin,
-        End&& end) noexcept
+    constexpr scoped_writer(json_writer& writer, Begin&& begin, End&& end)
         : writer_{&writer}, end_{std::forward<End>(end)} {
       std::forward<Begin>(begin)(*writer_);
     }
@@ -1054,6 +1051,7 @@ class json_writer {
     scoped_writer& operator=(const scoped_writer&) = delete;
     scoped_writer& operator=(scoped_writer&&) = delete;
 
+    // NOLINTNEXTLINE(bugprone-exception-escape)
     constexpr ~scoped_writer() { end_(*writer_); }
 
     [[nodiscard]] constexpr json_writer* operator->() noexcept {
@@ -1132,7 +1130,7 @@ public:
     return object();
   }
 
-  [[nodiscard]] constexpr auto member_object(json_trusted key_text) noexcept {
+  [[nodiscard]] constexpr auto member_object(json_trusted key_text) {
     key(key_text);
     return object();
   }
@@ -1144,7 +1142,7 @@ public:
     return array();
   }
 
-  [[nodiscard]] constexpr auto member_array(json_trusted key_text) noexcept {
+  [[nodiscard]] constexpr auto member_array(json_trusted key_text) {
     key(key_text);
     return array();
   }

--- a/corvid/proto/json_parser.h
+++ b/corvid/proto/json_parser.h
@@ -1,0 +1,1279 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <algorithm>
+#include <charconv>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "../strings/concat_join.h"
+#include "../strings/conversion.h"
+#include "../strings/trimming.h"
+
+// Strict JSON parser, non-owning value views, and compact JSON writer.
+namespace corvid { inline namespace proto { inline namespace json {
+
+size_t npos = std::string_view::npos;
+
+// Kind of JSON value represented by a `json_value_view`.
+enum class json_kind : uint8_t {
+  invalid,
+  null,
+  boolean,
+  number,
+  string,
+  array,
+  object,
+};
+
+// Parse error category reported in `json_error`.
+enum class json_errc : uint8_t {
+  none,
+  unexpected_end,
+  invalid_token,
+  invalid_literal,
+  invalid_number,
+  invalid_string,
+  invalid_escape,
+  invalid_unicode_escape,
+  invalid_surrogate_pair,
+  expected_key,
+  expected_colon,
+  expected_value,
+  expected_comma_or_end,
+  trailing_data,
+  depth_exceeded,
+};
+
+// Parse error plus byte offset within the original input.
+struct json_error {
+  json_errc code{json_errc::none};
+  size_t offset{};
+
+  constexpr void clear() {
+    code = json_errc::none;
+    offset = 0;
+  }
+
+  [[nodiscard]] constexpr static bool
+  fail(json_error* out_err, json_errc code_, size_t offset_) {
+    if (out_err) return out_err->fail(code_, offset_);
+    return false;
+  }
+
+  [[nodiscard]] constexpr bool fail(json_errc code_, size_t offset_) {
+    code = code_;
+    offset = offset_;
+    return false;
+  }
+};
+
+// Parser configuration. `max_depth` guards against adversarial nesting.
+struct json_parse_options {
+  size_t max_depth{64};
+};
+
+// String wrapper for bytes already known to be safe inside JSON quotes.
+//
+// This bypasses the usual escape scan in `json_writer`, so callers must
+// ensure the contents contain no characters that would require JSON
+// escaping.
+struct json_trusted {
+  std::string_view value;
+
+  [[nodiscard]] constexpr operator std::string_view() const noexcept {
+    return value;
+  }
+};
+
+// Fwd.
+class json_object_view;
+class json_array_view;
+
+// Non-owning view of one validated JSON value.
+//
+// The view borrows a slice of the original JSON source, so that source must
+// outlive the view and any derived object/array subviews.
+class json_value_view {
+public:
+  constexpr json_value_view() = default;
+  constexpr explicit json_value_view(std::string_view source,
+      json_kind kind) noexcept
+      : source_{source}, kind_{kind} {
+    assert(!source.empty() || is(json_kind::invalid));
+  }
+
+  [[nodiscard]] constexpr explicit operator bool() const noexcept {
+    return kind_ != json_kind::invalid;
+  }
+  [[nodiscard]] constexpr bool empty() const noexcept {
+    return kind_ == json_kind::invalid;
+  }
+  [[nodiscard]] constexpr json_kind kind() const noexcept { return kind_; }
+  [[nodiscard]] constexpr std::string_view source() const noexcept {
+    return source_;
+  }
+
+  [[nodiscard]] constexpr bool is(json_kind kind) const noexcept {
+    return kind_ == kind;
+  }
+  [[nodiscard]] constexpr bool is_null() const noexcept {
+    return is(json_kind::null);
+  }
+  [[nodiscard]] constexpr bool is_bool() const noexcept {
+    return is(json_kind::boolean);
+  }
+  [[nodiscard]] constexpr bool is_number() const noexcept {
+    return is(json_kind::number);
+  }
+  [[nodiscard]] constexpr bool is_string() const noexcept {
+    return is(json_kind::string);
+  }
+  [[nodiscard]] constexpr bool is_array() const noexcept {
+    return is(json_kind::array);
+  }
+  [[nodiscard]] constexpr bool is_object() const noexcept {
+    return is(json_kind::object);
+  }
+
+  [[nodiscard]] std::optional<bool> as_bool() const noexcept {
+    if (!is_bool()) return std::nullopt;
+    if (source_ == "true") return true;
+    if (source_ == "false") return false;
+    return std::nullopt;
+  }
+
+  template<std::integral T>
+  requires(!std::same_as<std::remove_cvref_t<T>, bool>)
+  [[nodiscard]] std::optional<T> as_number() const noexcept {
+    if (!is_number()) return std::nullopt;
+    T value{};
+    auto [ptr, ec] = std::from_chars(source_.data(),
+        source_.data() + source_.size(), value);
+    if (ec != std::errc{} || ptr != source_.data() + source_.size())
+      return std::nullopt;
+    return value;
+  }
+
+  template<std::floating_point T>
+  [[nodiscard]] std::optional<T> as_number() const noexcept {
+    if (!is_number()) return std::nullopt;
+    T value{};
+    auto [ptr, ec] = strings::std_from_chars(source_.data(),
+        source_.data() + source_.size(), value);
+    if (ec != std::errc{} || ptr != source_.data() + source_.size())
+      return std::nullopt;
+    return value;
+  }
+
+  // If this is a plain JSON string (properly quoted and containing no escape
+  // sequences), returns the inner `std::string_view`, which may be empty.
+  // Otherwise, returns `std::nullopt`.
+  [[nodiscard]] std::optional<std::string_view>
+  string_view_if_plain() const noexcept {
+    if (!is_string() || source_.size() < 2) return std::nullopt;
+    auto inner = source_.substr(1, source_.size() - 2);
+    if (inner.contains('\\')) return std::nullopt;
+    return inner;
+  }
+
+  // Decode a JSON string into `out`, including escape and Unicode handling.
+  // Returns false when this value is not a string.
+  [[nodiscard]] constexpr bool decode_string(std::string& out) const;
+
+  // If this value is a JSON object, returns a view into it.
+  // Otherwise, returns a default-constructed empty view.
+  [[nodiscard]] constexpr json_object_view as_object() const noexcept;
+
+  // If this value is a JSON array, returns a view into it.
+  // Otherwise, returns a default-constructed empty view.
+  [[nodiscard]] constexpr json_array_view as_array() const noexcept;
+
+private:
+  std::string_view source_;
+  json_kind kind_{json_kind::invalid};
+};
+
+// Non-owning view of a validated JSON array.
+class json_array_view {
+public:
+  // Forward iterator over the immediate elements of a validated JSON array.
+  class iterator {
+  public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = json_value_view;
+    using difference_type = std::ptrdiff_t;
+    using reference = value_type;
+    using pointer = void;
+
+    constexpr iterator() = default;
+
+    [[nodiscard]] constexpr value_type operator*() const noexcept {
+      return current_;
+    }
+    constexpr iterator& operator++();
+    constexpr iterator operator++(int) {
+      auto copy = *this;
+      ++*this;
+      return copy;
+    }
+
+    [[nodiscard]] constexpr bool operator==(
+        const iterator& other) const noexcept {
+      return owner_ == other.owner_ && pos_ == other.pos_;
+    }
+
+  private:
+    friend class json_array_view;
+
+    constexpr explicit iterator(const json_array_view* owner,
+        size_t pos) noexcept
+        : owner_{owner}, pos_{pos} {
+      load_current();
+    }
+
+    // Parse the element starting at `pos_` and cache it in `current_`.
+    constexpr void load_current();
+
+    const json_array_view* owner_{};
+    size_t pos_{npos};
+    size_t next_pos_{npos};
+    json_value_view current_;
+  };
+
+  constexpr json_array_view() = default;
+  constexpr explicit json_array_view(std::string_view source) noexcept
+      : source_{source} {}
+
+  [[nodiscard]] constexpr explicit operator bool() const noexcept {
+    return !source_.empty();
+  }
+  [[nodiscard]] constexpr bool empty_source() const noexcept {
+    return source_.empty();
+  }
+  [[nodiscard]] constexpr std::string_view source() const noexcept {
+    return source_;
+  }
+
+  [[nodiscard]] constexpr iterator begin() const noexcept;
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+  [[nodiscard]] constexpr iterator end() const noexcept { return {}; }
+
+private:
+  std::string_view source_;
+};
+
+// Non-owning view of a validated JSON object.
+//
+// Lookup is linear and iteration preserves the original field order.
+class json_object_view {
+public:
+  // One object member as two JSON subviews: key string and value.
+  struct entry {
+    json_value_view key;
+    json_value_view value;
+  };
+
+  // Forward iterator over the immediate members of a validated JSON object.
+  class iterator {
+  public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = entry;
+    using difference_type = std::ptrdiff_t;
+    using reference = value_type;
+    using pointer = void;
+
+    constexpr iterator() = default;
+
+    [[nodiscard]] constexpr value_type operator*() const noexcept {
+      return current_;
+    }
+    constexpr iterator& operator++();
+    constexpr iterator operator++(int) {
+      auto copy = *this;
+      ++*this;
+      return copy;
+    }
+
+    [[nodiscard]] constexpr bool operator==(
+        const iterator& other) const noexcept {
+      return owner_ == other.owner_ && pos_ == other.pos_;
+    }
+
+  private:
+    friend class json_object_view;
+
+    constexpr explicit iterator(const json_object_view* owner,
+        size_t pos) noexcept
+        : owner_{owner}, pos_{pos} {
+      load_current();
+    }
+
+    // Parse the member starting at `pos_` and cache it in `current_`.
+    constexpr void load_current();
+
+    const json_object_view* owner_{};
+    size_t pos_{npos};
+    size_t next_pos_{npos};
+    entry current_{};
+  };
+
+  constexpr json_object_view() = default;
+  constexpr explicit json_object_view(std::string_view source) noexcept
+      : source_{source} {}
+
+  [[nodiscard]] constexpr explicit operator bool() const noexcept {
+    return !source_.empty();
+  }
+  [[nodiscard]] constexpr bool empty_source() const noexcept {
+    return source_.empty();
+  }
+  [[nodiscard]] constexpr std::string_view source() const noexcept {
+    return source_;
+  }
+
+  [[nodiscard]] constexpr iterator begin() const noexcept;
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+  [[nodiscard]] constexpr iterator end() const noexcept { return {}; }
+
+  // Return the value for the first matching key, or an empty view if absent.
+  [[nodiscard]] constexpr json_value_view find(std::string_view key) const;
+  // Convenience typed getters layered on top of `find`.
+  [[nodiscard]] constexpr std::optional<bool> get_bool(
+      std::string_view key) const;
+
+  template<typename T>
+  requires(std::integral<T> || std::floating_point<T>)
+  [[nodiscard]] constexpr std::optional<T>
+  get_number(std::string_view key) const {
+    return find(key).template as_number<T>();
+  }
+
+  // If the value for `key` is a plain JSON string, returns the inner
+  // `std::string_view`. Otherwise, returns `std::nullopt`.
+  [[nodiscard]] constexpr std::optional<std::string_view>
+  get_string_view_if_plain(std::string_view key) const {
+    return find(key).string_view_if_plain();
+  }
+  // Decode the value for `key` as a JSON string into `out`. Returns false if
+  // the value is not a string or if decoding fails.
+  [[nodiscard]] constexpr bool
+  get_string(std::string_view key, std::string& out) const {
+    return find(key).decode_string(out);
+  }
+  // If the value for `key` is a JSON object or array, returns a view into
+  // it. Otherwise, returns an empty view.
+  [[nodiscard]] constexpr json_object_view get_object(
+      std::string_view key) const {
+    return find(key).as_object();
+  }
+  // If the value for `key` is a JSON array, returns a view into it.
+  // Otherwise, returns an empty view.
+  [[nodiscard]] constexpr json_array_view get_array(
+      std::string_view key) const {
+    return find(key).as_array();
+  }
+
+private:
+  std::string_view source_;
+};
+
+namespace detail {
+
+// JSON delimiters.
+inline constexpr strings::delim json_ws{" \t\r\n"};
+
+// Cursor into JSON input for parsing.
+struct json_cursor {
+  std::string_view input;
+  size_t pos{};
+
+  [[nodiscard]] constexpr bool at_end() const noexcept {
+    return pos >= input.size();
+  }
+
+  [[nodiscard]] constexpr char operator*() const noexcept {
+    return input[pos];
+  }
+
+  constexpr json_cursor& operator++() noexcept {
+    ++pos;
+    return *this;
+  }
+
+  constexpr json_cursor operator++(int) noexcept {
+    auto tmp = *this;
+    ++*this;
+    return tmp;
+  }
+
+  constexpr json_cursor& operator--() noexcept {
+    --pos;
+    return *this;
+  }
+
+  constexpr json_cursor operator--(int) noexcept {
+    auto tmp = *this;
+    --*this;
+    return tmp;
+  }
+
+  constexpr json_cursor& operator+=(size_t n) noexcept {
+    pos += n;
+    return *this;
+  }
+
+  constexpr json_cursor& operator-=(size_t n) noexcept {
+    pos -= n;
+    return *this;
+  }
+
+  [[nodiscard]] constexpr char operator[](std::ptrdiff_t n) const noexcept {
+    return input[static_cast<size_t>(static_cast<std::ptrdiff_t>(pos) + n)];
+  }
+
+  constexpr char next() noexcept { return input[pos++]; }
+
+  [[nodiscard]] constexpr auto
+  substr(size_t pos, size_t count = npos) const noexcept {
+    return input.substr(pos, count);
+  }
+
+  constexpr auto& skip_ws() {
+    const auto rest = substr(pos);
+    const auto trimmed = strings::trim_left(rest, json_ws);
+    pos += rest.size() - trimmed.size();
+    return *this;
+  }
+};
+
+[[nodiscard]] inline bool is_digit(char ch) noexcept {
+  return ch >= '0' && ch <= '9';
+}
+
+[[nodiscard]] inline bool is_lc_hex_alpha(char ch) noexcept {
+  return (ch >= 'a' && ch <= 'f');
+}
+
+[[nodiscard]] inline bool is_uc_hex_alpha(char ch) noexcept {
+  return (ch >= 'A' && ch <= 'F');
+}
+
+[[nodiscard]] inline bool is_hex_digit(char ch) noexcept {
+  return is_digit(ch) || is_lc_hex_alpha(ch) || is_uc_hex_alpha(ch);
+}
+
+[[nodiscard]] inline uint16_t hex_digit_value(char ch) noexcept {
+  if (is_digit(ch)) return static_cast<uint16_t>(ch - '0');
+  if (is_lc_hex_alpha(ch)) return static_cast<uint16_t>(10 + (ch - 'a'));
+  return static_cast<uint16_t>(10 + (ch - 'A'));
+}
+
+[[nodiscard]] inline std::optional<uint16_t>
+parse_hex4(std::string_view s, size_t pos) noexcept {
+  if (pos + 4 > s.size()) return std::nullopt;
+  uint16_t value{};
+  for (size_t i = 0; i < 4; ++i) {
+    const auto ch = s[pos + i];
+    if (!is_hex_digit(ch)) return std::nullopt;
+    value = static_cast<uint16_t>((value << 4U) | hex_digit_value(ch));
+  }
+  return value;
+}
+
+constexpr bool append_utf8(std::string& out, uint32_t code_point) {
+  if (code_point <= 0x7FU) {
+    out.push_back(static_cast<char>(code_point));
+  } else if (code_point <= 0x7FFU) {
+    out.push_back(static_cast<char>(0xC0U | (code_point >> 6U)));
+    out.push_back(static_cast<char>(0x80U | (code_point & 0x3FU)));
+  } else if (code_point <= 0xFFFFU) {
+    out.push_back(static_cast<char>(0xE0U | (code_point >> 12U)));
+    out.push_back(static_cast<char>(0x80U | ((code_point >> 6U) & 0x3FU)));
+    out.push_back(static_cast<char>(0x80U | (code_point & 0x3FU)));
+  } else {
+    out.push_back(static_cast<char>(0xF0U | (code_point >> 18U)));
+    out.push_back(static_cast<char>(0x80U | ((code_point >> 12U) & 0x3FU)));
+    out.push_back(static_cast<char>(0x80U | ((code_point >> 6U) & 0x3FU)));
+    out.push_back(static_cast<char>(0x80U | (code_point & 0x3FU)));
+  }
+  return true;
+}
+
+constexpr bool validate_unicode_escape(json_cursor& c, json_error* err) {
+  const auto start = c.pos;
+  const auto first = parse_hex4(c.input, c.pos);
+  if (!first)
+    return json_error::fail(err, json_errc::invalid_unicode_escape, start);
+  c += 4;
+
+  if (*first >= 0xD800U && *first <= 0xDBFFU) {
+    if (c.pos + 6 > c.input.size() || *c != '\\' || c[1] != 'u')
+      return json_error::fail(err, json_errc::invalid_surrogate_pair, start);
+    const auto second = parse_hex4(c.input, c.pos + 2);
+    if (!second || *second < 0xDC00U || *second > 0xDFFFU)
+      return json_error::fail(err, json_errc::invalid_surrogate_pair, start);
+    c += 6;
+    return true;
+  }
+
+  if (*first >= 0xDC00U && *first <= 0xDFFFU)
+    return json_error::fail(err, json_errc::invalid_surrogate_pair, start);
+
+  return true;
+}
+
+constexpr bool
+decode_unicode_escape(std::string_view source, size_t& pos, std::string& out) {
+  const auto first = parse_hex4(source, pos);
+  if (!first) return false;
+  pos += 4;
+
+  if (*first >= 0xD800U && *first <= 0xDBFFU) {
+    if (pos + 6 > source.size() || source[pos] != '\\' ||
+        source[pos + 1] != 'u')
+      return false;
+    const auto second = parse_hex4(source, pos + 2);
+    if (!second || *second < 0xDC00U || *second > 0xDFFFU) return false;
+    pos += 6;
+
+    const auto high = static_cast<uint32_t>(*first - 0xD800U);
+    const auto low = static_cast<uint32_t>(*second - 0xDC00U);
+    const auto code_point = 0x10000U + ((high << 10U) | low);
+    return append_utf8(out, code_point);
+  }
+
+  if (*first >= 0xDC00U && *first <= 0xDFFFU) return false;
+  return append_utf8(out, *first);
+}
+
+// Decode the full contents of a JSON string literal, excluding its quotes.
+constexpr bool
+decode_string_contents(std::string_view source, std::string& out) {
+  if (source.size() < 2 || source.front() != '"' || source.back() != '"')
+    return false;
+
+  source = source.substr(1, source.size() - 2);
+
+  out.clear();
+  out.reserve(source.size());
+
+  for (size_t pos = 0; pos < source.size();) {
+    const auto ch = source[pos++];
+    if (ch == '\\') {
+      if (pos >= source.size()) return false;
+      const auto esc = source[pos++];
+      switch (esc) {
+      case '"': out.push_back('"'); break;
+      case '\\': out.push_back('\\'); break;
+      case '/': out.push_back('/'); break;
+      case 'b': out.push_back('\b'); break;
+      case 'f': out.push_back('\f'); break;
+      case 'n': out.push_back('\n'); break;
+      case 'r': out.push_back('\r'); break;
+      case 't': out.push_back('\t'); break;
+      case 'u':
+        if (!decode_unicode_escape(source, pos, out)) return false;
+        break;
+      default: return false;
+      }
+      continue;
+    }
+
+    if (static_cast<unsigned char>(ch) < 0x20U) return false;
+    out.push_back(ch);
+  }
+
+  return true;
+}
+
+constexpr bool parse_literal(json_cursor& c, std::string_view literal,
+    json_kind kind, json_value_view& out, json_error* err) {
+  const auto start = c.pos;
+  if (!c.substr(c.pos).starts_with(literal))
+    return json_error::fail(err, json_errc::invalid_literal, start);
+  c += literal.size();
+  out = json_value_view{c.substr(start, literal.size()), kind};
+  return true;
+}
+
+constexpr bool
+parse_number(json_cursor& c, json_value_view& out, json_error* err) {
+  const auto start = c.pos;
+  if (*c == '-') ++c;
+  if (c.at_end())
+    return json_error::fail(err, json_errc::invalid_number, start);
+
+  if (*c == '0') {
+    ++c;
+    if (!c.at_end() && is_digit(*c))
+      return json_error::fail(err, json_errc::invalid_number, c.pos);
+  } else if (is_digit(*c)) {
+    while (!c.at_end() && is_digit(*c)) ++c;
+  } else {
+    return json_error::fail(err, json_errc::invalid_number, c.pos);
+  }
+
+  if (!c.at_end() && *c == '.') {
+    ++c;
+    if (c.at_end() || !is_digit(*c))
+      return json_error::fail(err, json_errc::invalid_number, c.pos);
+    while (!c.at_end() && is_digit(*c)) ++c;
+  }
+
+  if (!c.at_end() && (*c == 'e' || *c == 'E')) {
+    ++c;
+    if (!c.at_end() && (*c == '+' || *c == '-')) ++c;
+    if (c.at_end() || !is_digit(*c))
+      return json_error::fail(err, json_errc::invalid_number, c.pos);
+    while (!c.at_end() && is_digit(*c)) ++c;
+  }
+
+  out = json_value_view{c.substr(start, c.pos - start), json_kind::number};
+  return true;
+}
+
+constexpr bool
+parse_string(json_cursor& c, json_value_view& out, json_error* err) {
+  const auto start = c.pos;
+  if (*c != '"')
+    return json_error::fail(err, json_errc::invalid_string, c.pos);
+  ++c;
+
+  while (!c.at_end()) {
+    const auto ch = c.next();
+    if (ch == '"') {
+      out = json_value_view{c.substr(start, c.pos - start), json_kind::string};
+      return true;
+    }
+
+    if (static_cast<unsigned char>(ch) < 0x20U)
+      return json_error::fail(err, json_errc::invalid_string, c.pos - 1);
+
+    if (ch != '\\') continue;
+    if (c.at_end())
+      return json_error::fail(err, json_errc::unexpected_end, c.pos);
+
+    const auto esc = c.next();
+    switch (esc) {
+    case '"':
+    case '\\':
+    case '/':
+    case 'b':
+    case 'f':
+    case 'n':
+    case 'r':
+    case 't': break;
+    case 'u':
+      if (!validate_unicode_escape(c, err)) return false;
+      break;
+    default:
+      return json_error::fail(err, json_errc::invalid_escape, c.pos - 1);
+    }
+  }
+
+  return json_error::fail(err, json_errc::unexpected_end, start);
+}
+
+// Recursive-descent parser entrypoint for one JSON value at the current
+// cursor.
+constexpr bool parse_value(json_cursor& c, json_value_view& out,
+    json_error* err, const json_parse_options& opts, size_t depth);
+
+constexpr bool parse_array(json_cursor& c, json_value_view& out,
+    json_error* err, const json_parse_options& opts, size_t depth) {
+  const auto start = c.pos;
+  if (depth >= opts.max_depth)
+    return json_error::fail(err, json_errc::depth_exceeded, c.pos);
+
+  ++c;
+  if (c.skip_ws().at_end())
+    return json_error::fail(err, json_errc::unexpected_end, start);
+  if (*c == ']') {
+    ++c;
+    out = json_value_view{c.substr(start, c.pos - start), json_kind::array};
+    return true;
+  }
+
+  while (true) {
+    json_value_view item;
+    if (!parse_value(c, item, err, opts, depth + 1)) return false;
+
+    if (c.skip_ws().at_end())
+      return json_error::fail(err, json_errc::unexpected_end, start);
+
+    const auto ch = c.next();
+    if (ch == ']') {
+      out = json_value_view{c.substr(start, c.pos - start), json_kind::array};
+      return true;
+    }
+    if (ch != ',')
+      return json_error::fail(err, json_errc::expected_comma_or_end,
+          c.pos - 1);
+
+    if (c.skip_ws().at_end())
+      return json_error::fail(err, json_errc::unexpected_end, start);
+    if (*c == ']')
+      return json_error::fail(err, json_errc::expected_value, c.pos);
+  }
+}
+
+constexpr bool parse_object(json_cursor& c, json_value_view& out,
+    json_error* err, const json_parse_options& opts, size_t depth) {
+  const auto start = c.pos;
+  if (depth >= opts.max_depth)
+    return json_error::fail(err, json_errc::depth_exceeded, c.pos);
+
+  ++c;
+  if (c.skip_ws().at_end())
+    return json_error::fail(err, json_errc::unexpected_end, start);
+  if (*c == '}') {
+    ++c;
+    out = json_value_view{c.substr(start, c.pos - start), json_kind::object};
+    return true;
+  }
+
+  while (true) {
+    json_value_view key;
+    if (*c != '"')
+      return json_error::fail(err, json_errc::expected_key, c.pos);
+    if (!parse_string(c, key, err)) return false;
+
+    if (c.skip_ws().at_end())
+      return json_error::fail(err, json_errc::unexpected_end, start);
+    if (*c != ':')
+      return json_error::fail(err, json_errc::expected_colon, c.pos);
+    ++c;
+
+    json_value_view value;
+    if (!parse_value(c, value, err, opts, depth + 1)) return false;
+
+    if (c.skip_ws().at_end())
+      return json_error::fail(err, json_errc::unexpected_end, start);
+
+    const auto ch = c.next();
+    if (ch == '}') {
+      out = json_value_view{c.substr(start, c.pos - start), json_kind::object};
+      return true;
+    }
+    if (ch != ',')
+      return json_error::fail(err, json_errc::expected_comma_or_end,
+          c.pos - 1);
+
+    if (c.skip_ws().at_end())
+      return json_error::fail(err, json_errc::unexpected_end, start);
+    if (*c == '}')
+      return json_error::fail(err, json_errc::expected_key, c.pos);
+  }
+}
+
+constexpr bool parse_value(json_cursor& c, json_value_view& out,
+    json_error* err, const json_parse_options& opts, size_t depth) {
+  if (c.skip_ws().at_end())
+    return json_error::fail(err, json_errc::unexpected_end, c.pos);
+
+  switch (*c) {
+  case 'n': return parse_literal(c, "null", json_kind::null, out, err);
+  case 't': return parse_literal(c, "true", json_kind::boolean, out, err);
+  case 'f': return parse_literal(c, "false", json_kind::boolean, out, err);
+  case '"': return parse_string(c, out, err);
+  case '[': return parse_array(c, out, err, opts, depth);
+  case '{': return parse_object(c, out, err, opts, depth);
+  default:
+    if (*c == '-' || (is_digit(*c))) return parse_number(c, out, err);
+    return json_error::fail(err, json_errc::invalid_token, c.pos);
+  }
+}
+
+// Compare a JSON string value against plain text, decoding only when needed.
+constexpr bool
+string_equals(json_value_view candidate, std::string_view wanted) {
+  if (!candidate.is_string()) return false;
+  if (const auto plain = candidate.string_view_if_plain(); plain)
+    return *plain == wanted;
+  std::string decoded;
+  return candidate.decode_string(decoded) && decoded == wanted;
+}
+
+template<AppendTarget Target, std::floating_point Number>
+constexpr void append_float(Target& target, Number value,
+    std::chars_format fmt, int precision) {
+  if (!std::isfinite(value)) {
+    target += "null";
+    return;
+  }
+
+  char buffer[128];
+  std::to_chars_result result;
+  if (precision >= 0)
+    result =
+        std::to_chars(buffer, buffer + sizeof(buffer), value, fmt, precision);
+  else
+    result = std::to_chars(buffer, buffer + sizeof(buffer), value, fmt);
+
+  if (result.ec != std::errc{}) return;
+  target += std::string_view{buffer, static_cast<size_t>(result.ptr - buffer)};
+}
+
+constexpr json_parse_options iterator_parse_options{
+    std::numeric_limits<size_t>::max()};
+
+} // namespace detail
+
+// Parse and validate a complete JSON document.
+//
+// On success, `out` becomes a view of the root value. On failure, `out` is
+// cleared and `err`, when provided, receives the first parse failure.
+[[nodiscard]] constexpr bool parse_json(std::string_view input,
+    json_value_view& out, json_error* err = nullptr,
+    json_parse_options opts = {}) {
+  if (err) err->clear();
+
+  json_value_view parsed;
+  detail::json_cursor c{input};
+  if (!detail::parse_value(c.skip_ws(), parsed, err, opts, 0)) {
+    out = {};
+    return false;
+  }
+
+  if (!c.skip_ws().at_end()) {
+    out = {};
+    return json_error::fail(err, json_errc::trailing_data, c.pos);
+  }
+
+  out = parsed;
+  return true;
+}
+
+[[nodiscard]] constexpr bool needs_json_escaping(std::string_view s) noexcept {
+  return strings::needs_escaping(s);
+}
+
+constexpr bool json_value_view::decode_string(std::string& out) const {
+  if (!is_string()) return false;
+  return detail::decode_string_contents(source_, out);
+}
+
+constexpr json_object_view json_value_view::as_object() const noexcept {
+  return is_object() ? json_object_view{source_} : json_object_view{};
+}
+
+constexpr json_array_view json_value_view::as_array() const noexcept {
+  return is_array() ? json_array_view{source_} : json_array_view{};
+}
+
+constexpr json_array_view::iterator json_array_view::begin() const noexcept {
+  if (source_.size() < 2 || source_.front() != '[' || source_.back() != ']')
+    return {};
+  return iterator{this, 1};
+}
+
+constexpr void json_array_view::iterator::load_current() {
+  current_ = {};
+  next_pos_ = npos;
+  if (!owner_ || pos_ == npos) return;
+
+  detail::json_cursor c{owner_->source_, pos_};
+  if (c.skip_ws().at_end() || owner_->source_[c.pos] == ']') {
+    owner_ = nullptr;
+    pos_ = npos;
+    return;
+  }
+
+  if (!detail::parse_value(c, current_, nullptr,
+          detail::iterator_parse_options, 0))
+  {
+    owner_ = nullptr;
+    pos_ = npos;
+    return;
+  }
+
+  pos_ = c.pos;
+  next_pos_ = c.pos;
+}
+
+constexpr json_array_view::iterator& json_array_view::iterator::operator++() {
+  if (!owner_ || pos_ == npos) return *this;
+
+  detail::json_cursor c{owner_->source_, next_pos_};
+  if (c.skip_ws().at_end()) {
+    owner_ = nullptr;
+    pos_ = npos;
+    return *this;
+  }
+
+  if (owner_->source_[c.pos] == ',') {
+    pos_ = c.pos + 1;
+    load_current();
+    return *this;
+  }
+
+  owner_ = nullptr;
+  pos_ = npos;
+  return *this;
+}
+
+constexpr json_object_view::iterator json_object_view::begin() const noexcept {
+  if (source_.size() < 2 || source_.front() != '{' || source_.back() != '}')
+    return {};
+  return iterator{this, 1};
+}
+
+constexpr void json_object_view::iterator::load_current() {
+  current_ = {};
+  next_pos_ = npos;
+  if (!owner_ || pos_ == npos) return;
+
+  detail::json_cursor c{owner_->source_, pos_};
+  if (c.skip_ws().at_end() || *c == '}') {
+    owner_ = nullptr;
+    pos_ = npos;
+    return;
+  }
+
+  if (!detail::parse_string(c, current_.key, nullptr)) {
+    owner_ = nullptr;
+    pos_ = npos;
+    return;
+  }
+
+  if (c.skip_ws().at_end() || *c != ':') {
+    owner_ = nullptr;
+    pos_ = npos;
+    return;
+  }
+  ++c;
+
+  if (!detail::parse_value(c, current_.value, nullptr,
+          detail::iterator_parse_options, 0))
+  {
+    owner_ = nullptr;
+    pos_ = npos;
+    return;
+  }
+
+  pos_ = c.pos;
+  next_pos_ = c.pos;
+}
+
+constexpr json_object_view::iterator&
+json_object_view::iterator::operator++() {
+  if (!owner_ || pos_ == npos) return *this;
+
+  detail::json_cursor c{owner_->source_, next_pos_};
+  if (c.skip_ws().at_end()) {
+    owner_ = nullptr;
+    pos_ = npos;
+    return *this;
+  }
+
+  if (owner_->source_[c.pos] == ',') {
+    pos_ = c.pos + 1;
+    load_current();
+    return *this;
+  }
+
+  owner_ = nullptr;
+  pos_ = npos;
+  return *this;
+}
+
+constexpr json_value_view json_object_view::find(std::string_view key) const {
+  for (const auto entry : *this)
+    if (detail::string_equals(entry.key, key)) return entry.value;
+  return {};
+}
+
+constexpr std::optional<bool> json_object_view::get_bool(
+    std::string_view key) const {
+  return find(key).as_bool();
+}
+
+template<AppendTarget Target>
+// Stateful compact JSON writer over a `std::string` or `std::ostream`.
+//
+// The writer tracks container nesting and comma placement internally. It
+// does not validate call ordering aggressively; callers are expected to use
+// matching `begin_*` / `end_*` pairs and to write object keys before their
+// values.
+class json_writer {
+  template<typename Begin, typename End>
+  class scoped_writer {
+  public:
+    constexpr scoped_writer(json_writer& writer, Begin&& begin,
+        End&& end) noexcept
+        : writer_{&writer}, end_{std::forward<End>(end)} {
+      std::forward<Begin>(begin)(*writer_);
+    }
+
+    scoped_writer(const scoped_writer&) = delete;
+    scoped_writer(const scoped_writer&&) = delete;
+    scoped_writer& operator=(const scoped_writer&) = delete;
+    scoped_writer& operator=(scoped_writer&&) = delete;
+
+    constexpr ~scoped_writer() { end_(*writer_); }
+
+    [[nodiscard]] constexpr json_writer* operator->() noexcept {
+      return writer_;
+    }
+
+    [[nodiscard]] constexpr json_writer& operator*() noexcept {
+      return *writer_;
+    }
+
+    [[nodiscard]] constexpr json_writer& writer() noexcept { return *writer_; }
+
+    // This lets you scope the the instance to an `if` statement, so that you
+    // don't need to have braces without explanation.
+    [[nodiscard]] operator bool() const noexcept { return true; }
+
+  private:
+    json_writer* writer_;
+    [[no_unique_address]] End end_;
+  };
+
+  template<typename Begin, typename End>
+  [[nodiscard]] constexpr auto scoped(Begin&& begin, End&& end) noexcept {
+    return scoped_writer<std::decay_t<Begin>, std::decay_t<End>>{*this,
+        std::forward<Begin>(begin), std::forward<End>(end)};
+  }
+
+  // Begin/end a JSON object or array value.
+  constexpr json_writer& begin_object() {
+    before_value();
+    strings::append(target_, '{');
+    stack_.push_back(frame{frame_kind::object});
+    return *this;
+  }
+
+  constexpr json_writer& end_object() {
+    if (stack_.empty()) return *this;
+    strings::append(target_, '}');
+    stack_.pop_back();
+    return *this;
+  }
+
+  constexpr json_writer& begin_array() {
+    before_value();
+    strings::append(target_, '[');
+    stack_.push_back(frame{frame_kind::array});
+    return *this;
+  }
+
+  constexpr json_writer& end_array() {
+    if (stack_.empty()) return *this;
+    strings::append(target_, ']');
+    stack_.pop_back();
+    return *this;
+  }
+
+public:
+  explicit constexpr json_writer(Target& target) : target_{target} {}
+
+  [[nodiscard]] constexpr Target& target() noexcept { return target_; }
+
+  [[nodiscard]] constexpr auto object() noexcept {
+    return scoped([](json_writer& writer) { writer.begin_object(); },
+        [](json_writer& writer) { writer.end_object(); });
+  }
+
+  [[nodiscard]] constexpr auto array() noexcept {
+    return scoped([](json_writer& writer) { writer.begin_array(); },
+        [](json_writer& writer) { writer.end_array(); });
+  }
+
+  template<StringViewConvertible S>
+  requires(!SameAs<json_trusted, S>)
+  [[nodiscard]] constexpr auto member_object(const S& key_text) noexcept {
+    key(key_text);
+    return object();
+  }
+
+  [[nodiscard]] constexpr auto member_object(json_trusted key_text) noexcept {
+    key(key_text);
+    return object();
+  }
+
+  template<StringViewConvertible S>
+  requires(!SameAs<json_trusted, S>)
+  [[nodiscard]] constexpr auto member_array(const S& key_text) noexcept {
+    key(key_text);
+    return array();
+  }
+
+  [[nodiscard]] constexpr auto member_array(json_trusted key_text) noexcept {
+    key(key_text);
+    return array();
+  }
+
+  // Write an object key. `json_trusted` skips the escape scan.
+  template<StringViewConvertible S>
+  requires(!SameAs<json_trusted, S>)
+  constexpr json_writer& key(const S& key_text) {
+    write_key(std::string_view{key_text}, false);
+    return *this;
+  }
+
+  constexpr json_writer& key(json_trusted key_text) {
+    write_key(key_text.value, true);
+    return *this;
+  }
+
+  // Write scalar values. String overloads emit quoted JSON strings.
+  constexpr json_writer& value(std::nullptr_t) {
+    before_value();
+    strings::append(target_, "null");
+    return *this;
+  }
+
+  constexpr json_writer& value(bool v) {
+    before_value();
+    strings::append(target_, v ? "true" : "false");
+    return *this;
+  }
+
+  template<std::integral T>
+  requires(!std::same_as<std::remove_cvref_t<T>, bool>)
+  constexpr json_writer& value(T v) {
+    before_value();
+    strings::append(target_, v);
+    return *this;
+  }
+
+  template<std::floating_point T>
+  constexpr json_writer& value(T v,
+      std::chars_format fmt = std::chars_format::general, int precision = -1) {
+    before_value();
+    detail::append_float(target_, v, fmt, precision);
+    return *this;
+  }
+
+  template<StringViewConvertible S>
+  requires(!SameAs<json_trusted, S>)
+  constexpr json_writer& value(const S& s) {
+    before_value();
+    write_quoted(std::string_view{s}, false);
+    return *this;
+  }
+
+  constexpr json_writer& value(json_trusted s) {
+    before_value();
+    write_quoted(s.value, true);
+    return *this;
+  }
+
+  // Write one `"key": value` object member in a single call.
+  template<typename T>
+  constexpr json_writer&
+  member(std::string_view key_text, const T& value_text) {
+    return key(key_text).value(value_text);
+  }
+
+  constexpr json_writer&
+  member(std::string_view key_text, std::nullptr_t value_text = nullptr) {
+    return key(key_text).value(value_text);
+  }
+
+  constexpr json_writer& member(std::string_view key_text,
+      std::floating_point auto value_text, std::chars_format fmt,
+      int precision = -1) {
+    return key(key_text).value(value_text, fmt, precision);
+  }
+
+  template<typename T>
+  constexpr json_writer& member(json_trusted key_text, const T& value_text) {
+    return key(key_text).value(value_text);
+  }
+
+  constexpr json_writer&
+  member(json_trusted key_text, std::nullptr_t value_text = nullptr) {
+    return key(key_text).value(value_text);
+  }
+
+  constexpr json_writer& member(json_trusted key_text,
+      std::floating_point auto value_text, std::chars_format fmt,
+      int precision = -1) {
+    return key(key_text).value(value_text, fmt, precision);
+  }
+
+private:
+  enum class frame_kind : uint8_t { array, object };
+
+  // Per-container writer state. Objects use `expect_value` to distinguish
+  // between key and value positions after a colon has been emitted.
+  struct frame {
+    frame_kind kind;
+    bool first{true};
+    bool expect_value{};
+  };
+
+  // Emit any comma needed before the next array element or object value.
+  constexpr void before_value() {
+    if (stack_.empty()) return;
+
+    auto& top = stack_.back();
+    if (top.kind == frame_kind::array) {
+      if (!top.first) strings::append(target_, ',');
+      top.first = false;
+      return;
+    }
+
+    if (top.expect_value) {
+      top.expect_value = false;
+      return;
+    }
+  }
+
+  // Emit an escaped or trusted object key followed by `:`.
+  constexpr void write_key(std::string_view key_text, bool trusted) {
+    if (stack_.empty()) return;
+    auto& top = stack_.back();
+    if (top.kind != frame_kind::object || top.expect_value) return;
+
+    if (!top.first) strings::append(target_, ',');
+    top.first = false;
+    write_quoted(key_text, trusted);
+    strings::append(target_, ':');
+    top.expect_value = true;
+  }
+
+  // Emit one quoted JSON string, escaping unless explicitly trusted.
+  constexpr void write_quoted(std::string_view text, bool trusted) {
+    strings::append(target_, '"');
+    if (trusted)
+      strings::append(target_, text);
+    else
+      strings::append_escaped(target_, text);
+    strings::append(target_, '"');
+  }
+
+  Target& target_;
+  std::vector<frame> stack_;
+};
+
+template<AppendTarget Target>
+json_writer(Target&) -> json_writer<Target>;
+}}} // namespace corvid::proto::json

--- a/corvid/proto/json_parser.h
+++ b/corvid/proto/json_parser.h
@@ -278,7 +278,7 @@ public:
     return source_;
   }
 
-  [[nodiscard]] constexpr iterator begin() const noexcept;
+  [[nodiscard]] constexpr iterator begin() const;
   // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   [[nodiscard]] constexpr iterator end() const noexcept { return {}; }
 
@@ -354,7 +354,7 @@ public:
     return source_;
   }
 
-  [[nodiscard]] constexpr iterator begin() const noexcept;
+  [[nodiscard]] constexpr iterator begin() const;
   // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   [[nodiscard]] constexpr iterator end() const noexcept { return {}; }
 
@@ -630,6 +630,46 @@ constexpr bool parse_literal(json_cursor& c, std::string_view literal,
   return true;
 }
 
+constexpr bool consume_digits(json_cursor& c) {
+  if (c.at_end() || !is_digit(*c)) return false;
+  do {
+    ++c;
+  } while (!c.at_end() && is_digit(*c));
+  return true;
+}
+
+constexpr bool parse_number_integer_part(json_cursor& c, json_error* err) {
+  if (*c == '0') {
+    ++c;
+    if (!c.at_end() && is_digit(*c))
+      return json_error::fail(err, json_errc::invalid_number, c.pos);
+    return true;
+  }
+
+  if (!consume_digits(c))
+    return json_error::fail(err, json_errc::invalid_number, c.pos);
+  return true;
+}
+
+constexpr bool parse_number_fraction_part(json_cursor& c, json_error* err) {
+  if (c.at_end() || *c != '.') return true;
+
+  ++c;
+  if (!consume_digits(c))
+    return json_error::fail(err, json_errc::invalid_number, c.pos);
+  return true;
+}
+
+constexpr bool parse_number_exponent_part(json_cursor& c, json_error* err) {
+  if (c.at_end() || (*c != 'e' && *c != 'E')) return true;
+
+  ++c;
+  if (!c.at_end() && (*c == '+' || *c == '-')) ++c;
+  if (!consume_digits(c))
+    return json_error::fail(err, json_errc::invalid_number, c.pos);
+  return true;
+}
+
 constexpr bool
 parse_number(json_cursor& c, json_value_view& out, json_error* err) {
   const auto start = c.pos;
@@ -637,30 +677,9 @@ parse_number(json_cursor& c, json_value_view& out, json_error* err) {
   if (c.at_end())
     return json_error::fail(err, json_errc::invalid_number, start);
 
-  if (*c == '0') {
-    ++c;
-    if (!c.at_end() && is_digit(*c))
-      return json_error::fail(err, json_errc::invalid_number, c.pos);
-  } else if (is_digit(*c)) {
-    while (!c.at_end() && is_digit(*c)) ++c;
-  } else {
-    return json_error::fail(err, json_errc::invalid_number, c.pos);
-  }
-
-  if (!c.at_end() && *c == '.') {
-    ++c;
-    if (c.at_end() || !is_digit(*c))
-      return json_error::fail(err, json_errc::invalid_number, c.pos);
-    while (!c.at_end() && is_digit(*c)) ++c;
-  }
-
-  if (!c.at_end() && (*c == 'e' || *c == 'E')) {
-    ++c;
-    if (!c.at_end() && (*c == '+' || *c == '-')) ++c;
-    if (c.at_end() || !is_digit(*c))
-      return json_error::fail(err, json_errc::invalid_number, c.pos);
-    while (!c.at_end() && is_digit(*c)) ++c;
-  }
+  if (!parse_number_integer_part(c, err)) return false;
+  if (!parse_number_fraction_part(c, err)) return false;
+  if (!parse_number_exponent_part(c, err)) return false;
 
   out = json_value_view{c.substr(start, c.pos - start), json_kind::number};
   return true;
@@ -895,7 +914,7 @@ constexpr json_array_view json_value_view::as_array() const noexcept {
   return is_array() ? json_array_view{source_} : json_array_view{};
 }
 
-constexpr json_array_view::iterator json_array_view::begin() const noexcept {
+constexpr json_array_view::iterator json_array_view::begin() const {
   if (source_.size() < 2 || source_.front() != '[' || source_.back() != ']')
     return {};
   return iterator{this, 1};
@@ -946,7 +965,7 @@ constexpr json_array_view::iterator& json_array_view::iterator::operator++() {
   return *this;
 }
 
-constexpr json_object_view::iterator json_object_view::begin() const noexcept {
+constexpr json_object_view::iterator json_object_view::begin() const {
   if (source_.size() < 2 || source_.front() != '{' || source_.back() != '}')
     return {};
   return iterator{this, 1};
@@ -1074,7 +1093,7 @@ class json_writer {
   };
 
   template<typename Begin, typename End>
-  [[nodiscard]] constexpr auto scoped(Begin&& begin, End&& end) noexcept {
+  [[nodiscard]] constexpr auto scoped(Begin&& begin, End&& end) {
     return scoped_writer<std::decay_t<Begin>, std::decay_t<End>>{*this,
         std::forward<Begin>(begin), std::forward<End>(end)};
   }
@@ -1113,19 +1132,19 @@ public:
 
   [[nodiscard]] constexpr Target& target() noexcept { return target_; }
 
-  [[nodiscard]] constexpr auto object() noexcept {
+  [[nodiscard]] constexpr auto object() {
     return scoped([](json_writer& writer) { writer.begin_object(); },
         [](json_writer& writer) { writer.end_object(); });
   }
 
-  [[nodiscard]] constexpr auto array() noexcept {
+  [[nodiscard]] constexpr auto array() {
     return scoped([](json_writer& writer) { writer.begin_array(); },
         [](json_writer& writer) { writer.end_array(); });
   }
 
   template<StringViewConvertible S>
   requires(!SameAs<json_trusted, S>)
-  [[nodiscard]] constexpr auto member_object(const S& key_text) noexcept {
+  [[nodiscard]] constexpr auto member_object(const S& key_text) {
     key(key_text);
     return object();
   }
@@ -1137,7 +1156,7 @@ public:
 
   template<StringViewConvertible S>
   requires(!SameAs<json_trusted, S>)
-  [[nodiscard]] constexpr auto member_array(const S& key_text) noexcept {
+  [[nodiscard]] constexpr auto member_array(const S& key_text) {
     key(key_text);
     return array();
   }

--- a/corvid/proto/json_parser.h
+++ b/corvid/proto/json_parser.h
@@ -127,10 +127,10 @@ public:
   }
 
   [[nodiscard]] constexpr explicit operator bool() const noexcept {
-    return kind_ != json_kind::invalid;
+    return !empty();
   }
   [[nodiscard]] constexpr bool empty() const noexcept {
-    return kind_ == json_kind::invalid;
+    return is(json_kind::invalid);
   }
   [[nodiscard]] constexpr json_kind kind() const noexcept { return kind_; }
   [[nodiscard]] constexpr std::string_view source() const noexcept {

--- a/corvid/proto/json_parser.h
+++ b/corvid/proto/json_parser.h
@@ -364,12 +364,24 @@ public:
   // Convenience typed getters layered on top of `find`.
   [[nodiscard]] constexpr std::optional<bool> get_bool(
       std::string_view key) const;
+  [[nodiscard]] constexpr bool
+  parse_bool(std::string_view key, bool& out) const;
 
   template<typename T>
   requires(std::integral<T> || std::floating_point<T>)
   [[nodiscard]] constexpr std::optional<T>
   get_number(std::string_view key) const {
     return find(key).template as_number<T>();
+  }
+
+  template<typename T>
+  requires(std::integral<T> || std::floating_point<T>)
+  [[nodiscard]] constexpr bool
+  parse_number(std::string_view key, T& out) const {
+    auto opt = get_number<T>(key);
+    if (!opt) return false;
+    out = *opt;
+    return true;
   }
 
   // If the value for `key` is a plain JSON string, returns the inner
@@ -1010,6 +1022,14 @@ constexpr json_value_view json_object_view::find(std::string_view key) const {
 constexpr std::optional<bool> json_object_view::get_bool(
     std::string_view key) const {
   return find(key).as_bool();
+}
+
+constexpr bool
+json_object_view::parse_bool(std::string_view key, bool& out) const {
+  auto found = find(key).as_bool();
+  if (!found) return false;
+  out = *found;
+  return true;
 }
 
 template<AppendTarget Target>

--- a/corvid/proto/overview.md
+++ b/corvid/proto/overview.md
@@ -299,6 +299,21 @@ timeout) marks the connection closed and subsequent calls fail immediately.
 accumulates data until the delimiter appears, leaving any trailing bytes in an
 internal buffer for the next call.
 
+### `json_parser`
+
+Strict header-only JSON parser and writer. `parse_json(string_view, value,
+error, options)` validates a full JSON document and returns a non-owning
+`json_value_view` over the root. `json_value_view` exposes `kind()` plus typed
+accessors for booleans, numbers, strings, arrays, and objects; string decoding
+is lazy via `decode_string`, and plain unescaped strings can be borrowed with
+`string_view_if_plain()`. `json_object_view` and `json_array_view` are
+lightweight iterable facades over validated object and array values.
+
+`json_writer` appends compact JSON directly to a `std::string` or
+`std::ostream`, manages commas and nesting for arrays/objects, escapes strings
+by default, and also supports `json_trusted` for already-safe literals
+that can skip the escape scan.
+
 ## Layer 3: HTTP
 
 ### `http_head_codec`

--- a/corvid/proto/stream_conn.h
+++ b/corvid/proto/stream_conn.h
@@ -115,10 +115,11 @@ struct stream_conn_handlers {
 //
 // Send path: `send(std::string&&)` and its variants take ownership of the
 // caller's string(s). An immediate `::sendmsg` gather is attempted. Strings
-// whose bytes were fully written are discarded. If none are left,
-// `on_writable`. `EPOLLOUT` is armed so that subsequent `EPOLLOUT` events
-// flush the send queue. When the queue empties, `EPOLLOUT` is disarmed and
-// `on_writable` notifies any pending write waiter.
+// whose bytes were fully written are discarded. If that immediate write drains
+// all outbound data, `on_writable` notifies any pending write waiter.
+// Otherwise, `EPOLLOUT` is armed so that subsequent `EPOLLOUT` events flush
+// the remaining send queue. When the queue later empties, `EPOLLOUT` is
+// disarmed and `on_writable` notifies any pending write waiter.
 //
 // Receive path: `EPOLLIN` is armed while `recv_buf_.reads_enabled` is true.
 // When `EPOLLIN` fires, `on_readable` appends bytes to the persistent

--- a/corvid/proto/stream_conn.h
+++ b/corvid/proto/stream_conn.h
@@ -27,6 +27,8 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
+#include <vector>
 
 #include <unistd.h>
 #include <fcntl.h>
@@ -37,11 +39,13 @@
 #include "recv_buffer.h"
 #include "../concurrency/relaxed_atomic.h"
 #include "../enums/bool_enums.h"
+#include "../strings/any_strings.h"
 #include "../strings/no_zero.h"
 
 namespace corvid { inline namespace proto {
 
 using namespace corvid::strings::no_zero_funcs;
+using namespace corvid::strings::any_strings_types;
 
 // Forward declaration for `stream_conn_handlers`.
 class stream_conn;
@@ -109,14 +113,12 @@ struct stream_conn_handlers {
 // `epoll_loop::post`. All actual I/O and epoll-mask mutations run
 // exclusively on the loop thread.
 //
-// Send path: `send(std::string&&)` takes ownership of the caller's string.
-// If the send queue is empty, an immediate `::write` is attempted. If all
-// bytes are written, the string is discarded and `on_writable` notifies any
-// pending write waiter immediately because no outbound bytes remain pending.
-// Otherwise the remainder of the string is added to the send queue and
-// `EPOLLOUT` is armed so that subsequent `EPOLLOUT` events flush the send
-// queue. When the queue empties, `EPOLLOUT` is disarmed and `on_writable`
-// notifies any pending write waiter.
+// Send path: `send(std::string&&)` and its variants take ownership of the
+// caller's string(s). An immediate `::sendmsg` gather is attempted. Strings
+// whose bytes were fully written are discarded. If none are left,
+// `on_writable`. `EPOLLOUT` is armed so that subsequent `EPOLLOUT` events
+// flush the send queue. When the queue empties, `EPOLLOUT` is disarmed and
+// `on_writable` notifies any pending write waiter.
 //
 // Receive path: `EPOLLIN` is armed while `recv_buf_.reads_enabled` is true.
 // When `EPOLLIN` fires, `on_readable` appends bytes to the persistent
@@ -229,9 +231,8 @@ public:
   // of these conditions is not met, or if we are unable to write to this
   // socket.
   //
-  // Safe to call from any thread. Success does not mean that the
-  // buffers have been fully sent; send completion is signaled via the
-  // `on_drain` callback.
+  // Safe to call from any thread. Success does not mean that the buffers have
+  // been fully sent; send completion is signaled via the `on_drain` callback.
   template<typename... Bufs>
   requires(std::same_as<Bufs, std::string> && ...)
   [[nodiscard]] bool send(Bufs&&... bufs) {
@@ -244,6 +245,54 @@ public:
               [&p](auto&&... b) { return p->enqueue_send(std::move(b)...); },
               t);
         });
+  }
+
+  // Take ownership of a vector of `std::string` values and start sending them.
+  // There must be at least one non-empty buffer. Returns false if either of
+  // these conditions is not met, or if we are unable to write to this socket.
+  //
+  // Safe to call from any thread. Success does not mean that the buffers have
+  // been fully sent; send completion is signaled via the `on_drain` callback.
+  [[nodiscard]] bool send_vector(std::vector<std::string>&& bufs) {
+    if (!open_ || !write_open_) return false;
+    bool any{};
+    for (const auto& b : bufs)
+      if (!b.empty()) {
+        any = true;
+        break;
+      }
+    if (!any) return false;
+    return execute_or_post([p = self(), bufs = std::move(bufs)]() mutable {
+      return p->enqueue_send_vector(std::move(bufs));
+    });
+  }
+
+  // Take ownership of an `any_strings` (a single string or a vector of
+  // strings) and start sending. There must be at least one non-empty buffer.
+  // Returns false if either of these conditions is not met, or if we are
+  // unable to write to this socket.
+  //
+  // Safe to call from any thread. Success does not mean that the buffers have
+  // been fully sent; send completion is signaled via the `on_drain` callback.
+  [[nodiscard]] bool send_any(any_strings&& strings) {
+    if (!open_ || !write_open_) return false;
+    bool any = std::visit(
+        [](const auto& v) {
+          using T = std::decay_t<decltype(v)>;
+          if constexpr (std::is_same_v<T, std::string>)
+            return !v.empty();
+          else if constexpr (std::is_same_v<T, std::vector<std::string>>) {
+            for (const auto& b : v)
+              if (!b.empty()) return true;
+            return false;
+          } else
+            return false;
+        },
+        strings);
+    if (!any) return false;
+    return execute_or_post([p = self(), s = std::move(strings)]() mutable {
+      return p->enqueue_send_any(std::move(s));
+    });
   }
 
   // Start a close. If `coordination` is `unilateral` (the default), flushes
@@ -927,11 +976,54 @@ private:
              (void)iov_sender_.append(send_queue_.back()), (appended = true))),
         ...);
     if (!appended) return false;
+    return flush_send_queue();
+  }
 
-    // If an async connect is still in progress, sends would fail with
-    // `ENOTCONN`. `EPOLLOUT` is already armed; wait for connect resolution.
-    if (connecting_) return true;
+  // Enqueue a vector of buffers for sending, then flush. Follows the same
+  // rules as `enqueue_send`.
+  [[nodiscard]] bool enqueue_send_vector(std::vector<std::string>&& bufs) {
+    assert(loop_.is_loop_thread());
+    if (!open_ || !write_open_) return false;
 
+    bool appended{};
+    for (auto& b : bufs) {
+      if (b.empty()) continue;
+      send_queue_.push_back(std::move(b));
+      (void)iov_sender_.append(send_queue_.back());
+      appended = true;
+    }
+    if (!appended) return false;
+    return flush_send_queue();
+  }
+
+  // Enqueue an `any_strings` for sending, then flush. Follows the same rules
+  // as `enqueue_send`.
+  [[nodiscard]] bool enqueue_send_any(any_strings&& strings) {
+    assert(loop_.is_loop_thread());
+    if (!open_ || !write_open_) return false;
+
+    bool appended{};
+    std::visit(
+        [&](auto&& v) {
+          using T = std::decay_t<decltype(v)>;
+          if constexpr (std::is_same_v<T, std::string>) {
+            if (v.empty()) return;
+            send_queue_.push_back(std::forward<decltype(v)>(v));
+            (void)iov_sender_.append(send_queue_.back());
+            appended = true;
+          } else if constexpr (std::is_same_v<T, std::vector<std::string>>) {
+            for (auto& b : v) {
+              if (b.empty()) continue;
+              send_queue_.push_back(std::move(b));
+              (void)iov_sender_.append(send_queue_.back());
+              appended = true;
+            }
+          } else {
+            // Nothing to enqueue.
+          }
+        },
+        std::forward<any_strings>(strings));
+    if (!appended) return false;
     return flush_send_queue();
   }
 
@@ -942,6 +1034,9 @@ private:
   // `do_close_now` (e.g., when both `EPOLLIN` and `EPOLLOUT` fire in the same
   // event and the readable handler closes the connection before we get here).
   [[nodiscard]] bool flush_send_queue() {
+    // If an async connect is still in progress, sends would fail with
+    // `ENOTCONN`. `EPOLLOUT` is already armed; wait for connect resolution.
+    if (connecting_) return true;
     if (!open_) return false;
 
     if (!send_queue_.empty()) {
@@ -992,8 +1087,8 @@ private:
     return do_finish_close();
   }
 
-  // Finalize a requested close after the send queue has fully flushed.
-  // When `shutdown_` is `unilateral`, closes the socket immediately. When
+  // Finalize a requested close after the send queue has fully flushed. When
+  // `shutdown_` is `unilateral`, closes the socket immediately. When
   // `bilateral`, shuts down the write side and lets `handle_drain_reads` wait
   // for peer EOF. `close_requested_` is left set so `on_readable` routes to
   // `handle_drain_reads`.

--- a/corvid/sim/corvid_sim_main.h
+++ b/corvid/sim/corvid_sim_main.h
@@ -29,6 +29,30 @@
 #include "../proto.h"
 #include "ws_handler.h"
 
+// Blocks SIGINT and SIGTERM on all threads (including those spawned after
+// construction) so that `sigwait` can intercept them cleanly. Must be
+// constructed before any threads are created.
+class signal_waiter {
+public:
+  signal_waiter() {
+    sigemptyset(&mask_);
+    sigaddset(&mask_, SIGINT);
+    sigaddset(&mask_, SIGTERM);
+    pthread_sigmask(SIG_BLOCK, &mask_, nullptr);
+  }
+
+  // Block until one of the registered signals is delivered. Returns the
+  // signal number.
+  [[nodiscard]] int wait() const {
+    int sig{};
+    sigwait(&mask_, &sig);
+    return sig;
+  }
+
+private:
+  sigset_t mask_{};
+};
+
 using namespace corvid::proto;
 
 int main(int argc, char** argv) {
@@ -39,8 +63,9 @@ int main(int argc, char** argv) {
     if (std::string_view{argv[i]} == "-testonly") return 0;
   }
 
-  // Default web root: walk up from the executable until a `corvid/sim/web/dist`
-  // subdirectory is found. This works regardless of build output location.
+  // Default web root: walk up from the executable until a
+  // `corvid/sim/web/dist` subdirectory is found. This works regardless of
+  // build output location.
   std::filesystem::path web_root;
   if (argc > 1) {
     web_root = argv[1];
@@ -73,12 +98,7 @@ int main(int argc, char** argv) {
   std::cout << "Loaded " << cache->size() << " file(s) from " << web_root
             << "\n";
 
-  // Block SIGINT/SIGTERM on all threads so `sigwait` can intercept them.
-  sigset_t mask;
-  sigemptyset(&mask);
-  sigaddset(&mask, SIGINT);
-  sigaddset(&mask, SIGTERM);
-  pthread_sigmask(SIG_BLOCK, &mask, nullptr);
+  signal_waiter signals;
 
   // Create server (owns its own loop and timing wheel). The cache shared_ptr
   // is captured by the factory lambda and passed into each transaction, which
@@ -102,8 +122,7 @@ int main(int argc, char** argv) {
 
   std::cout << "Listening on http://" << server->local_endpoint() << "/\n";
 
-  int sig{};
-  sigwait(&mask, &sig);
+  (void)signals.wait();
   std::cout << "\nShutting down\n";
   return 0;
 }

--- a/corvid/sim/corvid_sim_main.h
+++ b/corvid/sim/corvid_sim_main.h
@@ -23,6 +23,8 @@
 #include <filesystem>
 #include <iostream>
 #include <memory>
+#include <string_view>
+#include <pthread.h>
 
 #include "../proto.h"
 #include "ws_handler.h"
@@ -89,7 +91,8 @@ int main(int argc, char** argv) {
                       std::move(req), cache);
                 }))
           return false;
-        return s.add_route({"", "/ws"}, make_ws_factory(s.loop(), s.wheel()));
+        return s.add_route({"", "/ws"},
+            sim_ws_transaction::make_factory(s.loop(), s.wheel()));
       });
 
   if (!server) {

--- a/corvid/sim/corvid_sim_main.h
+++ b/corvid/sim/corvid_sim_main.h
@@ -1,0 +1,103 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+// CorvidSim main entry point: static-file HTTP server for the sim web assets.
+//
+// Included exactly once from `tests/corvid_sim.cpp`. All implementation is
+// here so the translation unit stays trivial.
+#include <csignal>
+#include <filesystem>
+#include <iostream>
+#include <memory>
+
+#include "../proto.h"
+
+using namespace corvid::proto;
+
+int main(int argc, char** argv) {
+  // If invoked with "-testonly" (e.g., by the CI build script), skip the
+  // server entirely and exit cleanly. This lets the test runner include
+  // `corvid_sim` in its sweep without blocking on a live server.
+  for (int i = 1; i < argc; ++i) {
+    if (std::string_view{argv[i]} == "-testonly") return 0;
+  }
+
+  // Default web root: walk up from the executable until a `corvid/sim/web`
+  // subdirectory is found. This works regardless of build output location.
+  std::filesystem::path web_root;
+  if (argc > 1) {
+    web_root = argv[1];
+  } else {
+    std::error_code exe_ec;
+    auto exe = std::filesystem::read_symlink("/proc/self/exe", exe_ec);
+    if (exe_ec) {
+      std::cerr << "Cannot resolve executable path\n";
+      return 1;
+    }
+    for (auto dir = exe.parent_path(); dir != dir.parent_path();
+        dir = dir.parent_path())
+    {
+      auto candidate = dir / "corvid/sim/web";
+      std::error_code dir_ec;
+      if (std::filesystem::is_directory(candidate, dir_ec)) {
+        web_root = std::move(candidate);
+        break;
+      }
+    }
+  }
+
+  std::error_code ec;
+  if (!std::filesystem::is_directory(web_root, ec)) {
+    std::cerr << "Web root not found: " << web_root << "\n";
+    return 1;
+  }
+
+  auto cache = std::make_shared<const static_file_cache>(web_root);
+  std::cout << "Loaded " << cache->size() << " file(s) from " << web_root
+            << "\n";
+
+  // Block SIGINT/SIGTERM on all threads so `sigwait` can intercept them.
+  sigset_t mask;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGINT);
+  sigaddset(&mask, SIGTERM);
+  pthread_sigmask(SIG_BLOCK, &mask, nullptr);
+
+  // Create server (owns its own loop and timing wheel). The cache shared_ptr
+  // is captured by the factory lambda and passed into each transaction, which
+  // holds its own reference to keep the cache alive.
+  auto server = http_server::create(net_endpoint{ipv4_addr::loopback, 8080},
+      [cache](http_server& s) {
+        return s.add_route({"", "/"},
+            [cache](request_head&& req) -> transaction_ptr {
+              return std::make_shared<static_file_transaction>(std::move(req),
+                  cache);
+            });
+      });
+
+  if (!server) {
+    std::cerr << "Failed to create HTTP server\n";
+    return 1;
+  }
+
+  std::cout << "Listening on http://" << server->local_endpoint() << "/\n";
+
+  int sig{};
+  sigwait(&mask, &sig);
+  std::cout << "\nShutting down\n";
+  return 0;
+}

--- a/corvid/sim/corvid_sim_main.h
+++ b/corvid/sim/corvid_sim_main.h
@@ -27,7 +27,7 @@
 #include <pthread.h>
 
 #include "../proto.h"
-#include "ws_handler.h"
+#include "sim_ws_handler.h"
 
 // Blocks SIGINT and SIGTERM on all threads (including those spawned after
 // construction) so that `sigwait` can intercept them cleanly. Must be
@@ -112,7 +112,7 @@ int do_main(int argc, char** argv) {
                 }))
           return false;
         return s.add_route({"", "/ws"},
-            sim_ws_transaction::make_factory(s.loop(), s.wheel()));
+            sim_ws_handler::make_factory(s.loop(), s.wheel()));
       });
 
   if (!server) {

--- a/corvid/sim/corvid_sim_main.h
+++ b/corvid/sim/corvid_sim_main.h
@@ -112,7 +112,7 @@ int do_main(int argc, char** argv) {
                 }))
           return false;
         return s.add_route({"", "/ws"},
-            sim_ws_handler::make_factory(s.loop(), s.wheel()));
+            SimWsHandler::make_factory(s.loop(), s.wheel()));
       });
 
   if (!server) {

--- a/corvid/sim/corvid_sim_main.h
+++ b/corvid/sim/corvid_sim_main.h
@@ -25,6 +25,7 @@
 #include <memory>
 
 #include "../proto.h"
+#include "ws_handler.h"
 
 using namespace corvid::proto;
 
@@ -82,11 +83,13 @@ int main(int argc, char** argv) {
   // holds its own reference to keep the cache alive.
   auto server = http_server::create(net_endpoint{ipv4_addr::loopback, 8080},
       [cache](http_server& s) {
-        return s.add_route({"", "/"},
-            [cache](request_head&& req) -> transaction_ptr {
-              return std::make_shared<static_file_transaction>(std::move(req),
-                  cache);
-            });
+        if (!s.add_route({"", "/"},
+                [cache](request_head&& req) -> transaction_ptr {
+                  return std::make_shared<static_file_transaction>(
+                      std::move(req), cache);
+                }))
+          return false;
+        return s.add_route({"", "/ws"}, make_ws_factory(s.loop(), s.wheel()));
       });
 
   if (!server) {

--- a/corvid/sim/corvid_sim_main.h
+++ b/corvid/sim/corvid_sim_main.h
@@ -39,7 +39,7 @@ int main(int argc, char** argv) {
     if (std::string_view{argv[i]} == "-testonly") return 0;
   }
 
-  // Default web root: walk up from the executable until a `corvid/sim/web`
+  // Default web root: walk up from the executable until a `corvid/sim/web/dist`
   // subdirectory is found. This works regardless of build output location.
   std::filesystem::path web_root;
   if (argc > 1) {
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
     for (auto dir = exe.parent_path(); dir != dir.parent_path();
         dir = dir.parent_path())
     {
-      auto candidate = dir / "corvid/sim/web";
+      auto candidate = dir / "corvid/sim/web/dist";
       std::error_code dir_ec;
       if (std::filesystem::is_directory(candidate, dir_ec)) {
         web_root = std::move(candidate);

--- a/corvid/sim/corvid_sim_main.h
+++ b/corvid/sim/corvid_sim_main.h
@@ -55,7 +55,7 @@ private:
 
 using namespace corvid::proto;
 
-int main(int argc, char** argv) {
+int do_main(int argc, char** argv) {
   // If invoked with "-testonly" (e.g., by the CI build script), skip the
   // server entirely and exit cleanly. This lets the test runner include
   // `corvid_sim` in its sweep without blocking on a live server.
@@ -125,4 +125,14 @@ int main(int argc, char** argv) {
   (void)signals.wait();
   std::cout << "\nShutting down\n";
   return 0;
+}
+
+int main(int argc, char** argv) {
+  try {
+    return do_main(argc, argv);
+  }
+  catch (const std::exception& e) {
+    std::cerr << "Fatal error: " << e.what() << "\n";
+    return 1;
+  }
 }

--- a/corvid/sim/roadmap.md
+++ b/corvid/sim/roadmap.md
@@ -1,15 +1,118 @@
 # What is CorvidSim?
 
-CorvidSim, which is located in the "Sim" subdirectory, is a project leveraging and exercising the Corvid library. Using the WebSocket and ECS code, it hosts an eponymous browser-based tower defense game.
+CorvidSim, which is located in the "sim" subdirectory, is a project leveraging and
+exercising the Corvid library. Using the WebSocket and ECS code, it hosts an
+eponymous browser-based tower defense game.
 
 # Steps
 
-## Static HTML
-- corvid_sim.cpp -- Launches an HTTP server on localhost that serves files in "web" subdirectory.
-- web/index.html -- Simple page that's served up.
+## Static HTTP server
+- `corvid_sim_main.h` -- Entry point: walks up from the executable to find
+  `corvid/sim/web/dist`, loads it into a `static_file_cache`, and serves it on
+  `localhost:8080`. Accepts `-testonly` to exit cleanly in CI.
+- `web/index.html` -- Game page with status, tick, lives/resources/phase HUD,
+  "Start Wave" button, dual-canvas viewport, and a scrollable log pane.
 ---
+
+## WebSocket transport and JSON protocol
+- `sim_ws_handler.h` -- `SimWsHandler` (inherits `http_websocket_transaction`).
+  Registers `on_message`/`on_close` callbacks. Enables 20s-ping / 5s-pong
+  keepalive. Owns the 20 Hz tick timer via the `timer_fuse` double-check
+  pattern. Drives one `SimGame::next()` call per 50 ms frame, then sends the
+  game state.
+- `sim_json_parse.h` -- Parses client messages: `hello`, `ui_canvas`,
+  `ui_action`. Classifies by `"type"` field using enum reflection.
+- `sim_json_wire.h` -- Builds server messages using `json_writer`:
+  - `build_sim_hello_ack_json()` -- `{"type":"hello_ack",...}`
+  - `build_sim_game_state_json()` -- on the first frame sends
+    `{"type":"world_snapshot","paths":[...],"delta":{...}}`; subsequent frames
+    send `{"type":"world_delta",...}`. Incremental mode only emits entities
+    whose `Appearance` or `VisualEffects` changed on the current tick.
+  - `sim_game_state_json` reusable buffer with high-watermark reserves.
+- `web/src/main.ts` (TypeScript/Vite) -- WebSocket client:
+  - Sends `hello` on open; receives `hello_ack` then ticks start.
+  - Handles `world_snapshot` (resets state, draws path, applies delta) and
+    `world_delta` (incremental update).
+  - Validates every incoming message shape before processing.
+  - Sends `ui_canvas` for click / dblclick / contextmenu / drag events.
+  - Sends `ui_action` for button and form interactions.
 ---
+
+## ECS world (`sim_world.h`)
+- `SimWorld` owns the `archetype_scene` with five storages:
+  - `sidPos` / `ArchP` -- static background entities (`Position + Appearance`).
+  - `sidPosVel` / `ArchPV` -- velocity-driven movers
+    (`Position + Velocity + Appearance`).
+  - `sidEnemy` / `ArchEnemy` -- path-following invaders
+    (`Position + Appearance + VisualEffects + PathFollower + Invader`).
+  - `sidTower` / `ArchTower` -- placed towers
+    (`Position + Appearance + VisualEffects + Tower`).
+  - `sidBullet` / `ArchBullet` -- bullets
+    (`Position + Velocity + Bullet`).
+- Path geometry: `PathJoints` -> `SegmentedPath` with cumulative distances for
+  O(log n) progress-to-position mapping; corner snapping for fast movers.
+- Physics per frame (`next()`): velocity movers bounce at world boundary;
+  `PathFollower` entities advance by `speed` and are collected as escapees when
+  they exit the path.
+- Dirty tracking via registry metadata (last-change tick) and an
+  `updatedEntities_` list; `markAllDirty()` stamps `Appearance.modified` /
+  `VisualEffects.modified` for full snapshot serialization.
+- Tower attack range: `towersAttack()` detects circle-circle overlaps and
+  triggers flash visual effects on both tower and enemy. Actual
+  damage/kill/cooldown is stubbed out behind `#if 0`.
+- `flashEntity()` sets `flash_color` and `flash_expiry` (in ticks) on any
+  entity carrying `VisualEffects`.
 ---
-## WebSocket POC
-- Serve JS/TS by including the script in "index.html".
-- Using this to connect to server using WebSocket and exchange JSON messages (high-level ping/pong).
+
+## Game simulation (`sim_game.h`)
+- `SimGame` owns `SimWorld` and the game rules: `GamePhase` (build / wave /
+  game_over / victory), wave definitions, lives, and resources.
+- `WaveDefinition` holds a list of `EnemySpawn` records (startTick, enemyType).
+  `doLoadMap1()` builds a single hardcoded spiral path and one wave of 20
+  enemies spaced 20 ticks apart.
+- `next()` runs `SimWorld::next()`, advances `WaveTick`, spawns due enemies,
+  resolves escapees (decrement lives), and transitions to `game_over` at 0
+  lives.
+- Input handling:
+  - Left click -- selects tower (shows range circle via `VisualEffects`);
+    deselects previous.
+  - Double-click -- places a new tower at that world position.
+  - Right click -- flashes the entity under the cursor.
+  - `ui_action "start_wave"` -- transitions build -> wave phase.
+- `extractDelta()` / `extractPaths()` / `markAllDirty()` provide the data the
+  wire layer needs.
+---
+
+## Client rendering (`web/src/main.ts`)
+- Dual-canvas layout: `background-canvas` for the static path; `foreground-
+  canvas` for live entities + HUD compositing.
+- World space 1920x1080 mapped to 960x540 canvas pixels (uniform scale, no
+  letterboxing).
+- `requestAnimationFrame` loop (runs at the display's native refresh rate) with
+  linear interpolation between the last two 20 Hz snapshots for smooth motion.
+- Per-entity sprite cache (offscreen `HTMLCanvasElement`): filled circle + glyph
+  pre-rendered once per unique (glyph, radius, fg, bg) bucket; reused each frame
+  via `drawImage`.
+- Visual effects layered in draw order: range circle, entity sprite, selection
+  outline, flash overlay (flickers at 62.5 ms intervals until expiry).
+- Canvas HUD overlay (lives + resources) rendered to a separate offscreen
+  canvas and composited onto the visible foreground canvas only when dirty;
+  the same values are also mirrored in the DOM status text above the viewport.
+- FPS counter rendered to a separate offscreen canvas, refreshed at 100 ms
+  intervals, then composited onto the visible foreground canvas.
+- Drag throttling: `mousemove` batches `dragmove` messages to one per
+  `requestAnimationFrame`.
+---
+
+## Known gaps / next steps
+- Tower damage is disabled (`#if 0` in `towersAttack`); needs cooldown, health
+  reduction, bounty award, and tombstoning.
+- Only one hardcoded map and one wave; need data-driven map/wave loading.
+- `placeTower()` in `SimGame` is a stub; spending resources and enforcing build
+  slots is not implemented.
+- No victory condition when all waves clear with lives remaining.
+- Enemy variety (`enemyType` field exists but all enemies share the same speed
+  and appearance).
+- `sidBullet` archetype exists but no projectile-firing tower type is wired up.
+- Web asset pipeline (Vite/TypeScript) must be built separately (`npm run
+  build` in `web/`) before the C++ server can serve the dist files.

--- a/corvid/sim/roadmap.md
+++ b/corvid/sim/roadmap.md
@@ -7,7 +7,9 @@ CorvidSim, which is located in the "Sim" subdirectory, is a project leveraging a
 ## Static HTML
 - corvid_sim.cpp -- Launches an HTTP server on localhost that serves files in "web" subdirectory.
 - web/index.html -- Simple page that's served up.
-
+---
+---
+---
 ## WebSocket POC
-- Add JS files to "web/js" and include them in the "index.html".
-- Using JS, connect to server using WebSocket and exchange JSON messages (high-level ping/pong).
+- Serve JS/TS by including the script in "index.html".
+- Using this to connect to server using WebSocket and exchange JSON messages (high-level ping/pong).

--- a/corvid/sim/roadmap.md
+++ b/corvid/sim/roadmap.md
@@ -1,0 +1,13 @@
+# What is CorvidSim?
+
+CorvidSim, which is located in the "Sim" subdirectory, is a project leveraging and exercising the Corvid library. Using the WebSocket and ECS code, it hosts an eponymous browser-based tower defense game.
+
+# Steps
+
+## Static HTML
+- corvid_sim.cpp -- Launches an HTTP server on localhost that serves files in "web" subdirectory.
+- web/index.html -- Simple page that's served up.
+
+## WebSocket POC
+- Add JS files to "web/js" and include them in the "index.html".
+- Using JS, connect to server using WebSocket and exchange JSON messages (high-level ping/pong).

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -41,10 +41,6 @@ namespace corvid { inline namespace sim {
 // Snapshot of the game state for sending to clients. Contains all information
 // needed to render the current state of the world, but no information about
 // the rules or game flow.
-struct GameSnapshot {
-  std::vector<SimWorld::EntitySnapshot> entities;
-  std::vector<PathJoints> path_points;
-};
 
 enum class GamePhase : uint8_t {
   invalid,

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -50,6 +50,11 @@ enum class GamePhase : uint8_t {
   victory,   // All waves completed with lives remaining
 };
 
+// Tick from start of wave.
+enum class WaveTick : uint64_t {
+  invalid = std::numeric_limits<uint64_t>::max()
+};
+
 }} // namespace corvid::sim
 
 template<>
@@ -57,11 +62,16 @@ constexpr auto corvid::enums::registry::enum_spec_v<corvid::sim::GamePhase> =
     corvid::enums::sequence::make_sequence_enum_spec<corvid::sim::GamePhase,
         "invalid, build, wave, game_over, victory">();
 
+template<>
+constexpr auto corvid::enums::registry::enum_spec_v<corvid::sim::WaveTick> =
+    corvid::enums::sequence::make_sequence_enum_spec<corvid::sim::WaveTick,
+        "">();
+
 namespace corvid { inline namespace sim {
 
 // Enemy spawn definition for a wave.
 struct EnemySpawn {
-  Tick startTicks;
+  WaveTick startTicks;
   int enemyType;
 };
 
@@ -88,14 +98,14 @@ public:
     phase_ = GamePhase::build;
     waves_.clear();
     currentWave_ = 0;
-    waveTick = 0;
+    waveTick = {};
     nextSpawnIndex_ = 0;
     lives_ = 20;
     resources_ = 100;
   }
 
   // Advance the simulation one tick. Returns the new tick count.
-  Tick step() {
+  WorldTick step() {
     const auto tick = world_.tick();
     if (phase_ == GamePhase::wave) {
       ++waveTick;
@@ -122,7 +132,7 @@ public:
   void start_wave() {
     if (phase_ != GamePhase::build) return;
     phase_ = GamePhase::wave;
-    waveTick = 0;
+    waveTick = {};
     nextSpawnIndex_ = 0;
   }
 
@@ -206,7 +216,8 @@ private:
     (void)world_.addPath(p);
 
     WaveDefinition wave;
-    for (uint64_t i = 0; i < 20; ++i) wave.enemies.push_back({i * 20, 0});
+    for (uint64_t i = 0; i < 20; ++i)
+      wave.enemies.push_back({WaveTick{i * 20}, 0});
 
     waves_.push_back(std::move(wave));
   }
@@ -219,7 +230,7 @@ private:
   // Tick counter for the current wave, used to trigger spawns at the right
   // times. This is reset with each wave, so it is not the same tick counter as
   // the world's, and may not even run at the same speed.
-  Tick waveTick{};
+  WaveTick waveTick{};
 
   // Wave definitions for the current map.
   std::vector<WaveDefinition> waves_;

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -168,7 +168,7 @@ public:
     const auto tick = world_.tick();
     if (phase_ == GamePhase::wave) {
       ++waveTick_;
-      spawn_pending_wave_enemies();
+      spawnPendingWaveEnemies();
 
       auto lives = lives_;
       (void)world_.resolveEscapees(
@@ -195,14 +195,15 @@ public:
     nextSpawnIndex_ = 0;
   }
 
-  void handle_ui_canvas(const UiCanvasInput& input) {
+  void handleUiCanvas(const UiCanvasInput& input) {
     // Canvas gestures are intentionally semantic transport only for now; game
     // rules can opt into specific events as tower placement/tooling is added.
     (void)phase_; // !!! To disable a warning for now.
-    (void)input;
+
+    (void)world_.spawnTower({input.x, input.y});
   }
 
-  void handle_ui_action(const UiActionInput& input) {
+  void handle_UiAction(const UiActionInput& input) {
     if (input.action == "start_wave") {
       start_wave();
       return;
@@ -251,7 +252,7 @@ public:
 
 private:
   // Spawn all the enemies slated for this wave tick.
-  void spawn_pending_wave_enemies() {
+  void spawnPendingWaveEnemies() {
     const auto& wave = waves_[currentWave_];
     const auto& enemies = wave.enemies;
     for (; nextSpawnIndex_ < enemies.size(); ++nextSpawnIndex_) {

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -163,9 +163,10 @@ public:
     resources_ = 100;
   }
 
-  // Advance the simulation one tick. Returns the new tick count.
-  WorldTick step() {
-    const auto tick = world_.tick();
+  // Run all physics and game logic for the current tick, without advancing the
+  // counter. Call `tick()` after streaming the state to clients.
+  [[nodiscard]] bool next() {
+    (void)world_.next();
     if (phase_ == GamePhase::wave) {
       ++waveTick_;
       spawnPendingWaveEnemies();
@@ -183,9 +184,15 @@ public:
 
       if (lives_ <= 0) phase_ = GamePhase::game_over;
     }
-
-    return tick;
+    return true;
   }
+
+  // Advance the tick counter and return the new value. Call this at the end
+  // of each frame, after `next()` and streaming.
+  [[nodiscard]] WorldTick tick() { return world_.tick(); }
+
+  // Return the current tick counter without advancing it.
+  [[nodiscard]] WorldTick currentTick() const { return world_.currentTick(); }
 
   // Player action: start the next wave.
   void start_wave() {
@@ -267,8 +274,8 @@ public:
   }
 
   // See underlying method.
-  [[nodiscard]]
-  bool markAllDirty(update_strategy strategy = update_strategy::incremental) {
+  [[nodiscard]] bool markAllDirty(
+      update_strategy strategy = update_strategy::incremental) {
     (void)world_.markAllDirty(strategy);
     return true;
   }

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -87,6 +87,19 @@ constexpr auto corvid::enums::registry::enum_spec_v<corvid::sim::WaveTick> =
     corvid::enums::sequence::make_sequence_enum_spec<corvid::sim::WaveTick,
         "">();
 
+template<>
+constexpr auto
+    corvid::enums::registry::enum_spec_v<corvid::sim::UiCanvasEvent> =
+        corvid::enums::sequence::make_sequence_enum_spec<
+            corvid::sim::UiCanvasEvent,
+            "click, dblclick, contextmenu, dragstart, dragmove, dragend">();
+
+template<>
+constexpr auto
+    corvid::enums::registry::enum_spec_v<corvid::sim::UiMouseButton> =
+        corvid::enums::sequence::make_sequence_enum_spec<
+            corvid::sim::UiMouseButton, "left, middle, right, other">();
+
 namespace corvid { inline namespace sim {
 
 // Enemy spawn definition for a wave.

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -196,11 +196,22 @@ public:
   }
 
   void handleUiCanvas(const UiCanvasInput& input) {
-    // Canvas gestures are intentionally semantic transport only for now; game
-    // rules can opt into specific events as tower placement/tooling is added.
-    (void)phase_; // !!! To disable a warning for now.
+    // Select tower on click.
+    if (input.event == UiCanvasEvent::click &&
+        input.button == UiMouseButton::left)
+    {
+      auto id = world_.findEntityAt({input.x, input.y});
+      if (id != SimWorld::EntityId::invalid)
+        (void)world_.updateVisualEffects(id,
+            VisualEffects{.selection_color = 0xFFFF00FF});
+    }
 
-    (void)world_.spawnTower({input.x, input.y});
+    // Place tower on double-click.
+    if (input.event == UiCanvasEvent::dblclick &&
+        input.button == UiMouseButton::left)
+    {
+      (void)world_.spawnTower({input.x, input.y});
+    }
   }
 
   void handle_UiAction(const UiActionInput& input) {

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -167,7 +167,7 @@ private:
     for (; nextSpawnIndex_ < enemies.size(); ++nextSpawnIndex_) {
       const auto& enemy_def = enemies[nextSpawnIndex_];
       if (enemy_def.startTicks > waveTick) break;
-      (void)world_.spawnEnemy(PathId{0}, 100.F, 0.F);
+      (void)world_.spawnEnemy(PathId{0}, 20.F, 0.F);
     }
   }
 

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -51,8 +51,8 @@ enum class GamePhase : uint8_t {
 };
 
 // Tick from start of wave.
-enum class WaveTick : uint64_t {
-  invalid = std::numeric_limits<uint64_t>::max()
+enum class WaveTick : uint32_t {
+  invalid = std::numeric_limits<uint32_t>::max()
 };
 
 }} // namespace corvid::sim
@@ -216,7 +216,7 @@ private:
     (void)world_.addPath(p);
 
     WaveDefinition wave;
-    for (uint64_t i = 0; i < 20; ++i)
+    for (uint32_t i = 0; i < 20; ++i)
       wave.enemies.push_back({WaveTick{i * 20}, 0});
 
     waves_.push_back(std::move(wave));

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -75,6 +75,8 @@ enum class UiMouseButton : uint8_t {
   other,
 };
 
+enum class TargetMode : uint8_t { first, last, closest, strongest, weakest };
+
 }} // namespace corvid::sim
 
 template<>
@@ -99,6 +101,11 @@ constexpr auto
     corvid::enums::registry::enum_spec_v<corvid::sim::UiMouseButton> =
         corvid::enums::sequence::make_sequence_enum_spec<
             corvid::sim::UiMouseButton, "left, middle, right, other">();
+
+template<>
+constexpr auto corvid::enums::registry::enum_spec_v<corvid::sim::TargetMode> =
+    corvid::enums::sequence::make_sequence_enum_spec<corvid::sim::TargetMode,
+        "first, last, closest, strongest, weakest">();
 
 namespace corvid { inline namespace sim {
 
@@ -217,10 +224,12 @@ public:
 
       selected_tower_ =
           world_.getHandle(world_.findTowerAt({input.x, input.y}));
-      if (auto* fx = world_.changeVisualEffects(selected_tower_.id())) {
-        // TODO: These should actually come from the tower's stats.
-        fx->range_radius = 100.F;
-        fx->range_color = 0xFFFF007F;
+      if (selected_tower_.id() != SimWorld::EntityId::invalid) {
+        auto [pos, app, fx, tower] = world_.getTower(selected_tower_.id());
+        fx.range_radius = tower.attack_radius;
+        fx.range_color = 0xFFFF007F;
+        fx.modified = world_.currentTick();
+        (void)world_.markDirty(selected_tower_.id());
       }
     }
 

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -17,6 +17,10 @@
 #pragma once
 #include <sys/types.h>
 
+#include <string>
+#include <string_view>
+#include <utility>
+
 #include "sim_world.h"
 
 // SimGame: encapsulates the game rules and flow, using SimWorld for state and
@@ -55,6 +59,22 @@ enum class WaveTick : uint32_t {
   invalid = std::numeric_limits<uint32_t>::max()
 };
 
+enum class UiCanvasEvent : uint8_t {
+  click,
+  dblclick,
+  contextmenu,
+  dragstart,
+  dragmove,
+  dragend,
+};
+
+enum class UiMouseButton : uint8_t {
+  left,
+  middle,
+  right,
+  other,
+};
+
 }} // namespace corvid::sim
 
 template<>
@@ -79,6 +99,32 @@ struct EnemySpawn {
 struct WaveDefinition {
   std::vector<EnemySpawn> enemies;
   int resourceInflux = 0; // Resources rewarded at start of wave
+};
+
+struct UiCanvasInput {
+  uint64_t seq{};
+  UiCanvasEvent event{UiCanvasEvent::click};
+  UiMouseButton button{UiMouseButton::left};
+  uint32_t buttons{};
+  float x{};
+  float y{};
+  float canvasX{};
+  float canvasY{};
+  bool shift{};
+  bool ctrl{};
+  bool alt{};
+  bool meta{};
+};
+
+struct UiActionField {
+  std::string key;
+  std::string value;
+};
+
+struct UiActionInput {
+  uint64_t seq{};
+  std::string action;
+  std::vector<UiActionField> fields;
 };
 
 // Game simulation.
@@ -134,6 +180,19 @@ public:
     phase_ = GamePhase::wave;
     waveTick = {};
     nextSpawnIndex_ = 0;
+  }
+
+  void handle_ui_canvas(const UiCanvasInput& input) {
+    // Canvas gestures are intentionally semantic transport only for now; game
+    // rules can opt into specific events as tower placement/tooling is added.
+    (void)input;
+  }
+
+  void handle_ui_action(const UiActionInput& input) {
+    if (input.action == "start_wave") {
+      start_wave();
+      return;
+    }
   }
 
   void placeTower(/* later */);

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -135,8 +135,8 @@ public:
     return true;
   }
 
-  // Extract a delta of the game state. The `cbUpserts(EntityId, Position)` and
-  // `cbErased(EntityId)` callbacks will be interleaved. The
+  // Extract a delta of the game state. The `cbUpserts(EntityId, Position,
+  // Appearance)` and `cbErased(EntityId)` callbacks will be interleaved. The
   // `cbState(currentWave, waveTick, lives, resources)` callback is invoked
   // last.
   [[nodiscard]] bool

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -200,10 +200,21 @@ public:
     if (input.event == UiCanvasEvent::click &&
         input.button == UiMouseButton::left)
     {
-      auto id = world_.findEntityAt({input.x, input.y});
-      if (id != SimWorld::EntityId::invalid)
-        (void)world_.updateVisualEffects(id,
-            VisualEffects{.selection_color = 0xFFFF00FF});
+      // Deselect the previously selected tower, if it still exists.
+      if (auto* fx = world_.changeVisualEffects(world_.getId(selected_tower_)))
+      {
+        fx->range_radius = 0.F;
+        fx->range_color = 0;
+        selected_tower_ = {};
+      }
+
+      selected_tower_ =
+          world_.getHandle(world_.findTowerAt({input.x, input.y}));
+      if (auto* fx = world_.changeVisualEffects(selected_tower_.id())) {
+        // TODO: These should actually come from the tower's stats.
+        fx->range_radius = 100.F;
+        fx->range_color = 0xFFFF007F;
+      }
     }
 
     // Place tower on double-click.
@@ -337,5 +348,10 @@ private:
 
   int lives_{20};
   int resources_{100};
+
+  // Handle to the currently selected tower, used to clear its range circle
+  // when deselected. A default-constructed handle is invalid and indicates no
+  // selection.
+  SimWorld::Handle selected_tower_;
 };
 }} // namespace corvid::sim

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -164,8 +164,15 @@ public:
   [[nodiscard]] bool extractFull(auto&& cbPath, auto&& cbUpserts,
       auto&& cbErased, auto&& cbState) {
     (void)extractPaths(cbPath);
-    (void)world_.markAllDirty();
+    (void)markAllDirty();
     (void)extractDelta(cbUpserts, cbErased, cbState);
+    return true;
+  }
+
+  // See underlying method.
+  [[nodiscard]]
+  bool markAllDirty(update_strategy strategy = update_strategy::incremental) {
+    (void)world_.markAllDirty(strategy);
     return true;
   }
 

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -1,0 +1,151 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+#include <sys/types.h>
+
+#include "sim_world.h"
+
+namespace corvid { inline namespace sim {
+
+enum class GamePhase : uint8_t {
+  build,
+  wave,
+  game_over,
+  victory,
+};
+
+struct WaveEnemy {
+  Tick start_delay;
+  int enemy_type;
+};
+
+struct WaveDefinition {
+  std::vector<WaveEnemy> enemies;
+};
+
+struct GameSnapshot {
+  std::vector<SimWorld::EntitySnapshot> entities;
+  std::vector<PathJoints> path_points;
+};
+
+class SimGame {
+public:
+  explicit SimGame(/* maybe level data */) = default;
+
+  void load_level(/* level or map id/data */) {
+    world_.clear();
+    do_load_level_1();
+  }
+
+  void reset() {
+    world_.clear();
+    phase_ = GamePhase::build;
+    current_wave_index_ = 0;
+    wave_tick_ = 0;
+    next_spawn_index_ = 0;
+    lives_ = 20;
+    resources_ = 100;
+  }
+
+  Tick step() {
+    if (phase_ == GamePhase::wave) {
+      ++wave_tick_;
+      spawn_pending_wave_enemies();
+    }
+
+    const auto tick = world_.tick();
+    return tick;
+  }
+
+  void start_wave() {
+    if (phase_ != GamePhase::build) return;
+    phase_ = GamePhase::wave;
+    wave_tick_ = 0;
+    next_spawn_index_ = 0;
+  }
+
+  void place_tower(/* later */);
+
+  [[nodiscard]] GameSnapshot snapshot() const {
+    GameSnapshot snap;
+    snap.entities = world_.snapshot();
+    snap.path_points = world_.path_snapshot();
+    return snap;
+  }
+
+private:
+  void update_build_phase();
+  void update_wave_phase();
+  void spawn_pending_wave_enemies() {
+    const auto& wave = waves_[current_wave_index_];
+    const auto& enemies = wave.enemies;
+    for (; next_spawn_index_ < wave.enemies.size(); ++next_spawn_index_) {
+      const auto& enemy_def = wave.enemies[next_spawn_index_];
+      if (enemy_def.start_delay > wave_tick_) break;
+      (void)world_.spawn_enemy(PathId{0}, 20.F, 0.F);
+    }
+  }
+
+  void do_load_level_1() {
+    // Example level: one path and one wave of three enemies.
+    world_.clear();
+    PathJoints p;
+    p.joints.push_back({Position{0.0, 0.0}});
+    constexpr float kStepSize = 80.0;
+    constexpr float kAspect = SimWorld::world_width / SimWorld::world_height;
+    constexpr float kXStepSize = kStepSize * kAspect;
+    float x = 0.0;
+    float y = 0.0;
+    float x_run = kXStepSize;
+    float y_run = kStepSize;
+    for (int i = 0; i < 100; ++i) {
+      x += x_run;
+      p.joints.push_back({Position{x, y}});
+      y += y_run;
+      p.joints.push_back({Position{x, y}});
+      x_run += kXStepSize;
+      x -= x_run;
+      p.joints.push_back({Position{x, y}});
+      y_run += kStepSize;
+      y -= y_run;
+      p.joints.push_back({Position{x, y}});
+      x_run += kXStepSize;
+      y_run += kStepSize;
+    }
+    (void)world_.add_path(p);
+
+    WaveDefinition wave;
+    for (uint64_t i = 0; i < 20; ++i) wave.enemies.push_back({i * 20, 0});
+
+    waves_.push_back(std::move(wave));
+  }
+
+private:
+  SimWorld world_;
+
+  GamePhase phase_ = GamePhase::build;
+
+  std::vector<WaveDefinition> waves_;
+  int current_wave_index_ = 0;
+
+  Tick wave_tick_ = 0;
+  size_t next_spawn_index_ = 0;
+
+  int lives_ = 20;
+  int resources_ = 100;
+};
+}} // namespace corvid::sim

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -19,58 +19,100 @@
 
 #include "sim_world.h"
 
+// SimGame: encapsulates the game rules and flow, using SimWorld for state and
+// logic. Owns the current game phase, the wave definitions, and the player's
+// lives and resources. Relies on SimWsHandler for I/O.
+
 namespace corvid { inline namespace sim {
 
-enum class GamePhase : uint8_t {
-  build,
-  wave,
-  game_over,
-  victory,
-};
+// Concepts:
+// - A map is a persistent layout defined by a collection of paths and build
+// slots, as well as resources, background graphics, and other metadata.
+// - The player selects a map and faces subsequent waves until the end of the
+// game run. The run ends with defeat or victory. Potentially, runs could be
+// grouped into campaigns or other higher-level structures.
+// - A player's towers, score, lives, and resources persist throughout the game
+// run, albeit with modifications from wave to wave.
+// - A wave is a collection of enemy spawns. At the end of the wave, the player
+// gets a chance to build or upgrade before the next wave starts.
+// - Within a wave, spawns are enemies that appear on the track at fixed times
+// from the start of the wave.
 
-struct WaveEnemy {
-  Tick start_delay;
-  int enemy_type;
-};
-
-struct WaveDefinition {
-  std::vector<WaveEnemy> enemies;
-};
-
+// Snapshot of the game state for sending to clients. Contains all information
+// needed to render the current state of the world, but no information about
+// the rules or game flow.
 struct GameSnapshot {
   std::vector<SimWorld::EntitySnapshot> entities;
   std::vector<PathJoints> path_points;
 };
 
+enum class GamePhase : uint8_t {
+  build,     // Tower building
+  wave,      // Active wave with enemies spawning and moving
+  game_over, // Player has no lives left
+  victory,   // All waves completed with lives remaining
+};
+
+// Enemy spawn definition for a wave.
+struct EnemySpawn {
+  Tick start_delay;
+  int enemy_type;
+};
+
+// All of the enemy spawns for a wave.
+struct WaveDefinition {
+  std::vector<EnemySpawn> enemies;
+  int resource_influx = 0; // Resources rewarded at start of wave
+};
+
+// Game simulation.
 class SimGame {
 public:
-  explicit SimGame(/* maybe level data */) = default;
+  explicit SimGame() = default;
 
-  void load_level(/* level or map id/data */) {
-    world_.clear();
-    do_load_level_1();
+  // Load the chosen map, resetting all game state.
+  void load_map() {
+    // TODO: Have multiple maps.
+    do_load_map_1();
   }
 
-  void reset() {
+  // Resets all map information.
+  void reset_map() {
     world_.clear();
     phase_ = GamePhase::build;
-    current_wave_index_ = 0;
+    waves_.clear();
+    current_wave = 0;
     wave_tick_ = 0;
     next_spawn_index_ = 0;
     lives_ = 20;
     resources_ = 100;
   }
 
+  // Advance the simulation one tick. Returns the new tick count.
   Tick step() {
     if (phase_ == GamePhase::wave) {
       ++wave_tick_;
       spawn_pending_wave_enemies();
+
+      auto lives = lives_;
+      (void)world_.resolve_escapes(
+          [&lives](SimWorld::EntityId, const Position&, const PathFollower&) {
+            --lives;
+            // TODO: Treat front-escapees different from rear-escapees, and
+            // treat different enemies differently in terms of how many lives
+            // they consume.
+            return true;
+          });
+      lives_ = lives;
+
+      if (lives_ <= 0) phase_ = GamePhase::game_over;
     }
 
     const auto tick = world_.tick();
     return tick;
   }
 
+  // Player action: start the next wave.
   void start_wave() {
     if (phase_ != GamePhase::build) return;
     phase_ = GamePhase::wave;
@@ -80,6 +122,7 @@ public:
 
   void place_tower(/* later */);
 
+  // Get a snapshot of the current game state for sending to clients.
   [[nodiscard]] GameSnapshot snapshot() const {
     GameSnapshot snap;
     snap.entities = world_.snapshot();
@@ -88,21 +131,20 @@ public:
   }
 
 private:
-  void update_build_phase();
-  void update_wave_phase();
+  // Spawn all the enemies slated for this wave tick.
   void spawn_pending_wave_enemies() {
-    const auto& wave = waves_[current_wave_index_];
+    const auto& wave = waves_[current_wave];
     const auto& enemies = wave.enemies;
-    for (; next_spawn_index_ < wave.enemies.size(); ++next_spawn_index_) {
-      const auto& enemy_def = wave.enemies[next_spawn_index_];
+    for (; next_spawn_index_ < enemies.size(); ++next_spawn_index_) {
+      const auto& enemy_def = enemies[next_spawn_index_];
       if (enemy_def.start_delay > wave_tick_) break;
       (void)world_.spawn_enemy(PathId{0}, 20.F, 0.F);
     }
   }
 
-  void do_load_level_1() {
-    // Example level: one path and one wave of three enemies.
-    world_.clear();
+  void do_load_map_1() {
+    reset_map();
+    // For now, a hardcoded spiral.
     PathJoints p;
     p.joints.push_back({Position{0.0, 0.0}});
     constexpr float kStepSize = 80.0;
@@ -139,10 +181,19 @@ private:
 
   GamePhase phase_ = GamePhase::build;
 
-  std::vector<WaveDefinition> waves_;
-  int current_wave_index_ = 0;
-
+  // Tick counter for the current wave, used to trigger spawns at the right
+  // times. This is reset with each wave, so it is not the same tick counter as
+  // the world's, and may not even run at the same speed.
   Tick wave_tick_ = 0;
+
+  // Wave definitions for the current map.
+  std::vector<WaveDefinition> waves_;
+
+  // Current wave.
+  size_t current_wave = 0;
+
+  // Index of the next spawn in the current `WaveDefinition`, which is checked
+  // against `wave_tick_`.
   size_t next_spawn_index_ = 0;
 
   int lives_ = 20;

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -144,7 +144,7 @@ public:
     phase_ = GamePhase::build;
     waves_.clear();
     currentWave_ = 0;
-    waveTick = {};
+    waveTick_ = {};
     nextSpawnIndex_ = 0;
     lives_ = 20;
     resources_ = 100;
@@ -154,7 +154,7 @@ public:
   WorldTick step() {
     const auto tick = world_.tick();
     if (phase_ == GamePhase::wave) {
-      ++waveTick;
+      ++waveTick_;
       spawn_pending_wave_enemies();
 
       auto lives = lives_;
@@ -178,13 +178,14 @@ public:
   void start_wave() {
     if (phase_ != GamePhase::build) return;
     phase_ = GamePhase::wave;
-    waveTick = {};
+    waveTick_ = {};
     nextSpawnIndex_ = 0;
   }
 
   void handle_ui_canvas(const UiCanvasInput& input) {
     // Canvas gestures are intentionally semantic transport only for now; game
     // rules can opt into specific events as tower placement/tooling is added.
+    (void)phase_; // !!! To disable a warning for now.
     (void)input;
   }
 
@@ -211,7 +212,7 @@ public:
   [[nodiscard]] bool
   extractDelta(auto&& cbUpserts, auto&& cbErased, auto&& cbState) {
     (void)world_.extractUpdatedEntities(cbUpserts, cbErased);
-    (void)cbState(currentWave_, waveTick, lives_, resources_,
+    (void)cbState(currentWave_, waveTick_, lives_, resources_,
         sequence::enum_as_view(phase_));
 
     return true;
@@ -242,7 +243,7 @@ private:
     const auto& enemies = wave.enemies;
     for (; nextSpawnIndex_ < enemies.size(); ++nextSpawnIndex_) {
       const auto& enemy_def = enemies[nextSpawnIndex_];
-      if (enemy_def.startTicks > waveTick) break;
+      if (enemy_def.startTicks > waveTick_) break;
       (void)world_.spawnEnemy(PathId{0}, 20.F, 0.F);
     }
   }
@@ -296,7 +297,7 @@ private:
   // Tick counter for the current wave, used to trigger spawns at the right
   // times. This is reset with each wave, so it is not the same tick counter as
   // the world's, and may not even run at the same speed.
-  WaveTick waveTick{};
+  WaveTick waveTick_{};
 
   // Wave definitions for the current map.
   std::vector<WaveDefinition> waves_;

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -167,7 +167,7 @@ private:
     for (; nextSpawnIndex_ < enemies.size(); ++nextSpawnIndex_) {
       const auto& enemy_def = enemies[nextSpawnIndex_];
       if (enemy_def.startTicks > waveTick) break;
-      (void)world_.spawnEnemy(PathId{0}, 20.F, 0.F);
+      (void)world_.spawnEnemy(PathId{0}, 100.F, 0.F);
     }
   }
 
@@ -200,7 +200,7 @@ private:
     (void)world_.addPath(p);
 
     WaveDefinition wave;
-    for (uint64_t i = 0; i < 20; ++i) wave.enemies.push_back({i * 20, 0});
+    for (uint64_t i = 0; i < 200; ++i) wave.enemies.push_back({i * 20, 0});
 
     waves_.push_back(std::move(wave));
   }

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -55,14 +55,14 @@ enum class GamePhase : uint8_t {
 
 // Enemy spawn definition for a wave.
 struct EnemySpawn {
-  Tick start_delay;
-  int enemy_type;
+  Tick startTicks;
+  int enemyType;
 };
 
 // All of the enemy spawns for a wave.
 struct WaveDefinition {
   std::vector<EnemySpawn> enemies;
-  int resource_influx = 0; // Resources rewarded at start of wave
+  int resourceInflux = 0; // Resources rewarded at start of wave
 };
 
 // Game simulation.
@@ -70,32 +70,43 @@ class SimGame {
 public:
   explicit SimGame() = default;
 
+  [[nodiscard]] static constexpr std::string_view phase_name(GamePhase phase) {
+    switch (phase) {
+    case GamePhase::build: return "build";
+    case GamePhase::wave: return "wave";
+    case GamePhase::game_over: return "game_over";
+    case GamePhase::victory: return "victory";
+    }
+    return "unknown";
+  }
+
   // Load the chosen map, resetting all game state.
-  void load_map() {
+  void loadMap() {
     // TODO: Have multiple maps.
-    do_load_map_1();
+    doLoadMap1();
   }
 
   // Resets all map information.
-  void reset_map() {
+  void resetMap() {
     world_.clear();
     phase_ = GamePhase::build;
     waves_.clear();
-    current_wave = 0;
-    wave_tick_ = 0;
-    next_spawn_index_ = 0;
+    currentWave = 0;
+    waveTick = 0;
+    nextSpawnIndex = 0;
     lives_ = 20;
     resources_ = 100;
   }
 
   // Advance the simulation one tick. Returns the new tick count.
   Tick step() {
+    const auto tick = world_.tick();
     if (phase_ == GamePhase::wave) {
-      ++wave_tick_;
+      ++waveTick;
       spawn_pending_wave_enemies();
 
       auto lives = lives_;
-      (void)world_.resolve_escapes(
+      (void)world_.resolveEscapees(
           [&lives](SimWorld::EntityId, const Position&, const PathFollower&) {
             --lives;
             // TODO: Treat front-escapees different from rear-escapees, and
@@ -108,7 +119,6 @@ public:
       if (lives_ <= 0) phase_ = GamePhase::game_over;
     }
 
-    const auto tick = world_.tick();
     return tick;
   }
 
@@ -116,11 +126,11 @@ public:
   void start_wave() {
     if (phase_ != GamePhase::build) return;
     phase_ = GamePhase::wave;
-    wave_tick_ = 0;
-    next_spawn_index_ = 0;
+    waveTick = 0;
+    nextSpawnIndex = 0;
   }
 
-  void place_tower(/* later */);
+  void placeTower(/* later */);
 
   // Get a snapshot of the current game state for sending to clients.
   [[nodiscard]] GameSnapshot snapshot() const {
@@ -130,25 +140,55 @@ public:
     return snap;
   }
 
+  // Extract a snapshot of the paths by calling `cbPath(pathId, Position)` for
+  // all joints of all paths.
+  [[nodiscard]] bool extractPaths(auto&& cbPath) const {
+    (void)world_.obtainPaths(cbPath);
+    return true;
+  }
+
+  // Extract a delta of the game state. The `cbUpserts(EntityId, Position)` and
+  // `cbErased(EntityId)` callbacks will be interleaved. The
+  // `cbState(currentWave, waveTick, lives, resources)` callback is invoked
+  // last.
+  [[nodiscard]] bool
+  extractDelta(auto&& cbUpserts, auto&& cbErased, auto&& cbState) {
+    (void)world_.extractUpdatedEntities(cbUpserts, cbErased);
+    (void)cbState(currentWave, waveTick, lives_, resources_, phase_name(phase_));
+
+    return true;
+  }
+
+  // Extract a full snapshot of the game state. The `cbPath` callback will be
+  // invoked first, with `cbUpserts` and `cbErased` invoked afterwards and
+  // interleaved. The `cbState` callback is invoked last.
+  [[nodiscard]] bool extractFull(auto&& cbPath, auto&& cbUpserts,
+      auto&& cbErased, auto&& cbState) {
+    (void)extractPaths(cbPath);
+    // TODO: Call markDirty on all.
+    (void)extractDelta(cbUpserts, cbErased, cbState);
+    return true;
+  }
+
 private:
   // Spawn all the enemies slated for this wave tick.
   void spawn_pending_wave_enemies() {
-    const auto& wave = waves_[current_wave];
+    const auto& wave = waves_[currentWave];
     const auto& enemies = wave.enemies;
-    for (; next_spawn_index_ < enemies.size(); ++next_spawn_index_) {
-      const auto& enemy_def = enemies[next_spawn_index_];
-      if (enemy_def.start_delay > wave_tick_) break;
-      (void)world_.spawn_enemy(PathId{0}, 20.F, 0.F);
+    for (; nextSpawnIndex < enemies.size(); ++nextSpawnIndex) {
+      const auto& enemy_def = enemies[nextSpawnIndex];
+      if (enemy_def.startTicks > waveTick) break;
+      (void)world_.spawnEnemy(PathId{0}, 20.F, 0.F);
     }
   }
 
-  void do_load_map_1() {
-    reset_map();
+  void doLoadMap1() {
+    resetMap();
     // For now, a hardcoded spiral.
     PathJoints p;
     p.joints.push_back({Position{0.0, 0.0}});
     constexpr float kStepSize = 80.0;
-    constexpr float kAspect = SimWorld::world_width / SimWorld::world_height;
+    constexpr float kAspect = SimWorld::widthOfWorld / SimWorld::heightOfWorld;
     constexpr float kXStepSize = kStepSize * kAspect;
     float x = 0.0;
     float y = 0.0;
@@ -168,7 +208,7 @@ private:
       x_run += kXStepSize;
       y_run += kStepSize;
     }
-    (void)world_.add_path(p);
+    (void)world_.addPath(p);
 
     WaveDefinition wave;
     for (uint64_t i = 0; i < 20; ++i) wave.enemies.push_back({i * 20, 0});
@@ -184,17 +224,17 @@ private:
   // Tick counter for the current wave, used to trigger spawns at the right
   // times. This is reset with each wave, so it is not the same tick counter as
   // the world's, and may not even run at the same speed.
-  Tick wave_tick_ = 0;
+  Tick waveTick = 0;
 
   // Wave definitions for the current map.
   std::vector<WaveDefinition> waves_;
 
   // Current wave.
-  size_t current_wave = 0;
+  size_t currentWave = 0;
 
   // Index of the next spawn in the current `WaveDefinition`, which is checked
   // against `wave_tick_`.
-  size_t next_spawn_index_ = 0;
+  size_t nextSpawnIndex = 0;
 
   int lives_ = 20;
   int resources_ = 100;

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -230,6 +230,13 @@ public:
     {
       (void)world_.spawnTower({input.x, input.y});
     }
+
+    if (input.event == UiCanvasEvent::click &&
+        input.button == UiMouseButton::right)
+    {
+      (void)world_.flashEntity(world_.findEntityAt({input.x, input.y}),
+          0xFF7F7FAF, WorldTick{5});
+    }
   }
 
   void handle_UiAction(const UiActionInput& input) {

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -220,9 +220,9 @@ public:
   }
 
   // Extract a delta of the game state. The `cbUpserts(EntityId, Position,
-  // Appearance)` and `cbErased(EntityId)` callbacks will be interleaved. The
-  // `cbState(currentWave, waveTick, lives, resources)` callback is invoked
-  // last.
+  // Appearance, VisualEffects)` and `cbErased(EntityId)` callbacks will be
+  // interleaved. The `cbState(currentWave, waveTick, lives, resources)`
+  // callback is invoked last.
   [[nodiscard]] bool
   extractDelta(auto&& cbUpserts, auto&& cbErased, auto&& cbState) {
     (void)world_.extractUpdatedEntities(cbUpserts, cbErased);
@@ -234,7 +234,8 @@ public:
 
   // Extract a full snapshot of the game state. The `cbPath` callback will be
   // invoked first, with `cbUpserts` and `cbErased` invoked afterwards and
-  // interleaved. The `cbState` callback is invoked last.
+  // interleaved. `cbUpserts` receives an optional `VisualEffects` pointer. The
+  // `cbState` callback is invoked last.
   [[nodiscard]] bool extractFull(auto&& cbPath, auto&& cbUpserts,
       auto&& cbErased, auto&& cbState) {
     (void)extractPaths(cbPath);

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -176,6 +176,8 @@ private:
     // For now, a hardcoded spiral.
     PathJoints p;
     p.joints.push_back({Position{0.0, 0.0}});
+    constexpr float kHalfWidth = SimWorld::widthOfWorld / 2.F;
+    constexpr float kHalfHeight = SimWorld::heightOfWorld / 2.F;
     constexpr float kStepSize = 80.0;
     constexpr float kAspect = SimWorld::widthOfWorld / SimWorld::heightOfWorld;
     constexpr float kXStepSize = kStepSize * kAspect;
@@ -183,24 +185,28 @@ private:
     float y = 0.0;
     float x_run = kXStepSize;
     float y_run = kStepSize;
-    for (int i = 0; i < 100; ++i) {
-      x += x_run;
+    auto append_segment = [&](float dx, float dy) {
+      x = std::clamp(x + dx, -kHalfWidth, kHalfWidth);
+      y = std::clamp(y + dy, -kHalfHeight, kHalfHeight);
       p.joints.push_back({Position{x, y}});
-      y += y_run;
-      p.joints.push_back({Position{x, y}});
+      return x > -kHalfWidth && x < kHalfWidth && y > -kHalfHeight &&
+             y < kHalfHeight;
+    };
+
+    while (true) {
+      if (!append_segment(x_run, 0.F)) break;
+      if (!append_segment(0.F, y_run)) break;
       x_run += kXStepSize;
-      x -= x_run;
-      p.joints.push_back({Position{x, y}});
+      if (!append_segment(-x_run, 0.F)) break;
       y_run += kStepSize;
-      y -= y_run;
-      p.joints.push_back({Position{x, y}});
+      if (!append_segment(0.F, -y_run)) break;
       x_run += kXStepSize;
       y_run += kStepSize;
     }
     (void)world_.addPath(p);
 
     WaveDefinition wave;
-    for (uint64_t i = 0; i < 200; ++i) wave.enemies.push_back({i * 20, 0});
+    for (uint64_t i = 0; i < 20; ++i) wave.enemies.push_back({i * 20, 0});
 
     waves_.push_back(std::move(wave));
   }

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -47,6 +47,7 @@ struct GameSnapshot {
 };
 
 enum class GamePhase : uint8_t {
+  invalid,
   build,     // Tower building
   wave,      // Active wave with enemies spawning and moving
   game_over, // Player has no lives left
@@ -58,7 +59,7 @@ enum class GamePhase : uint8_t {
 template<>
 constexpr auto corvid::enums::registry::enum_spec_v<corvid::sim::GamePhase> =
     corvid::enums::sequence::make_sequence_enum_spec<corvid::sim::GamePhase,
-        "build, wave, game_over, victory">();
+        "invalid, build, wave, game_over, victory">();
 
 namespace corvid { inline namespace sim {
 
@@ -79,16 +80,6 @@ class SimGame {
 public:
   explicit SimGame() = default;
 
-  [[nodiscard]] static constexpr std::string_view phase_name(GamePhase phase) {
-    switch (phase) {
-    case GamePhase::build: return "build";
-    case GamePhase::wave: return "wave";
-    case GamePhase::game_over: return "game_over";
-    case GamePhase::victory: return "victory";
-    }
-    return "unknown";
-  }
-
   // Load the chosen map, resetting all game state.
   void loadMap() {
     // TODO: Have multiple maps.
@@ -100,9 +91,9 @@ public:
     world_.clear();
     phase_ = GamePhase::build;
     waves_.clear();
-    currentWave = 0;
+    currentWave_ = 0;
     waveTick = 0;
-    nextSpawnIndex = 0;
+    nextSpawnIndex_ = 0;
     lives_ = 20;
     resources_ = 100;
   }
@@ -136,18 +127,10 @@ public:
     if (phase_ != GamePhase::build) return;
     phase_ = GamePhase::wave;
     waveTick = 0;
-    nextSpawnIndex = 0;
+    nextSpawnIndex_ = 0;
   }
 
   void placeTower(/* later */);
-
-  // Get a snapshot of the current game state for sending to clients.
-  [[nodiscard]] GameSnapshot snapshot() const {
-    GameSnapshot snap;
-    snap.entities = world_.snapshot();
-    snap.path_points = world_.path_snapshot();
-    return snap;
-  }
 
   // Extract a snapshot of the paths by calling `cbPath(pathId, Position)` for
   // all joints of all paths.
@@ -163,8 +146,8 @@ public:
   [[nodiscard]] bool
   extractDelta(auto&& cbUpserts, auto&& cbErased, auto&& cbState) {
     (void)world_.extractUpdatedEntities(cbUpserts, cbErased);
-    (void)cbState(currentWave, waveTick, lives_, resources_,
-        phase_name(phase_));
+    (void)cbState(currentWave_, waveTick, lives_, resources_,
+        sequence::enum_as_view(phase_));
 
     return true;
   }
@@ -175,7 +158,7 @@ public:
   [[nodiscard]] bool extractFull(auto&& cbPath, auto&& cbUpserts,
       auto&& cbErased, auto&& cbState) {
     (void)extractPaths(cbPath);
-    // TODO: Call markDirty on all.
+    (void)world_.markAllDirty();
     (void)extractDelta(cbUpserts, cbErased, cbState);
     return true;
   }
@@ -183,10 +166,10 @@ public:
 private:
   // Spawn all the enemies slated for this wave tick.
   void spawn_pending_wave_enemies() {
-    const auto& wave = waves_[currentWave];
+    const auto& wave = waves_[currentWave_];
     const auto& enemies = wave.enemies;
-    for (; nextSpawnIndex < enemies.size(); ++nextSpawnIndex) {
-      const auto& enemy_def = enemies[nextSpawnIndex];
+    for (; nextSpawnIndex_ < enemies.size(); ++nextSpawnIndex_) {
+      const auto& enemy_def = enemies[nextSpawnIndex_];
       if (enemy_def.startTicks > waveTick) break;
       (void)world_.spawnEnemy(PathId{0}, 20.F, 0.F);
     }
@@ -234,19 +217,19 @@ private:
   // Tick counter for the current wave, used to trigger spawns at the right
   // times. This is reset with each wave, so it is not the same tick counter as
   // the world's, and may not even run at the same speed.
-  Tick waveTick = 0;
+  Tick waveTick{};
 
   // Wave definitions for the current map.
   std::vector<WaveDefinition> waves_;
 
   // Current wave.
-  size_t currentWave = 0;
+  size_t currentWave_{};
 
   // Index of the next spawn in the current `WaveDefinition`, which is checked
   // against `wave_tick_`.
-  size_t nextSpawnIndex = 0;
+  size_t nextSpawnIndex_{};
 
-  int lives_ = 20;
-  int resources_ = 100;
+  int lives_{20};
+  int resources_{100};
 };
 }} // namespace corvid::sim

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -53,6 +53,15 @@ enum class GamePhase : uint8_t {
   victory,   // All waves completed with lives remaining
 };
 
+}} // namespace corvid::sim
+
+template<>
+constexpr auto corvid::enums::registry::enum_spec_v<corvid::sim::GamePhase> =
+    corvid::enums::sequence::make_sequence_enum_spec<corvid::sim::GamePhase,
+        "build, wave, game_over, victory">();
+
+namespace corvid { inline namespace sim {
+
 // Enemy spawn definition for a wave.
 struct EnemySpawn {
   Tick startTicks;
@@ -154,7 +163,8 @@ public:
   [[nodiscard]] bool
   extractDelta(auto&& cbUpserts, auto&& cbErased, auto&& cbState) {
     (void)world_.extractUpdatedEntities(cbUpserts, cbErased);
-    (void)cbState(currentWave, waveTick, lives_, resources_, phase_name(phase_));
+    (void)cbState(currentWave, waveTick, lives_, resources_,
+        phase_name(phase_));
 
     return true;
   }

--- a/corvid/sim/sim_json_parse.h
+++ b/corvid/sim/sim_json_parse.h
@@ -16,18 +16,16 @@
 // limitations under the License.
 #pragma once
 
-#include <cctype>
-#include <charconv>
 #include <cstdint>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#include "../proto/json_parser.h"
 #include "sim_game.h"
 
 namespace corvid { inline namespace sim {
-
 enum class SimClientMessageKind : uint8_t {
   unknown,
   hello,
@@ -37,147 +35,90 @@ enum class SimClientMessageKind : uint8_t {
 
 namespace detail {
 
-[[nodiscard]] inline std::size_t
-skip_json_ws(std::string_view msg, std::size_t pos) {
-  while (
-      pos < msg.size() && std::isspace(static_cast<unsigned char>(msg[pos])))
-    ++pos;
-  return pos;
+[[nodiscard]] constexpr bool decode_json_string_field(json_object_view obj,
+    std::string_view key, std::string& out) {
+  const auto value = obj.find(key);
+  return value && value.decode_string(out);
 }
 
-[[nodiscard]] inline std::optional<std::size_t>
-find_json_value_pos(std::string_view msg, std::string_view key) {
-  std::string needle;
-  needle.reserve(key.size() + 2);
-  needle.push_back('"');
-  needle.append(key);
-  needle.push_back('"');
-
-  auto pos = msg.find(needle);
-  if (pos == std::string_view::npos) return std::nullopt;
-  pos = msg.find(':', pos + needle.size());
-  if (pos == std::string_view::npos) return std::nullopt;
-  return skip_json_ws(msg, pos + 1);
+template<typename T>
+[[nodiscard]] constexpr std::optional<T>
+get_json_number(json_object_view obj, std::string_view key) {
+  return obj.get_number<T>(key);
 }
 
-[[nodiscard]] inline std::optional<std::string>
-parse_json_string_token(std::string_view msg, std::size_t pos) {
-  if (pos >= msg.size() || msg[pos] != '"') return std::nullopt;
-  ++pos;
-
-  std::string out;
-  while (pos < msg.size()) {
-    const auto ch = msg[pos++];
-    if (ch == '"') return out;
-    if (ch == '\\') {
-      if (pos >= msg.size()) return std::nullopt;
-      out.push_back(msg[pos++]);
-      continue;
-    }
-    out.push_back(ch);
-  }
-  return std::nullopt;
-}
-
-[[nodiscard]] inline std::optional<std::string>
-parse_json_string_field(std::string_view msg, std::string_view key) {
-  const auto pos = find_json_value_pos(msg, key);
-  if (!pos) return std::nullopt;
-  return parse_json_string_token(msg, *pos);
-}
-
-template<typename UInt>
-[[nodiscard]] inline std::optional<UInt>
-parse_json_unsigned(std::string_view msg, std::string_view key) {
-  const auto pos = find_json_value_pos(msg, key);
-  if (!pos) return std::nullopt;
-  UInt val{};
-  auto [ptr, ec] =
-      std::from_chars(msg.data() + *pos, msg.data() + msg.size(), val);
-  if (ec != std::errc{}) return std::nullopt;
-  return val;
-}
-
-[[nodiscard]] inline std::optional<float>
-parse_json_float(std::string_view msg, std::string_view key) {
-  const auto pos = find_json_value_pos(msg, key);
-  if (!pos) return std::nullopt;
-  float val{};
-  auto [ptr, ec] =
-      std::from_chars(msg.data() + *pos, msg.data() + msg.size(), val);
-  if (ec != std::errc{}) return std::nullopt;
-  return val;
-}
-
-[[nodiscard]] inline std::optional<bool>
-parse_json_bool(std::string_view msg, std::string_view key) {
-  const auto pos = find_json_value_pos(msg, key);
-  if (!pos) return std::nullopt;
-  if (msg.substr(*pos, 4) == "true") return true;
-  if (msg.substr(*pos, 5) == "false") return false;
-  return std::nullopt;
-}
-
-[[nodiscard]] inline std::vector<UiActionField> parse_json_fields(
-    std::string_view msg) {
-  const auto start = find_json_value_pos(msg, "fields");
-  if (!start || *start >= msg.size() || msg[*start] != '{') return {};
-
+[[nodiscard]] constexpr std::vector<UiActionField> parse_json_fields(
+    json_object_view obj) {
   std::vector<UiActionField> fields;
-  auto pos = *start + 1;
-  while (pos < msg.size()) {
-    pos = skip_json_ws(msg, pos);
-    if (pos >= msg.size() || msg[pos] == '}') break;
+  const auto fields_obj = obj.get_object("fields");
+  if (!fields_obj) return fields;
 
-    auto key = parse_json_string_token(msg, pos);
-    if (!key) return {};
-    pos = msg.find(':', pos);
-    if (pos == std::string_view::npos) return {};
-    pos = skip_json_ws(msg, pos + 1);
-
-    auto value = parse_json_string_token(msg, pos);
-    if (!value) return {};
-    fields.push_back({std::move(*key), std::move(*value)});
-
-    pos = msg.find_first_of(",}", pos);
-    if (pos == std::string_view::npos || msg[pos] == '}') break;
-    ++pos;
+  std::string key;
+  std::string value;
+  for (const auto field : fields_obj) {
+    if (!field.key.decode_string(key) || !field.value.decode_string(value)) {
+      fields.clear();
+      return fields;
+    }
+    fields.push_back({key, value});
   }
   return fields;
 }
 
 } // namespace detail
 
-[[nodiscard]] inline SimClientMessageKind classify_sim_client_message(
-    std::string_view msg) {
-  if (msg.contains(R"("type":"hello")") || msg.contains(R"("type": "hello")"))
-    return SimClientMessageKind::hello;
-  if (msg.contains(R"("type":"ui_canvas")") ||
-      msg.contains(R"("type": "ui_canvas")"))
-    return SimClientMessageKind::ui_canvas;
-  if (msg.contains(R"("type":"ui_action")") ||
-      msg.contains(R"("type": "ui_action")"))
-    return SimClientMessageKind::ui_action;
+[[nodiscard]] constexpr std::optional<json_object_view>
+parse_sim_client_message_root(std::string_view msg) {
+  json_value_view root;
+  if (!parse_json(msg, root)) return std::nullopt;
+  const auto obj = root.as_object();
+  if (!obj) return std::nullopt;
+  return obj;
+}
+
+[[nodiscard]] constexpr SimClientMessageKind classify_sim_client_message(
+    json_object_view msg) {
+  if (!msg) return SimClientMessageKind::unknown;
+
+  std::string type;
+  if (!detail::decode_json_string_field(msg, "type", type))
+    return SimClientMessageKind::unknown;
+
+  if (type == "hello") return SimClientMessageKind::hello;
+  if (type == "ui_canvas") return SimClientMessageKind::ui_canvas;
+  if (type == "ui_action") return SimClientMessageKind::ui_action;
   return SimClientMessageKind::unknown;
 }
 
-[[nodiscard]] inline std::optional<UiCanvasInput> parse_ui_canvas_message(
+[[nodiscard]] constexpr SimClientMessageKind classify_sim_client_message(
     std::string_view msg) {
+  const auto root = parse_sim_client_message_root(msg);
+  return root ? classify_sim_client_message(*root)
+              : SimClientMessageKind::unknown;
+}
+
+[[nodiscard]] constexpr std::optional<UiCanvasInput> parse_ui_canvas_message(
+    json_object_view msg) {
+  if (!msg) return std::nullopt;
+
   UiCanvasInput input;
-  const auto seq = detail::parse_json_unsigned<uint64_t>(msg, "seq");
-  const auto event = detail::parse_json_string_field(msg, "event");
-  const auto button = detail::parse_json_string_field(msg, "button");
-  const auto buttons = detail::parse_json_unsigned<uint32_t>(msg, "buttons");
-  const auto x = detail::parse_json_float(msg, "x");
-  const auto y = detail::parse_json_float(msg, "y");
-  const auto canvas_x = detail::parse_json_float(msg, "canvasX");
-  const auto canvas_y = detail::parse_json_float(msg, "canvasY");
-  const auto shift = detail::parse_json_bool(msg, "shift");
-  const auto ctrl = detail::parse_json_bool(msg, "ctrl");
-  const auto alt = detail::parse_json_bool(msg, "alt");
-  const auto meta = detail::parse_json_bool(msg, "meta");
-  if (!seq || !event || !button || !buttons || !x || !y || !canvas_x ||
-      !canvas_y || !shift || !ctrl || !alt || !meta)
+  const auto seq = detail::get_json_number<uint64_t>(msg, "seq");
+  const auto buttons = detail::get_json_number<uint32_t>(msg, "buttons");
+  const auto x = detail::get_json_number<float>(msg, "x");
+  const auto y = detail::get_json_number<float>(msg, "y");
+  const auto canvas_x = detail::get_json_number<float>(msg, "canvasX");
+  const auto canvas_y = detail::get_json_number<float>(msg, "canvasY");
+  const auto shift = msg.get_bool("shift");
+  const auto ctrl = msg.get_bool("ctrl");
+  const auto alt = msg.get_bool("alt");
+  const auto meta = msg.get_bool("meta");
+
+  std::string event;
+  std::string button;
+  if (!seq || !buttons || !x || !y || !canvas_x || !canvas_y || !shift ||
+      !ctrl || !alt || !meta ||
+      !detail::decode_json_string_field(msg, "event", event) ||
+      !detail::decode_json_string_field(msg, "button", button))
     return std::nullopt;
 
   input.seq = *seq;
@@ -191,28 +132,28 @@ parse_json_bool(std::string_view msg, std::string_view key) {
   input.alt = *alt;
   input.meta = *meta;
 
-  if (*event == "click")
+  if (event == "click")
     input.event = UiCanvasEvent::click;
-  else if (*event == "dblclick")
+  else if (event == "dblclick")
     input.event = UiCanvasEvent::dblclick;
-  else if (*event == "contextmenu")
+  else if (event == "contextmenu")
     input.event = UiCanvasEvent::contextmenu;
-  else if (*event == "dragstart")
+  else if (event == "dragstart")
     input.event = UiCanvasEvent::dragstart;
-  else if (*event == "dragmove")
+  else if (event == "dragmove")
     input.event = UiCanvasEvent::dragmove;
-  else if (*event == "dragend")
+  else if (event == "dragend")
     input.event = UiCanvasEvent::dragend;
   else
     return std::nullopt;
 
-  if (*button == "left")
+  if (button == "left")
     input.button = UiMouseButton::left;
-  else if (*button == "middle")
+  else if (button == "middle")
     input.button = UiMouseButton::middle;
-  else if (*button == "right")
+  else if (button == "right")
     input.button = UiMouseButton::right;
-  else if (*button == "other")
+  else if (button == "other")
     input.button = UiMouseButton::other;
   else
     return std::nullopt;
@@ -220,17 +161,29 @@ parse_json_bool(std::string_view msg, std::string_view key) {
   return input;
 }
 
-[[nodiscard]] inline std::optional<UiActionInput> parse_ui_action_message(
+[[nodiscard]] constexpr std::optional<UiCanvasInput> parse_ui_canvas_message(
     std::string_view msg) {
+  const auto root = parse_sim_client_message_root(msg);
+  return root ? parse_ui_canvas_message(*root) : std::nullopt;
+}
+
+[[nodiscard]] constexpr std::optional<UiActionInput> parse_ui_action_message(
+    json_object_view msg) {
+  if (!msg) return std::nullopt;
+
   UiActionInput input;
-  const auto seq = detail::parse_json_unsigned<uint64_t>(msg, "seq");
-  auto action = detail::parse_json_string_field(msg, "action");
-  if (!seq || !action) return std::nullopt;
+  const auto seq = detail::get_json_number<uint64_t>(msg, "seq");
+  if (!seq || !detail::decode_json_string_field(msg, "action", input.action))
+    return std::nullopt;
 
   input.seq = *seq;
-  input.action = std::move(*action);
   input.fields = detail::parse_json_fields(msg);
   return input;
 }
 
+[[nodiscard]] constexpr std::optional<UiActionInput> parse_ui_action_message(
+    std::string_view msg) {
+  const auto root = parse_sim_client_message_root(msg);
+  return root ? parse_ui_action_message(*root) : std::nullopt;
+}
 }} // namespace corvid::sim

--- a/corvid/sim/sim_json_parse.h
+++ b/corvid/sim/sim_json_parse.h
@@ -1,0 +1,237 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cctype>
+#include <charconv>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "sim_game.h"
+
+namespace corvid { inline namespace sim {
+
+enum class SimClientMessageKind : uint8_t {
+  unknown,
+  hello,
+  ui_canvas,
+  ui_action,
+};
+
+namespace detail {
+
+[[nodiscard]] inline std::size_t
+skip_json_ws(std::string_view msg, std::size_t pos) {
+  while (pos < msg.size() &&
+         std::isspace(static_cast<unsigned char>(msg[pos])))
+    ++pos;
+  return pos;
+}
+
+[[nodiscard]] inline std::optional<std::size_t>
+find_json_value_pos(std::string_view msg, std::string_view key) {
+  std::string needle;
+  needle.reserve(key.size() + 2);
+  needle.push_back('"');
+  needle.append(key);
+  needle.push_back('"');
+
+  auto pos = msg.find(needle);
+  if (pos == std::string_view::npos) return std::nullopt;
+  pos = msg.find(':', pos + needle.size());
+  if (pos == std::string_view::npos) return std::nullopt;
+  return skip_json_ws(msg, pos + 1);
+}
+
+[[nodiscard]] inline std::optional<std::string>
+parse_json_string_token(std::string_view msg, std::size_t pos) {
+  if (pos >= msg.size() || msg[pos] != '"') return std::nullopt;
+  ++pos;
+
+  std::string out;
+  while (pos < msg.size()) {
+    const auto ch = msg[pos++];
+    if (ch == '"') return out;
+    if (ch == '\\') {
+      if (pos >= msg.size()) return std::nullopt;
+      out.push_back(msg[pos++]);
+      continue;
+    }
+    out.push_back(ch);
+  }
+  return std::nullopt;
+}
+
+[[nodiscard]] inline std::optional<std::string>
+parse_json_string_field(std::string_view msg, std::string_view key) {
+  const auto pos = find_json_value_pos(msg, key);
+  if (!pos) return std::nullopt;
+  return parse_json_string_token(msg, *pos);
+}
+
+template<typename UInt>
+[[nodiscard]] inline std::optional<UInt>
+parse_json_unsigned(std::string_view msg, std::string_view key) {
+  const auto pos = find_json_value_pos(msg, key);
+  if (!pos) return std::nullopt;
+  UInt val{};
+  auto [ptr, ec] =
+      std::from_chars(msg.data() + *pos, msg.data() + msg.size(), val);
+  if (ec != std::errc{}) return std::nullopt;
+  return val;
+}
+
+[[nodiscard]] inline std::optional<float>
+parse_json_float(std::string_view msg, std::string_view key) {
+  const auto pos = find_json_value_pos(msg, key);
+  if (!pos) return std::nullopt;
+  float val{};
+  auto [ptr, ec] =
+      std::from_chars(msg.data() + *pos, msg.data() + msg.size(), val);
+  if (ec != std::errc{}) return std::nullopt;
+  return val;
+}
+
+[[nodiscard]] inline std::optional<bool>
+parse_json_bool(std::string_view msg, std::string_view key) {
+  const auto pos = find_json_value_pos(msg, key);
+  if (!pos) return std::nullopt;
+  if (msg.substr(*pos, 4) == "true") return true;
+  if (msg.substr(*pos, 5) == "false") return false;
+  return std::nullopt;
+}
+
+[[nodiscard]] inline std::vector<UiActionField>
+parse_json_fields(std::string_view msg) {
+  const auto start = find_json_value_pos(msg, "fields");
+  if (!start || *start >= msg.size() || msg[*start] != '{') return {};
+
+  std::vector<UiActionField> fields;
+  auto pos = *start + 1;
+  while (pos < msg.size()) {
+    pos = skip_json_ws(msg, pos);
+    if (pos >= msg.size() || msg[pos] == '}') break;
+
+    const auto key = parse_json_string_token(msg, pos);
+    if (!key) return {};
+    pos = msg.find(':', pos);
+    if (pos == std::string_view::npos) return {};
+    pos = skip_json_ws(msg, pos + 1);
+
+    const auto value = parse_json_string_token(msg, pos);
+    if (!value) return {};
+    fields.push_back({std::move(*key), std::move(*value)});
+
+    pos = msg.find_first_of(",}", pos);
+    if (pos == std::string_view::npos || msg[pos] == '}') break;
+    ++pos;
+  }
+  return fields;
+}
+
+} // namespace detail
+
+[[nodiscard]] inline SimClientMessageKind
+classify_sim_client_message(std::string_view msg) {
+  if (msg.contains(R"("type":"hello")") ||
+      msg.contains(R"("type": "hello")"))
+    return SimClientMessageKind::hello;
+  if (msg.contains(R"("type":"ui_canvas")") ||
+      msg.contains(R"("type": "ui_canvas")"))
+    return SimClientMessageKind::ui_canvas;
+  if (msg.contains(R"("type":"ui_action")") ||
+      msg.contains(R"("type": "ui_action")"))
+    return SimClientMessageKind::ui_action;
+  return SimClientMessageKind::unknown;
+}
+
+[[nodiscard]] inline std::optional<UiCanvasInput>
+parse_ui_canvas_message(std::string_view msg) {
+  UiCanvasInput input;
+  const auto seq = detail::parse_json_unsigned<uint64_t>(msg, "seq");
+  const auto event = detail::parse_json_string_field(msg, "event");
+  const auto button = detail::parse_json_string_field(msg, "button");
+  const auto buttons = detail::parse_json_unsigned<uint32_t>(msg, "buttons");
+  const auto x = detail::parse_json_float(msg, "x");
+  const auto y = detail::parse_json_float(msg, "y");
+  const auto canvas_x = detail::parse_json_float(msg, "canvasX");
+  const auto canvas_y = detail::parse_json_float(msg, "canvasY");
+  const auto shift = detail::parse_json_bool(msg, "shift");
+  const auto ctrl = detail::parse_json_bool(msg, "ctrl");
+  const auto alt = detail::parse_json_bool(msg, "alt");
+  const auto meta = detail::parse_json_bool(msg, "meta");
+  if (!seq || !event || !button || !buttons || !x || !y || !canvas_x ||
+      !canvas_y || !shift || !ctrl || !alt || !meta)
+    return std::nullopt;
+
+  input.seq = *seq;
+  input.buttons = *buttons;
+  input.x = *x;
+  input.y = *y;
+  input.canvasX = *canvas_x;
+  input.canvasY = *canvas_y;
+  input.shift = *shift;
+  input.ctrl = *ctrl;
+  input.alt = *alt;
+  input.meta = *meta;
+
+  if (*event == "click")
+    input.event = UiCanvasEvent::click;
+  else if (*event == "dblclick")
+    input.event = UiCanvasEvent::dblclick;
+  else if (*event == "contextmenu")
+    input.event = UiCanvasEvent::contextmenu;
+  else if (*event == "dragstart")
+    input.event = UiCanvasEvent::dragstart;
+  else if (*event == "dragmove")
+    input.event = UiCanvasEvent::dragmove;
+  else if (*event == "dragend")
+    input.event = UiCanvasEvent::dragend;
+  else
+    return std::nullopt;
+
+  if (*button == "left")
+    input.button = UiMouseButton::left;
+  else if (*button == "middle")
+    input.button = UiMouseButton::middle;
+  else if (*button == "right")
+    input.button = UiMouseButton::right;
+  else if (*button == "other")
+    input.button = UiMouseButton::other;
+  else
+    return std::nullopt;
+
+  return input;
+}
+
+[[nodiscard]] inline std::optional<UiActionInput>
+parse_ui_action_message(std::string_view msg) {
+  UiActionInput input;
+  const auto seq = detail::parse_json_unsigned<uint64_t>(msg, "seq");
+  const auto action = detail::parse_json_string_field(msg, "action");
+  if (!seq || !action) return std::nullopt;
+
+  input.seq = *seq;
+  input.action = std::move(*action);
+  input.fields = detail::parse_json_fields(msg);
+  return input;
+}
+
+}} // namespace corvid::sim

--- a/corvid/sim/sim_json_parse.h
+++ b/corvid/sim/sim_json_parse.h
@@ -39,8 +39,8 @@ namespace detail {
 
 [[nodiscard]] inline std::size_t
 skip_json_ws(std::string_view msg, std::size_t pos) {
-  while (pos < msg.size() &&
-         std::isspace(static_cast<unsigned char>(msg[pos])))
+  while (
+      pos < msg.size() && std::isspace(static_cast<unsigned char>(msg[pos])))
     ++pos;
   return pos;
 }
@@ -118,8 +118,8 @@ parse_json_bool(std::string_view msg, std::string_view key) {
   return std::nullopt;
 }
 
-[[nodiscard]] inline std::vector<UiActionField>
-parse_json_fields(std::string_view msg) {
+[[nodiscard]] inline std::vector<UiActionField> parse_json_fields(
+    std::string_view msg) {
   const auto start = find_json_value_pos(msg, "fields");
   if (!start || *start >= msg.size() || msg[*start] != '{') return {};
 
@@ -129,13 +129,13 @@ parse_json_fields(std::string_view msg) {
     pos = skip_json_ws(msg, pos);
     if (pos >= msg.size() || msg[pos] == '}') break;
 
-    const auto key = parse_json_string_token(msg, pos);
+    auto key = parse_json_string_token(msg, pos);
     if (!key) return {};
     pos = msg.find(':', pos);
     if (pos == std::string_view::npos) return {};
     pos = skip_json_ws(msg, pos + 1);
 
-    const auto value = parse_json_string_token(msg, pos);
+    auto value = parse_json_string_token(msg, pos);
     if (!value) return {};
     fields.push_back({std::move(*key), std::move(*value)});
 
@@ -148,10 +148,9 @@ parse_json_fields(std::string_view msg) {
 
 } // namespace detail
 
-[[nodiscard]] inline SimClientMessageKind
-classify_sim_client_message(std::string_view msg) {
-  if (msg.contains(R"("type":"hello")") ||
-      msg.contains(R"("type": "hello")"))
+[[nodiscard]] inline SimClientMessageKind classify_sim_client_message(
+    std::string_view msg) {
+  if (msg.contains(R"("type":"hello")") || msg.contains(R"("type": "hello")"))
     return SimClientMessageKind::hello;
   if (msg.contains(R"("type":"ui_canvas")") ||
       msg.contains(R"("type": "ui_canvas")"))
@@ -162,8 +161,8 @@ classify_sim_client_message(std::string_view msg) {
   return SimClientMessageKind::unknown;
 }
 
-[[nodiscard]] inline std::optional<UiCanvasInput>
-parse_ui_canvas_message(std::string_view msg) {
+[[nodiscard]] inline std::optional<UiCanvasInput> parse_ui_canvas_message(
+    std::string_view msg) {
   UiCanvasInput input;
   const auto seq = detail::parse_json_unsigned<uint64_t>(msg, "seq");
   const auto event = detail::parse_json_string_field(msg, "event");
@@ -221,11 +220,11 @@ parse_ui_canvas_message(std::string_view msg) {
   return input;
 }
 
-[[nodiscard]] inline std::optional<UiActionInput>
-parse_ui_action_message(std::string_view msg) {
+[[nodiscard]] inline std::optional<UiActionInput> parse_ui_action_message(
+    std::string_view msg) {
   UiActionInput input;
   const auto seq = detail::parse_json_unsigned<uint64_t>(msg, "seq");
-  const auto action = detail::parse_json_string_field(msg, "action");
+  auto action = detail::parse_json_string_field(msg, "action");
   if (!seq || !action) return std::nullopt;
 
   input.seq = *seq;

--- a/corvid/sim/sim_json_parse.h
+++ b/corvid/sim/sim_json_parse.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "../proto/json_parser.h"
+#include "../strings/enum_conversion.h"
 #include "sim_game.h"
 
 namespace corvid { inline namespace sim {
@@ -33,21 +34,25 @@ enum class SimClientMessageKind : uint8_t {
   ui_action,
 };
 
+}} // namespace corvid::sim
+
+template<>
+constexpr auto
+    corvid::enums::registry::enum_spec_v<corvid::sim::SimClientMessageKind> =
+        corvid::enums::sequence::make_sequence_enum_spec<
+            corvid::sim::SimClientMessageKind,
+            "unknown, hello, ui_canvas, ui_action">();
+
+namespace corvid { inline namespace sim {
 namespace detail {
 
-[[nodiscard]] constexpr bool decode_json_string_field(json_object_view obj,
+[[nodiscard]] constexpr bool decodeJsonStringField(json_object_view obj,
     std::string_view key, std::string& out) {
   const auto value = obj.find(key);
   return value && value.decode_string(out);
 }
 
-template<typename T>
-[[nodiscard]] constexpr std::optional<T>
-get_json_number(json_object_view obj, std::string_view key) {
-  return obj.get_number<T>(key);
-}
-
-[[nodiscard]] constexpr std::vector<UiActionField> parse_json_fields(
+[[nodiscard]] constexpr std::vector<UiActionField> parseActionFields(
     json_object_view obj) {
   std::vector<UiActionField> fields;
   const auto fields_obj = obj.get_object("fields");
@@ -68,7 +73,7 @@ get_json_number(json_object_view obj, std::string_view key) {
 } // namespace detail
 
 [[nodiscard]] constexpr std::optional<json_object_view>
-parse_sim_client_message_root(std::string_view msg) {
+parseSimClientMessageRoot(std::string_view msg) {
   json_value_view root;
   if (!parse_json(msg, root)) return std::nullopt;
   const auto obj = root.as_object();
@@ -76,38 +81,31 @@ parse_sim_client_message_root(std::string_view msg) {
   return obj;
 }
 
-[[nodiscard]] constexpr SimClientMessageKind classify_sim_client_message(
+[[nodiscard]] constexpr SimClientMessageKind classifySimClientMessage(
     json_object_view msg) {
-  if (!msg) return SimClientMessageKind::unknown;
-
+  SimClientMessageKind kind{};
   std::string type;
-  if (!detail::decode_json_string_field(msg, "type", type))
-    return SimClientMessageKind::unknown;
-
-  if (type == "hello") return SimClientMessageKind::hello;
-  if (type == "ui_canvas") return SimClientMessageKind::ui_canvas;
-  if (type == "ui_action") return SimClientMessageKind::ui_action;
-  return SimClientMessageKind::unknown;
+  if (!msg || !detail::decodeJsonStringField(msg, "type", type)) return kind;
+  (void)strings::convert_text_enum(kind, type);
+  return kind;
 }
 
-[[nodiscard]] constexpr SimClientMessageKind classify_sim_client_message(
+[[nodiscard]] constexpr SimClientMessageKind classifySimClientMessage(
     std::string_view msg) {
-  const auto root = parse_sim_client_message_root(msg);
-  return root ? classify_sim_client_message(*root)
-              : SimClientMessageKind::unknown;
+  return classifySimClientMessage(parseSimClientMessageRoot(msg).value_or({}));
 }
 
-[[nodiscard]] constexpr std::optional<UiCanvasInput> parse_ui_canvas_message(
+[[nodiscard]] constexpr std::optional<UiCanvasInput> parseUiCanvasMessage(
     json_object_view msg) {
   if (!msg) return std::nullopt;
 
   UiCanvasInput input;
-  const auto seq = detail::get_json_number<uint64_t>(msg, "seq");
-  const auto buttons = detail::get_json_number<uint32_t>(msg, "buttons");
-  const auto x = detail::get_json_number<float>(msg, "x");
-  const auto y = detail::get_json_number<float>(msg, "y");
-  const auto canvas_x = detail::get_json_number<float>(msg, "canvasX");
-  const auto canvas_y = detail::get_json_number<float>(msg, "canvasY");
+  const auto seq = msg.get_number<uint64_t>("seq");
+  const auto buttons = msg.get_number<uint32_t>("buttons");
+  const auto x = msg.get_number<float>("x");
+  const auto y = msg.get_number<float>("y");
+  const auto canvas_x = msg.get_number<float>("canvasX");
+  const auto canvas_y = msg.get_number<float>("canvasY");
   const auto shift = msg.get_bool("shift");
   const auto ctrl = msg.get_bool("ctrl");
   const auto alt = msg.get_bool("alt");
@@ -117,8 +115,8 @@ parse_sim_client_message_root(std::string_view msg) {
   std::string button;
   if (!seq || !buttons || !x || !y || !canvas_x || !canvas_y || !shift ||
       !ctrl || !alt || !meta ||
-      !detail::decode_json_string_field(msg, "event", event) ||
-      !detail::decode_json_string_field(msg, "button", button))
+      !detail::decodeJsonStringField(msg, "event", event) ||
+      !detail::decodeJsonStringField(msg, "button", button))
     return std::nullopt;
 
   input.seq = *seq;
@@ -163,8 +161,8 @@ parse_sim_client_message_root(std::string_view msg) {
 
 [[nodiscard]] constexpr std::optional<UiCanvasInput> parse_ui_canvas_message(
     std::string_view msg) {
-  const auto root = parse_sim_client_message_root(msg);
-  return root ? parse_ui_canvas_message(*root) : std::nullopt;
+  const auto root = parseSimClientMessageRoot(msg);
+  return root ? parseUiCanvasMessage(*root) : std::nullopt;
 }
 
 [[nodiscard]] constexpr std::optional<UiActionInput> parse_ui_action_message(
@@ -172,18 +170,18 @@ parse_sim_client_message_root(std::string_view msg) {
   if (!msg) return std::nullopt;
 
   UiActionInput input;
-  const auto seq = detail::get_json_number<uint64_t>(msg, "seq");
-  if (!seq || !detail::decode_json_string_field(msg, "action", input.action))
+  const auto seq = msg.get_number<uint64_t>("seq");
+  if (!seq || !detail::decodeJsonStringField(msg, "action", input.action))
     return std::nullopt;
 
   input.seq = *seq;
-  input.fields = detail::parse_json_fields(msg);
+  input.fields = detail::parseActionFields(msg);
   return input;
 }
 
 [[nodiscard]] constexpr std::optional<UiActionInput> parse_ui_action_message(
     std::string_view msg) {
-  const auto root = parse_sim_client_message_root(msg);
+  const auto root = parseSimClientMessageRoot(msg);
   return root ? parse_ui_action_message(*root) : std::nullopt;
 }
 }} // namespace corvid::sim

--- a/corvid/sim/sim_json_parse.h
+++ b/corvid/sim/sim_json_parse.h
@@ -97,7 +97,8 @@ parseSimClientMessageRoot(std::string_view msg) {
 
 [[nodiscard]] constexpr SimClientMessageKind classifySimClientMessage(
     std::string_view msg) {
-  return classifySimClientMessage(parseSimClientMessageRoot(msg).value_or({}));
+  return classifySimClientMessage(
+      parseSimClientMessageRoot(msg).value_or(json_object_view{}));
 }
 
 [[nodiscard]] constexpr std::optional<UiCanvasInput> parseUiCanvasMessage(

--- a/corvid/sim/sim_json_parse.h
+++ b/corvid/sim/sim_json_parse.h
@@ -46,10 +46,17 @@ constexpr auto
 namespace corvid { inline namespace sim {
 namespace detail {
 
-[[nodiscard]] constexpr bool decodeJsonStringField(json_object_view obj,
-    std::string_view key, std::string& out) {
+[[nodiscard]] constexpr bool
+decodeString(json_object_view obj, std::string_view key, std::string& out) {
   const auto value = obj.find(key);
   return value && value.decode_string(out);
+}
+
+[[nodiscard]] constexpr std::string
+decodeString(json_object_view obj, std::string_view key) {
+  std::string str;
+  (void)decodeString(obj, key, str);
+  return str;
 }
 
 [[nodiscard]] constexpr std::vector<UiActionField> parseActionFields(
@@ -84,9 +91,7 @@ parseSimClientMessageRoot(std::string_view msg) {
 [[nodiscard]] constexpr SimClientMessageKind classifySimClientMessage(
     json_object_view msg) {
   SimClientMessageKind kind{};
-  std::string type;
-  if (!msg || !detail::decodeJsonStringField(msg, "type", type)) return kind;
-  (void)strings::convert_text_enum(kind, type);
+  (void)strings::convert_text_enum(kind, detail::decodeString(msg, "type"));
   return kind;
 }
 
@@ -100,78 +105,41 @@ parseSimClientMessageRoot(std::string_view msg) {
   if (!msg) return std::nullopt;
 
   UiCanvasInput input;
-  const auto seq = msg.get_number<uint64_t>("seq");
-  const auto buttons = msg.get_number<uint32_t>("buttons");
-  const auto x = msg.get_number<float>("x");
-  const auto y = msg.get_number<float>("y");
-  const auto canvas_x = msg.get_number<float>("canvasX");
-  const auto canvas_y = msg.get_number<float>("canvasY");
-  const auto shift = msg.get_bool("shift");
-  const auto ctrl = msg.get_bool("ctrl");
-  const auto alt = msg.get_bool("alt");
-  const auto meta = msg.get_bool("meta");
-
-  std::string event;
-  std::string button;
-  if (!seq || !buttons || !x || !y || !canvas_x || !canvas_y || !shift ||
-      !ctrl || !alt || !meta ||
-      !detail::decodeJsonStringField(msg, "event", event) ||
-      !detail::decodeJsonStringField(msg, "button", button))
+  if (!msg.parse_number<uint64_t>("seq", input.seq) ||
+      !msg.parse_number<uint32_t>("buttons", input.buttons) ||
+      !msg.parse_number<float>("x", input.x) ||
+      !msg.parse_number<float>("y", input.y) ||
+      !msg.parse_number<float>("canvasX", input.canvasX) ||
+      !msg.parse_number<float>("canvasY", input.canvasY) ||
+      !msg.parse_bool("shift", input.shift) ||
+      !msg.parse_bool("ctrl", input.ctrl) ||
+      !msg.parse_bool("alt", input.alt) || !msg.parse_bool("meta", input.meta))
     return std::nullopt;
 
-  input.seq = *seq;
-  input.buttons = *buttons;
-  input.x = *x;
-  input.y = *y;
-  input.canvasX = *canvas_x;
-  input.canvasY = *canvas_y;
-  input.shift = *shift;
-  input.ctrl = *ctrl;
-  input.alt = *alt;
-  input.meta = *meta;
-
-  if (event == "click")
-    input.event = UiCanvasEvent::click;
-  else if (event == "dblclick")
-    input.event = UiCanvasEvent::dblclick;
-  else if (event == "contextmenu")
-    input.event = UiCanvasEvent::contextmenu;
-  else if (event == "dragstart")
-    input.event = UiCanvasEvent::dragstart;
-  else if (event == "dragmove")
-    input.event = UiCanvasEvent::dragmove;
-  else if (event == "dragend")
-    input.event = UiCanvasEvent::dragend;
-  else
+  if (!strings::convert_text_enum(input.event,
+          detail::decodeString(msg, "event")))
     return std::nullopt;
 
-  if (button == "left")
-    input.button = UiMouseButton::left;
-  else if (button == "middle")
-    input.button = UiMouseButton::middle;
-  else if (button == "right")
-    input.button = UiMouseButton::right;
-  else if (button == "other")
-    input.button = UiMouseButton::other;
-  else
+  if (!strings::convert_text_enum(input.button,
+          detail::decodeString(msg, "button")))
     return std::nullopt;
 
   return input;
 }
 
-[[nodiscard]] constexpr std::optional<UiCanvasInput> parse_ui_canvas_message(
+[[nodiscard]] constexpr std::optional<UiCanvasInput> parseUiCanvasMessage(
     std::string_view msg) {
   const auto root = parseSimClientMessageRoot(msg);
   return root ? parseUiCanvasMessage(*root) : std::nullopt;
 }
 
-[[nodiscard]] constexpr std::optional<UiActionInput> parse_ui_action_message(
+[[nodiscard]] constexpr std::optional<UiActionInput> parseUiActionMessage(
     json_object_view msg) {
   if (!msg) return std::nullopt;
 
   UiActionInput input;
   const auto seq = msg.get_number<uint64_t>("seq");
-  if (!seq || !detail::decodeJsonStringField(msg, "action", input.action))
+  if (!seq || !detail::decodeString(msg, "action", input.action))
     return std::nullopt;
 
   input.seq = *seq;
@@ -179,9 +147,9 @@ parseSimClientMessageRoot(std::string_view msg) {
   return input;
 }
 
-[[nodiscard]] constexpr std::optional<UiActionInput> parse_ui_action_message(
+[[nodiscard]] constexpr std::optional<UiActionInput> parseUiActionMessage(
     std::string_view msg) {
   const auto root = parseSimClientMessageRoot(msg);
-  return root ? parse_ui_action_message(*root) : std::nullopt;
+  return root ? parseUiActionMessage(*root) : std::nullopt;
 }
 }} // namespace corvid::sim

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -42,9 +42,29 @@ flash_expiry_delay_ms(const VisualEffects& effects, WorldTick current_tick) {
       static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())));
 }
 
+// Reusable state, to avoid repeated allocations.
 struct sim_game_state_json {
   std::string body;
   std::vector<SimWorld::EntityId> erased_ids;
+
+  // Clear the body and erased IDs, updating highwater marks for future
+  // reserve.
+  [[nodiscard]] bool clear() {
+    body_highwater = std::max(body.size(), body_highwater);
+    erased_ids_highwater = std::max(erased_ids.size(), erased_ids_highwater);
+    body.clear();
+    erased_ids.clear();
+    return true;
+  }
+
+  [[nodiscard]] bool reset() {
+    (void)clear();
+    body.reserve(body_highwater);
+    erased_ids.reserve(erased_ids_highwater);
+    return true;
+  }
+
+private:
   size_t body_highwater{16ULL * 1024};
   size_t erased_ids_highwater{64};
 };
@@ -59,18 +79,14 @@ struct sim_game_state_json {
   return body;
 }
 
-[[nodiscard]] inline bool build_sim_game_state_json(
-    sim_game_state_json& result, SimGame& game, WorldTick current_tick,
+[[nodiscard]] inline bool
+build_sim_game_state_json(sim_game_state_json& result, SimGame& game,
     update_strategy send_strategy = update_strategy::incremental) {
-  result.body.clear();
-  result.body.reserve(result.body_highwater);
-
+  (void)result.reset();
+  const auto current_tick = game.currentTick();
   json_writer writer{result.body};
   if (send_strategy == update_strategy::full)
     (void)game.markAllDirty(update_strategy::full);
-
-  result.erased_ids.clear();
-  result.erased_ids.reserve(result.erased_ids_highwater);
 
   size_t current_wave{};
   WaveTick wave_tick{};
@@ -138,9 +154,6 @@ struct sim_game_state_json {
           });
     }
 
-    result.erased_ids_highwater =
-        std::max(result.erased_ids.size(), result.erased_ids_highwater);
-
     if (auto erased = target.member_array(json_trusted{"erased"})) {
       for (const auto entity_id : result.erased_ids) erased->value(*entity_id);
     }
@@ -167,7 +180,6 @@ struct sim_game_state_json {
   } else
     write_delta(*writer.object());
 
-  result.body_highwater = std::max(result.body.size(), result.body_highwater);
   return true;
 }
 

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -1,0 +1,151 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "../proto/json_parser.h"
+#include "sim_game.h"
+
+namespace corvid { inline namespace sim {
+
+struct sim_game_state_json {
+  std::string body;
+  std::vector<SimWorld::EntityId> erased_ids;
+  size_t body_highwater{16ULL * 1024};
+  size_t erased_ids_highwater{64};
+};
+
+[[nodiscard]] inline std::string build_sim_hello_ack_json(
+    std::string_view message = "connected") {
+  std::string body;
+  json_writer{body}
+      .object()
+      ->member(json_trusted{"type"}, json_trusted{"hello_ack"})
+      .member(json_trusted{"message"}, message);
+  return body;
+}
+
+[[nodiscard]] inline bool build_sim_game_state_json(
+    sim_game_state_json& result, SimGame& game, WorldTick current_tick,
+    update_strategy send_strategy = update_strategy::incremental) {
+  result.body.clear();
+  result.body.reserve(result.body_highwater);
+
+  json_writer writer{result.body};
+  if (send_strategy == update_strategy::full)
+    (void)game.markAllDirty(update_strategy::full);
+
+  result.erased_ids.clear();
+  result.erased_ids.reserve(result.erased_ids_highwater);
+
+  size_t current_wave{};
+  WaveTick wave_tick{};
+  int lives_count{};
+  int resources_count{};
+  std::string_view phase{};
+
+  auto write_delta =
+      [&writer, &game, &result, current_tick, &current_wave, &wave_tick,
+          &lives_count, &resources_count,
+          &phase](json_writer<std::string>& target) {
+        target.member(json_trusted{"type"}, json_trusted{"world_delta"})
+            .member(json_trusted{"tick"}, *current_tick);
+
+        if (auto upserts = target.member_array(json_trusted{"upserts"})) {
+          (void)game.extractDelta(
+              [&writer, current_tick](SimWorld::EntityId entity_id,
+                  const Position& pos, const Appearance& app) {
+                auto entity = writer.object();
+
+                if (auto position =
+                        entity->member_object(json_trusted{"pos"})) {
+                  position->member(json_trusted{"id"}, *entity_id)
+                      .member(json_trusted{"x"}, pos.x,
+                          std::chars_format::fixed, 1)
+                      .member(json_trusted{"y"}, pos.y,
+                          std::chars_format::fixed, 1);
+                }
+
+                if (app.modified + 1 == current_tick) {
+                  const auto glow_color =
+                      app.effect_expiry < current_tick ? 0U : app.glow_color;
+                  entity->member_object(json_trusted{"app"})
+                      ->member(json_trusted{"glyph"},
+                          static_cast<uint32_t>(app.glyph))
+                      .member(json_trusted{"scale"}, app.scale,
+                          std::chars_format::fixed, 3)
+                      .member(json_trusted{"fg"}, app.fg_color)
+                      .member(json_trusted{"bg"}, app.bg_color)
+                      .member(json_trusted{"glow"}, glow_color);
+                }
+
+                return true;
+              },
+              [&result](SimWorld::EntityId entity_id) {
+                result.erased_ids.push_back(entity_id);
+                return true;
+              },
+              [&current_wave, &wave_tick, &lives_count, &resources_count,
+                  &phase](auto new_current_wave, auto new_wave_tick,
+                  auto new_lives, auto new_resources, auto new_phase) {
+                current_wave = new_current_wave;
+                wave_tick = new_wave_tick;
+                lives_count = new_lives;
+                resources_count = new_resources;
+                phase = new_phase;
+                return true;
+              });
+        }
+
+        result.erased_ids_highwater =
+            std::max(result.erased_ids.size(), result.erased_ids_highwater);
+
+        if (auto erased = target.member_array(json_trusted{"erased"})) {
+          for (const auto entity_id : result.erased_ids)
+            erased->value(*entity_id);
+        }
+
+        target.member(json_trusted{"currentWave"}, current_wave)
+            .member(json_trusted{"waveTick"}, *wave_tick)
+            .member(json_trusted{"lives"}, lives_count)
+            .member(json_trusted{"resources"}, resources_count)
+            .member(json_trusted{"phase"}, json_trusted{phase});
+      };
+
+  if (send_strategy == update_strategy::full) {
+    auto snapshot = writer.object();
+    snapshot->member(json_trusted{"type"}, json_trusted{"world_snapshot"});
+    if (auto paths = snapshot->member_array(json_trusted{"paths"})) {
+      (void)game.extractPaths([&writer](auto, const Position& pos) {
+        auto path = writer.object();
+        path->member(json_trusted{"x"}, pos.x, std::chars_format::fixed, 1)
+            .member(json_trusted{"y"}, pos.y, std::chars_format::fixed, 1);
+        return true;
+      });
+    }
+    write_delta(*snapshot->member_object(json_trusted{"delta"}));
+  } else
+    write_delta(*writer.object());
+
+  result.body_highwater = std::max(result.body.size(), result.body_highwater);
+  return true;
+}
+
+}} // namespace corvid::sim

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -103,7 +103,7 @@ struct sim_game_state_json {
               entity->member_object(json_trusted{"app"})
                   ->member(json_trusted{"glyph"},
                       static_cast<uint32_t>(app.glyph))
-                  .member(json_trusted{"scale"}, app.scale,
+                  .member(json_trusted{"radius"}, app.radius,
                       std::chars_format::fixed, 3)
                   .member(json_trusted{"fg"}, app.fg_color)
                   .member(json_trusted{"bg"}, app.bg_color);

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -61,73 +61,77 @@ struct sim_game_state_json {
   int resources_count{};
   std::string_view phase{};
 
-  auto write_delta =
-      [&writer, &game, &result, current_tick, &current_wave, &wave_tick,
-          &lives_count, &resources_count,
-          &phase](json_writer<std::string>& target) {
-        target.member(json_trusted{"type"}, json_trusted{"world_delta"})
-            .member(json_trusted{"tick"}, *current_tick);
+  auto write_delta = [&writer, &game, &result, current_tick, &current_wave,
+                         &wave_tick, &lives_count, &resources_count,
+                         &phase](json_writer<std::string>& target) {
+    target.member(json_trusted{"type"}, json_trusted{"world_delta"})
+        .member(json_trusted{"tick"}, *current_tick);
 
-        if (auto upserts = target.member_array(json_trusted{"upserts"})) {
-          (void)game.extractDelta(
-              [&writer, current_tick](SimWorld::EntityId entity_id,
-                  const Position& pos, const Appearance& app) {
-                auto entity = writer.object();
+    if (auto upserts = target.member_array(json_trusted{"upserts"})) {
+      (void)game.extractDelta(
+          [&writer, current_tick](SimWorld::EntityId entity_id,
+              const Position& pos, const Appearance& app,
+              const VisualEffects& effects) {
+            auto entity = writer.object();
 
-                if (auto position =
-                        entity->member_object(json_trusted{"pos"})) {
-                  position->member(json_trusted{"id"}, *entity_id)
-                      .member(json_trusted{"x"}, pos.x,
-                          std::chars_format::fixed, 1)
-                      .member(json_trusted{"y"}, pos.y,
-                          std::chars_format::fixed, 1);
-                }
+            if (auto position = entity->member_object(json_trusted{"pos"})) {
+              position->member(json_trusted{"id"}, *entity_id)
+                  .member(json_trusted{"x"}, pos.x, std::chars_format::fixed,
+                      1)
+                  .member(json_trusted{"y"}, pos.y, std::chars_format::fixed,
+                      1);
+            }
 
-                if (app.modified + 1 == current_tick) {
-                  const auto glow_color =
-                      app.effect_expiry < current_tick ? 0U : app.glow_color;
-                  entity->member_object(json_trusted{"app"})
-                      ->member(json_trusted{"glyph"},
-                          static_cast<uint32_t>(app.glyph))
-                      .member(json_trusted{"scale"}, app.scale,
-                          std::chars_format::fixed, 3)
-                      .member(json_trusted{"fg"}, app.fg_color)
-                      .member(json_trusted{"bg"}, app.bg_color)
-                      .member(json_trusted{"glow"}, glow_color);
-                }
+            if (app.modified == current_tick) {
+              entity->member_object(json_trusted{"app"})
+                  ->member(json_trusted{"glyph"},
+                      static_cast<uint32_t>(app.glyph))
+                  .member(json_trusted{"scale"}, app.scale,
+                      std::chars_format::fixed, 3)
+                  .member(json_trusted{"fg"}, app.fg_color)
+                  .member(json_trusted{"bg"}, app.bg_color);
+            }
 
-                return true;
-              },
-              [&result](SimWorld::EntityId entity_id) {
-                result.erased_ids.push_back(entity_id);
-                return true;
-              },
-              [&current_wave, &wave_tick, &lives_count, &resources_count,
-                  &phase](auto new_current_wave, auto new_wave_tick,
-                  auto new_lives, auto new_resources, auto new_phase) {
-                current_wave = new_current_wave;
-                wave_tick = new_wave_tick;
-                lives_count = new_lives;
-                resources_count = new_resources;
-                phase = new_phase;
-                return true;
-              });
-        }
+            if (effects.modified == current_tick) {
+              entity->member_object(json_trusted{"vfx"})
+                  ->member(json_trusted{"selection"}, effects.selection_color)
+                  .member(json_trusted{"rangeRadius"}, effects.range_radius,
+                      std::chars_format::fixed, 3)
+                  .member(json_trusted{"range"}, effects.range_color)
+                  .member(json_trusted{"flash"}, effects.flash_color);
+            }
 
-        result.erased_ids_highwater =
-            std::max(result.erased_ids.size(), result.erased_ids_highwater);
+            return true;
+          },
+          [&result](SimWorld::EntityId entity_id) {
+            result.erased_ids.push_back(entity_id);
+            return true;
+          },
+          [&current_wave, &wave_tick, &lives_count, &resources_count,
+              &phase](auto new_current_wave, auto new_wave_tick,
+              auto new_lives, auto new_resources, auto new_phase) {
+            current_wave = new_current_wave;
+            wave_tick = new_wave_tick;
+            lives_count = new_lives;
+            resources_count = new_resources;
+            phase = new_phase;
+            return true;
+          });
+    }
 
-        if (auto erased = target.member_array(json_trusted{"erased"})) {
-          for (const auto entity_id : result.erased_ids)
-            erased->value(*entity_id);
-        }
+    result.erased_ids_highwater =
+        std::max(result.erased_ids.size(), result.erased_ids_highwater);
 
-        target.member(json_trusted{"currentWave"}, current_wave)
-            .member(json_trusted{"waveTick"}, *wave_tick)
-            .member(json_trusted{"lives"}, lives_count)
-            .member(json_trusted{"resources"}, resources_count)
-            .member(json_trusted{"phase"}, json_trusted{phase});
-      };
+    if (auto erased = target.member_array(json_trusted{"erased"})) {
+      for (const auto entity_id : result.erased_ids) erased->value(*entity_id);
+    }
+
+    target.member(json_trusted{"currentWave"}, current_wave)
+        .member(json_trusted{"waveTick"}, *wave_tick)
+        .member(json_trusted{"lives"}, lives_count)
+        .member(json_trusted{"resources"}, resources_count)
+        .member(json_trusted{"phase"}, json_trusted{phase});
+  };
 
   if (send_strategy == update_strategy::full) {
     auto snapshot = writer.object();

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -16,6 +16,8 @@
 // limitations under the License.
 #pragma once
 
+#include <cstdint>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -24,6 +26,21 @@
 #include "sim_game.h"
 
 namespace corvid { inline namespace sim {
+
+[[nodiscard]] inline uint32_t
+flash_expiry_delay_ms(const VisualEffects& effects, WorldTick current_tick) {
+  if (effects.flash_color == 0 || effects.flash_expiry == WorldTick::invalid ||
+      effects.flash_expiry < current_tick)
+    return 0;
+
+  constexpr uint64_t ms_per_tick = 50;
+  const auto ticks_until_expiry =
+      static_cast<uint64_t>(*effects.flash_expiry) -
+      static_cast<uint64_t>(*current_tick);
+  const auto expiry_delay_ms = ticks_until_expiry * ms_per_tick;
+  return static_cast<uint32_t>(std::min(expiry_delay_ms,
+      static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())));
+}
 
 struct sim_game_state_json {
   std::string body;
@@ -98,7 +115,9 @@ struct sim_game_state_json {
                   .member(json_trusted{"rangeRadius"}, effects.range_radius,
                       std::chars_format::fixed, 3)
                   .member(json_trusted{"range"}, effects.range_color)
-                  .member(json_trusted{"flash"}, effects.flash_color);
+                  .member(json_trusted{"flash"}, effects.flash_color)
+                  .member(json_trusted{"flashExpiryMs"},
+                      flash_expiry_delay_ms(effects, current_tick));
             }
 
             return true;

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -50,8 +50,8 @@ enum class PathId : uint16_t {
 };
 
 // Tick for world state.
-enum class WorldTick : uint64_t {
-  invalid = std::numeric_limits<uint64_t>::max()
+enum class WorldTick : uint32_t {
+  invalid = std::numeric_limits<uint32_t>::max()
 };
 
 }} // namespace corvid::sim
@@ -245,6 +245,7 @@ struct Appearance {
   uint32_t bg_color{};   // RGB color, if any.
   uint32_t glow_color{}; // RGB color for glow effect, if any.
   WorldTick effect_expiry{WorldTick::invalid}; // When glow effect expires.
+  WorldTick modified{}; // Tick when this entity was last modified
 };
 
 // Defensive tower component. Stored alongside `Position` in the tower
@@ -378,11 +379,23 @@ public:
   [[nodiscard]] Handle
   spawnEnemy(PathId pathId, float speed, float progress = 0.F) {
     if (pathId >= paths_.size_as_enum()) return {};
-    Appearance app{U'U', 2.F, 0xFFFFFFFF, 0xFF, 0, WorldTick::invalid};
+    Appearance app{U'U', 2.F, 0xFFFFFFFF, 0xFF, 0, WorldTick::invalid, tick_};
     const auto pos =
         paths_[pathId].calculatePositionFromProgress(progress, progress);
     return scene_.store_new_entity<sidEnemy>(tick_, pos, app,
         PathFollower{pathId, progress, speed}, Invader{});
+  }
+
+  // Update entity appearance.
+  [[nodiscard]] bool updateAppearance(EntityId id, const Appearance& newApp) {
+    auto& reg = scene_.registry();
+    if (!reg.is_valid(id)) return false;
+    auto* app = scene_.try_get_component<Appearance>(id);
+    if (!app) return false;
+    *app = newApp;
+    app->modified = tick_;
+    (void)markDirty(id);
+    return true;
   }
 
   // Advance one simulation frame. Sets each changed entity's registry metadata

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -439,46 +439,50 @@ public:
     return h;
   }
 
-  // Update entity appearance for the next streamed tick.
-  [[nodiscard]] bool updateAppearance(EntityId id, const Appearance& newApp) {
-    auto& reg = scene_.registry();
-    if (!reg.is_valid(id)) return false;
+  // Obtain a pointer to the `Appearance` for the entity. It is already marked
+  // dirty and `modified`, so the caller only needs to change the other fields.
+  [[nodiscard]] Appearance* changeAppearance(EntityId id) {
     auto* app = scene_.try_get_component<Appearance>(id);
-    if (!app) return false;
-    *app = newApp;
+    if (!app) return nullptr;
     app->modified = nextSyncTick();
     (void)markDirty(id);
-    return true;
+    return app;
   }
 
-  // Update entity visual effects for the next streamed tick.
-  [[nodiscard]] bool
-  updateVisualEffects(EntityId id, const VisualEffects& newEffects) {
-    auto& reg = scene_.registry();
-    if (!reg.is_valid(id)) return false;
+  // Obtain a pointer to the `VisualEffects` for the entity. It is already
+  // marked dirty and `modified`, so the caller only needs to change the other
+  // fields.
+  [[nodiscard]] VisualEffects* changeVisualEffects(EntityId id) {
     auto* effects = scene_.try_get_component<VisualEffects>(id);
-    if (!effects) return false;
-    *effects = newEffects;
+    if (!effects) return nullptr;
     effects->modified = nextSyncTick();
     (void)markDirty(id);
-    return true;
+    return effects;
   }
 
   // Trigger or replace a flashing overlay for an entity that carries visual
   // effects. The flash remains active until a later update or expiry clears
   // it.
-  [[nodiscard]] bool
-  flashEntity(EntityId id, uint32_t color, WorldTick duration) {
-    auto& reg = scene_.registry();
-    if (!reg.is_valid(id)) return false;
-    auto* effects = scene_.try_get_component<VisualEffects>(id);
+  [[nodiscard]] bool flashEntity(EntityId id, uint32_t color,
+      WorldTick duration = WorldTick{20}) {
+    auto* effects = changeVisualEffects(id);
     if (!effects) return false;
-
     effects->flash_color = color;
     effects->flash_expiry = WorldTick{*tick_ + *duration};
-    effects->modified = nextSyncTick();
-    (void)markDirty(id);
     return true;
+  }
+
+  // Return a generation-versioned handle for `id`, suitable for storage across
+  // ticks, or whenever there is a risk of the underlying entity going away.
+  // Use `getId` to get the ID back, just in time.
+  [[nodiscard]] Handle getHandle(EntityId id) const {
+    return scene_.registry().get_handle(id);
+  }
+
+  // Return the entity ID for `handle`, or `EntityId::invalid` if the handle is
+  // invalid.
+  [[nodiscard]] EntityId getId(Handle h) const {
+    return scene_.registry().id_from_handle(h);
   }
 
   [[nodiscard]] EntityId findEntityAt(const Position& pos) const {
@@ -486,13 +490,30 @@ public:
     scene_.for_each<Position, Appearance>([&](auto id, auto comps) {
       const auto& [epos, app] = comps;
       const auto radius = app.radius;
-      if (std::abs(epos.x - pos.x) < radius &&
-          std::abs(epos.y - pos.y) < radius)
-      {
-        found_id = id;
-        return false;
-      }
-      return true;
+      // If point outside of bounding box, keep searching.
+      if (std::abs(epos.x - pos.x) >= radius ||
+          std::abs(epos.y - pos.y) >= radius)
+        return true;
+
+      found_id = id;
+      return false;
+    });
+
+    return found_id;
+  }
+
+  [[nodiscard]] EntityId findTowerAt(const Position& pos) const {
+    EntityId found_id = EntityId::invalid;
+    scene_.for_each<Position, Appearance, Tower>([&](auto id, auto comps) {
+      const auto& [epos, app, _] = comps;
+      const auto radius = app.radius;
+      // If point outside of bounding box, keep searching.
+      if (std::abs(epos.x - pos.x) >= radius ||
+          std::abs(epos.y - pos.y) >= radius)
+        return true;
+
+      found_id = id;
+      return false;
     });
 
     return found_id;

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -46,7 +46,7 @@ namespace corvid { inline namespace sim {
 // Convert Cartesian coordinates (x, y) to a Euclidean vector, in polar form
 // (length, direction). `direction` is in radians,
 [[nodiscard]] constexpr std::pair<float, float>
-cartesian_to_polar(float x, float y) noexcept {
+convertCartesianToPolar(float x, float y) noexcept {
   float length = std::sqrt((x * x) + (y * y));
   float direction = std::atan2(y, x);
   return {length, direction};
@@ -55,7 +55,7 @@ cartesian_to_polar(float x, float y) noexcept {
 // Convert a Euclidean vector, in polar form, to Cartesian coordinates.
 // `direction` is in radians.
 [[nodiscard]] constexpr std::pair<float, float>
-polar_to_cartesian(float length, float direction) noexcept {
+convertPolarToCartesian(float length, float direction) noexcept {
   float x = length * std::cos(direction);
   float y = length * std::sin(direction);
   return {x, y};
@@ -71,8 +71,8 @@ struct Position {
   float x{};
   float y{};
 
-  static Position from_polar(float radius, float angle) {
-    auto [x, y] = polar_to_cartesian(radius, angle);
+  static Position fromPolar(float radius, float angle) {
+    auto [x, y] = convertPolarToCartesian(radius, angle);
     return {x, y};
   }
 };
@@ -82,8 +82,8 @@ struct Velocity {
   float vx{};
   float vy{};
 
-  [[nodiscard]] static Velocity from_polar(float speed, float angle) {
-    auto [vx, vy] = polar_to_cartesian(speed, angle);
+  [[nodiscard]] static Velocity fromPolar(float speed, float angle) {
+    auto [vx, vy] = convertPolarToCartesian(speed, angle);
     return {vx, vy};
   }
 };
@@ -110,31 +110,31 @@ struct SegmentedPath {
   struct Segment {
     Position front;
     Position back;
-    float length;           // Euclidean distance from `front` to `back`.
-    float cumulative_start; // Sum of lengths of all preceding segments.
+    float length;          // Euclidean distance from `front` to `back`.
+    float cumulativeStart; // Sum of lengths of all preceding segments.
   };
 
   std::vector<Segment> segments;
-  float total_length{};
+  float totalLength{};
   float width{};
 
   // Map a distance traveled (`progress`) to a world-space `Position`.
-  // `progress` is clamped to `[0, total_length]`. Returns the origin if
+  // `progress` is clamped to `[0, totalLength]`. Returns the origin if
   // `segments` is empty.
-  [[nodiscard]] Position position_from_progress(float progress) const {
+  [[nodiscard]] Position calculatePositionFromProgress(float progress) const {
     if (segments.empty()) return {};
-    progress = std::clamp(progress, 0.F, total_length);
+    progress = std::clamp(progress, 0.F, totalLength);
 
-    // Find the last segment whose cumulative_start <= progress.
+    // Find the last segment whose cumulativeStart <= progress.
     auto it = std::ranges::upper_bound(segments, progress, {},
-        &SegmentedPath::Segment::cumulative_start);
+        &SegmentedPath::Segment::cumulativeStart);
     if (it != segments.begin()) --it;
     const auto& seg = *it;
 
     // Calculate the interpolation factor `t` along this segment, then lerp the
     // front and back positions to get the world position.
     float t = 0.F;
-    if (seg.length > 0.F) t = (progress - seg.cumulative_start) / seg.length;
+    if (seg.length > 0.F) t = (progress - seg.cumulativeStart) / seg.length;
 
     return {lerp(seg.front.x, seg.back.x, t),
         lerp(seg.front.y, seg.back.y, t)};
@@ -143,7 +143,7 @@ struct SegmentedPath {
   // Convert authored `PathJoints` into a `SegmentedPath`. Requires at
   // least two joints; returns an empty `SegmentedPath` if the input is
   // degenerate.
-  static SegmentedPath from_joints(const PathJoints& p) {
+  static SegmentedPath fromJoints(const PathJoints& p) {
     if (p.joints.size() < 2) return {};
     SegmentedPath sp;
     sp.width = p.width;
@@ -159,11 +159,11 @@ struct SegmentedPath {
       sp.segments.push_back({front, back, len, cumulative});
       cumulative += len;
     }
-    sp.total_length = cumulative;
+    sp.totalLength = cumulative;
     return sp;
   }
 
-  [[nodiscard]] PathJoints to_joints() const {
+  [[nodiscard]] PathJoints toJoints() const {
     PathJoints pj;
     pj.width = width;
     pj.joints.reserve(segments.size() + 1);
@@ -177,7 +177,7 @@ struct SegmentedPath {
 // archetype. Each tick, `progress` advances by `speed`; the entity's
 // `Position` is re-derived from the segmented path geometry.
 struct PathFollower {
-  PathId path_id{}; // Index into `sim_world::paths_`.
+  PathId pathId{};  // Index into `sim_world::paths_`.
   float progress{}; // Distance traveled along the path so far.
   float speed{};    // Distance per tick.
 };
@@ -188,14 +188,16 @@ struct PathFollower {
 // enabling delta snapshots without a separate dirty set.
 //
 // Storage layout (store_id assignment is positional, 1-based):
-//   `p_sid`      = 1  -> `arch_p_t`      : background / destructible / retired
-//                                          (Position)
-
-//   `pv_sid`     = 2  -> `arch_pv_t`     : moving entities
-//                                          (Position + Velocity)
-
-//   `enemy_sid`  = 3  -> `arch_enemy_t`  : path-following enemies
-//                                          (Position + PathFollower)
+//   `sidStaging`  = 0                     : staging storage, used as tombstone
+//
+//   `sidPos`      = 1  -> `arch_p_t`      : background / destructible entities
+//                                           (Position)
+//
+//   `sidPosVel`     = 2  -> `arch_pv_t`   : moving entities
+//                                           (Position + Velocity)
+//
+//   `sidEnemy`   = 3  -> `arch_enemy_t`   : path-following enemies
+//                                           (Position + PathFollower)
 //
 // Background storage comes first so that retiring a mobile entity is a
 // natural `archetype_scene::migrate_entity` call rather than erase+re-add.
@@ -210,26 +212,27 @@ using WorldScene = archetype_scene<WorldReg, ArchP, ArchPV, ArchEnemy>;
 
 // Simulation world: encapsulates all ECS entity state for the game.
 //
-// Background entities (Position only) live in `p_sid`. Moving entities
-// (Position + Velocity) live in `pv_sid`. Each `tick()` advances positions by
-// velocity and bounces off the world boundary. The registry metadata records
-// the tick count at each entity's last state change so callers can request
-// delta snapshots starting from any past tick.
+// Background entities (Position only) live in `sidPos`. Moving entities
+// (Position + Velocity) live in `sidPosVel`. Each `tick()` advances positions
+// by velocity and bounces off the world boundary. The registry metadata
+// records the tick count at each entity's last state change so callers can
+// request delta snapshots starting from any past tick.
 class SimWorld {
 public:
   using EntityId = WorldReg::id_t;
   using Handle = WorldReg::handle_t;
 
-  static constexpr WorldSid staging_sid{0};
-  static constexpr WorldSid p_sid{1};
-  static constexpr WorldSid pv_sid{2};
-  static constexpr WorldSid enemy_sid{3};
+  static constexpr WorldSid sidStaging{0};
+  static constexpr WorldSid sidPos{1};
+  static constexpr WorldSid sidPosVel{2};
+  static constexpr WorldSid sidEnemy{3};
 
-  static constexpr float world_width = 1920.0;
-  static constexpr float world_height = 1080.0;
+  static constexpr float widthOfWorld = 1920.F;
+  static constexpr float heightOfWorld = 1080.F;
 
   // State snapshot for a single entity. This is the serialization format for
   // the entity state sent to clients.
+  // !!!KILLME
   struct EntitySnapshot {
     EntityId id;
     Position pos;
@@ -238,84 +241,77 @@ public:
   void clear() {
     scene_.clear();
     paths_.clear();
-    tick_n_ = 0;
+    tick_ = 0;
   }
 
   // Spawn a moving entity with the given initial position and velocity.
   // Returns a handle for later `despawn()`. The entity's last-change tick
   // is set to the current tick count.
-  [[nodiscard]] Handle spawn(Position pos, Velocity vel) {
-    return scene_.store_new_entity<pv_sid>(tick_n_, pos, vel);
+  [[nodiscard]] Handle spawnMover(Position pos, Velocity vel) {
+    return scene_.store_new_entity<sidPosVel>(tick_, pos, vel);
   }
 
   // Spawn an immobile entity. Returns a handle for later `despawn()`.
-  [[nodiscard]] Handle spawn_background(Position pos) {
-    return scene_.store_new_entity<p_sid>(tick_n_, pos);
+  [[nodiscard]] Handle spawnBackground(Position pos) {
+    return scene_.store_new_entity<sidPos>(tick_, pos);
   }
 
   // Bake and store a path. Returns the index used as `path_follower::path_id`.
   // The index is stable for the lifetime of the world.
-  [[nodiscard]] PathId add_path(const PathJoints& p) {
-    if (!paths_.push_back(SegmentedPath::from_joints(p)))
+  [[nodiscard]] PathId addPath(const PathJoints& p) {
+    if (!paths_.push_back(SegmentedPath::fromJoints(p)))
       return PathId::invalid;
     return paths_.size_as_enum() - 1;
   }
 
   // Return a pointer to the baked path at `id`, or `nullptr` if out of range.
-  [[nodiscard]] const SegmentedPath* get_path(PathId path_id) const {
-    if (path_id >= paths_.size_as_enum()) return nullptr;
-    return &paths_[path_id];
+  [[nodiscard]] const SegmentedPath* getPath(PathId pathId) const {
+    if (pathId >= paths_.size_as_enum()) return nullptr;
+    return &paths_[pathId];
   }
 
   // Return snapshots for all authored paths so the client can render the
   // original joints while runtime movement follows the baked geometry.
+  //!!! KILLME
   [[nodiscard]] std::vector<PathJoints> path_snapshot() const {
     std::vector<PathJoints> result;
     result.reserve(paths_.size() + 1);
-    for (const auto& p : paths_) result.push_back(p.to_joints());
+    for (const auto& p : paths_) result.push_back(p.toJoints());
     return result;
   }
 
   // Spawn a path-following enemy. Initial position is derived from `progress`
   // on the named path. Returns a handle for later `despawn()`.
   [[nodiscard]] Handle
-  spawn_enemy(PathId path_id, float speed, float progress = 0.F) {
-    if (path_id >= paths_.size_as_enum()) return {};
-    const auto pos = paths_[path_id].position_from_progress(progress);
-    return scene_.store_new_entity<enemy_sid>(tick_n_, pos,
-        PathFollower{path_id, progress, speed});
+  spawnEnemy(PathId pathId, float speed, float progress = 0.F) {
+    if (pathId >= paths_.size_as_enum()) return {};
+    const auto pos = paths_[pathId].calculatePositionFromProgress(progress);
+    return scene_.store_new_entity<sidEnemy>(tick_, pos,
+        PathFollower{pathId, progress, speed});
   }
-
-  // Returns true if the handle refers to a live entity.
-  [[nodiscard]] bool is_alive(Handle h) const {
-    return scene_.registry().is_valid(h);
-  }
-
-  // Erase an entity by handle. Invalidates the handle. Returns false if the
-  // handle is no longer valid (entity already dead).
-  bool despawn(Handle& h) { return scene_.erase_entity(h); }
 
   // Advance one simulation frame. Sets each changed entity's registry metadata
   // to the new tick count and tracks changed entities for callbacks.
   [[nodiscard]] Tick tick() {
-    ++tick_n_;
+    ++tick_;
 
-    (void)tick_movers();
-    (void)tick_path_followers();
+    (void)updateMovers();
+    (void)updatePathFollowers();
 
-    return tick_n_;
+    return tick_;
   }
 
   // Return snapshots for every entity whose that has changed since
   // `since_tick`. Pass 0 (the default) to return all entities. Visits all
-  // storages that carry `Position` (`p_sid`, `pv_sid`, `enemy_sid`).
+  // storages that carry `Position` (`sidPos`, `sidPosVel`, `sidEnemy`).
+  //!!! KILLME
   [[nodiscard]] std::vector<EntitySnapshot> snapshot(
-      Tick since_tick = 0) const {
+      Tick tickSince = 0) const {
     std::vector<EntitySnapshot> result;
     result.reserve(scene_.size());
     scene_.for_each<Position>([&](auto id, auto comps) {
       auto& [pos] = comps;
-      if (scene_.registry()[id] >= since_tick) result.push_back({id, pos});
+      if (scene_.registry()[id] >= tickSince) result.push_back({id, pos});
       return true;
     });
     return result;
@@ -323,6 +319,7 @@ public:
 
   // Return snapshots for a specific list of entity IDs. Invalid or dead IDs
   // are silently skipped.
+  //!!! KILLME
   [[nodiscard]] std::vector<EntitySnapshot> snapshot(
       const std::vector<EntityId>& ids) const {
     std::vector<EntitySnapshot> result;
@@ -337,64 +334,93 @@ public:
   // Total number of entities in all storages (does not count staged entities).
   [[nodiscard]] std::size_t size() const { return scene_.size(); }
 
-  // List of entities that have escaped the path.
-  [[nodiscard]] auto& path_escapees() const { return path_escapees_; }
-
-  // Resolve path escapees by calling `cb` on each one, where `cb` is of the
-  // shape:
-  // `std::function<bool(EntityId, const Position&, constPathFollower&)`
+  // Destructively extract upserts and erasures.
   //
-  // Destructively iterates through the list of path escapees.  If `cb` returns
-  // true, the escapee is erased; if false, it's left alive, so the caller
-  // ought to have done something with it, such as migrating it to a different
-  // path. Note that you must not modify `path_escapees_` in the process.
-  [[nodiscard]] bool resolve_escapes(auto&& cb) {
-    for (auto id : path_escapees_) {
+  // Call back `cbUpserts(EntityId, Position)` for each changed entity that has
+  // a `Position` and has changed since the last tick, and `cbErased(EntityId)`
+  // for each entity that has been erased since the last tick. These calls will
+  // be interleaved.
+  [[nodiscard]] bool
+  extractUpdatedEntities(auto&& cbUpserts, auto&& cbErased) {
+    for (auto id : updatedEntities_)
+      if (const auto* pos = scene_.try_get_component<Position>(id))
+        (void)cbUpserts(id, *pos);
+      else {
+        // TODO: Ensure that this entity is in staging. If so, erase it.
+        (void)cbErased(id);
+      }
+
+    updatedEntities_.clear();
+    return true;
+  }
+
+  // Call back `extractPath(pathId, Position)` for all joints of the path
+  // identified by `pathId`.
+  [[nodiscard]] bool obtainPath(auto&& cbPath, PathId pathId) const {
+    if (pathId >= paths_.size_as_enum()) return false;
+    const auto& sp = paths_[pathId];
+    for (const auto& seg : sp.segments) cbPath(pathId, Position{seg.front});
+    return true;
+  }
+
+  // Call back `cbPath(pathId, Position)` for all joints of all paths.
+  [[nodiscard]] bool obtainPaths(auto&& cbPath) const {
+    for (PathId pathId{0}; pathId < paths_.size_as_enum(); ++pathId)
+      if (!obtainPath(cbPath, pathId)) return false;
+    return true;
+  }
+
+  // Resolve path escapees by calling `cbEscapee(EntityId, const Position&,
+  // const PathFollower&)` for each.
+  //
+  // Destructively iterates through the list of path escapees. If `cbEscapee`
+  // returns true, the escapee is erased; if false, it's left alive, so the
+  // caller ought to have done something with it, such as migrating it to a
+  // different path.
+  [[nodiscard]] bool resolveEscapees(auto&& cbEscapee) {
+    for (auto id : pathEscapees_) {
       if (!scene_.registry().is_valid(id)) continue;
       auto [pos, pf] = scene_.try_get_components<Position, PathFollower>(id);
       if (!pos || !pf) continue;
-      if (!cb(id, *pos, *pf)) continue;
-      (void)erase_entity(id);
+      if (!cbEscapee(id, *pos, *pf)) continue;
+      (void)tombstoneEntity(id);
     }
-    path_escapees_.clear();
+    pathEscapees_.clear();
     return true;
   }
 
 private:
   WorldScene scene_;
-  Tick tick_n_{0};
+  Tick tick_{0};
   id_container<SegmentedPath, PathId> paths_;
 
-  std::vector<EntityId> updated_entities_;
-  std::vector<EntityId> path_escapees_;
+  std::vector<EntityId> updatedEntities_;
+  std::vector<EntityId> pathEscapees_;
 
   // Marks an entity as dirty so that it will be included in the next delta
   // snapshot.
-  bool mark_dirty(EntityId id) {
+  bool markDirty(EntityId id) {
     // If it's been deleted, it's already dirty.
     if (!scene_.registry().is_valid(id)) return false;
     auto& last_updated = scene_.registry()[id];
-    if (last_updated != tick_n_) {
-      last_updated = tick_n_;
-      updated_entities_.push_back(id);
+    if (last_updated != tick_) {
+      last_updated = tick_;
+      updatedEntities_.push_back(id);
       return true;
     }
     return false;
   }
 
-  // Logically erases an entity, adding it to the dirty list. Actually, it's
-  // tombstoned into staging.
-  bool erase_entity(EntityId id) {
+  // Logically erases an entity, adding it to the dirty list.
+  bool tombstoneEntity(EntityId id) {
     // Can't kill the dead.
     if (!scene_.registry().is_valid(id)) return false;
-    (void)mark_dirty(id);
-    // We don't actually erase it yet, just migrate it to staging so that we
-    // can erase it as part of the snapshot process.
-    return scene_.migrate_entity(id, staging_sid);
+    (void)markDirty(id);
+    return scene_.migrate_entity(id, sidStaging);
   }
 
   // Advance velocity-driven entities.
-  [[nodiscard]] bool tick_movers() {
+  [[nodiscard]] bool updateMovers() {
     scene_.for_each<Position, Velocity>([&](auto id, auto comps) {
       auto& [pos, vel] = comps;
       // Skip over currently immobile entities.
@@ -413,15 +439,15 @@ private:
       // a bounding box, so the balls enter the boundary before reversing. Even
       // then, a square bounding box would be hit-detected prematurely if the
       // entity is moving at a diagonal.
-      (void)mark_dirty(id);
+      (void)markDirty(id);
 
       pos.x += vel.vx;
       pos.y += vel.vy;
 
-      bounce_from_boundary(pos.x, vel.vx, world_width);
-      bounce_from_boundary(pos.y, vel.vy, world_height);
+      bounce_from_boundary(pos.x, vel.vx, widthOfWorld);
+      bounce_from_boundary(pos.y, vel.vy, heightOfWorld);
 
-      updated_entities_.push_back(id);
+      updatedEntities_.push_back(id);
       return true;
     });
 
@@ -430,23 +456,24 @@ private:
 
   // Advance path-following enemies. Collect entities that changed, as well as
   // those that escaped the path.
-  [[nodiscard]] bool tick_path_followers() {
+  [[nodiscard]] bool updatePathFollowers() {
     scene_.for_each<Position, PathFollower>([&](auto id, auto comps) {
       auto& [pos, pf] = comps;
-      assert(pf.path_id < paths_.size_as_enum());
+      assert(pf.pathId < paths_.size_as_enum());
       if (pf.speed == 0.F) return true;
 
-      (void)mark_dirty(id);
+      (void)markDirty(id);
 
       pf.progress += pf.speed;
+      const auto& sp = paths_[pf.pathId];
 
-      const auto& sp = paths_[pf.path_id];
-      if (pf.progress >= sp.total_length || pf.progress < 0.F) {
-        path_escapees_.push_back(id);
+      // Collect escapees.
+      if (pf.progress >= sp.totalLength || pf.progress < 0.F) {
+        pathEscapees_.push_back(id);
         return true;
       }
 
-      pos = sp.position_from_progress(pf.progress);
+      pos = sp.calculatePositionFromProgress(pf.progress);
       return true;
     });
 

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -357,8 +357,8 @@ public:
 
   // Spawn an immobile entity. Returns a handle for later `despawn()`.
   [[nodiscard]] Handle spawnBackground(Position pos) {
-    auto h = scene_.store_new_entity<sidPos>(
-        {WorldTick::invalid}, pos, Appearance{.modified = tick_});
+    auto h = scene_.store_new_entity<sidPos>({WorldTick::invalid}, pos,
+        Appearance{.modified = tick_});
     if (h) (void)markDirty(h.id());
     return h;
   }

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -95,7 +95,7 @@ struct baked_path {
   // Map a distance traveled (`progress`) along `bp` to a world-space
   // `Position`. `progress` is clamped to `[0, total_length]`. Returns the
   // origin if `bp` has no segments.
-  Position position_from_progress(float progress) const {
+  [[nodiscard]] Position position_from_progress(float progress) const {
     if (segments.empty()) return {};
     progress = std::clamp(progress, 0.F, total_length);
     // Find the last segment whose cumulative_start <= progress.

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -231,6 +231,12 @@ public:
     Position pos;
   };
 
+  void clear() {
+    scene_.clear();
+    paths_.clear();
+    tick_n_ = 0;
+  }
+
   // Spawn a moving entity with the given initial position and velocity.
   // Returns a handle for later `despawn()`. The entity's last-change tick
   // is set to the current tick count.

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -239,13 +239,22 @@ struct PathFollower {
 // Appearance component. Controls rendering on client side, but has no effect
 // on physics or game logic.
 struct Appearance {
-  char32_t glyph{};      // a Unicode character to display, if any.
-  float scale{1.F};      // multiplier on the base size of the shape, if any.
-  uint32_t fg_color{};   // RGB color, if any.
-  uint32_t bg_color{};   // RGB color, if any.
-  uint32_t glow_color{}; // RGB color for glow effect, if any.
-  WorldTick effect_expiry{WorldTick::invalid}; // When glow effect expires.
-  WorldTick modified{}; // Tick when this entity was last modified
+  WorldTick modified{WorldTick::invalid}; // Tick when last modified.
+  char32_t glyph{};    // a Unicode character to display, if any.
+  float scale{1.F};    // multiplier on the base size of the shape, if any.
+  uint32_t fg_color{}; // RGBA.
+  uint32_t bg_color{}; // RGBA.
+};
+
+// Visual effects component. Controls transient overlays on the client side,
+// but has no effect on physics or game logic.
+struct VisualEffects {
+  WorldTick modified{WorldTick::invalid}; // Tick when last modified.
+  uint32_t selection_color{};             // RGBA.
+  float range_radius{};
+  uint32_t range_color{}; // RGBA.
+  uint32_t flash_color{}; // RGBA.
+  WorldTick flash_expiry{WorldTick::invalid};
 };
 
 // Defensive tower component. Stored alongside `Position` in the tower
@@ -295,10 +304,12 @@ struct Bullet {
 //
 //   `sidEnemy`   = 3  -> `ArchEnemy`      : path-following enemies
 //                                           (Position + Appearance +
-//                                           PathFollower + Invader)
+//                                           VisualEffects + PathFollower +
+//                                           Invader)
 //
 //   `sidTower`   = 4  -> `ArchTower`      : placed towers
-//                                          (Position + Appearance + Tower)
+//                                          (Position + Appearance +
+//                                          VisualEffects + Tower)
 //
 //   `sidBullet`  = 5  -> `ArchBullet`     : bullets
 //                                           (Position + Velocity + Bullet)
@@ -311,9 +322,9 @@ using ArchP = archetype_storage<WorldReg, std::tuple<Position, Appearance>>;
 using ArchPV =
     archetype_storage<WorldReg, std::tuple<Position, Velocity, Appearance>>;
 using ArchEnemy = archetype_storage<WorldReg,
-    std::tuple<Position, Appearance, PathFollower, Invader>>;
-using ArchTower =
-    archetype_storage<WorldReg, std::tuple<Position, Appearance, Tower>>;
+    std::tuple<Position, Appearance, VisualEffects, PathFollower, Invader>>;
+using ArchTower = archetype_storage<WorldReg,
+    std::tuple<Position, Appearance, VisualEffects, Tower>>;
 using ArchBullet =
     archetype_storage<WorldReg, std::tuple<Position, Velocity, Bullet>>;
 using WorldScene =
@@ -342,6 +353,8 @@ public:
   void clear() {
     scene_.clear();
     paths_.clear();
+    updatedEntities_.clear();
+    pathEscapees_.clear();
     tick_ = {};
   }
 
@@ -349,7 +362,11 @@ public:
   // Returns a handle for later `despawn()`. The entity's last-change tick
   // is set to the current tick count.
   [[nodiscard]] Handle spawnMover(Position pos, Velocity vel) {
-    Appearance app{U'M', 1.F, 0xFFFFFFFF, 0xFF, 0, WorldTick::invalid, tick_};
+    Appearance app{.modified = nextSyncTick(),
+        .glyph = U'M',
+        .scale = 1.F,
+        .fg_color = 0xFFFFFFFF,
+        .bg_color = 0xFF};
     auto h = scene_.store_new_entity<sidPosVel>({WorldTick::invalid}, pos, vel,
         app);
     if (h) (void)markDirty(h.id());
@@ -358,8 +375,12 @@ public:
 
   // Spawn an immobile entity. Returns a handle for later `despawn()`.
   [[nodiscard]] Handle spawnBackground(Position pos) {
-    auto h = scene_.store_new_entity<sidPos>({WorldTick::invalid}, pos,
-        Appearance{.modified = tick_});
+    Appearance app{.modified = nextSyncTick(),
+        .glyph = U'B',
+        .scale = 1.F,
+        .fg_color = 0xFFFFFFFF,
+        .bg_color = 0xFF};
+    auto h = scene_.store_new_entity<sidPos>({WorldTick::invalid}, pos, app);
     if (h) (void)markDirty(h.id());
     return h;
   }
@@ -371,9 +392,14 @@ public:
         .attack_damage = 10.F,
         .cooldown = {},
         .next_attack = tick_};
-    Appearance app{U'T', 4.F, 0xFFFFFFFF, 0xFF, 0, WorldTick::invalid, tick_};
+    Appearance app{.modified = nextSyncTick(),
+        .glyph = U'T',
+        .scale = 4.F,
+        .fg_color = 0xFFFFFFFF,
+        .bg_color = 0xFF};
+    VisualEffects fx;
     auto h = scene_.store_new_entity<sidTower>({WorldTick::invalid}, pos, app,
-        tower);
+        fx, tower);
     if (h) (void)markDirty(h.id());
     return h;
   }
@@ -397,21 +423,60 @@ public:
   [[nodiscard]] Handle
   spawnEnemy(PathId pathId, float speed, float progress = 0.F) {
     if (pathId >= paths_.size_as_enum()) return {};
-    Appearance app{U'U', 2.F, 0xFFFFFFFF, 0xFF, 0, WorldTick::invalid, tick_};
+    // Enemies are only spawned during the active world step, so their
+    // appearance must replicate on the current tick rather than the next one.
+    Appearance app{.modified = tick_,
+        .glyph = U'U',
+        .scale = 2.F,
+        .fg_color = 0xFFFFFFFF,
+        .bg_color = 0xFF};
+    VisualEffects fx{};
     const auto pos =
         paths_[pathId].calculatePositionFromProgress(progress, progress);
-    return scene_.store_new_entity<sidEnemy>(tick_, pos, app,
-        PathFollower{pathId, progress, speed}, Invader{});
+    auto h = scene_.store_new_entity<sidEnemy>({WorldTick::invalid}, pos, app,
+        fx, PathFollower{pathId, progress, speed}, Invader{});
+    if (h) (void)markDirty(h.id());
+    return h;
   }
 
-  // Update entity appearance.
+  // Update entity appearance for the next streamed tick.
   [[nodiscard]] bool updateAppearance(EntityId id, const Appearance& newApp) {
     auto& reg = scene_.registry();
     if (!reg.is_valid(id)) return false;
     auto* app = scene_.try_get_component<Appearance>(id);
     if (!app) return false;
     *app = newApp;
-    app->modified = tick_;
+    app->modified = nextSyncTick();
+    (void)markDirty(id);
+    return true;
+  }
+
+  // Update entity visual effects for the next streamed tick.
+  [[nodiscard]] bool
+  updateVisualEffects(EntityId id, const VisualEffects& newEffects) {
+    auto& reg = scene_.registry();
+    if (!reg.is_valid(id)) return false;
+    auto* effects = scene_.try_get_component<VisualEffects>(id);
+    if (!effects) return false;
+    *effects = newEffects;
+    effects->modified = nextSyncTick();
+    (void)markDirty(id);
+    return true;
+  }
+
+  // Trigger or replace a flashing overlay for an entity that carries visual
+  // effects. The flash remains active until a later update or expiry clears
+  // it.
+  [[nodiscard]] bool
+  flashEntity(EntityId id, uint32_t color, WorldTick duration) {
+    auto& reg = scene_.registry();
+    if (!reg.is_valid(id)) return false;
+    auto* effects = scene_.try_get_component<VisualEffects>(id);
+    if (!effects) return false;
+
+    effects->flash_color = color;
+    effects->flash_expiry = WorldTick{*tick_ + *duration};
+    effects->modified = nextSyncTick();
     (void)markDirty(id);
     return true;
   }
@@ -432,18 +497,25 @@ public:
 
   // Destructively extract upserts and erasures.
   //
-  // Call back `cbUpserts(EntityId, Position, Appearance)` for each changed
-  // entity that has a `Position` and `Appearance` and has changed since the
-  // last tick, and `cbErased(EntityId)` for each entity that has been erased
-  // since the last tick. These calls will be interleaved.
+  // Call back `cbUpserts(EntityId, Position, Appearance, VisualEffects)` for
+  // each changed entity that has a `Position` and `Appearance` and has changed
+  // since the last tick, and `cbErased(EntityId)` for each entity that has
+  // been erased since the last tick. The visual effects pointer is null for
+  // archetypes that do not carry that component. These calls will be
+  // interleaved.
   [[nodiscard]] bool
   extractUpdatedEntities(auto&& cbUpserts, auto&& cbErased) {
+    static constexpr VisualEffects nfx;
     auto& reg = scene_.registry();
     for (auto id : updatedEntities_) {
+      if (!reg.is_valid(id)) continue;
       const auto [pos, app] =
           scene_.try_get_components<Position, Appearance>(id);
       if (pos && app) {
-        (void)cbUpserts(id, *pos, *app);
+        const auto* fx = &nfx;
+        auto maybeFx = scene_.try_get_component<VisualEffects>(id);
+        if (maybeFx) fx = maybeFx;
+        (void)cbUpserts(id, *pos, *app, *fx);
       } else {
         if (reg.get_location(id).store_id != sidStaging) continue;
         (void)cbErased(id);
@@ -493,7 +565,8 @@ public:
 
   // Mark all entities dirty. When `update_strategy::incremental`, does not
   // mark appearances, just entities. When `update_strategy::full`, also marks
-  // appearances dirty by updating their `modified` field.
+  // appearance and visual-effect components dirty by updating their
+  // `modified` field.
   [[nodiscard]] bool markAllDirty(
       update_strategy strategy = update_strategy::incremental) {
     scene_.registry().for_each([&](auto id, auto&) {
@@ -505,6 +578,8 @@ public:
 
       if (auto app = scene_.try_get_component<Appearance>(id))
         app->modified = tick_;
+      if (auto effects = scene_.try_get_component<VisualEffects>(id))
+        effects->modified = tick_;
       return true;
     });
     return true;
@@ -517,6 +592,14 @@ private:
 
   std::vector<EntityId> updatedEntities_;
   std::vector<EntityId> pathEscapees_;
+
+  // Return the tick count for the next snapshot, which is after the next call
+  // to `tick()`. This is the tick that should be used for any changes that
+  // need to be included in the next snapshot, such as newly spawned entities
+  // or appearance updates.
+  [[nodiscard]] WorldTick nextSyncTick() const {
+    return WorldTick{*tick_ + 1U};
+  }
 
   // Marks an entity as dirty so that it will be included in the next delta
   // snapshot.
@@ -598,6 +681,10 @@ private:
     });
 
     return true;
+  }
+
+  [[nodiscard]] static constexpr bool isVisibleColor(uint32_t color) noexcept {
+    return (color & 0xFFU) != 0U;
   }
 
   // Clamp `pos` to `[-limit/2, +limit/2]` and, if it was out of range, negate

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -272,6 +272,17 @@ struct Tower {
   WorldTick next_attack{}; // Tick when the next attack can occur.
 };
 
+// TODO: Standardize on Defender and Invader as the two sides, rather than
+// Tower and Enemy. Defender is more general and can apply to both towers and
+// bullets, while Enemy is more specific and only applies to the path-following
+// invaders. We may want to add a separate archetype for non-path-following
+// enemies, such as flying ones.
+
+// TODO: Rename Tower to DefenderAoe.  Add DefenderHitscan, which is similar
+// except that it has a beam_color and beam_duration. Add DefenderProjective,
+// which has a projectile_speed and projectile_damage, which is used to spawn a
+// bullet.
+
 // Enemy invader component. Stored alongside `Position` and `PathFollower` in
 // the enemy archetype.
 struct Invader {
@@ -744,6 +755,34 @@ private:
     // Range over all towers. For each tower, range over all enemies and check
     // for hits. If an enemy is in range and the tower is off cooldown, apply
     // damage and trigger a flash on both.
+    scene_.for_each<Position, Tower>([&](auto towerId, auto towerComps) {
+      auto& [towerPos, tower] = towerComps;
+      if (tick_ < tower.next_attack) return true;
+
+      scene_.for_each<Position, Invader>([&](auto enemyId, auto enemyComps) {
+        auto& [enemyPos, invader] = enemyComps;
+        if (!circlesOverlap(towerPos, tower.attack_radius, enemyPos,
+                invader.radius))
+          return true;
+
+        (void)flashEntity(towerId, 0xFFFFFFFF, WorldTick{5});
+        (void)flashEntity(enemyId, 0xFF7F7FFF, WorldTick{5});
+        return true;
+#if 0
+        invader.health -= tower.attack_damage;
+        tower.next_attack = WorldTick{*tick_ + *tower.cooldown};
+        (void)flashEntity(towerId, 0xFFFFFFFF);
+        if (invader.health <= 0.F) {
+          (void)tombstoneEntity(enemyId);
+        } else {
+          (void)flashEntity(enemyId, 0xFF0000FF);
+        }
+        return false; // Stop after first hit per tower per tick.
+#endif
+      });
+
+      return true;
+    });
 
     return true;
   }

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -215,7 +215,7 @@ constexpr Tick invalidTick = std::numeric_limits<Tick>::max();
 // TODO: We likely want to break out the physics-relevant properties into
 // components. We already have Position and Velocity (as well as PathFollower,
 // which is a type of velocity). We may need a Shape component which has the
-// geometric type (square, circle, etc), its scale, radius, length, width,
+// geometric type (square, circle, etc), its size, radius, length, width,
 // etc., and local basis (orientation). This can be used to compute the
 // bounding box (which could be AABB (axis-aligned bounding box) or OBB
 // (oriented bounding box) or even a circle collider (super-fast for towers))
@@ -241,7 +241,7 @@ struct PathFollower {
 struct Appearance {
   WorldTick modified{WorldTick::invalid}; // Tick when last modified.
   char32_t glyph{};    // a Unicode character to display, if any.
-  float scale{1.F};    // multiplier on the base size of the shape, if any.
+  float radius{5.F};   // world-space radius of the rendered shape.
   uint32_t fg_color{}; // RGBA.
   uint32_t bg_color{}; // RGBA.
 };
@@ -364,7 +364,7 @@ public:
   [[nodiscard]] Handle spawnMover(Position pos, Velocity vel) {
     Appearance app{.modified = nextSyncTick(),
         .glyph = U'M',
-        .scale = 1.F,
+        .radius = 5.F,
         .fg_color = 0xFFFFFFFF,
         .bg_color = 0xFF};
     auto h = scene_.store_new_entity<sidPosVel>({WorldTick::invalid}, pos, vel,
@@ -377,7 +377,7 @@ public:
   [[nodiscard]] Handle spawnBackground(Position pos) {
     Appearance app{.modified = nextSyncTick(),
         .glyph = U'B',
-        .scale = 1.F,
+        .radius = 5.F,
         .fg_color = 0xFFFFFFFF,
         .bg_color = 0xFF};
     auto h = scene_.store_new_entity<sidPos>({WorldTick::invalid}, pos, app);
@@ -394,7 +394,7 @@ public:
         .next_attack = tick_};
     Appearance app{.modified = nextSyncTick(),
         .glyph = U'T',
-        .scale = 4.F,
+        .radius = 20.F,
         .fg_color = 0xFFFFFFFF,
         .bg_color = 0xFF};
     VisualEffects fx;
@@ -427,7 +427,7 @@ public:
     // appearance must replicate on the current tick rather than the next one.
     Appearance app{.modified = tick_,
         .glyph = U'U',
-        .scale = 2.F,
+        .radius = 10.F,
         .fg_color = 0xFFFFFFFF,
         .bg_color = 0xFF};
     VisualEffects fx{};
@@ -479,6 +479,23 @@ public:
     effects->modified = nextSyncTick();
     (void)markDirty(id);
     return true;
+  }
+
+  [[nodiscard]] EntityId findEntityAt(const Position& pos) const {
+    EntityId found_id = EntityId::invalid;
+    scene_.for_each<Position, Appearance>([&](auto id, auto comps) {
+      const auto& [epos, app] = comps;
+      const auto radius = app.radius;
+      if (std::abs(epos.x - pos.x) < radius &&
+          std::abs(epos.y - pos.y) < radius)
+      {
+        found_id = id;
+        return false;
+      }
+      return true;
+    });
+
+    return found_id;
   }
 
   // Advance one simulation frame. Sets each changed entity's registry metadata

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -266,6 +266,7 @@ struct VisualEffects {
 struct Tower {
   int tower_type{};
   float attack_radius{};
+  uint32_t range_color{};  // RGBA.
   float attack_damage{};   // Per-attack damage.
   WorldTick cooldown{};    // Cooldown for this sort of tower, in ticks.
   WorldTick next_attack{}; // Tick when the next attack can occur.
@@ -389,6 +390,7 @@ public:
   [[nodiscard]] Handle spawnTower(Position pos) {
     Tower tower{.tower_type = 1,
         .attack_radius = 100.F,
+        .range_color = 0xFFFF007F,
         .attack_damage = 10.F,
         .cooldown = {},
         .next_attack = tick_};
@@ -529,6 +531,7 @@ public:
   [[nodiscard]] bool next() {
     (void)updateMovers();
     (void)updatePathFollowers();
+    (void)towersAttack();
     return true;
   }
 
@@ -611,6 +614,20 @@ public:
     return true;
   }
 
+  // Marks an entity as dirty so that it will be included in the next delta
+  // snapshot.
+  [[nodiscard]] bool markDirty(EntityId id) {
+    // If it's been deleted, it's already dirty.
+    if (!scene_.registry().is_valid(id)) return false;
+    auto& last_updated = scene_.registry()[id];
+    if (last_updated != tick_) {
+      last_updated = tick_;
+      updatedEntities_.push_back(id);
+      return true;
+    }
+    return false;
+  }
+
   // Mark all entities dirty. When `update_strategy::incremental`, marks
   // entities for extraction only. When `update_strategy::full`, also stamps
   // `Appearance` and `VisualEffects` `modified` fields with `tick_` so the
@@ -634,6 +651,19 @@ public:
     return true;
   }
 
+  static constexpr float
+  distanceSquared(const Position& a, const Position& b) {
+    const float dx = a.x - b.x;
+    const float dy = a.y - b.y;
+    return (dx * dx) + (dy * dy);
+  }
+
+  static constexpr bool circlesOverlap(const Position& posA, float radiusA,
+      const Position& posB, float radiusB) {
+    const float r = radiusA + radiusB;
+    return distanceSquared(posA, posB) <= r * r;
+  }
+
 private:
   WorldScene scene_;
   WorldTick tick_{};
@@ -641,20 +671,6 @@ private:
 
   std::vector<EntityId> updatedEntities_;
   std::vector<EntityId> pathEscapees_;
-
-  // Marks an entity as dirty so that it will be included in the next delta
-  // snapshot.
-  [[nodiscard]] bool markDirty(EntityId id) {
-    // If it's been deleted, it's already dirty.
-    if (!scene_.registry().is_valid(id)) return false;
-    auto& last_updated = scene_.registry()[id];
-    if (last_updated != tick_) {
-      last_updated = tick_;
-      updatedEntities_.push_back(id);
-      return true;
-    }
-    return false;
-  }
 
   // Logically erases an entity, adding it to the dirty list.
   [[nodiscard]] bool tombstoneEntity(EntityId id) {
@@ -720,6 +736,14 @@ private:
       pos = sp.calculatePositionFromProgress(pf.progress, previousProgress);
       return true;
     });
+
+    return true;
+  }
+
+  [[nodiscard]] bool towersAttack() {
+    // Range over all towers. For each tower, range over all enemies and check
+    // for hits. If an enemy is in range and the tower is off cooldown, apply
+    // damage and trigger a flash on both.
 
     return true;
   }

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -473,13 +473,20 @@ public:
     return true;
   }
 
-  // Mark all entities dirty, to force a full snapshot.
-  [[nodiscard]] bool markAllDirty() {
+  // Mark all entities dirty. When `update_strategy::incremental`, does not
+  // mark appearances, just entities. When `update_strategy::full`, also marks
+  // appearances dirty by updating their `modified` field.
+  [[nodiscard]] bool markAllDirty(
+      update_strategy strategy = update_strategy::incremental) {
     scene_.registry().for_each([&](auto id, auto&) {
       const auto loc = scene_.registry().get_location(id);
       if (loc.store_id == sidStaging) return true;
 
       (void)markDirty(id);
+      if (strategy == update_strategy::incremental) return true;
+
+      if (auto app = scene_.try_get_component<Appearance>(id))
+        app->modified = tick_;
       return true;
     });
     return true;

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -24,6 +24,9 @@
 
 #include "../ecs.h"
 
+// SimWorld: authoritative server-side world state and logic for the CorvidSim
+// game. Owns the entities and the physics, but not the rules or the game flow.
+
 namespace corvid { inline namespace sim {
 
 // ID of path.
@@ -217,6 +220,7 @@ public:
   using EntityId = WorldReg::id_t;
   using Handle = WorldReg::handle_t;
 
+  static constexpr WorldSid staging_sid{0};
   static constexpr WorldSid p_sid{1};
   static constexpr WorldSid pv_sid{2};
   static constexpr WorldSid enemy_sid{3};
@@ -291,81 +295,13 @@ public:
   // handle is no longer valid (entity already dead).
   bool despawn(Handle& h) { return scene_.erase_entity(h); }
 
-  // Advance one simulation frame. For every PV entity: add velocity to
-  // position, then bounce off the world boundary by reversing the relevant
-  // velocity component and clamping the position. Sets each moved entity's
-  // registry metadata to the new tick count.
-  //
-  // If `out` is non-null, the IDs of all entities whose state changed are
-  // appended to `*out`. Pass `nullptr` (the default) when only the side
-  // effects are needed, to avoid the allocation.
-  [[nodiscard]] Tick tick(std::vector<EntityId>* out = nullptr) {
+  // Advance one simulation frame. Sets each changed entity's registry metadata
+  // to the new tick count and tracks changed entities for callbacks.
+  [[nodiscard]] Tick tick() {
     ++tick_n_;
 
-    // Advance velocity-driven entities.
-    scene_.for_each<Position, Velocity>([&](auto id, auto comps) {
-      auto& [pos, vel] = comps;
-      // Skip over currently immobile entities.
-      if (vel.vx == 0.F && vel.vy == 0.F) return true;
-
-      // TODO: Consider refactoring the increment and bounce into a single
-      // method that does both. For that matter, the current algorithm is
-      // wrong: an entity hitting a boundary shouldn't be clipped to the
-      // boundary and its velocity reversed. Rather, part of its movement
-      // should be reflected back. So, for example, if dx is 20 and the entity
-      // is 5 pixels from the right edge, it should spend 5 of those 20 moving
-      // to the right, and then 15 moving back. Its velocity should be reversed
-      // starting at the edge. The only reason the current algorithm works at
-      // all is that velocities are small. The algorithm is also bad in a
-      // different way, which is that it measures position from the center, not
-      // a bounding box, so the balls enter the boundary before reversing. Even
-      // then, a square bounding box would be hit-detected prematurely if the
-      // entity is moving at a diagonal.
-
-      pos.x += vel.vx;
-      pos.y += vel.vy;
-
-      bounce_from_boundary(pos.x, vel.vx, world_width);
-      bounce_from_boundary(pos.y, vel.vy, world_height);
-
-      scene_.registry()[id] = tick_n_;
-      if (out) out->push_back(id);
-      return true;
-    });
-
-    // Advance path-following enemies. Collect entities that reached the end
-    // so they can be despawned after iteration.
-    std::vector<EntityId> finished;
-    scene_.for_each<Position, PathFollower>([&](auto id, auto comps) {
-      auto& [pos, pf] = comps;
-      pf.progress += pf.speed;
-
-      // TODO: Is this even possible?
-      if (pf.path_id >= paths_.size_as_enum()) return true;
-
-      // TODO: Speed can be negative, so we need to collect entities that
-      // exited front and back, separately. Why separately? So that we can
-      // count them against the score. Note that we also have to be careful
-      // here to deal with the possibility of a non-enemy that follows the
-      // track and therefore doesn't count against the score. The easy way is
-      // to iterate through the entities and ask which archetype they are. This
-      // might be possible with ducktyping is enemies have a component that the
-      // player doesn't, such as an enemy type that defines how to draw them.
-      const auto& sp = paths_[pf.path_id];
-      if (pf.progress >= sp.total_length) {
-        finished.push_back(id);
-        return true;
-      }
-
-      pos = sp.position_from_progress(pf.progress);
-      scene_.registry()[id] = tick_n_;
-
-      if (out) out->push_back(id);
-      return true;
-    });
-    // IDs were collected from an active iteration, so erase_entity will not
-    // fail; the return value is voided intentionally.
-    for (auto id : finished) (void)scene_.erase_entity(id);
+    (void)tick_movers();
+    (void)tick_path_followers();
 
     return tick_n_;
   }
@@ -401,10 +337,121 @@ public:
   // Total number of entities in all storages (does not count staged entities).
   [[nodiscard]] std::size_t size() const { return scene_.size(); }
 
+  // List of entities that have escaped the path.
+  [[nodiscard]] auto& path_escapees() const { return path_escapees_; }
+
+  // Resolve path escapees by calling `cb` on each one, where `cb` is of the
+  // shape:
+  // `std::function<bool(EntityId, const Position&, constPathFollower&)`
+  //
+  // Destructively iterates through the list of path escapees.  If `cb` returns
+  // true, the escapee is erased; if false, it's left alive, so the caller
+  // ought to have done something with it, such as migrating it to a different
+  // path. Note that you must not modify `path_escapees_` in the process.
+  [[nodiscard]] bool resolve_escapes(auto&& cb) {
+    for (auto id : path_escapees_) {
+      if (!scene_.registry().is_valid(id)) continue;
+      auto [pos, pf] = scene_.try_get_components<Position, PathFollower>(id);
+      if (!pos || !pf) continue;
+      if (!cb(id, *pos, *pf)) continue;
+      (void)erase_entity(id);
+    }
+    path_escapees_.clear();
+    return true;
+  }
+
 private:
   WorldScene scene_;
   Tick tick_n_{0};
   id_container<SegmentedPath, PathId> paths_;
+
+  std::vector<EntityId> updated_entities_;
+  std::vector<EntityId> path_escapees_;
+
+  // Marks an entity as dirty so that it will be included in the next delta
+  // snapshot.
+  bool mark_dirty(EntityId id) {
+    // If it's been deleted, it's already dirty.
+    if (!scene_.registry().is_valid(id)) return false;
+    auto& last_updated = scene_.registry()[id];
+    if (last_updated != tick_n_) {
+      last_updated = tick_n_;
+      updated_entities_.push_back(id);
+      return true;
+    }
+    return false;
+  }
+
+  // Logically erases an entity, adding it to the dirty list. Actually, it's
+  // tombstoned into staging.
+  bool erase_entity(EntityId id) {
+    // Can't kill the dead.
+    if (!scene_.registry().is_valid(id)) return false;
+    (void)mark_dirty(id);
+    // We don't actually erase it yet, just migrate it to staging so that we
+    // can erase it as part of the snapshot process.
+    return scene_.migrate_entity(id, staging_sid);
+  }
+
+  // Advance velocity-driven entities.
+  [[nodiscard]] bool tick_movers() {
+    scene_.for_each<Position, Velocity>([&](auto id, auto comps) {
+      auto& [pos, vel] = comps;
+      // Skip over currently immobile entities.
+      if (vel.vx == 0.F && vel.vy == 0.F) return true;
+
+      // TODO: Consider refactoring the increment and bounce into a single
+      // method that does both. For that matter, the current algorithm is
+      // wrong: an entity hitting a boundary shouldn't be clipped to the
+      // boundary and its velocity reversed. Rather, part of its movement
+      // should be reflected back. So, for example, if dx is 20 and the entity
+      // is 5 pixels from the right edge, it should spend 5 of those 20 moving
+      // to the right, and then 15 moving back. Its velocity should be reversed
+      // starting at the edge. The only reason the current algorithm works at
+      // all is that velocities are small. The algorithm is also bad in a
+      // different way, which is that it measures position from the center, not
+      // a bounding box, so the balls enter the boundary before reversing. Even
+      // then, a square bounding box would be hit-detected prematurely if the
+      // entity is moving at a diagonal.
+      (void)mark_dirty(id);
+
+      pos.x += vel.vx;
+      pos.y += vel.vy;
+
+      bounce_from_boundary(pos.x, vel.vx, world_width);
+      bounce_from_boundary(pos.y, vel.vy, world_height);
+
+      updated_entities_.push_back(id);
+      return true;
+    });
+
+    return true;
+  }
+
+  // Advance path-following enemies. Collect entities that changed, as well as
+  // those that escaped the path.
+  [[nodiscard]] bool tick_path_followers() {
+    scene_.for_each<Position, PathFollower>([&](auto id, auto comps) {
+      auto& [pos, pf] = comps;
+      assert(pf.path_id < paths_.size_as_enum());
+      if (pf.speed == 0.F) return true;
+
+      (void)mark_dirty(id);
+
+      pf.progress += pf.speed;
+
+      const auto& sp = paths_[pf.path_id];
+      if (pf.progress >= sp.total_length || pf.progress < 0.F) {
+        path_escapees_.push_back(id);
+        return true;
+      }
+
+      pos = sp.position_from_progress(pf.progress);
+      return true;
+    });
+
+    return true;
+  }
 
   // Clamp `pos` to `[-limit/2, +limit/2]` and, if it was out of range, negate
   // `vel` so the entity bounces off that boundary wall.

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -435,18 +435,7 @@ public:
       const auto loc = scene_.registry().get_location(id);
       if (loc.store_id == sidStaging) return true;
 
-#if 1
       (void)markDirty(id);
-#else
-
-      if (scene_.registry()[id] != tick_) {
-        (void)markDirty(id);
-        return true;
-      }
-
-      if (std::ranges::find(updatedEntities_, id) == updatedEntities_.end())
-        updatedEntities_.push_back(id);
-#endif
       return true;
     });
     return true;

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -184,6 +184,7 @@ struct SegmentedPath {
 };
 
 using Tick = uint64_t;
+constexpr Tick invalidTick = std::numeric_limits<Tick>::max();
 
 // `Shape` is not a component, but entities may reference it to define an
 // aspect of their appearance. For now, we keep it simple by allowing a shape
@@ -311,14 +312,6 @@ public:
   static constexpr float widthOfWorld = 1920.F;
   static constexpr float heightOfWorld = 1080.F;
 
-  // State snapshot for a single entity. This is the serialization format for
-  // the entity state sent to clients.
-  // !!!KILLME
-  struct EntitySnapshot {
-    EntityId id;
-    Position pos;
-  };
-
   void clear() {
     scene_.clear();
     paths_.clear();
@@ -329,12 +322,16 @@ public:
   // Returns a handle for later `despawn()`. The entity's last-change tick
   // is set to the current tick count.
   [[nodiscard]] Handle spawnMover(Position pos, Velocity vel) {
-    return scene_.store_new_entity<sidPosVel>(tick_, pos, vel);
+    auto h = scene_.store_new_entity<sidPosVel>({invalidTick}, pos, vel);
+    if (h) (void)markDirty(h.id());
+    return h;
   }
 
   // Spawn an immobile entity. Returns a handle for later `despawn()`.
   [[nodiscard]] Handle spawnBackground(Position pos) {
-    return scene_.store_new_entity<sidPos>(tick_, pos);
+    auto h = scene_.store_new_entity<sidPos>(invalidTick, pos);
+    if (h) (void)markDirty(h.id());
+    return h;
   }
 
   // Bake and store a path. Returns the index used as `path_follower::path_id`.
@@ -435,7 +432,21 @@ public:
   // Mark all entities dirty, to force a full snapshot.
   [[nodiscard]] bool markAllDirty() {
     scene_.registry().for_each([&](auto id, auto&) {
-      markDirty(id);
+      const auto loc = scene_.registry().get_location(id);
+      if (loc.store_id == sidStaging) return true;
+
+#if 1
+      (void)markDirty(id);
+#else
+
+      if (scene_.registry()[id] != tick_) {
+        (void)markDirty(id);
+        return true;
+      }
+
+      if (std::ranges::find(updatedEntities_, id) == updatedEntities_.end())
+        updatedEntities_.push_back(id);
+#endif
       return true;
     });
     return true;
@@ -498,8 +509,6 @@ private:
 
       bounce_from_boundary(pos.x, vel.vx, widthOfWorld);
       bounce_from_boundary(pos.y, vel.vy, heightOfWorld);
-
-      updatedEntities_.push_back(id);
       return true;
     });
 

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -287,10 +287,11 @@ struct Bullet {
 //   `sidStaging` = 0                      : staging storage, used as tombstone
 //
 //   `sidPos`     = 1  -> `arch_p_t`       : background / destructible entities
-//                                           (Position)
+//                                           (Position + Appearance)
 //
 //   `sidPosVel`  = 2  -> `arch_pv_t`      : moving entities
-//                                           (Position + Velocity)
+//                                           (Position + Velocity +
+//                                           Appearance)
 //
 //   `sidEnemy`   = 3  -> `arch_enemy_t`   : path-following enemies
 //                                           (Position + Appearance +
@@ -306,8 +307,9 @@ struct Bullet {
 // natural `archetype_scene::migrate_entity` call rather than erase + re-add.
 using WorldReg = entity_registry<WorldTick>;
 using WorldSid = WorldReg::store_id_t;
-using ArchP = archetype_storage<WorldReg, std::tuple<Position>>;
-using ArchPV = archetype_storage<WorldReg, std::tuple<Position, Velocity>>;
+using ArchP = archetype_storage<WorldReg, std::tuple<Position, Appearance>>;
+using ArchPV =
+    archetype_storage<WorldReg, std::tuple<Position, Velocity, Appearance>>;
 using ArchEnemy = archetype_storage<WorldReg,
     std::tuple<Position, Appearance, PathFollower, Invader>>;
 using ArchTower =
@@ -347,15 +349,16 @@ public:
   // Returns a handle for later `despawn()`. The entity's last-change tick
   // is set to the current tick count.
   [[nodiscard]] Handle spawnMover(Position pos, Velocity vel) {
-    auto h =
-        scene_.store_new_entity<sidPosVel>({WorldTick::invalid}, pos, vel);
+    auto h = scene_.store_new_entity<sidPosVel>({WorldTick::invalid}, pos, vel,
+        Appearance{.modified = tick_});
     if (h) (void)markDirty(h.id());
     return h;
   }
 
   // Spawn an immobile entity. Returns a handle for later `despawn()`.
   [[nodiscard]] Handle spawnBackground(Position pos) {
-    auto h = scene_.store_new_entity<sidPos>({WorldTick::invalid}, pos);
+    auto h = scene_.store_new_entity<sidPos>(
+        {WorldTick::invalid}, pos, Appearance{.modified = tick_});
     if (h) (void)markDirty(h.id());
     return h;
   }

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -26,6 +26,18 @@
 
 namespace corvid { inline namespace sim {
 
+// ID of path.
+enum class path_id_t : uint8_t { invalid = 255 };
+
+}} // namespace corvid::sim
+
+template<>
+constexpr auto corvid::enums::registry::enum_spec_v<corvid::sim::path_id_t> =
+    corvid::enums::sequence::make_sequence_enum_spec<corvid::sim::path_id_t,
+        "">();
+
+namespace corvid { inline namespace sim {
+
 // Convert Cartesian coordinates (x, y) to a Euclidean vector, in polar form
 // (length, direction). `direction` is in radians,
 [[nodiscard]] constexpr std::pair<float, float>
@@ -160,9 +172,9 @@ struct segmented_path {
 // archetype. Each tick, `progress` advances by `speed`; the entity's
 // `Position` is re-derived from the segmented path geometry.
 struct PathFollower {
-  uint8_t path_id{}; // Index into `sim_world::paths_`.
-  float progress{};  // Distance traveled along the path so far.
-  float speed{};     // Distance per tick.
+  path_id_t path_id{}; // Index into `sim_world::paths_`.
+  float progress{};    // Distance traveled along the path so far.
+  float speed{};       // Distance per tick.
 };
 
 // ECS types for the simulation world.
@@ -233,15 +245,16 @@ public:
 
   // Bake and store a path. Returns the index used as `PathFollower::path_id`.
   // The index is stable for the lifetime of the world.
-  [[nodiscard]] uint8_t add_path(const path_joints& p) {
-    paths_.push_back(segmented_path::from_joints(p));
-    return static_cast<uint8_t>(paths_.size() - 1);
+  [[nodiscard]] path_id_t add_path(const path_joints& p) {
+    if (!paths_.push_back(segmented_path::from_joints(p)))
+      return path_id_t::invalid;
+    return paths_.size_as_enum() - 1;
   }
 
   // Return a pointer to the baked path at `id`, or `nullptr` if out of range.
-  [[nodiscard]] const segmented_path* get_path(uint8_t id) const {
-    if (id >= paths_.size()) return nullptr;
-    return &paths_[id];
+  [[nodiscard]] const segmented_path* get_path(path_id_t path_id) const {
+    if (*path_id >= paths_.size()) return nullptr;
+    return &paths_[path_id];
   }
 
   // Return snapshots for all authored paths so the client can render the
@@ -256,8 +269,8 @@ public:
   // Spawn a path-following enemy. Initial position is derived from `progress`
   // on the named path. Returns a handle for later `despawn()`.
   [[nodiscard]] handle_t
-  spawn_enemy(uint8_t path_id, float speed, float progress = 0.F) {
-    if (path_id >= paths_.size()) return {};
+  spawn_enemy(path_id_t path_id, float speed, float progress = 0.F) {
+    if (static_cast<uint8_t>(path_id) >= paths_.size()) return {};
     const auto pos = paths_[path_id].position_from_progress(progress);
     return scene_.store_new_entity<enemy_sid>(tick_n_, pos,
         PathFollower{path_id, progress, speed});
@@ -322,7 +335,7 @@ public:
       pf.progress += pf.speed;
 
       // TODO: Is this even possible?
-      if (pf.path_id >= paths_.size()) return true;
+      if (pf.path_id >= paths_.size_as_enum()) return true;
 
       // TODO: Speed can be negative, so we need to collect entities that
       // exited front and back, separately. Why separately? So that we can
@@ -385,7 +398,7 @@ public:
 private:
   world_scene_t scene_;
   tick_t tick_n_{0};
-  std::vector<segmented_path> paths_;
+  id_container<segmented_path, path_id_t> paths_;
 
   // Clamp `pos` to `[-limit/2, +limit/2]` and, if it was out of range, negate
   // `vel` so the entity bounces off that boundary wall.

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -49,11 +49,21 @@ enum class PathId : uint16_t {
   invalid = std::numeric_limits<uint16_t>::max()
 };
 
+// Tick for world state.
+enum class WorldTick : uint64_t {
+  invalid = std::numeric_limits<uint64_t>::max()
+};
+
 }} // namespace corvid::sim
 
 template<>
 constexpr auto corvid::enums::registry::enum_spec_v<corvid::sim::PathId> =
     corvid::enums::sequence::make_sequence_enum_spec<corvid::sim::PathId,
+        "">();
+
+template<>
+constexpr auto corvid::enums::registry::enum_spec_v<corvid::sim::WorldTick> =
+    corvid::enums::sequence::make_sequence_enum_spec<corvid::sim::WorldTick,
         "">();
 
 namespace corvid { inline namespace sim {
@@ -234,7 +244,7 @@ struct Appearance {
   uint32_t fg_color{};   // RGB color, if any.
   uint32_t bg_color{};   // RGB color, if any.
   uint32_t glow_color{}; // RGB color for glow effect, if any.
-  Tick effect_expiry{invalidTick}; // When glow effect expires.
+  WorldTick effect_expiry{WorldTick::invalid}; // When glow effect expires.
 };
 
 // Defensive tower component. Stored alongside `Position` in the tower
@@ -246,9 +256,9 @@ struct Appearance {
 struct Tower {
   int tower_type{};
   float attack_radius{};
-  float attack_damage{}; // Per-attack damage.
-  Tick cooldown{};       // Cooldown for this sort of tower, in ticks.
-  Tick next_attack{};    // Tick when the next attack can occur.
+  float attack_damage{};   // Per-attack damage.
+  WorldTick cooldown{};    // Cooldown for this sort of tower, in ticks.
+  WorldTick next_attack{}; // Tick when the next attack can occur.
 };
 
 // Enemy invader component. Stored alongside `Position` and `PathFollower` in
@@ -264,7 +274,7 @@ struct Invader {
 struct Bullet {
   int bullet_type{};
   float damage{};
-  Tick expiration{};
+  WorldTick expiration{};
 };
 
 // ECS types for the simulation world.
@@ -293,7 +303,7 @@ struct Bullet {
 //
 // Background storage comes first so that retiring a mobile entity is a
 // natural `archetype_scene::migrate_entity` call rather than erase + re-add.
-using WorldReg = entity_registry<Tick>;
+using WorldReg = entity_registry<WorldTick>;
 using WorldSid = WorldReg::store_id_t;
 using ArchP = archetype_storage<WorldReg, std::tuple<Position>>;
 using ArchPV = archetype_storage<WorldReg, std::tuple<Position, Velocity>>;
@@ -329,21 +339,22 @@ public:
   void clear() {
     scene_.clear();
     paths_.clear();
-    tick_ = 0;
+    tick_ = {};
   }
 
   // Spawn a moving entity with the given initial position and velocity.
   // Returns a handle for later `despawn()`. The entity's last-change tick
   // is set to the current tick count.
   [[nodiscard]] Handle spawnMover(Position pos, Velocity vel) {
-    auto h = scene_.store_new_entity<sidPosVel>({invalidTick}, pos, vel);
+    auto h =
+        scene_.store_new_entity<sidPosVel>({WorldTick::invalid}, pos, vel);
     if (h) (void)markDirty(h.id());
     return h;
   }
 
   // Spawn an immobile entity. Returns a handle for later `despawn()`.
   [[nodiscard]] Handle spawnBackground(Position pos) {
-    auto h = scene_.store_new_entity<sidPos>(invalidTick, pos);
+    auto h = scene_.store_new_entity<sidPos>({WorldTick::invalid}, pos);
     if (h) (void)markDirty(h.id());
     return h;
   }
@@ -367,7 +378,7 @@ public:
   [[nodiscard]] Handle
   spawnEnemy(PathId pathId, float speed, float progress = 0.F) {
     if (pathId >= paths_.size_as_enum()) return {};
-    Appearance app{U'U', 2.F, 0xFFFFFFFF, 0xFF, 0, invalidTick};
+    Appearance app{U'U', 2.F, 0xFFFFFFFF, 0xFF, 0, WorldTick::invalid};
     const auto pos =
         paths_[pathId].calculatePositionFromProgress(progress, progress);
     return scene_.store_new_entity<sidEnemy>(tick_, pos, app,
@@ -376,7 +387,7 @@ public:
 
   // Advance one simulation frame. Sets each changed entity's registry metadata
   // to the new tick count and tracks changed entities for callbacks.
-  [[nodiscard]] Tick tick() {
+  [[nodiscard]] WorldTick tick() {
     ++tick_;
 
     (void)updateMovers();
@@ -463,7 +474,7 @@ public:
 
 private:
   WorldScene scene_;
-  Tick tick_{0};
+  WorldTick tick_{};
   id_container<SegmentedPath, PathId> paths_;
 
   std::vector<EntityId> updatedEntities_;

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -16,6 +16,7 @@
 // limitations under the License.
 #pragma once
 
+#include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <numbers>
@@ -64,14 +65,93 @@ struct Velocity {
   }
 };
 
+// --- Path geometry ---
+
+// Authored path: a sequence of joints and a road half-width in world-space
+// pixels. Processed into a `baked_path` before use at runtime.
+struct path {
+  struct joint {
+    Position p;
+  };
+
+  std::vector<joint> joints;
+  float width{40.F};
+};
+
+// Runtime-ready path: pre-computed segments with cumulative distances,
+// produced once from a `path` by `bake_path()`.
+struct baked_path {
+  struct segment {
+    Position front;
+    Position back;
+    float length;           // Euclidean distance from `front` to `back`.
+    float cumulative_start; // Sum of lengths of all preceding segments.
+  };
+
+  std::vector<segment> segments;
+  float total_length{};
+  float width{};
+
+  // Map a distance traveled (`progress`) along `bp` to a world-space
+  // `Position`. `progress` is clamped to `[0, total_length]`. Returns the
+  // origin if `bp` has no segments.
+  Position position_from_progress(float progress) const {
+    if (segments.empty()) return {};
+    progress = std::clamp(progress, 0.F, total_length);
+    // Find the last segment whose cumulative_start <= progress.
+    auto it = std::ranges::upper_bound(segments, progress, {},
+        &baked_path::segment::cumulative_start);
+    if (it != segments.begin()) --it;
+    const auto& seg = *it;
+    const float t =
+        (seg.length > 0.F)
+            ? ((progress - seg.cumulative_start) / seg.length)
+            : 0.F;
+    return {(seg.front.x + ((seg.back.x - seg.front.x) * t)),
+        (seg.front.y + ((seg.back.y - seg.front.y) * t))};
+  }
+
+  // Convert an authored `path` into a `baked_path`. Requires at least two
+  // joints; returns an empty `baked_path` if the input is degenerate.
+  static baked_path from_path(const path& p) {
+    if (p.joints.size() < 2) return {};
+    baked_path bp;
+    bp.width = p.width;
+    bp.segments.reserve(p.joints.size() - 1);
+    float cumulative{};
+    for (std::size_t i = 0; i + 1 < p.joints.size(); ++i) {
+      const Position& front = p.joints[i].p;
+      const Position& back = p.joints[i + 1].p;
+      const float dx = back.x - front.x;
+      const float dy = back.y - front.y;
+      const float len = std::hypot(dx, dy);
+      bp.segments.push_back({front, back, len, cumulative});
+      cumulative += len;
+    }
+    bp.total_length = cumulative;
+    return bp;
+  }
+};
+
+// Path-following component. Stored alongside `Position` in the enemy
+// archetype. Each tick, `progress` advances by `speed`; the entity's
+// `Position` is re-derived from the baked path geometry.
+struct PathFollower {
+  uint8_t path_id{}; // Index into `sim_world::paths_`.
+  float progress{};  // Distance traveled along the path so far.
+  float speed{};     // Distance per tick.
+};
+
 // ECS types for the simulation world.
 //
 // Registry metadata (`uint64_t`) stores each entity's last-change tick count,
 // enabling delta snapshots without a separate dirty set.
 //
 // Storage layout (store_id assignment is positional, 1-based):
-//   `p_sid`  = 1  -> `arch_p_t`  : background / retired entities (Position)
-//   `pv_sid` = 2  -> `arch_pv_t` : moving entities (Position + Velocity)
+//   `p_sid`      = 1  -> `arch_p_t`      : background / retired (Position)
+//   `pv_sid`     = 2  -> `arch_pv_t`     : moving entities (Position +
+//   Velocity) `enemy_sid`  = 3  -> `arch_enemy_t`  : path-following enemies
+//   (Position + PathFollower)
 //
 // Background storage comes first so that retiring a mobile entity is a
 // natural `archetype_scene::migrate_entity` call rather than erase+re-add.
@@ -81,7 +161,10 @@ using world_sid_t = world_reg_t::store_id_t;
 using arch_p_t = archetype_storage<world_reg_t, std::tuple<Position>>;
 using arch_pv_t =
     archetype_storage<world_reg_t, std::tuple<Position, Velocity>>;
-using world_scene_t = archetype_scene<world_reg_t, arch_p_t, arch_pv_t>;
+using arch_enemy_t =
+    archetype_storage<world_reg_t, std::tuple<Position, PathFollower>>;
+using world_scene_t =
+    archetype_scene<world_reg_t, arch_p_t, arch_pv_t, arch_enemy_t>;
 
 // Simulation world: encapsulates all ECS entity state for the game.
 //
@@ -97,6 +180,7 @@ public:
 
   static constexpr world_sid_t p_sid{1};
   static constexpr world_sid_t pv_sid{2};
+  static constexpr world_sid_t enemy_sid{3};
 
   static constexpr float world_width = 1920.0;
   static constexpr float world_height = 1080.0;
@@ -119,6 +203,30 @@ public:
     return scene_.store_new_entity<p_sid>(tick_n_, pos);
   }
 
+  // Bake and store a path. Returns the index used as `PathFollower::path_id`.
+  // The index is stable for the lifetime of the world.
+  [[nodiscard]] uint8_t add_path(const path& p) {
+    paths_.push_back(baked_path::from_path(p));
+    return static_cast<uint8_t>(paths_.size() - 1);
+  }
+
+  // Return a pointer to the baked path at `id`, or `nullptr` if out of range.
+  [[nodiscard]] const baked_path* get_path(uint8_t id) const {
+    if (id >= paths_.size()) return nullptr;
+    return &paths_[id];
+  }
+
+  // Spawn a path-following enemy. Initial position is derived from `progress`
+  // on the named path. Returns a handle for later `despawn()`.
+  [[nodiscard]] handle_t
+  spawn_enemy(uint8_t path_id, float speed, float progress = 0.F) {
+    Position pos{};
+    if (path_id < paths_.size())
+      pos = paths_[path_id].position_from_progress(progress);
+    return scene_.store_new_entity<enemy_sid>(tick_n_, pos,
+        PathFollower{path_id, progress, speed});
+  }
+
   // Returns true if the handle refers to a live entity.
   [[nodiscard]] bool is_alive(handle_t h) const {
     return scene_.registry().is_valid(h);
@@ -138,6 +246,8 @@ public:
   // effects are needed, to avoid the allocation.
   [[nodiscard]] tick_t tick(std::vector<entity_id_t>* out = nullptr) {
     ++tick_n_;
+
+    // Advance velocity-driven entities.
     scene_.for_each<Position, Velocity>([&](auto id, auto comps) {
       auto& [pos, vel] = comps;
 
@@ -151,12 +261,42 @@ public:
       if (out) out->push_back(id);
       return true;
     });
+
+    // Advance path-following enemies. Collect entities that reached the end
+    // so they can be despawned after iteration.
+    std::vector<entity_id_t> finished;
+    scene_.for_each<Position, PathFollower>([&](auto id, auto comps) {
+      auto& [pos, pf] = comps;
+      pf.progress += pf.speed;
+      // TODO: Speed can be negative, so we need to collect entities that
+      // exited front and back, separately. Why separately? So that we can
+      // count them against the score. Note that we also have to be careful
+      // here to deal with the possibility of a non-enemy that follows the
+      // track and therefore doesn't count against the score. Not sure how best
+      // to do this, but I imagine a component value that's constant and
+      // therefore takes up no space.
+      if (pf.path_id < paths_.size()) {
+        const auto& bp = paths_[pf.path_id];
+        if (pf.progress >= bp.total_length) {
+          finished.push_back(id);
+        } else {
+          pos = bp.position_from_progress(pf.progress);
+          scene_.registry()[id] = tick_n_;
+          if (out) out->push_back(id);
+        }
+      }
+      return true;
+    });
+    // IDs were collected from an active iteration, so erase_entity will not
+    // fail; the return value is voided intentionally.
+    for (auto id : finished) (void)scene_.erase_entity(id);
+
     return tick_n_;
   }
 
   // Return snapshots for every entity whose last-change tick is >=
-  // `since_tick`. Pass 0 (the default) to return all entities. Visits both
-  // `p_sid` and `pv_sid` storages since both carry `Position`.
+  // `since_tick`. Pass 0 (the default) to return all entities. Visits all
+  // storages that carry `Position` (`p_sid`, `pv_sid`, `enemy_sid`).
   [[nodiscard]] std::vector<entity_snapshot> snapshot(
       tick_t since_tick = 0) const {
     std::vector<entity_snapshot> result;
@@ -188,6 +328,7 @@ public:
 private:
   world_scene_t scene_;
   tick_t tick_n_{0};
+  std::vector<baked_path> paths_;
 
   // Clamp `pos` to `[-limit/2, +limit/2]` and, if it was out of range, negate
   // `vel` so the entity bounces off that boundary wall.

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -286,21 +286,21 @@ struct Bullet {
 // Storage layout (store_id assignment is positional, 1-based):
 //   `sidStaging` = 0                      : staging storage, used as tombstone
 //
-//   `sidPos`     = 1  -> `arch_p_t`       : background / destructible entities
+//   `sidPos`     = 1  -> `ArchP`          : background / destructible entities
 //                                           (Position + Appearance)
 //
-//   `sidPosVel`  = 2  -> `arch_pv_t`      : moving entities
+//   `sidPosVel`  = 2  -> `ArchPV`         : moving entities
 //                                           (Position + Velocity +
 //                                           Appearance)
 //
-//   `sidEnemy`   = 3  -> `arch_enemy_t`   : path-following enemies
+//   `sidEnemy`   = 3  -> `ArchEnemy`      : path-following enemies
 //                                           (Position + Appearance +
 //                                           PathFollower + Invader)
 //
-//   `sidTower`   = 4  -> `arch_tower_t`   : placed towers
+//   `sidTower`   = 4  -> `ArchTower`      : placed towers
 //                                          (Position + Appearance + Tower)
 //
-//   `sidBullet`  = 5  -> `arch_bullet_t`  : bullets
+//   `sidBullet`  = 5  -> `ArchBullet`     : bullets
 //                                           (Position + Velocity + Bullet)
 //
 // Background storage comes first so that retiring a mobile entity is a
@@ -349,8 +349,9 @@ public:
   // Returns a handle for later `despawn()`. The entity's last-change tick
   // is set to the current tick count.
   [[nodiscard]] Handle spawnMover(Position pos, Velocity vel) {
+    Appearance app{U'M', 1.F, 0xFFFFFFFF, 0xFF, 0, WorldTick::invalid, tick_};
     auto h = scene_.store_new_entity<sidPosVel>({WorldTick::invalid}, pos, vel,
-        Appearance{.modified = tick_});
+        app);
     if (h) (void)markDirty(h.id());
     return h;
   }
@@ -359,6 +360,20 @@ public:
   [[nodiscard]] Handle spawnBackground(Position pos) {
     auto h = scene_.store_new_entity<sidPos>({WorldTick::invalid}, pos,
         Appearance{.modified = tick_});
+    if (h) (void)markDirty(h.id());
+    return h;
+  }
+
+  // Spawn an immobile entity. Returns a handle for later `despawn()`.
+  [[nodiscard]] Handle spawnTower(Position pos) {
+    Tower tower{.tower_type = 1,
+        .attack_radius = 100.F,
+        .attack_damage = 10.F,
+        .cooldown = {},
+        .next_attack = tick_};
+    Appearance app{U'T', 4.F, 0xFFFFFFFF, 0xFF, 0, WorldTick::invalid, tick_};
+    auto h = scene_.store_new_entity<sidTower>({WorldTick::invalid}, pos, app,
+        tower);
     if (h) (void)markDirty(h.id());
     return h;
   }

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -502,6 +502,10 @@ public:
     return found_id;
   }
 
+  [[nodiscard]] auto getTower(EntityId id) {
+    return scene_.storage<sidTower>()[id].components();
+  }
+
   [[nodiscard]] EntityId findTowerAt(const Position& pos) const {
     EntityId found_id = EntityId::invalid;
     scene_.for_each<Position, Appearance, Tower>([&](auto id, auto comps) {

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -32,9 +32,9 @@
 // - Put all of the shapes and skins into a raw JSON file and serve it up. The
 //   C++ code never reads it, but does reference IDs defined in it.
 // - The shapes could, in principle, reference sprites, which are likewise
-//   served up as one of more PNG files. Again, only the client has to care
-//   about how to render, while the server focuses on geometry and logic, such
-//   as hit boxes.
+//   served up as one or more PNG files. Again, only the client has to care
+//   about how to render, while the server focuses on physics, geometry, and
+//   logic.
 // - The definitions of enemies, towers, maps, and waves are kept in plain CSV
 //   files, which we can parse with nothing more than a comma splitter. These
 //   are deserialized into C++ structs at startup. We do not serve the CSV
@@ -143,8 +143,8 @@ struct SegmentedPath {
   // first so fast-moving entities visibly take corners instead of cutting
   // across them between updates. `progress` is clamped to `[0, totalLength]`.
   // Returns the origin if `segments` is empty.
-  [[nodiscard]] Position calculatePositionFromProgress(float progress,
-      float previousProgress) const {
+  [[nodiscard]] Position
+  calculatePositionFromProgress(float progress, float previousProgress) const {
     if (segments.empty()) return {};
     progress = std::clamp(progress, 0.F, totalLength);
 
@@ -257,7 +257,7 @@ struct PathFollower {
 // Note that towers sitting in the catalog or being dragged and dropped into
 // place are not entities, just client-side UI ephemera. Only once a tower is
 // placed does it become part of the world.
-struct PlacedTower {
+struct Defender {
   int tower_type{};
   float tower_radius{};
   float lever_multiplier{};
@@ -301,8 +301,7 @@ using ArchP = archetype_storage<WorldReg, std::tuple<Position>>;
 using ArchPV = archetype_storage<WorldReg, std::tuple<Position, Velocity>>;
 using ArchEnemy =
     archetype_storage<WorldReg, std::tuple<Position, PathFollower>>;
-using ArchTower =
-    archetype_storage<WorldReg, std::tuple<Position, PlacedTower>>;
+using ArchTower = archetype_storage<WorldReg, std::tuple<Position, Defender>>;
 using ArchBullet =
     archetype_storage<WorldReg, std::tuple<Position, Velocity, Bullet>>;
 using WorldScene =

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -202,32 +202,6 @@ struct SegmentedPath {
 using Tick = uint64_t;
 constexpr Tick invalidTick = std::numeric_limits<Tick>::max();
 
-// `Shape` is not a component, but entities may reference it to define an
-// aspect of their appearance. For now, we keep it simple by allowing a shape
-// and/or a Unicode character. This would allow, for example, a numerial "1"
-// inside a square.
-//
-// This is a placeholder.
-struct Shape {
-  int shape_id{};
-  int shape{};     // when it's made of a shape that the client knows about
-  char32_t logo{}; // when it uses an alphabetical character for display
-};
-
-// `Skin` is likewise not a component, and it builds upon `Shape`. A particular
-// object can be defined by a list of skins for its various manifestations.
-// It's possible that we might refactor all of this into a plain JSON file
-// that's sent to the client, keeping only the properties that need to be
-// tracked for gameplay, such as size and perhaps rotation.
-//
-// This is a placeholder.
-struct Skin {
-  int shape_id{};
-  uint32_t color{};
-  int size{};
-  int orientation{};
-};
-
 // TODO: We likely want to break out the physics-relevant properties into
 // components. We already have Position and Velocity (as well as PathFollower,
 // which is a type of velocity). We may need a Shape component which has the
@@ -252,22 +226,45 @@ struct PathFollower {
   float speed{};    // Distance per tick.
 };
 
-// Placed tower component. Stored alongside `Position` in the tower archetype.
+// Appearance component. Controls rendering on client side, but has no effect
+// on physics or game logic.
+struct Appearance {
+  char32_t glyph{};      // a Unicode character to display, if any.
+  float scale{1.F};      // multiplier on the base size of the shape, if any.
+  uint32_t fg_color{};   // RGB color, if any.
+  uint32_t bg_color{};   // RGB color, if any.
+  uint32_t glow_color{}; // RGB color for glow effect, if any.
+  Tick effect_expiry{invalidTick}; // When glow effect expires.
+};
+
+// Defensive tower component. Stored alongside `Position` in the tower
+// archetype.
 //
 // Note that towers sitting in the catalog or being dragged and dropped into
 // place are not entities, just client-side UI ephemera. Only once a tower is
 // placed does it become part of the world.
-struct Defender {
+struct Tower {
   int tower_type{};
-  float tower_radius{};
-  float lever_multiplier{};
+  float attack_radius{};
+  float attack_damage{}; // Per-attack damage.
+  Tick cooldown{};       // Cooldown for this sort of tower, in ticks.
+  Tick next_attack{};    // Tick when the next attack can occur.
+};
+
+// Enemy invader component. Stored alongside `Position` and `PathFollower` in
+// the enemy archetype.
+struct Invader {
+  float health{};
+  float radius{}; // Distinct from appearance: this is used for hit detection.
+  int bounty{1};  // Resources awarded to the player for killing this enemy.
 };
 
 // Bullet component. Stored alongside `Position` and `Velocity` in the bullet
 // archetype.
 struct Bullet {
   int bullet_type{};
-  Tick lifetime{};
+  float damage{};
+  Tick expiration{};
 };
 
 // ECS types for the simulation world.
@@ -285,10 +282,11 @@ struct Bullet {
 //                                           (Position + Velocity)
 //
 //   `sidEnemy`   = 3  -> `arch_enemy_t`   : path-following enemies
-//                                           (Position + PathFollower)
+//                                           (Position + Appearance +
+//                                           PathFollower + Invader)
 //
 //   `sidTower`   = 4  -> `arch_tower_t`   : placed towers
-//                                          (Position + PlacedTower)
+//                                          (Position + Appearance + Tower)
 //
 //   `sidBullet`  = 5  -> `arch_bullet_t`  : bullets
 //                                           (Position + Velocity + Bullet)
@@ -299,9 +297,10 @@ using WorldReg = entity_registry<Tick>;
 using WorldSid = WorldReg::store_id_t;
 using ArchP = archetype_storage<WorldReg, std::tuple<Position>>;
 using ArchPV = archetype_storage<WorldReg, std::tuple<Position, Velocity>>;
-using ArchEnemy =
-    archetype_storage<WorldReg, std::tuple<Position, PathFollower>>;
-using ArchTower = archetype_storage<WorldReg, std::tuple<Position, Defender>>;
+using ArchEnemy = archetype_storage<WorldReg,
+    std::tuple<Position, Appearance, PathFollower, Invader>>;
+using ArchTower =
+    archetype_storage<WorldReg, std::tuple<Position, Appearance, Tower>>;
 using ArchBullet =
     archetype_storage<WorldReg, std::tuple<Position, Velocity, Bullet>>;
 using WorldScene =
@@ -370,8 +369,8 @@ public:
     if (pathId >= paths_.size_as_enum()) return {};
     const auto pos =
         paths_[pathId].calculatePositionFromProgress(progress, progress);
-    return scene_.store_new_entity<sidEnemy>(tick_, pos,
-        PathFollower{pathId, progress, speed});
+    return scene_.store_new_entity<sidEnemy>(tick_, pos, Appearance{},
+        PathFollower{pathId, progress, speed}, Invader{});
   }
 
   // Advance one simulation frame. Sets each changed entity's registry metadata

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -1,0 +1,206 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <numbers>
+#include <vector>
+
+#include "../ecs.h"
+
+namespace corvid { inline namespace sim {
+
+// Convert Euclidean vector (x, y) to polar form (length, direction).
+// `direction` is in radians,
+inline std::pair<float, float> cartesian_to_polar(float x, float y) {
+  float length = std::sqrt((x * x) + (y * y));
+  float direction = std::atan2(y, x);
+  return {length, direction};
+}
+
+// Convert a Euclidean vector in polar form to Cartesian form. `direction` is
+// in radians.
+inline std::pair<float, float>
+polar_to_cartesian(float length, float direction) {
+  float x = length * std::cos(direction);
+  float y = length * std::sin(direction);
+  return {x, y};
+}
+
+// 2D Cartesian position component, in world-space pixels.
+struct Position {
+  float x{};
+  float y{};
+
+  static Position from_polar(float radius, float angle) {
+    auto [x, y] = polar_to_cartesian(radius, angle);
+    return {x, y};
+  }
+};
+
+// 2D Cartesian velocity component, in world-space pixels per frame.
+struct Velocity {
+  float vx{};
+  float vy{};
+
+  [[nodiscard]] static Velocity from_polar(float speed, float angle) {
+    auto [vx, vy] = polar_to_cartesian(speed, angle);
+    return {vx, vy};
+  }
+};
+
+// ECS types for the simulation world.
+//
+// Registry metadata (`uint64_t`) stores each entity's last-change tick count,
+// enabling delta snapshots without a separate dirty set.
+//
+// Storage layout (store_id assignment is positional, 1-based):
+//   `p_sid`  = 1  -> `arch_p_t`  : background / retired entities (Position)
+//   `pv_sid` = 2  -> `arch_pv_t` : moving entities (Position + Velocity)
+//
+// Background storage comes first so that retiring a mobile entity is a
+// natural `archetype_scene::migrate_entity` call rather than erase+re-add.
+using tick_t = uint64_t;
+using world_reg_t = entity_registry<tick_t>;
+using world_sid_t = world_reg_t::store_id_t;
+using arch_p_t = archetype_storage<world_reg_t, std::tuple<Position>>;
+using arch_pv_t =
+    archetype_storage<world_reg_t, std::tuple<Position, Velocity>>;
+using world_scene_t = archetype_scene<world_reg_t, arch_p_t, arch_pv_t>;
+
+// Simulation world: encapsulates all ECS entity state for the game.
+//
+// Background entities (Position only) live in `p_sid`. Moving entities
+// (Position + Velocity) live in `pv_sid`. Each `tick()` advances positions by
+// velocity and bounces off the world boundary. The registry metadata records
+// the tick count at each entity's last state change so callers can request
+// delta snapshots starting from any past tick.
+class sim_world {
+public:
+  using entity_id_t = world_reg_t::id_t;
+  using handle_t = world_reg_t::handle_t;
+
+  static constexpr world_sid_t p_sid{1};
+  static constexpr world_sid_t pv_sid{2};
+
+  static constexpr float world_width = 1920.0;
+  static constexpr float world_height = 1080.0;
+
+  // State snapshot for a single entity.
+  struct entity_snapshot {
+    entity_id_t id;
+    Position pos;
+  };
+
+  // Spawn a moving entity with the given initial position and velocity.
+  // Returns a handle for later `despawn()`. The entity's last-change tick
+  // is set to the current tick count.
+  [[nodiscard]] handle_t spawn(Position pos, Velocity vel) {
+    return scene_.store_new_entity<pv_sid>(tick_n_, pos, vel);
+  }
+
+  // Spawn a static background entity. Returns a handle for later `despawn()`.
+  [[nodiscard]] handle_t spawn_background(Position pos) {
+    return scene_.store_new_entity<p_sid>(tick_n_, pos);
+  }
+
+  // Returns true if the handle refers to a live entity.
+  [[nodiscard]] bool is_alive(handle_t h) const {
+    return scene_.registry().is_valid(h);
+  }
+
+  // Erase an entity by handle. Invalidates the handle. Returns false if the
+  // handle is no longer valid (entity already dead).
+  bool despawn(handle_t& h) { return scene_.erase_entity(h); }
+
+  // Advance one simulation frame. For every PV entity: add velocity to
+  // position, then bounce off the world boundary by reversing the relevant
+  // velocity component and clamping the position. Sets each moved entity's
+  // registry metadata to the new tick count.
+  //
+  // If `out` is non-null, the IDs of all entities whose state changed are
+  // appended to `*out`. Pass `nullptr` (the default) when only the side
+  // effects are needed, to avoid the allocation.
+  [[nodiscard]] tick_t tick(std::vector<entity_id_t>* out = nullptr) {
+    ++tick_n_;
+    scene_.for_each<Position, Velocity>([&](auto id, auto comps) {
+      auto& [pos, vel] = comps;
+
+      pos.x += vel.vx;
+      pos.y += vel.vy;
+
+      apply_boundary(pos.x, vel.vx, world_width);
+      apply_boundary(pos.y, vel.vy, world_height);
+
+      scene_.registry()[id] = tick_n_;
+      if (out) out->push_back(id);
+      return true;
+    });
+    return tick_n_;
+  }
+
+  // Return snapshots for every entity whose last-change tick is >=
+  // `since_tick`. Pass 0 (the default) to return all entities. Visits both
+  // `p_sid` and `pv_sid` storages since both carry `Position`.
+  [[nodiscard]] std::vector<entity_snapshot> snapshot(
+      tick_t since_tick = 0) const {
+    std::vector<entity_snapshot> result;
+    result.reserve(scene_.size());
+    scene_.for_each<Position>([&](auto id, auto comps) {
+      auto& [pos] = comps;
+      if (scene_.registry()[id] >= since_tick) result.push_back({id, pos});
+      return true;
+    });
+    return result;
+  }
+
+  // Return snapshots for a specific list of entity IDs. Invalid or dead IDs
+  // are silently skipped.
+  [[nodiscard]] std::vector<entity_snapshot> snapshot(
+      const std::vector<entity_id_t>& ids) const {
+    std::vector<entity_snapshot> result;
+    result.reserve(ids.size());
+    for (auto id : ids) {
+      if (const auto* pos = scene_.try_get_component<Position>(id))
+        result.push_back({id, *pos});
+    }
+    return result;
+  }
+
+  // Total number of entities in all storages (does not count staged entities).
+  [[nodiscard]] std::size_t size() const { return scene_.size(); }
+
+private:
+  world_scene_t scene_;
+  tick_t tick_n_{0};
+
+  // Clamp `pos` to `[-limit/2, +limit/2]` and, if it was out of range, negate
+  // `vel` so the entity bounces off that boundary wall.
+  static void apply_boundary(float& pos, float& vel, float limit) {
+    const float half = limit * 0.5F;
+    if (pos < -half) {
+      pos = -half;
+      vel = -vel;
+    } else if (pos > half) {
+      pos = half;
+      vel = -vel;
+    }
+  }
+};
+
+}} // namespace corvid::sim

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -389,22 +389,24 @@ public:
 
   // Destructively extract upserts and erasures.
   //
-  // Call back `cbUpserts(EntityId, Position)` for each changed entity that has
-  // a `Position` and has changed since the last tick, and `cbErased(EntityId)`
-  // for each entity that has been erased since the last tick. These calls will
-  // be interleaved.
+  // Call back `cbUpserts(EntityId, Position, Appearance)` for each changed
+  // entity that has a `Position` and `Appearance` and has changed since the
+  // last tick, and `cbErased(EntityId)` for each entity that has been erased
+  // since the last tick. These calls will be interleaved.
   [[nodiscard]] bool
   extractUpdatedEntities(auto&& cbUpserts, auto&& cbErased) {
     auto& reg = scene_.registry();
-    for (auto id : updatedEntities_)
-      if (const auto* pos = scene_.try_get_component<Position>(id))
-        (void)cbUpserts(id, *pos);
-      else {
+    for (auto id : updatedEntities_) {
+      const auto [pos, app] =
+          scene_.try_get_components<Position, Appearance>(id);
+      if (pos && app) {
+        (void)cbUpserts(id, *pos, *app);
+      } else {
         if (reg.get_location(id).store_id != sidStaging) continue;
         (void)cbErased(id);
         (void)scene_.erase_entity(id);
       }
-
+    }
     updatedEntities_.clear();
     return true;
   }

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -20,6 +20,7 @@
 #include <cmath>
 #include <cstdint>
 #include <numbers>
+#include <stdexcept>
 #include <vector>
 
 #include "../ecs.h"
@@ -168,6 +169,16 @@ struct SegmentedPath {
     sp.width = p.width;
     sp.segments.reserve(p.joints.size() - 1);
     float cumulative{};
+    constexpr float half_w = 1920.F / 2.F;
+    constexpr float half_h = 1080.F / 2.F;
+
+    for (const auto& joint : p.joints) {
+      const auto& pos = joint.p;
+      // Check for configuration errors.
+      if (pos.x < -half_w || pos.x > half_w || pos.y < -half_h ||
+          pos.y > half_h)
+        throw std::runtime_error("Path joint lies outside the world bounds");
+    }
 
     for (std::size_t i = 0; i + 1 < p.joints.size(); ++i) {
       const Position& front = p.joints[i].p;
@@ -400,6 +411,8 @@ public:
     if (pathId >= paths_.size_as_enum()) return false;
     const auto& sp = paths_[pathId];
     for (const auto& seg : sp.segments) cbPath(pathId, Position{seg.front});
+    if (!sp.segments.empty())
+      cbPath(pathId, Position{sp.segments.back().back});
     return true;
   }
 

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -139,9 +139,12 @@ struct SegmentedPath {
   float width{};
 
   // Map a distance traveled (`progress`) to a world-space `Position`.
-  // `progress` is clamped to `[0, totalLength]`. Returns the origin if
-  // `segments` is empty.
-  [[nodiscard]] Position calculatePositionFromProgress(float progress) const {
+  // If `previousProgress` was on an earlier segment, emit the joint position
+  // first so fast-moving entities visibly take corners instead of cutting
+  // across them between updates. `progress` is clamped to `[0, totalLength]`.
+  // Returns the origin if `segments` is empty.
+  [[nodiscard]] Position calculatePositionFromProgress(float progress,
+      float previousProgress) const {
     if (segments.empty()) return {};
     progress = std::clamp(progress, 0.F, totalLength);
 
@@ -150,6 +153,8 @@ struct SegmentedPath {
         &SegmentedPath::Segment::cumulativeStart);
     if (it != segments.begin()) --it;
     const auto& seg = *it;
+
+    if (previousProgress < seg.cumulativeStart) return seg.front;
 
     // Calculate the interpolation factor `t` along this segment, then lerp the
     // front and back positions to get the world position.
@@ -364,7 +369,8 @@ public:
   [[nodiscard]] Handle
   spawnEnemy(PathId pathId, float speed, float progress = 0.F) {
     if (pathId >= paths_.size_as_enum()) return {};
-    const auto pos = paths_[pathId].calculatePositionFromProgress(progress);
+    const auto pos =
+        paths_[pathId].calculatePositionFromProgress(progress, progress);
     return scene_.store_new_entity<sidEnemy>(tick_, pos,
         PathFollower{pathId, progress, speed});
   }
@@ -527,6 +533,7 @@ private:
 
       (void)markDirty(id);
 
+      const float previousProgress = pf.progress;
       pf.progress += pf.speed;
       const auto& sp = paths_[pf.pathId];
 
@@ -536,7 +543,7 @@ private:
         return true;
       }
 
-      pos = sp.calculatePositionFromProgress(pf.progress);
+      pos = sp.calculatePositionFromProgress(pf.progress, previousProgress);
       return true;
     });
 

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -26,21 +26,27 @@
 
 namespace corvid { inline namespace sim {
 
-// Convert Euclidean vector (x, y) to polar form (length, direction).
-// `direction` is in radians,
-inline std::pair<float, float> cartesian_to_polar(float x, float y) {
+// Convert Cartesian coordinates (x, y) to a Euclidean vector, in polar form
+// (length, direction). `direction` is in radians,
+[[nodiscard]] constexpr std::pair<float, float>
+cartesian_to_polar(float x, float y) noexcept {
   float length = std::sqrt((x * x) + (y * y));
   float direction = std::atan2(y, x);
   return {length, direction};
 }
 
-// Convert a Euclidean vector in polar form to Cartesian form. `direction` is
-// in radians.
-inline std::pair<float, float>
-polar_to_cartesian(float length, float direction) {
+// Convert a Euclidean vector, in polar form, to Cartesian coordinates.
+// `direction` is in radians.
+[[nodiscard]] constexpr std::pair<float, float>
+polar_to_cartesian(float length, float direction) noexcept {
   float x = length * std::cos(direction);
   float y = length * std::sin(direction);
   return {x, y};
+}
+
+// Linear interpolation calculator
+[[nodiscard]] constexpr float lerp(float a, float b, float t) noexcept {
+  return a + ((b - a) * t);
 }
 
 // 2D Cartesian position component, in world-space pixels.
@@ -67,9 +73,10 @@ struct Velocity {
 
 // --- Path geometry ---
 
-// Authored path: a sequence of joints and a road half-width in world-space
-// pixels. Processed into a `baked_path` before use at runtime.
-struct path {
+// `path_joints` defines a path in terms of the coordinates of its joints. This
+// is the authored path, a compact format suitable for defining the path, but
+// not ideal for runtime use, which is why it's converted to `segmented_path`.
+struct path_joints {
   struct joint {
     Position p;
   };
@@ -78,9 +85,11 @@ struct path {
   float width{40.F};
 };
 
-// Runtime-ready path: pre-computed segments with cumulative distances,
-// produced once from a `path` by `bake_path()`.
-struct baked_path {
+// `segmented_path` is built from a `path_joints` and consists of pre-computed
+// segments with cumulative distances, enabling efficient runtime mapping from
+// distance traveled to world position. Essentially, it's an indexed vertex
+// buffer for the path geometry.
+struct segmented_path {
   struct segment {
     Position front;
     Position back;
@@ -92,50 +101,55 @@ struct baked_path {
   float total_length{};
   float width{};
 
-  // Map a distance traveled (`progress`) along `bp` to a world-space
-  // `Position`. `progress` is clamped to `[0, total_length]`. Returns the
-  // origin if `bp` has no segments.
+  // Map a distance traveled (`progress`) to a world-space `Position`.
+  // `progress` is clamped to `[0, total_length]`. Returns the origin if
+  // `segments` is empty.
   [[nodiscard]] Position position_from_progress(float progress) const {
     if (segments.empty()) return {};
     progress = std::clamp(progress, 0.F, total_length);
+
     // Find the last segment whose cumulative_start <= progress.
     auto it = std::ranges::upper_bound(segments, progress, {},
-        &baked_path::segment::cumulative_start);
+        &segmented_path::segment::cumulative_start);
     if (it != segments.begin()) --it;
     const auto& seg = *it;
-    const float t =
-        (seg.length > 0.F)
-            ? ((progress - seg.cumulative_start) / seg.length)
-            : 0.F;
-    return {(seg.front.x + ((seg.back.x - seg.front.x) * t)),
-        (seg.front.y + ((seg.back.y - seg.front.y) * t))};
+
+    // Calculate the interpolation factor `t` along this segment, then lerp the
+    // front and back positions to get the world position.
+    float t = 0.F;
+    if (seg.length > 0.F) t = (progress - seg.cumulative_start) / seg.length;
+
+    return {lerp(seg.front.x, seg.back.x, t),
+        lerp(seg.front.y, seg.back.y, t)};
   }
 
-  // Convert an authored `path` into a `baked_path`. Requires at least two
-  // joints; returns an empty `baked_path` if the input is degenerate.
-  static baked_path from_path(const path& p) {
+  // Convert authored `path_joints` into a `segmented_path`. Requires at
+  // least two joints; returns an empty `segmented_path` if the input is
+  // degenerate.
+  static segmented_path from_joints(const path_joints& p) {
     if (p.joints.size() < 2) return {};
-    baked_path bp;
-    bp.width = p.width;
-    bp.segments.reserve(p.joints.size() - 1);
+    segmented_path sp;
+    sp.width = p.width;
+    sp.segments.reserve(p.joints.size() - 1);
     float cumulative{};
+
     for (std::size_t i = 0; i + 1 < p.joints.size(); ++i) {
       const Position& front = p.joints[i].p;
       const Position& back = p.joints[i + 1].p;
       const float dx = back.x - front.x;
       const float dy = back.y - front.y;
       const float len = std::hypot(dx, dy);
-      bp.segments.push_back({front, back, len, cumulative});
+      sp.segments.push_back({front, back, len, cumulative});
       cumulative += len;
     }
-    bp.total_length = cumulative;
-    return bp;
+    sp.total_length = cumulative;
+    return sp;
   }
 };
 
 // Path-following component. Stored alongside `Position` in the enemy
 // archetype. Each tick, `progress` advances by `speed`; the entity's
-// `Position` is re-derived from the baked path geometry.
+// `Position` is re-derived from the segmented path geometry.
 struct PathFollower {
   uint8_t path_id{}; // Index into `sim_world::paths_`.
   float progress{};  // Distance traveled along the path so far.
@@ -148,10 +162,14 @@ struct PathFollower {
 // enabling delta snapshots without a separate dirty set.
 //
 // Storage layout (store_id assignment is positional, 1-based):
-//   `p_sid`      = 1  -> `arch_p_t`      : background / retired (Position)
-//   `pv_sid`     = 2  -> `arch_pv_t`     : moving entities (Position +
-//   Velocity) `enemy_sid`  = 3  -> `arch_enemy_t`  : path-following enemies
-//   (Position + PathFollower)
+//   `p_sid`      = 1  -> `arch_p_t`      : background / destructible / retired
+//                                          (Position)
+
+//   `pv_sid`     = 2  -> `arch_pv_t`     : moving entities
+//                                          (Position + Velocity)
+
+//   `enemy_sid`  = 3  -> `arch_enemy_t`  : path-following enemies
+//                                          (Position + PathFollower)
 //
 // Background storage comes first so that retiring a mobile entity is a
 // natural `archetype_scene::migrate_entity` call rather than erase+re-add.
@@ -185,10 +203,16 @@ public:
   static constexpr float world_width = 1920.0;
   static constexpr float world_height = 1080.0;
 
-  // State snapshot for a single entity.
+  // State snapshot for a single entity. This is the serialization format for
+  // the entity state sent to clients.
   struct entity_snapshot {
     entity_id_t id;
     Position pos;
+  };
+
+  struct authored_path_snapshot {
+    std::vector<Position> joints;
+    float width{};
   };
 
   // Spawn a moving entity with the given initial position and velocity.
@@ -205,15 +229,38 @@ public:
 
   // Bake and store a path. Returns the index used as `PathFollower::path_id`.
   // The index is stable for the lifetime of the world.
-  [[nodiscard]] uint8_t add_path(const path& p) {
-    paths_.push_back(baked_path::from_path(p));
+  [[nodiscard]] uint8_t add_path(const path_joints& p) {
+    authored_paths_.push_back(p);
+    paths_.push_back(segmented_path::from_joints(p));
     return static_cast<uint8_t>(paths_.size() - 1);
   }
 
+  // Return the authored path at `id`, or `nullptr` if out of range.
+  [[nodiscard]] const path_joints* get_authored_path(uint8_t id) const {
+    if (id >= authored_paths_.size()) return nullptr;
+    return &authored_paths_[id];
+  }
+
   // Return a pointer to the baked path at `id`, or `nullptr` if out of range.
-  [[nodiscard]] const baked_path* get_path(uint8_t id) const {
+  [[nodiscard]] const segmented_path* get_path(uint8_t id) const {
     if (id >= paths_.size()) return nullptr;
     return &paths_[id];
+  }
+
+  // Return snapshots for all authored paths so the client can render the
+  // original joints while runtime movement follows the baked geometry.
+  [[nodiscard]] std::vector<authored_path_snapshot> path_snapshot() const {
+    std::vector<authored_path_snapshot> result;
+    result.reserve(authored_paths_.size());
+
+    for (const auto& p : authored_paths_) {
+      authored_path_snapshot snap;
+      snap.width = p.width;
+      snap.joints.reserve(p.joints.size());
+      for (const auto& joint : p.joints) snap.joints.push_back(joint.p);
+      result.push_back(std::move(snap));
+    }
+    return result;
   }
 
   // Spawn a path-following enemy. Initial position is derived from `progress`
@@ -223,6 +270,7 @@ public:
     Position pos{};
     if (path_id < paths_.size())
       pos = paths_[path_id].position_from_progress(progress);
+
     return scene_.store_new_entity<enemy_sid>(tick_n_, pos,
         PathFollower{path_id, progress, speed});
   }
@@ -328,7 +376,8 @@ public:
 private:
   world_scene_t scene_;
   tick_t tick_n_{0};
-  std::vector<baked_path> paths_;
+  std::vector<path_joints> authored_paths_;
+  std::vector<segmented_path> paths_;
 
   // Clamp `pos` to `[-limit/2, +limit/2]` and, if it was out of range, negate
   // `vel` so the entity bounces off that boundary wall.

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -27,13 +27,15 @@
 namespace corvid { inline namespace sim {
 
 // ID of path.
-enum class path_id_t : uint8_t { invalid = 255 };
+enum class PathId : uint16_t {
+  invalid = std::numeric_limits<uint16_t>::max()
+};
 
 }} // namespace corvid::sim
 
 template<>
-constexpr auto corvid::enums::registry::enum_spec_v<corvid::sim::path_id_t> =
-    corvid::enums::sequence::make_sequence_enum_spec<corvid::sim::path_id_t,
+constexpr auto corvid::enums::registry::enum_spec_v<corvid::sim::PathId> =
+    corvid::enums::sequence::make_sequence_enum_spec<corvid::sim::PathId,
         "">();
 
 namespace corvid { inline namespace sim {
@@ -85,31 +87,31 @@ struct Velocity {
 
 // --- Path geometry ---
 
-// `path_joints` defines a path in terms of the coordinates of its joints. This
+// `PathJoints` defines a path in terms of the coordinates of its joints. This
 // is the authored path, a compact format suitable for defining the path, but
-// not ideal for runtime use, which is why it's converted to `segmented_path`.
-struct path_joints {
-  struct joint {
+// not ideal for runtime use, which is why it's converted to `SegmentedPath`.
+struct PathJoints {
+  struct Joint {
     Position p;
   };
 
-  std::vector<joint> joints;
+  std::vector<Joint> joints;
   float width{40.F};
 };
 
-// `segmented_path` is built from a `path_joints` and consists of pre-computed
+// `SegmentedPath` is built from a `PathJoints` and consists of pre-computed
 // segments with cumulative distances, enabling efficient runtime mapping from
 // distance traveled to world position. Essentially, it's an indexed vertex
 // buffer for the path geometry.
-struct segmented_path {
-  struct segment {
+struct SegmentedPath {
+  struct Segment {
     Position front;
     Position back;
     float length;           // Euclidean distance from `front` to `back`.
     float cumulative_start; // Sum of lengths of all preceding segments.
   };
 
-  std::vector<segment> segments;
+  std::vector<Segment> segments;
   float total_length{};
   float width{};
 
@@ -122,7 +124,7 @@ struct segmented_path {
 
     // Find the last segment whose cumulative_start <= progress.
     auto it = std::ranges::upper_bound(segments, progress, {},
-        &segmented_path::segment::cumulative_start);
+        &SegmentedPath::Segment::cumulative_start);
     if (it != segments.begin()) --it;
     const auto& seg = *it;
 
@@ -135,12 +137,12 @@ struct segmented_path {
         lerp(seg.front.y, seg.back.y, t)};
   }
 
-  // Convert authored `path_joints` into a `segmented_path`. Requires at
-  // least two joints; returns an empty `segmented_path` if the input is
+  // Convert authored `PathJoints` into a `SegmentedPath`. Requires at
+  // least two joints; returns an empty `SegmentedPath` if the input is
   // degenerate.
-  static segmented_path from_joints(const path_joints& p) {
+  static SegmentedPath from_joints(const PathJoints& p) {
     if (p.joints.size() < 2) return {};
-    segmented_path sp;
+    SegmentedPath sp;
     sp.width = p.width;
     sp.segments.reserve(p.joints.size() - 1);
     float cumulative{};
@@ -158,8 +160,8 @@ struct segmented_path {
     return sp;
   }
 
-  [[nodiscard]] path_joints to_joints() const {
-    path_joints pj;
+  [[nodiscard]] PathJoints to_joints() const {
+    PathJoints pj;
     pj.width = width;
     pj.joints.reserve(segments.size() + 1);
     for (const auto& seg : segments) pj.joints.push_back({seg.front});
@@ -172,9 +174,9 @@ struct segmented_path {
 // archetype. Each tick, `progress` advances by `speed`; the entity's
 // `Position` is re-derived from the segmented path geometry.
 struct PathFollower {
-  path_id_t path_id{}; // Index into `sim_world::paths_`.
-  float progress{};    // Distance traveled along the path so far.
-  float speed{};       // Distance per tick.
+  PathId path_id{}; // Index into `sim_world::paths_`.
+  float progress{}; // Distance traveled along the path so far.
+  float speed{};    // Distance per tick.
 };
 
 // ECS types for the simulation world.
@@ -194,16 +196,14 @@ struct PathFollower {
 //
 // Background storage comes first so that retiring a mobile entity is a
 // natural `archetype_scene::migrate_entity` call rather than erase+re-add.
-using tick_t = uint64_t;
-using world_reg_t = entity_registry<tick_t>;
-using world_sid_t = world_reg_t::store_id_t;
-using arch_p_t = archetype_storage<world_reg_t, std::tuple<Position>>;
-using arch_pv_t =
-    archetype_storage<world_reg_t, std::tuple<Position, Velocity>>;
-using arch_enemy_t =
-    archetype_storage<world_reg_t, std::tuple<Position, PathFollower>>;
-using world_scene_t =
-    archetype_scene<world_reg_t, arch_p_t, arch_pv_t, arch_enemy_t>;
+using Tick = uint64_t;
+using WorldReg = entity_registry<Tick>;
+using WorldSid = WorldReg::store_id_t;
+using ArchP = archetype_storage<WorldReg, std::tuple<Position>>;
+using ArchPV = archetype_storage<WorldReg, std::tuple<Position, Velocity>>;
+using ArchEnemy =
+    archetype_storage<WorldReg, std::tuple<Position, PathFollower>>;
+using WorldScene = archetype_scene<WorldReg, ArchP, ArchPV, ArchEnemy>;
 
 // Simulation world: encapsulates all ECS entity state for the game.
 //
@@ -212,55 +212,55 @@ using world_scene_t =
 // velocity and bounces off the world boundary. The registry metadata records
 // the tick count at each entity's last state change so callers can request
 // delta snapshots starting from any past tick.
-class sim_world {
+class SimWorld {
 public:
-  using entity_id_t = world_reg_t::id_t;
-  using handle_t = world_reg_t::handle_t;
+  using EntityId = WorldReg::id_t;
+  using Handle = WorldReg::handle_t;
 
-  static constexpr world_sid_t p_sid{1};
-  static constexpr world_sid_t pv_sid{2};
-  static constexpr world_sid_t enemy_sid{3};
+  static constexpr WorldSid p_sid{1};
+  static constexpr WorldSid pv_sid{2};
+  static constexpr WorldSid enemy_sid{3};
 
   static constexpr float world_width = 1920.0;
   static constexpr float world_height = 1080.0;
 
   // State snapshot for a single entity. This is the serialization format for
   // the entity state sent to clients.
-  struct entity_snapshot {
-    entity_id_t id;
+  struct EntitySnapshot {
+    EntityId id;
     Position pos;
   };
 
   // Spawn a moving entity with the given initial position and velocity.
   // Returns a handle for later `despawn()`. The entity's last-change tick
   // is set to the current tick count.
-  [[nodiscard]] handle_t spawn(Position pos, Velocity vel) {
+  [[nodiscard]] Handle spawn(Position pos, Velocity vel) {
     return scene_.store_new_entity<pv_sid>(tick_n_, pos, vel);
   }
 
-  // Spawn a static background entity. Returns a handle for later `despawn()`.
-  [[nodiscard]] handle_t spawn_background(Position pos) {
+  // Spawn an immobile entity. Returns a handle for later `despawn()`.
+  [[nodiscard]] Handle spawn_background(Position pos) {
     return scene_.store_new_entity<p_sid>(tick_n_, pos);
   }
 
-  // Bake and store a path. Returns the index used as `PathFollower::path_id`.
+  // Bake and store a path. Returns the index used as `path_follower::path_id`.
   // The index is stable for the lifetime of the world.
-  [[nodiscard]] path_id_t add_path(const path_joints& p) {
-    if (!paths_.push_back(segmented_path::from_joints(p)))
-      return path_id_t::invalid;
+  [[nodiscard]] PathId add_path(const PathJoints& p) {
+    if (!paths_.push_back(SegmentedPath::from_joints(p)))
+      return PathId::invalid;
     return paths_.size_as_enum() - 1;
   }
 
   // Return a pointer to the baked path at `id`, or `nullptr` if out of range.
-  [[nodiscard]] const segmented_path* get_path(path_id_t path_id) const {
-    if (*path_id >= paths_.size()) return nullptr;
+  [[nodiscard]] const SegmentedPath* get_path(PathId path_id) const {
+    if (path_id >= paths_.size_as_enum()) return nullptr;
     return &paths_[path_id];
   }
 
   // Return snapshots for all authored paths so the client can render the
   // original joints while runtime movement follows the baked geometry.
-  [[nodiscard]] std::vector<path_joints> path_snapshot() const {
-    std::vector<path_joints> result;
+  [[nodiscard]] std::vector<PathJoints> path_snapshot() const {
+    std::vector<PathJoints> result;
     result.reserve(paths_.size() + 1);
     for (const auto& p : paths_) result.push_back(p.to_joints());
     return result;
@@ -268,22 +268,22 @@ public:
 
   // Spawn a path-following enemy. Initial position is derived from `progress`
   // on the named path. Returns a handle for later `despawn()`.
-  [[nodiscard]] handle_t
-  spawn_enemy(path_id_t path_id, float speed, float progress = 0.F) {
-    if (static_cast<uint8_t>(path_id) >= paths_.size()) return {};
+  [[nodiscard]] Handle
+  spawn_enemy(PathId path_id, float speed, float progress = 0.F) {
+    if (path_id >= paths_.size_as_enum()) return {};
     const auto pos = paths_[path_id].position_from_progress(progress);
     return scene_.store_new_entity<enemy_sid>(tick_n_, pos,
         PathFollower{path_id, progress, speed});
   }
 
   // Returns true if the handle refers to a live entity.
-  [[nodiscard]] bool is_alive(handle_t h) const {
+  [[nodiscard]] bool is_alive(Handle h) const {
     return scene_.registry().is_valid(h);
   }
 
   // Erase an entity by handle. Invalidates the handle. Returns false if the
   // handle is no longer valid (entity already dead).
-  bool despawn(handle_t& h) { return scene_.erase_entity(h); }
+  bool despawn(Handle& h) { return scene_.erase_entity(h); }
 
   // Advance one simulation frame. For every PV entity: add velocity to
   // position, then bounce off the world boundary by reversing the relevant
@@ -293,7 +293,7 @@ public:
   // If `out` is non-null, the IDs of all entities whose state changed are
   // appended to `*out`. Pass `nullptr` (the default) when only the side
   // effects are needed, to avoid the allocation.
-  [[nodiscard]] tick_t tick(std::vector<entity_id_t>* out = nullptr) {
+  [[nodiscard]] Tick tick(std::vector<EntityId>* out = nullptr) {
     ++tick_n_;
 
     // Advance velocity-driven entities.
@@ -329,7 +329,7 @@ public:
 
     // Advance path-following enemies. Collect entities that reached the end
     // so they can be despawned after iteration.
-    std::vector<entity_id_t> finished;
+    std::vector<EntityId> finished;
     scene_.for_each<Position, PathFollower>([&](auto id, auto comps) {
       auto& [pos, pf] = comps;
       pf.progress += pf.speed;
@@ -367,9 +367,9 @@ public:
   // Return snapshots for every entity whose that has changed since
   // `since_tick`. Pass 0 (the default) to return all entities. Visits all
   // storages that carry `Position` (`p_sid`, `pv_sid`, `enemy_sid`).
-  [[nodiscard]] std::vector<entity_snapshot> snapshot(
-      tick_t since_tick = 0) const {
-    std::vector<entity_snapshot> result;
+  [[nodiscard]] std::vector<EntitySnapshot> snapshot(
+      Tick since_tick = 0) const {
+    std::vector<EntitySnapshot> result;
     result.reserve(scene_.size());
     scene_.for_each<Position>([&](auto id, auto comps) {
       auto& [pos] = comps;
@@ -381,9 +381,9 @@ public:
 
   // Return snapshots for a specific list of entity IDs. Invalid or dead IDs
   // are silently skipped.
-  [[nodiscard]] std::vector<entity_snapshot> snapshot(
-      const std::vector<entity_id_t>& ids) const {
-    std::vector<entity_snapshot> result;
+  [[nodiscard]] std::vector<EntitySnapshot> snapshot(
+      const std::vector<EntityId>& ids) const {
+    std::vector<EntitySnapshot> result;
     result.reserve(ids.size());
     for (auto id : ids) {
       if (const auto* pos = scene_.try_get_component<Position>(id))
@@ -396,9 +396,9 @@ public:
   [[nodiscard]] std::size_t size() const { return scene_.size(); }
 
 private:
-  world_scene_t scene_;
-  tick_t tick_n_{0};
-  id_container<segmented_path, path_id_t> paths_;
+  WorldScene scene_;
+  Tick tick_n_{0};
+  id_container<SegmentedPath, PathId> paths_;
 
   // Clamp `pos` to `[-limit/2, +limit/2]` and, if it was out of range, negate
   // `vel` so the entity bounces off that boundary wall.

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -362,7 +362,7 @@ public:
   // Returns a handle for later `despawn()`. The entity's last-change tick
   // is set to the current tick count.
   [[nodiscard]] Handle spawnMover(Position pos, Velocity vel) {
-    Appearance app{.modified = nextSyncTick(),
+    Appearance app{.modified = tick_,
         .glyph = U'M',
         .radius = 5.F,
         .fg_color = 0xFFFFFFFF,
@@ -375,7 +375,7 @@ public:
 
   // Spawn an immobile entity. Returns a handle for later `despawn()`.
   [[nodiscard]] Handle spawnBackground(Position pos) {
-    Appearance app{.modified = nextSyncTick(),
+    Appearance app{.modified = tick_,
         .glyph = U'B',
         .radius = 5.F,
         .fg_color = 0xFFFFFFFF,
@@ -392,7 +392,7 @@ public:
         .attack_damage = 10.F,
         .cooldown = {},
         .next_attack = tick_};
-    Appearance app{.modified = nextSyncTick(),
+    Appearance app{.modified = tick_,
         .glyph = U'T',
         .radius = 20.F,
         .fg_color = 0xFFFFFFFF,
@@ -444,7 +444,7 @@ public:
   [[nodiscard]] Appearance* changeAppearance(EntityId id) {
     auto* app = scene_.try_get_component<Appearance>(id);
     if (!app) return nullptr;
-    app->modified = nextSyncTick();
+    app->modified = tick_;
     (void)markDirty(id);
     return app;
   }
@@ -455,7 +455,7 @@ public:
   [[nodiscard]] VisualEffects* changeVisualEffects(EntityId id) {
     auto* effects = scene_.try_get_component<VisualEffects>(id);
     if (!effects) return nullptr;
-    effects->modified = nextSyncTick();
+    effects->modified = tick_;
     (void)markDirty(id);
     return effects;
   }
@@ -523,16 +523,22 @@ public:
     return found_id;
   }
 
-  // Advance one simulation frame. Sets each changed entity's registry metadata
-  // to the new tick count and tracks changed entities for callbacks.
-  [[nodiscard]] WorldTick tick() {
-    ++tick_;
-
+  // Run all physics for the current tick without advancing the counter. Call
+  // `tick()` once all game logic for this frame is complete, including
+  // streaming the state to clients.
+  [[nodiscard]] bool next() {
     (void)updateMovers();
     (void)updatePathFollowers();
-
-    return tick_;
+    return true;
   }
+
+  // Advance the tick counter and return the new value. Call this at the end
+  // of each frame, after `next()`, all game-level logic, and streaming have
+  // run.
+  [[nodiscard]] WorldTick tick() { return ++tick_; }
+
+  // Return the current tick counter without advancing it.
+  [[nodiscard]] WorldTick currentTick() const { return tick_; }
 
   // Total number of entities in all storages (does not count staged entities).
   [[nodiscard]] std::size_t size() const { return scene_.size(); }
@@ -605,10 +611,11 @@ public:
     return true;
   }
 
-  // Mark all entities dirty. When `update_strategy::incremental`, does not
-  // mark appearances, just entities. When `update_strategy::full`, also marks
-  // appearance and visual-effect components dirty by updating their
-  // `modified` field.
+  // Mark all entities dirty. When `update_strategy::incremental`, marks
+  // entities for extraction only. When `update_strategy::full`, also stamps
+  // `Appearance` and `VisualEffects` `modified` fields with `tick_` so the
+  // next extraction includes them. Must be called before `tick()` so
+  // `markDirty`'s deduplication check (`last_updated == tick_`) is valid.
   [[nodiscard]] bool markAllDirty(
       update_strategy strategy = update_strategy::incremental) {
     scene_.registry().for_each([&](auto id, auto&) {
@@ -634,14 +641,6 @@ private:
 
   std::vector<EntityId> updatedEntities_;
   std::vector<EntityId> pathEscapees_;
-
-  // Return the tick count for the next snapshot, which is after the next call
-  // to `tick()`. This is the tick that should be used for any changes that
-  // need to be included in the next snapshot, such as newly spawned entities
-  // or appearance updates.
-  [[nodiscard]] WorldTick nextSyncTick() const {
-    return WorldTick{*tick_ + 1U};
-  }
 
   // Marks an entity as dirty so that it will be included in the next delta
   // snapshot.

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -367,9 +367,10 @@ public:
   [[nodiscard]] Handle
   spawnEnemy(PathId pathId, float speed, float progress = 0.F) {
     if (pathId >= paths_.size_as_enum()) return {};
+    Appearance app{U'U', 2.F, 0xFFFFFFFF, 0xFF, 0, invalidTick};
     const auto pos =
         paths_[pathId].calculatePositionFromProgress(progress, progress);
-    return scene_.store_new_entity<sidEnemy>(tick_, pos, Appearance{},
+    return scene_.store_new_entity<sidEnemy>(tick_, pos, app,
         PathFollower{pathId, progress, speed}, Invader{});
   }
 

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -27,6 +27,20 @@
 // SimWorld: authoritative server-side world state and logic for the CorvidSim
 // game. Owns the entities and the physics, but not the rules or the game flow.
 
+// Architectural Notes:
+// - Put all of the shapes and skins into a raw JSON file and serve it up. The
+//   C++ code never reads it, but does reference IDs defined in it.
+// - The shapes could, in principle, reference sprites, which are likewise
+//   served up as one of more PNG files. Again, only the client has to care
+//   about how to render, while the server focuses on geometry and logic, such
+//   as hit boxes.
+// - The definitions of enemies, towers, maps, and waves are kept in plain CSV
+//   files, which we can parse with nothing more than a comma splitter. These
+//   are deserialized into C++ structs at startup. We do not serve the CSV
+//   files.
+// - To aid this, we might change the default web server to skip over anything
+//   with a leading dot, allowing us to store ".game-definitions.csv" even if
+//   CSV files were enabled.
 namespace corvid { inline namespace sim {
 
 // ID of path.
@@ -43,25 +57,30 @@ constexpr auto corvid::enums::registry::enum_spec_v<corvid::sim::PathId> =
 
 namespace corvid { inline namespace sim {
 
-// Convert Cartesian coordinates (x, y) to a Euclidean vector, in polar form
-// (length, direction). `direction` is in radians,
+// Conversions between Cartesian coordinates (x, y) and Euclidean vectors in
+// polar form (length, direction). Direction is in radians, with 0 along the
+// positive x-axis and increasing counter-clockwise.
+namespace convert {
+// Convert Cartesian coordinates Euclidean vector,
 [[nodiscard]] constexpr std::pair<float, float>
-convertCartesianToPolar(float x, float y) noexcept {
+CartesianToPolar(float x, float y) noexcept {
   float length = std::sqrt((x * x) + (y * y));
   float direction = std::atan2(y, x);
   return {length, direction};
 }
 
-// Convert a Euclidean vector, in polar form, to Cartesian coordinates.
-// `direction` is in radians.
+// Convert a Euclidean vector to Cartesian coordinates.
 [[nodiscard]] constexpr std::pair<float, float>
-convertPolarToCartesian(float length, float direction) noexcept {
+PolarToCartesian(float length, float direction) noexcept {
   float x = length * std::cos(direction);
   float y = length * std::sin(direction);
   return {x, y};
 }
+} // namespace convert
 
-// Linear interpolation calculator
+// Linear interpolation, where t is the interpolation factor in [0,1]. Returns
+// a when t=0 and b when t=1. Can also be used for extrapolation when t is
+// outside [0,1].
 [[nodiscard]] constexpr float lerp(float a, float b, float t) noexcept {
   return a + ((b - a) * t);
 }
@@ -72,7 +91,7 @@ struct Position {
   float y{};
 
   static Position fromPolar(float radius, float angle) {
-    auto [x, y] = convertPolarToCartesian(radius, angle);
+    auto [x, y] = convert::PolarToCartesian(radius, angle);
     return {x, y};
   }
 };
@@ -83,7 +102,7 @@ struct Velocity {
   float vy{};
 
   [[nodiscard]] static Velocity fromPolar(float speed, float angle) {
-    auto [vx, vy] = convertPolarToCartesian(speed, angle);
+    auto [vx, vy] = convert::PolarToCartesian(speed, angle);
     return {vx, vy};
   }
 };
@@ -162,16 +181,50 @@ struct SegmentedPath {
     sp.totalLength = cumulative;
     return sp;
   }
-
-  [[nodiscard]] PathJoints toJoints() const {
-    PathJoints pj;
-    pj.width = width;
-    pj.joints.reserve(segments.size() + 1);
-    for (const auto& seg : segments) pj.joints.push_back({seg.front});
-    if (!segments.empty()) { pj.joints.push_back({segments.back().back}); }
-    return pj;
-  }
 };
+
+using Tick = uint64_t;
+
+// `Shape` is not a component, but entities may reference it to define an
+// aspect of their appearance. For now, we keep it simple by allowing a shape
+// and/or a Unicode character. This would allow, for example, a numerial "1"
+// inside a square.
+//
+// This is a placeholder.
+struct Shape {
+  int shape_id{};
+  int shape{};     // when it's made of a shape that the client knows about
+  char32_t logo{}; // when it uses an alphabetical character for display
+};
+
+// `Skin` is likewise not a component, and it builds upon `Shape`. A particular
+// object can be defined by a list of skins for its various manifestations.
+// It's possible that we might refactor all of this into a plain JSON file
+// that's sent to the client, keeping only the properties that need to be
+// tracked for gameplay, such as size and perhaps rotation.
+//
+// This is a placeholder.
+struct Skin {
+  int shape_id{};
+  uint32_t color{};
+  int size{};
+  int orientation{};
+};
+
+// TODO: We likely want to break out the physics-relevant properties into
+// components. We already have Position and Velocity (as well as PathFollower,
+// which is a type of velocity). We may need a Shape component which has the
+// geometric type (square, circle, etc), its scale, radius, length, width,
+// etc., and local basis (orientation). This can be used to compute the
+// bounding box (which could be AABB (axis-aligned bounding box) or OBB
+// (oriented bounding box) or even a circle collider (super-fast for towers))
+// for collision detection and hit box purposes. We may also need an Aura for
+// field effects. Rendering cares about the origin/anchor point of the shape,
+// which may not be the center. Towers may have an Aura (radius, damage,
+// dmgtype) or ProjectileRange (), or both. We could use Components for Hitbox,
+// Hurtbox, Attack (dmg, knockback, statusEffect), Expiry (ttl in ticks).
+// For circle hitboxes, collision is trivial: when the distance between centers
+// is less than the sum of the radii, they collide.
 
 // Path-following component. Stored alongside `Position` in the enemy
 // archetype. Each tick, `progress` advances by `speed`; the entity's
@@ -182,38 +235,66 @@ struct PathFollower {
   float speed{};    // Distance per tick.
 };
 
+// Placed tower component. Stored alongside `Position` in the tower archetype.
+//
+// Note that towers sitting in the catalog or being dragged and dropped into
+// place are not entities, just client-side UI ephemera. Only once a tower is
+// placed does it become part of the world.
+struct PlacedTower {
+  int tower_type{};
+  float tower_radius{};
+  float lever_multiplier{};
+};
+
+// Bullet component. Stored alongside `Position` and `Velocity` in the bullet
+// archetype.
+struct Bullet {
+  int bullet_type{};
+  Tick lifetime{};
+};
+
 // ECS types for the simulation world.
 //
 // Registry metadata (`uint64_t`) stores each entity's last-change tick count,
 // enabling delta snapshots without a separate dirty set.
 //
 // Storage layout (store_id assignment is positional, 1-based):
-//   `sidStaging`  = 0                     : staging storage, used as tombstone
+//   `sidStaging` = 0                      : staging storage, used as tombstone
 //
-//   `sidPos`      = 1  -> `arch_p_t`      : background / destructible entities
+//   `sidPos`     = 1  -> `arch_p_t`       : background / destructible entities
 //                                           (Position)
 //
-//   `sidPosVel`     = 2  -> `arch_pv_t`   : moving entities
+//   `sidPosVel`  = 2  -> `arch_pv_t`      : moving entities
 //                                           (Position + Velocity)
 //
 //   `sidEnemy`   = 3  -> `arch_enemy_t`   : path-following enemies
 //                                           (Position + PathFollower)
 //
+//   `sidTower`   = 4  -> `arch_tower_t`   : placed towers
+//                                          (Position + PlacedTower)
+//
+//   `sidBullet`  = 5  -> `arch_bullet_t`  : bullets
+//                                           (Position + Velocity + Bullet)
+//
 // Background storage comes first so that retiring a mobile entity is a
-// natural `archetype_scene::migrate_entity` call rather than erase+re-add.
-using Tick = uint64_t;
+// natural `archetype_scene::migrate_entity` call rather than erase + re-add.
 using WorldReg = entity_registry<Tick>;
 using WorldSid = WorldReg::store_id_t;
 using ArchP = archetype_storage<WorldReg, std::tuple<Position>>;
 using ArchPV = archetype_storage<WorldReg, std::tuple<Position, Velocity>>;
 using ArchEnemy =
     archetype_storage<WorldReg, std::tuple<Position, PathFollower>>;
-using WorldScene = archetype_scene<WorldReg, ArchP, ArchPV, ArchEnemy>;
+using ArchTower =
+    archetype_storage<WorldReg, std::tuple<Position, PlacedTower>>;
+using ArchBullet =
+    archetype_storage<WorldReg, std::tuple<Position, Velocity, Bullet>>;
+using WorldScene =
+    archetype_scene<WorldReg, ArchP, ArchPV, ArchEnemy, ArchTower, ArchBullet>;
 
-// Simulation world: encapsulates all ECS entity state for the game.
+// Simulation world: encapsulates all ECS entity state for the game and
+// provides physics.
 //
-// Background entities (Position only) live in `sidPos`. Moving entities
-// (Position + Velocity) live in `sidPosVel`. Each `tick()` advances positions
+// Each `tick()` advances `Position` components based on
 // by velocity and bounces off the world boundary. The registry metadata
 // records the tick count at each entity's last state change so callers can
 // request delta snapshots starting from any past tick.
@@ -226,7 +307,7 @@ public:
   static constexpr WorldSid sidPos{1};
   static constexpr WorldSid sidPosVel{2};
   static constexpr WorldSid sidEnemy{3};
-
+  static constexpr WorldSid sidTower{4};
   static constexpr float widthOfWorld = 1920.F;
   static constexpr float heightOfWorld = 1080.F;
 
@@ -270,16 +351,6 @@ public:
     return &paths_[pathId];
   }
 
-  // Return snapshots for all authored paths so the client can render the
-  // original joints while runtime movement follows the baked geometry.
-  //!!! KILLME
-  [[nodiscard]] std::vector<PathJoints> path_snapshot() const {
-    std::vector<PathJoints> result;
-    result.reserve(paths_.size() + 1);
-    for (const auto& p : paths_) result.push_back(p.toJoints());
-    return result;
-  }
-
   // Spawn a path-following enemy. Initial position is derived from `progress`
   // on the named path. Returns a handle for later `despawn()`.
   [[nodiscard]] Handle
@@ -301,36 +372,6 @@ public:
     return tick_;
   }
 
-  // Return snapshots for every entity whose that has changed since
-  // `since_tick`. Pass 0 (the default) to return all entities. Visits all
-  // storages that carry `Position` (`sidPos`, `sidPosVel`, `sidEnemy`).
-  //!!! KILLME
-  [[nodiscard]] std::vector<EntitySnapshot> snapshot(
-      Tick tickSince = 0) const {
-    std::vector<EntitySnapshot> result;
-    result.reserve(scene_.size());
-    scene_.for_each<Position>([&](auto id, auto comps) {
-      auto& [pos] = comps;
-      if (scene_.registry()[id] >= tickSince) result.push_back({id, pos});
-      return true;
-    });
-    return result;
-  }
-
-  // Return snapshots for a specific list of entity IDs. Invalid or dead IDs
-  // are silently skipped.
-  //!!! KILLME
-  [[nodiscard]] std::vector<EntitySnapshot> snapshot(
-      const std::vector<EntityId>& ids) const {
-    std::vector<EntitySnapshot> result;
-    result.reserve(ids.size());
-    for (auto id : ids) {
-      if (const auto* pos = scene_.try_get_component<Position>(id))
-        result.push_back({id, *pos});
-    }
-    return result;
-  }
-
   // Total number of entities in all storages (does not count staged entities).
   [[nodiscard]] std::size_t size() const { return scene_.size(); }
 
@@ -342,12 +383,14 @@ public:
   // be interleaved.
   [[nodiscard]] bool
   extractUpdatedEntities(auto&& cbUpserts, auto&& cbErased) {
+    auto& reg = scene_.registry();
     for (auto id : updatedEntities_)
       if (const auto* pos = scene_.try_get_component<Position>(id))
         (void)cbUpserts(id, *pos);
       else {
-        // TODO: Ensure that this entity is in staging. If so, erase it.
+        if (reg.get_location(id).store_id != sidStaging) continue;
         (void)cbErased(id);
+        (void)scene_.erase_entity(id);
       }
 
     updatedEntities_.clear();
@@ -389,6 +432,15 @@ public:
     return true;
   }
 
+  // Mark all entities dirty, to force a full snapshot.
+  [[nodiscard]] bool markAllDirty() {
+    scene_.registry().for_each([&](auto id, auto&) {
+      markDirty(id);
+      return true;
+    });
+    return true;
+  }
+
 private:
   WorldScene scene_;
   Tick tick_{0};
@@ -399,7 +451,7 @@ private:
 
   // Marks an entity as dirty so that it will be included in the next delta
   // snapshot.
-  bool markDirty(EntityId id) {
+  [[nodiscard]] bool markDirty(EntityId id) {
     // If it's been deleted, it's already dirty.
     if (!scene_.registry().is_valid(id)) return false;
     auto& last_updated = scene_.registry()[id];
@@ -412,11 +464,11 @@ private:
   }
 
   // Logically erases an entity, adding it to the dirty list.
-  bool tombstoneEntity(EntityId id) {
+  [[nodiscard]] bool tombstoneEntity(EntityId id) {
     // Can't kill the dead.
     if (!scene_.registry().is_valid(id)) return false;
     (void)markDirty(id);
-    return scene_.migrate_entity(id, sidStaging);
+    return scene_.remove_entity(id);
   }
 
   // Advance velocity-driven entities.

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -145,6 +145,15 @@ struct segmented_path {
     sp.total_length = cumulative;
     return sp;
   }
+
+  [[nodiscard]] path_joints to_joints() const {
+    path_joints pj;
+    pj.width = width;
+    pj.joints.reserve(segments.size() + 1);
+    for (const auto& seg : segments) pj.joints.push_back({seg.front});
+    if (!segments.empty()) { pj.joints.push_back({segments.back().back}); }
+    return pj;
+  }
 };
 
 // Path-following component. Stored alongside `Position` in the enemy
@@ -210,11 +219,6 @@ public:
     Position pos;
   };
 
-  struct authored_path_snapshot {
-    std::vector<Position> joints;
-    float width{};
-  };
-
   // Spawn a moving entity with the given initial position and velocity.
   // Returns a handle for later `despawn()`. The entity's last-change tick
   // is set to the current tick count.
@@ -230,15 +234,8 @@ public:
   // Bake and store a path. Returns the index used as `PathFollower::path_id`.
   // The index is stable for the lifetime of the world.
   [[nodiscard]] uint8_t add_path(const path_joints& p) {
-    authored_paths_.push_back(p);
     paths_.push_back(segmented_path::from_joints(p));
     return static_cast<uint8_t>(paths_.size() - 1);
-  }
-
-  // Return the authored path at `id`, or `nullptr` if out of range.
-  [[nodiscard]] const path_joints* get_authored_path(uint8_t id) const {
-    if (id >= authored_paths_.size()) return nullptr;
-    return &authored_paths_[id];
   }
 
   // Return a pointer to the baked path at `id`, or `nullptr` if out of range.
@@ -249,17 +246,10 @@ public:
 
   // Return snapshots for all authored paths so the client can render the
   // original joints while runtime movement follows the baked geometry.
-  [[nodiscard]] std::vector<authored_path_snapshot> path_snapshot() const {
-    std::vector<authored_path_snapshot> result;
-    result.reserve(authored_paths_.size());
-
-    for (const auto& p : authored_paths_) {
-      authored_path_snapshot snap;
-      snap.width = p.width;
-      snap.joints.reserve(p.joints.size());
-      for (const auto& joint : p.joints) snap.joints.push_back(joint.p);
-      result.push_back(std::move(snap));
-    }
+  [[nodiscard]] std::vector<path_joints> path_snapshot() const {
+    std::vector<path_joints> result;
+    result.reserve(paths_.size() + 1);
+    for (const auto& p : paths_) result.push_back(p.to_joints());
     return result;
   }
 
@@ -267,10 +257,8 @@ public:
   // on the named path. Returns a handle for later `despawn()`.
   [[nodiscard]] handle_t
   spawn_enemy(uint8_t path_id, float speed, float progress = 0.F) {
-    Position pos{};
-    if (path_id < paths_.size())
-      pos = paths_[path_id].position_from_progress(progress);
-
+    if (path_id >= paths_.size()) return {};
+    const auto pos = paths_[path_id].position_from_progress(progress);
     return scene_.store_new_entity<enemy_sid>(tick_n_, pos,
         PathFollower{path_id, progress, speed});
   }
@@ -298,12 +286,28 @@ public:
     // Advance velocity-driven entities.
     scene_.for_each<Position, Velocity>([&](auto id, auto comps) {
       auto& [pos, vel] = comps;
+      // Skip over currently immobile entities.
+      if (vel.vx == 0.F && vel.vy == 0.F) return true;
+
+      // TODO: Consider refactoring the increment and bounce into a single
+      // method that does both. For that matter, the current algorithm is
+      // wrong: an entity hitting a boundary shouldn't be clipped to the
+      // boundary and its velocity reversed. Rather, part of its movement
+      // should be reflected back. So, for example, if dx is 20 and the entity
+      // is 5 pixels from the right edge, it should spend 5 of those 20 moving
+      // to the right, and then 15 moving back. Its velocity should be reversed
+      // starting at the edge. The only reason the current algorithm works at
+      // all is that velocities are small. The algorithm is also bad in a
+      // different way, which is that it measures position from the center, not
+      // a bounding box, so the balls enter the boundary before reversing. Even
+      // then, a square bounding box would be hit-detected prematurely if the
+      // entity is moving at a diagonal.
 
       pos.x += vel.vx;
       pos.y += vel.vy;
 
-      apply_boundary(pos.x, vel.vx, world_width);
-      apply_boundary(pos.y, vel.vy, world_height);
+      bounce_from_boundary(pos.x, vel.vx, world_width);
+      bounce_from_boundary(pos.y, vel.vy, world_height);
 
       scene_.registry()[id] = tick_n_;
       if (out) out->push_back(id);
@@ -316,23 +320,28 @@ public:
     scene_.for_each<Position, PathFollower>([&](auto id, auto comps) {
       auto& [pos, pf] = comps;
       pf.progress += pf.speed;
+
+      // TODO: Is this even possible?
+      if (pf.path_id >= paths_.size()) return true;
+
       // TODO: Speed can be negative, so we need to collect entities that
       // exited front and back, separately. Why separately? So that we can
       // count them against the score. Note that we also have to be careful
       // here to deal with the possibility of a non-enemy that follows the
-      // track and therefore doesn't count against the score. Not sure how best
-      // to do this, but I imagine a component value that's constant and
-      // therefore takes up no space.
-      if (pf.path_id < paths_.size()) {
-        const auto& bp = paths_[pf.path_id];
-        if (pf.progress >= bp.total_length) {
-          finished.push_back(id);
-        } else {
-          pos = bp.position_from_progress(pf.progress);
-          scene_.registry()[id] = tick_n_;
-          if (out) out->push_back(id);
-        }
+      // track and therefore doesn't count against the score. The easy way is
+      // to iterate through the entities and ask which archetype they are. This
+      // might be possible with ducktyping is enemies have a component that the
+      // player doesn't, such as an enemy type that defines how to draw them.
+      const auto& sp = paths_[pf.path_id];
+      if (pf.progress >= sp.total_length) {
+        finished.push_back(id);
+        return true;
       }
+
+      pos = sp.position_from_progress(pf.progress);
+      scene_.registry()[id] = tick_n_;
+
+      if (out) out->push_back(id);
       return true;
     });
     // IDs were collected from an active iteration, so erase_entity will not
@@ -342,7 +351,7 @@ public:
     return tick_n_;
   }
 
-  // Return snapshots for every entity whose last-change tick is >=
+  // Return snapshots for every entity whose that has changed since
   // `since_tick`. Pass 0 (the default) to return all entities. Visits all
   // storages that carry `Position` (`p_sid`, `pv_sid`, `enemy_sid`).
   [[nodiscard]] std::vector<entity_snapshot> snapshot(
@@ -376,13 +385,15 @@ public:
 private:
   world_scene_t scene_;
   tick_t tick_n_{0};
-  std::vector<path_joints> authored_paths_;
   std::vector<segmented_path> paths_;
 
   // Clamp `pos` to `[-limit/2, +limit/2]` and, if it was out of range, negate
   // `vel` so the entity bounces off that boundary wall.
-  static void apply_boundary(float& pos, float& vel, float limit) {
-    const float half = limit * 0.5F;
+  // TODO: Is there an off-by-one error here? If the world is 1920 wide, the
+  // actual range isn't [-960, +960], it's [-960, +960). Do we need to deal
+  // with this? It depends on how the client scales it, right?
+  static void bounce_from_boundary(float& pos, float& vel, float limit) {
+    const float half = limit / 2.F;
     if (pos < -half) {
       pos = -half;
       vel = -vel;

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -689,8 +689,8 @@ private:
       pos.x += vel.vx;
       pos.y += vel.vy;
 
-      bounce_from_boundary(pos.x, vel.vx, widthOfWorld);
-      bounce_from_boundary(pos.y, vel.vy, heightOfWorld);
+      bounceFromBoundary(pos.x, vel.vx, widthOfWorld);
+      bounceFromBoundary(pos.y, vel.vy, heightOfWorld);
       return true;
     });
 
@@ -733,7 +733,7 @@ private:
   // TODO: Is there an off-by-one error here? If the world is 1920 wide, the
   // actual range isn't [-960, +960], it's [-960, +960). Do we need to deal
   // with this? It depends on how the client scales it, right?
-  static void bounce_from_boundary(float& pos, float& vel, float limit) {
+  static void bounceFromBoundary(float& pos, float& vel, float limit) {
     const float half = limit / 2.F;
     if (pos < -half) {
       pos = -half;

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -44,7 +44,7 @@ using namespace std::chrono_literals;
 //   Client sends: {"type":"hello","client":"browser"}
 //   Server replies: {"type":"hello_ack","message":"connected"}
 //   Client sends: {"type":"spawn","x":N,"y":N}
-//   Server then sends at 20 Hz: {"type":"snapshot","entities":[...]}
+//   Server then sends at 20 Hz: {"type":"world_delta",...}
 //   Server also sends at 1 Hz: {"type":"tick","tick":N}
 //
 // Keepalive (20s ping / 5s pong timeout) is enabled so that browser pong

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -71,7 +71,6 @@ public:
     websocket().on_close = [](http_websocket&, uint16_t, std::string_view) {
       do_close();
     };
-    // `enable_keepalive` stores weak_ptrs and sets `on_pong`.
     (void)enable_keepalive(loop, wheel, 20s, 5s);
 
     // As an optical dial tone, populate the world with entities bouncing
@@ -83,19 +82,30 @@ public:
       (void)world_.spawn(Position{0.0, 0.0},
           Velocity::from_polar(kSpeed, static_cast<float>(i) * kStep));
 
-    // Populate the tracking path with a square spiral starting at the center
-    // and stepping outwards.
+    // Populate the tracking path with an axis-aligned square spiral starting
+    // at the center and stepping outwards.
     path_joints p;
-    float step = 20.0;
+    p.joints.push_back({Position{0.0, 0.0}});
+    constexpr float kStepSize = 80.0;
+    constexpr float kAspect = sim_world::world_width / sim_world::world_height;
+    constexpr float kXStepSize = kStepSize * kAspect;
+    float x = 0.0;
+    float y = 0.0;
+    float x_run = kXStepSize;
+    float y_run = kStepSize;
     for (int i = 0; i < 100; ++i) {
-      p.joints.push_back({Position{step, 0.0}});
-      step += 20.0;
-      p.joints.push_back({Position{0.0, step}});
-      step += 20.0;
-      p.joints.push_back({Position{-step, 0.0}});
-      step += 20.0;
-      p.joints.push_back({Position{0.0, -step}});
-      step += 20.0;
+      x += x_run;
+      p.joints.push_back({Position{x, y}});
+      y += y_run;
+      p.joints.push_back({Position{x, y}});
+      x_run += kXStepSize;
+      x -= x_run;
+      p.joints.push_back({Position{x, y}});
+      y_run += kStepSize;
+      y -= y_run;
+      p.joints.push_back({Position{x, y}});
+      x_run += kXStepSize;
+      y_run += kStepSize;
     }
     (void)world_.add_path(p);
 
@@ -206,8 +216,8 @@ private:
 
     current_tick_ = world_.tick();
 
-    auto snaps = world_.snapshot();
-    auto paths = world_.path_snapshot();
+    const auto snaps = world_.snapshot();
+    const auto paths = world_.path_snapshot();
     std::string entities;
     entities.reserve(snaps.size() * 40);
     for (const auto& e : snaps) {
@@ -224,7 +234,7 @@ private:
       for (const auto& joint : path.joints) {
         if (!joints.empty()) joints += ',';
         joints +=
-            std::format(R"({{"x":{:.1f},"y":{:.1f}}})", joint.x, joint.y);
+            std::format(R"({{"x":{:.1f},"y":{:.1f}}})", joint.p.x, joint.p.y);
       }
       path_json = std::format("[{}]", joints);
     }

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -122,7 +122,7 @@ private:
     if (!pos) return true; // malformed, ignore
 
     // Aim new point based on its angle from the center, with a fixed speed.
-    const auto [length, direction] = convertCartesianToPolar(pos->x, pos->y);
+    const auto [length, direction] = convert::CartesianToPolar(pos->x, pos->y);
     const auto vel = Velocity::fromPolar(40.0, direction);
     (void)vel;
     //!!! (void)world_.spawn(*pos, vel);

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -72,7 +72,7 @@ public:
       do_close();
     };
     (void)enable_keepalive(loop, wheel, 20s, 5s);
-    game_.load_level();
+    game_.load_map();
     game_.start_wave();
     std::cout << "WebSocket client connected\n";
   }

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -23,10 +23,13 @@
 #include <format>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "../proto/http_websocket_transaction.h"
+#include "../strings/any_strings.h"
 #include "sim_game.h"
+#include "sim_world.h"
 
 namespace corvid { inline namespace proto {
 
@@ -72,7 +75,7 @@ public:
       do_close();
     };
     (void)enable_keepalive(loop, wheel, 20s, 5s);
-    game_.load_map();
+    game_.loadMap();
     game_.start_wave();
     std::cout << "WebSocket client connected\n";
   }
@@ -90,9 +93,10 @@ public:
 private:
   using Fuse = timer_fuse<http_transaction>;
 
-  std::atomic<Tick> tick_seq_; // Uses for sequencing tick timers
-  Tick current_tick_{0};       // updated each frame; loop-thread only
-  SimGame game_;               // all simulation entity state
+  std::atomic<Tick> tick_seq_{0}; // Uses for sequencing tick timers
+  Tick current_tick_{0};          // updated each frame; loop-thread only
+  SimGame game_;                  // all simulation entity state
+  update_strategy send_strategy_{update_strategy::full};
 
   // Handle an incoming text frame. Dispatches on `"type"` by substring search
   // (no parser needed for these fixed message shapes).
@@ -118,8 +122,8 @@ private:
     if (!pos) return true; // malformed, ignore
 
     // Aim new point based on its angle from the center, with a fixed speed.
-    const auto [length, direction] = cartesian_to_polar(pos->x, pos->y);
-    const auto vel = Velocity::from_polar(40.0, direction);
+    const auto [length, direction] = convertCartesianToPolar(pos->x, pos->y);
+    const auto vel = Velocity::fromPolar(40.0, direction);
     (void)vel;
     //!!! (void)world_.spawn(*pos, vel);
     return true;
@@ -180,7 +184,10 @@ private:
     if (websocket().is_send_in_fragment()) return do_arm_tick(tick_n);
 
     current_tick_ = game_.step();
-
+    if (!send_game_state()) return false;
+    send_strategy_ = update_strategy::incremental;
+    return do_arm_tick(tick_n + 1);
+#if 0
     auto snap = game_.snapshot();
 
     const auto snaps = snap.entities;
@@ -218,7 +225,95 @@ private:
     }
 
     return do_arm_tick(tick_n + 1);
+#endif
+  }
+
+  [[nodiscard]] bool send_game_state() {
+    std::string buf;
+    buf.reserve(16ULL * 1024);
+    auto it = std::back_inserter(buf);
+    bool wrote_any_path = false;
+    bool wrote_any_joint = false;
+    bool wrote_any_upsert = false;
+    bool wrote_any_erased = false;
+
+    // If full send, wrap in `world_snapshot` envelope and include paths.
+    if (send_strategy_ == update_strategy::full) {
+      it = std::format_to(it, R"({{"type":"world_snapshot","paths":[)");
+      (void)game_.extractPaths(
+          [&it, &wrote_any_path, &wrote_any_joint](auto, const Position& pos) {
+            if (wrote_any_joint) it = std::format_to(it, ",");
+            wrote_any_path = true;
+            wrote_any_joint = true;
+            it = std::format_to(it, R"({{"x":{:.1f},"y":{:.1f}}})", pos.x,
+                pos.y);
+            return true;
+          });
+      buf += R"(],"delta":)";
+      it = std::back_inserter(buf);
+    }
+
+    std::vector<SimWorld::EntityId> erasedIds;
+    erasedIds.reserve(64);
+    it = std::format_to(it, R"({{"type":"world_delta","tick":{}, "upserts":[)",
+        current_tick_);
+
+    size_t current_wave{};
+    Tick wave_tick{};
+    int lives_count{};
+    int resources_count{};
+    std::string_view phase{};
+
+    (void)game_.extractDelta(
+        // Upserts.
+        [&it, &wrote_any_upsert](SimWorld::EntityId entityId,
+            const Position& pos) {
+          if (wrote_any_upsert) it = std::format_to(it, ",");
+          wrote_any_upsert = true;
+          it = std::format_to(it, R"({{"id":{},"x":{:.1f},"y":{:.1f}}})",
+              static_cast<std::size_t>(entityId), pos.x, pos.y);
+          return true;
+        },
+        // Erasures.
+        [&erasedIds](SimWorld::EntityId entityId) {
+          erasedIds.push_back(entityId);
+          return true;
+        },
+        [&current_wave, &wave_tick, &lives_count, &resources_count,
+            &phase](auto currentWave, auto waveTick, auto lives,
+            auto resources, auto currentPhase) {
+          current_wave = currentWave;
+          wave_tick = waveTick;
+          lives_count = lives;
+          resources_count = resources;
+          phase = currentPhase;
+          return true;
+        });
+
+    it = std::format_to(it, R"(],"erased":[)");
+    for (auto entityId : erasedIds) {
+      if (wrote_any_erased) it = std::format_to(it, ",");
+      wrote_any_erased = true;
+      it = std::format_to(it, R"({})", *entityId);
+    }
+    it = std::format_to(it,
+        R"(],"currentWave":{},"waveTick":{},"lives":{},"resources":{},"phase":"{}"}})",
+        current_wave, wave_tick, lives_count, resources_count, phase);
+
+    if (send_strategy_ == update_strategy::full) buf += "}";
+
+    std::cout << buf << '\n';
+
+    std::string header_buf;
+    (void)ws_frame_lens::build(header_buf,
+        ws_frame_control::text | ws_frame_control::fin, buf.size(),
+        std::nullopt);
+
+    auto buffers =
+        strings::make_any_strings(std::move(header_buf), std::move(buf));
+
+    if (!websocket().send_frame(std::move(buffers))) return false;
+    return true;
   }
 };
-
 }} // namespace corvid::proto

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -94,10 +94,10 @@ private:
 
   // Handle an incoming text frame by classifying and forwarding the message.
   [[nodiscard]] bool do_message(http_websocket& ws, std::string&& msg) {
-    const auto root = parse_sim_client_message_root(msg);
+    const auto root = parseSimClientMessageRoot(msg);
     if (!root) return true; // malformed, ignore
 
-    switch (classify_sim_client_message(*root)) {
+    switch (classifySimClientMessage(*root)) {
     case SimClientMessageKind::hello:
       if (!ws.send_text(build_sim_hello_ack_json())) return false;
       return do_arm_tick();
@@ -109,7 +109,7 @@ private:
   }
 
   [[nodiscard]] bool do_ui_canvas(json_object_view msg) {
-    const auto input = parse_ui_canvas_message(msg);
+    const auto input = parseUiCanvasMessage(msg);
     if (!input) return true; // malformed, ignore
     game_.handle_ui_canvas(*input);
     return true;

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -17,19 +17,15 @@
 #pragma once
 
 #include <atomic>
-#include <charconv>
-#include <cmath>
 #include <format>
 #include <iostream>
 #include <memory>
-#include <numbers>
-#include <optional>
 #include <vector>
 
 #include "../proto/http_websocket_transaction.h"
 #include "../strings/any_strings.h"
 #include "sim_game.h"
-#include "sim_world.h"
+#include "sim_json_parse.h"
 
 namespace corvid { inline namespace proto {
 
@@ -43,7 +39,7 @@ using namespace std::chrono_literals;
 // Protocol:
 //   Client sends: {"type":"hello","client":"browser"}
 //   Server replies: {"type":"hello_ack","message":"connected"}
-//   Client sends: {"type":"spawn","x":N,"y":N}
+//   Client sends: {"type":"ui_canvas",...} or {"type":"ui_action",...}
 //   Server then sends at 20 Hz: {"type":"world_delta",...}
 //
 // Keepalive (20s ping / 5s pong timeout) is enabled so that browser pong
@@ -75,7 +71,6 @@ public:
     };
     (void)enable_keepalive(loop, wheel, 20s, 5s);
     game_.loadMap();
-    game_.start_wave();
     std::cout << "WebSocket client connected\n";
   }
 
@@ -99,58 +94,35 @@ private:
   size_t buffer_high_watermark_ = 16ULL * 1024; // try to avoid resizes
   size_t erased_ids_high_watermark = 64;        // ditto for erased ID vector
 
-  // Handle an incoming text frame. Dispatches on `"type"` by substring search
-  // (no parser needed for these fixed message shapes).
+  // Handle an incoming text frame by classifying and forwarding the message.
   [[nodiscard]] bool do_message(http_websocket& ws, std::string&& msg) {
-    if (msg.contains(R"("type":"hello")") ||
-        msg.contains(R"("type": "hello")"))
-    {
-      if (!ws.send_text(R"({"type":"hello_ack","message":"connected"})"))
-        return false;
-      return do_arm_tick();
-    }
-    if (msg.contains(R"("type":"spawn")") ||
-        msg.contains(R"("type": "spawn")"))
-    {
-      return do_spawn(msg);
+    switch (classify_sim_client_message(msg)) {
+      case SimClientMessageKind::hello:
+        if (!ws.send_text(R"({"type":"hello_ack","message":"connected"})"))
+          return false;
+        return do_arm_tick();
+      case SimClientMessageKind::ui_canvas:
+        return do_ui_canvas(msg);
+      case SimClientMessageKind::ui_action:
+        return do_ui_action(msg);
+      case SimClientMessageKind::unknown:
+        break;
     }
     return true;
   }
 
-  // Parse a `spawn` message and add a new entity at the click position.
-  [[nodiscard]] bool do_spawn(std::string_view msg) {
-    const auto pos = parse_position(msg);
-    if (!pos) return true; // malformed, ignore
-
-    // Aim new point based on its angle from the center, with a fixed speed.
-    const auto [length, direction] = convert::CartesianToPolar(pos->x, pos->y);
-    const auto vel = Velocity::fromPolar(40.0, direction);
-    (void)vel;
-    (void)game_;
+  [[nodiscard]] bool do_ui_canvas(std::string_view msg) {
+    const auto input = parse_ui_canvas_message(msg);
+    if (!input) return true; // malformed, ignore
+    game_.handle_ui_canvas(*input);
     return true;
   }
 
-  // Parse an `{x, y}` position from the fixed message shape used by the sim.
-  [[nodiscard]] static std::optional<Position> parse_position(
-      std::string_view msg) {
-    const auto ox = parse_coord(msg, R"("x":)");
-    const auto oy = parse_coord(msg, R"("y":)");
-    if (!ox || !oy) return std::nullopt;
-    return Position{*ox, *oy};
-  }
-
-  // Find `key` in `msg` and parse the number that follows it.
-  [[nodiscard]] static std::optional<float>
-  parse_coord(std::string_view msg, std::string_view key) {
-    auto pos = msg.find(key);
-    if (pos == std::string_view::npos) return std::nullopt;
-    pos += key.size();
-    while (pos < msg.size() && msg[pos] == ' ') ++pos;
-    float val{};
-    auto [ptr, ec] =
-        std::from_chars(msg.data() + pos, msg.data() + msg.size(), val);
-    if (ec != std::errc{}) return std::nullopt;
-    return val;
+  [[nodiscard]] bool do_ui_action(std::string_view msg) {
+    const auto input = parse_ui_action_message(msg);
+    if (!input) return true; // malformed, ignore
+    game_.handle_ui_action(*input);
+    return true;
   }
 
   static void do_close() { std::cout << "WebSocket client disconnected\n"; }

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -125,7 +125,7 @@ private:
     const auto [length, direction] = convert::CartesianToPolar(pos->x, pos->y);
     const auto vel = Velocity::fromPolar(40.0, direction);
     (void)vel;
-    //!!! (void)world_.spawn(*pos, vel);
+    (void)game_;
     return true;
   }
 

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -93,9 +93,9 @@ public:
 private:
   using Fuse = timer_fuse<http_transaction>;
 
-  std::atomic<Tick> tick_seq_{0}; // Uses for sequencing tick timers
-  Tick current_tick_{0};          // updated each frame; loop-thread only
-  SimGame game_;                  // all simulation entity state
+  std::atomic<uint64_t> tick_seq_{}; // Uses for sequencing tick timers
+  WorldTick current_tick_{};         // updated each frame; loop-thread only
+  SimGame game_;                     // all simulation entity state
   update_strategy send_strategy_{update_strategy::full};
 
   // Handle an incoming text frame. Dispatches on `"type"` by substring search
@@ -221,13 +221,13 @@ private:
 
     // Display state.
     size_t current_wave{};
-    Tick wave_tick{};
+    WaveTick wave_tick{};
     int lives_count{};
     int resources_count{};
     std::string_view phase{};
 
     it = std::format_to(it, R"({{"type":"world_delta","tick":{}, "upserts":[)",
-        current_tick_);
+        *current_tick_);
 
     (void)game_.extractDelta(
         // Upserts.
@@ -265,7 +265,7 @@ private:
     }
     it = std::format_to(it,
         R"(],"currentWave":{},"waveTick":{},"lives":{},"resources":{},"phase":"{}"}})",
-        current_wave, wave_tick, lives_count, resources_count, phase);
+        current_wave, *wave_tick, lives_count, resources_count, phase);
 
     if (send_strategy_ == update_strategy::full) buf += "}";
 

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -150,17 +150,17 @@ private:
     if (websocket().is_close_started()) return true;
     if (websocket().is_send_in_fragment()) return do_arm_tick();
 
-    current_tick_ = game_.step();
+    (void)game_.next();
     if (!send_game_state()) return false;
     send_strategy_ = update_strategy::incremental;
+    current_tick_ = game_.tick();
     return do_arm_tick();
   }
 
   // Stream snapshot of game state to the client as JSON. Uses deltas when
   // possible.
   [[nodiscard]] bool send_game_state() {
-    (void)build_sim_game_state_json(json_buffer_, game_, current_tick_,
-        send_strategy_);
+    (void)build_sim_game_state_json(json_buffer_, game_, send_strategy_);
 
     std::string header_buf;
     (void)ws_frame_lens::build(header_buf,

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -187,51 +187,13 @@ private:
     if (!send_game_state()) return false;
     send_strategy_ = update_strategy::incremental;
     return do_arm_tick(tick_n + 1);
-#if 0
-    auto snap = game_.snapshot();
-
-    const auto snaps = snap.entities;
-    const auto paths = snap.path_points;
-    std::string entities;
-    entities.reserve(snaps.size() * 40);
-    for (const auto& e : snaps) {
-      if (!entities.empty()) entities += ',';
-      entities += std::format(R"({{"id":{},"x":{:.1f},"y":{:.1f}}})",
-          static_cast<std::size_t>(e.id), e.pos.x, e.pos.y);
-    }
-
-    std::string path_json = "[]";
-    if (!paths.empty()) {
-      const auto& path = paths.front();
-      std::string joints;
-      joints.reserve(path.joints.size() * 24);
-      for (const auto& joint : path.joints) {
-        if (!joints.empty()) joints += ',';
-        joints +=
-            std::format(R"({{"x":{:.1f},"y":{:.1f}}})", joint.p.x, joint.p.y);
-      }
-      path_json = std::format("[{}]", joints);
-    }
-
-    auto snap_msg = std::format(
-        R"({{"type":"snapshot","entities":[{}],"path":{}}})", entities,
-        path_json);
-    if (!websocket().send_text(snap_msg)) return false;
-
-    if (tick_n % 20 == 0) {
-      auto tick_msg =
-          std::format(R"({{"type":"tick","tick":{}}})", tick_n / 20);
-      if (!websocket().send_text(tick_msg)) return false;
-    }
-
-    return do_arm_tick(tick_n + 1);
-#endif
   }
 
   [[nodiscard]] bool send_game_state() {
     std::string buf;
     buf.reserve(16ULL * 1024);
     auto it = std::back_inserter(buf);
+    // State to allow comma delimiter management in callbacks.
     bool wrote_any_path = false;
     bool wrote_any_joint = false;
     bool wrote_any_upsert = false;
@@ -255,14 +217,16 @@ private:
 
     std::vector<SimWorld::EntityId> erasedIds;
     erasedIds.reserve(64);
-    it = std::format_to(it, R"({{"type":"world_delta","tick":{}, "upserts":[)",
-        current_tick_);
 
+    // Display state.
     size_t current_wave{};
     Tick wave_tick{};
     int lives_count{};
     int resources_count{};
     std::string_view phase{};
+
+    it = std::format_to(it, R"({{"type":"world_delta","tick":{}, "upserts":[)",
+        current_tick_);
 
     (void)game_.extractDelta(
         // Upserts.
@@ -271,7 +235,7 @@ private:
           if (wrote_any_upsert) it = std::format_to(it, ",");
           wrote_any_upsert = true;
           it = std::format_to(it, R"({{"id":{},"x":{:.1f},"y":{:.1f}}})",
-              static_cast<std::size_t>(entityId), pos.x, pos.y);
+              *entityId, pos.x, pos.y);
           return true;
         },
         // Erasures.
@@ -302,17 +266,15 @@ private:
 
     if (send_strategy_ == update_strategy::full) buf += "}";
 
-    std::cout << buf << '\n';
-
     std::string header_buf;
     (void)ws_frame_lens::build(header_buf,
         ws_frame_control::text | ws_frame_control::fin, buf.size(),
         std::nullopt);
 
-    auto buffers =
-        strings::make_any_strings(std::move(header_buf), std::move(buf));
+    if (!websocket().send_frame(
+            strings::as_vector(std::move(header_buf), std::move(buf))))
+      return false;
 
-    if (!websocket().send_frame(std::move(buffers))) return false;
     return true;
   }
 };

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -84,10 +84,10 @@ public:
 
     // Populate the tracking path with an axis-aligned square spiral starting
     // at the center and stepping outwards.
-    path_joints p;
+    PathJoints p;
     p.joints.push_back({Position{0.0, 0.0}});
     constexpr float kStepSize = 80.0;
-    constexpr float kAspect = sim_world::world_width / sim_world::world_height;
+    constexpr float kAspect = SimWorld::world_width / SimWorld::world_height;
     constexpr float kXStepSize = kStepSize * kAspect;
     float x = 0.0;
     float y = 0.0;
@@ -125,9 +125,9 @@ public:
 private:
   using fuse_t = timer_fuse<http_transaction>;
 
-  std::atomic<tick_t> tick_seq_; // Uses for sequencing tick timers
-  tick_t current_tick_{0};       // updated each frame; loop-thread only
-  sim_world world_;              // all simulation entity state
+  std::atomic<Tick> tick_seq_; // Uses for sequencing tick timers
+  Tick current_tick_{0};       // updated each frame; loop-thread only
+  SimWorld world_;             // all simulation entity state
 
   // Handle an incoming text frame. Dispatches on `"type"` by substring search
   // (no parser needed for these fixed message shapes).
@@ -188,7 +188,7 @@ private:
   // Schedule the next tick. Uses the `timer_fuse` double-check pattern:
   // the wheel-thread callback pre-checks liveness and posts to the loop
   // thread, which performs the definitive check and calls `do_tick_fire`.
-  [[nodiscard]] bool do_arm_tick(tick_t tick_n) {
+  [[nodiscard]] bool do_arm_tick(Tick tick_n) {
     auto wheel = keepalive_wheel_.lock();
     if (!wheel) return true;
     return fuse_t::set_timeout(*wheel, tick_seq_,
@@ -210,7 +210,7 @@ private:
   // snapshot message (20 Hz) and, once per 20 frames, a tick message (1 Hz).
   // Re-arms for the next 50 ms interval. If a fragmented send is in progress,
   // defers by re-arming with the same counter so the sequence has no gaps.
-  [[nodiscard]] bool do_tick_fire(tick_t tick_n) {
+  [[nodiscard]] bool do_tick_fire(Tick tick_n) {
     if (websocket().is_close_started()) return true;
     if (websocket().is_send_in_fragment()) return do_arm_tick(tick_n);
 
@@ -249,6 +249,8 @@ private:
           std::format(R"({{"type":"tick","tick":{}}})", tick_n / 20);
       if (!websocket().send_text(tick_msg)) return false;
     }
+
+    if (tick_n % 40 == 0) { (void)world_.spawn_enemy(PathId{0}, 20.F); }
 
     return do_arm_tick(tick_n + 1);
   }

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -26,7 +26,7 @@
 #include <vector>
 
 #include "../proto/http_websocket_transaction.h"
-#include "sim_world.h"
+#include "sim_game.h"
 
 namespace corvid { inline namespace proto {
 
@@ -56,11 +56,11 @@ using namespace std::chrono_literals;
 // the base) because `timer_fuse::get_if_armed` locks the `weak_ptr` before
 // dereferencing the sequencer, so the sequencer is never accessed after the
 // transaction is destroyed.
-class sim_ws_handler final: public http_websocket_transaction {
+class SimWsHandler final: public http_websocket_transaction {
 public:
-  // Construct and initialize a new transaction, with its own `sim_world` and
+  // Construct and initialize a new transaction, with its own `SimGame` and
   // tick timer.
-  sim_ws_handler(request_head&& req, const std::shared_ptr<epoll_loop>& loop,
+  SimWsHandler(request_head&& req, const std::shared_ptr<epoll_loop>& loop,
       const std::shared_ptr<timing_wheel>& wheel)
       : http_websocket_transaction{std::move(req)} {
     // Register methods as callbacks.
@@ -72,43 +72,8 @@ public:
       do_close();
     };
     (void)enable_keepalive(loop, wheel, 20s, 5s);
-
-    // As an optical dial tone, populate the world with entities bouncing
-    // around.
-    constexpr int kCount = 100;
-    constexpr float kSpeed = 40.0;
-    constexpr float kStep = 2.0 * std::numbers::pi / kCount;
-    for (int i = 0; i < kCount; ++i)
-      (void)world_.spawn(Position{0.0, 0.0},
-          Velocity::from_polar(kSpeed, static_cast<float>(i) * kStep));
-
-    // Populate the tracking path with an axis-aligned square spiral starting
-    // at the center and stepping outwards.
-    PathJoints p;
-    p.joints.push_back({Position{0.0, 0.0}});
-    constexpr float kStepSize = 80.0;
-    constexpr float kAspect = SimWorld::world_width / SimWorld::world_height;
-    constexpr float kXStepSize = kStepSize * kAspect;
-    float x = 0.0;
-    float y = 0.0;
-    float x_run = kXStepSize;
-    float y_run = kStepSize;
-    for (int i = 0; i < 100; ++i) {
-      x += x_run;
-      p.joints.push_back({Position{x, y}});
-      y += y_run;
-      p.joints.push_back({Position{x, y}});
-      x_run += kXStepSize;
-      x -= x_run;
-      p.joints.push_back({Position{x, y}});
-      y_run += kStepSize;
-      y -= y_run;
-      p.joints.push_back({Position{x, y}});
-      x_run += kXStepSize;
-      y_run += kStepSize;
-    }
-    (void)world_.add_path(p);
-
+    game_.load_level();
+    game_.start_wave();
     std::cout << "WebSocket client connected\n";
   }
 
@@ -118,16 +83,16 @@ public:
     // Factory factory.
     return [loop = std::move(loop), wheel = std::move(wheel)](
                request_head&& req) -> transaction_ptr {
-      return std::make_shared<sim_ws_handler>(std::move(req), loop, wheel);
+      return std::make_shared<SimWsHandler>(std::move(req), loop, wheel);
     };
   }
 
 private:
-  using fuse_t = timer_fuse<http_transaction>;
+  using Fuse = timer_fuse<http_transaction>;
 
   std::atomic<Tick> tick_seq_; // Uses for sequencing tick timers
   Tick current_tick_{0};       // updated each frame; loop-thread only
-  SimWorld world_;             // all simulation entity state
+  SimGame game_;               // all simulation entity state
 
   // Handle an incoming text frame. Dispatches on `"type"` by substring search
   // (no parser needed for these fixed message shapes).
@@ -155,8 +120,8 @@ private:
     // Aim new point based on its angle from the center, with a fixed speed.
     const auto [length, direction] = cartesian_to_polar(pos->x, pos->y);
     const auto vel = Velocity::from_polar(40.0, direction);
-
-    (void)world_.spawn(*pos, vel);
+    (void)vel;
+    //!!! (void)world_.spawn(*pos, vel);
     return true;
   }
 
@@ -191,16 +156,16 @@ private:
   [[nodiscard]] bool do_arm_tick(Tick tick_n) {
     auto wheel = keepalive_wheel_.lock();
     if (!wheel) return true;
-    return fuse_t::set_timeout(*wheel, tick_seq_,
+    return Fuse::set_timeout(*wheel, tick_seq_,
         std::weak_ptr<http_transaction>{shared_from_this()}, 50ms,
-        [loop_w = keepalive_loop_, tick_n](const fuse_t& fuse) -> bool {
+        [loop_w = keepalive_loop_, tick_n](const Fuse& fuse) -> bool {
           auto tx = fuse.get_if_armed();
           auto loop = loop_w.lock();
           if (!tx || !loop) return true;
           return loop->post([fuse, tick_n]() -> bool {
             auto tx = fuse.get_if_armed();
             if (!tx) return true;
-            return std::static_pointer_cast<sim_ws_handler>(tx)->do_tick_fire(
+            return std::static_pointer_cast<SimWsHandler>(tx)->do_tick_fire(
                 tick_n);
           });
         });
@@ -214,10 +179,12 @@ private:
     if (websocket().is_close_started()) return true;
     if (websocket().is_send_in_fragment()) return do_arm_tick(tick_n);
 
-    current_tick_ = world_.tick();
+    current_tick_ = game_.step();
 
-    const auto snaps = world_.snapshot();
-    const auto paths = world_.path_snapshot();
+    auto snap = game_.snapshot();
+
+    const auto snaps = snap.entities;
+    const auto paths = snap.path_points;
     std::string entities;
     entities.reserve(snaps.size() * 40);
     for (const auto& e : snaps) {
@@ -249,8 +216,6 @@ private:
           std::format(R"({{"type":"tick","tick":{}}})", tick_n / 20);
       if (!websocket().send_text(tick_msg)) return false;
     }
-
-    if (tick_n % 40 == 0) { (void)world_.spawn_enemy(PathId{0}, 20.F); }
 
     return do_arm_tick(tick_n + 1);
   }

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -45,7 +45,6 @@ using namespace std::chrono_literals;
 //   Server replies: {"type":"hello_ack","message":"connected"}
 //   Client sends: {"type":"spawn","x":N,"y":N}
 //   Server then sends at 20 Hz: {"type":"world_delta",...}
-//   Server also sends at 1 Hz: {"type":"tick","tick":N}
 //
 // Keepalive (20s ping / 5s pong timeout) is enabled so that browser pong
 // replies reset the HTTP server's 30s read timeout; the constraint
@@ -93,9 +92,9 @@ public:
 private:
   using Fuse = timer_fuse<http_transaction>;
 
-  std::atomic<uint64_t> tick_seq_{}; // Uses for sequencing tick timers
-  WorldTick current_tick_{};         // updated each frame; loop-thread only
-  SimGame game_;                     // all simulation entity state
+  std::atomic<uint64_t> tick_seq_; // Uses for sequencing tick timers
+  WorldTick current_tick_{};       // updated each frame; loop-thread only
+  SimGame game_;                   // all simulation entity state
   update_strategy send_strategy_{update_strategy::full};
 
   // Handle an incoming text frame. Dispatches on `"type"` by substring search
@@ -106,7 +105,7 @@ private:
     {
       if (!ws.send_text(R"({"type":"hello_ack","message":"connected"})"))
         return false;
-      return do_arm_tick(1);
+      return do_arm_tick();
     }
     if (msg.contains(R"("type":"spawn")") ||
         msg.contains(R"("type": "spawn")"))
@@ -157,37 +156,33 @@ private:
   // Schedule the next tick. Uses the `timer_fuse` double-check pattern:
   // the wheel-thread callback pre-checks liveness and posts to the loop
   // thread, which performs the definitive check and calls `do_tick_fire`.
-  [[nodiscard]] bool do_arm_tick(Tick tick_n) {
+  [[nodiscard]] bool do_arm_tick() {
     auto wheel = keepalive_wheel_.lock();
     if (!wheel) return true;
     return Fuse::set_timeout(*wheel, tick_seq_,
         std::weak_ptr<http_transaction>{shared_from_this()}, 50ms,
-        [loop_w = keepalive_loop_, tick_n](const Fuse& fuse) -> bool {
+        [loop_w = keepalive_loop_](const Fuse& fuse) -> bool {
           auto tx = fuse.get_if_armed();
           auto loop = loop_w.lock();
           if (!tx || !loop) return true;
-          return loop->post([fuse, tick_n]() -> bool {
+          return loop->post([fuse]() -> bool {
             auto tx = fuse.get_if_armed();
             if (!tx) return true;
-            return std::static_pointer_cast<SimWsHandler>(tx)->do_tick_fire(
-                tick_n);
+            return std::static_pointer_cast<SimWsHandler>(tx)->do_tick_fire();
           });
         });
   }
 
-  // Called on the loop thread: advance the simulation one frame, send a
-  // world update message (20 Hz) and, once per 20 frames, a tick message
-  // (1 Hz).
-  // Re-arms for the next 50 ms interval. If a fragmented send is in progress,
-  // defers by re-arming with the same counter so the sequence has no gaps.
-  [[nodiscard]] bool do_tick_fire(Tick tick_n) {
+  // Called on the loop thread: advance the simulation one frame and send a
+  // world update message at 20 Hz. Re-arms for the next 50 ms interval.
+  [[nodiscard]] bool do_tick_fire() {
     if (websocket().is_close_started()) return true;
-    if (websocket().is_send_in_fragment()) return do_arm_tick(tick_n);
+    if (websocket().is_send_in_fragment()) return do_arm_tick();
 
     current_tick_ = game_.step();
     if (!send_game_state()) return false;
     send_strategy_ = update_strategy::incremental;
-    return do_arm_tick(tick_n + 1);
+    return do_arm_tick();
   }
 
   [[nodiscard]] bool send_game_state() {
@@ -244,7 +239,7 @@ private:
           }
 
           const auto glow_color =
-              app.effect_expiry <= current_tick ? 0U : app.glow_color;
+              app.effect_expiry < current_tick ? 0U : app.glow_color;
           it = std::format_to(it,
               R"({{"pos":{{"id":{},"x":{:.1f},"y":{:.1f}}},"app":{{"glyph":{},"scale":{:.3f},"fg":{},"bg":{},"glow":{}}}}})",
               *entityId, pos.x, pos.y, static_cast<uint32_t>(app.glyph),

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -231,14 +231,24 @@ private:
 
     (void)game_.extractDelta(
         // Upserts.
-        [&it, &wrote_any_upsert](SimWorld::EntityId entityId,
+        [&it, &wrote_any_upsert,
+            current_tick = current_tick_](SimWorld::EntityId entityId,
             const Position& pos, const Appearance& app) {
           if (wrote_any_upsert) it = std::format_to(it, ",");
           wrote_any_upsert = true;
+          if (app.modified + 1 != current_tick) {
+            it = std::format_to(it,
+                R"({{"pos":{{"id":{},"x":{:.1f},"y":{:.1f}}}}})", *entityId,
+                pos.x, pos.y);
+            return true;
+          }
+
+          const auto glow_color =
+              app.effect_expiry <= current_tick ? 0U : app.glow_color;
           it = std::format_to(it,
               R"({{"pos":{{"id":{},"x":{:.1f},"y":{:.1f}}},"app":{{"glyph":{},"scale":{:.3f},"fg":{},"bg":{},"glow":{}}}}})",
               *entityId, pos.x, pos.y, static_cast<uint32_t>(app.glyph),
-              app.scale, app.fg_color, app.bg_color, app.glow_color);
+              app.scale, app.fg_color, app.bg_color, glow_color);
           return true;
         },
         // Erasures.

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -116,7 +116,7 @@ private:
   }
 
   [[nodiscard]] bool do_ui_action(json_object_view msg) {
-    const auto input = parse_ui_action_message(msg);
+    const auto input = parseUiActionMessage(msg);
     if (!input) return true; // malformed, ignore
     game_.handle_ui_action(*input);
     return true;

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -35,7 +35,7 @@ using namespace std::chrono_literals;
 // WebSocket transaction for the CorvidSim `/ws` route.
 //
 // Inherits from `http_websocket_transaction` and wires up all callbacks in the
-// constructor so behaviour lives in named private methods rather than lambdas.
+// constructor so behavior lives in named private methods rather than lambdas.
 //
 // Protocol:
 //   Client sends: {"type":"hello","client":"browser"}
@@ -56,12 +56,14 @@ using namespace std::chrono_literals;
 // the base) because `timer_fuse::get_if_armed` locks the `weak_ptr` before
 // dereferencing the sequencer, so the sequencer is never accessed after the
 // transaction is destroyed.
-class sim_ws_transaction final: public http_websocket_transaction {
+class sim_ws_handler final: public http_websocket_transaction {
 public:
-  sim_ws_transaction(request_head&& req,
-      const std::shared_ptr<epoll_loop>& loop,
+  // Construct and initialize a new transaction, with its own `sim_world` and
+  // tick timer.
+  sim_ws_handler(request_head&& req, const std::shared_ptr<epoll_loop>& loop,
       const std::shared_ptr<timing_wheel>& wheel)
       : http_websocket_transaction{std::move(req)} {
+    // Register methods as callbacks.
     websocket().on_message =
         [this](http_websocket& ws, std::string&& msg, ws_frame_control) {
           return do_message(ws, std::move(msg));
@@ -69,18 +71,33 @@ public:
     websocket().on_close = [](http_websocket&, uint16_t, std::string_view) {
       do_close();
     };
-    // `enable_keepalive` stores weak_ptrs and sets `on_pong`; it always
-    // returns `true`, so voiding the result is safe here.
+    // `enable_keepalive` stores weak_ptrs and sets `on_pong`.
     (void)enable_keepalive(loop, wheel, 20s, 5s);
 
-    // Populate the world with five entities at the origin, evenly fanned
-    // around the full circle at the same speed.
-    constexpr int kCount = 5000;
+    // As an optical dial tone, populate the world with entities bouncing
+    // around.
+    constexpr int kCount = 100;
     constexpr float kSpeed = 40.0;
     constexpr float kStep = 2.0 * std::numbers::pi / kCount;
     for (int i = 0; i < kCount; ++i)
-      (void)world_.spawn(sim::Position{0.0, 0.0},
-          sim::Velocity::from_polar(kSpeed, static_cast<float>(i) * kStep));
+      (void)world_.spawn(Position{0.0, 0.0},
+          Velocity::from_polar(kSpeed, static_cast<float>(i) * kStep));
+
+    // Populate the tracking path with a square spiral starting at the center
+    // and stepping outwards.
+    path_joints p;
+    float step = 20.0;
+    for (int i = 0; i < 100; ++i) {
+      p.joints.push_back({Position{step, 0.0}});
+      step += 20.0;
+      p.joints.push_back({Position{0.0, step}});
+      step += 20.0;
+      p.joints.push_back({Position{-step, 0.0}});
+      step += 20.0;
+      p.joints.push_back({Position{0.0, -step}});
+      step += 20.0;
+    }
+    (void)world_.add_path(p);
 
     std::cout << "WebSocket client connected\n";
   }
@@ -88,9 +105,10 @@ public:
   // Returns a `transaction_factory` for use with `http_server::add_route`.
   [[nodiscard]] static transaction_factory make_factory(
       std::shared_ptr<epoll_loop> loop, std::shared_ptr<timing_wheel> wheel) {
+    // Factory factory.
     return [loop = std::move(loop), wheel = std::move(wheel)](
                request_head&& req) -> transaction_ptr {
-      return std::make_shared<sim_ws_transaction>(std::move(req), loop, wheel);
+      return std::make_shared<sim_ws_handler>(std::move(req), loop, wheel);
     };
   }
 
@@ -99,7 +117,7 @@ private:
 
   std::atomic<tick_t> tick_seq_; // Uses for sequencing tick timers
   tick_t current_tick_{0};       // updated each frame; loop-thread only
-  sim::sim_world world_;         // all simulation entity state
+  sim_world world_;              // all simulation entity state
 
   // Handle an incoming text frame. Dispatches on `"type"` by substring search
   // (no parser needed for these fixed message shapes).
@@ -120,22 +138,25 @@ private:
   }
 
   // Parse a `spawn` message and add a new entity at the click position.
-  //
-  // The entity travels in a straight line; velocity is set perpendicular to
-  // the vector from the canvas centre to the click point (tangential), with
-  // a fixed speed of 40 pixels per frame. If the click is exactly on-centre,
-  // the entity moves rightward.
   [[nodiscard]] bool do_spawn(std::string_view msg) {
-    auto x = parse_coord(msg, R"("x":)");
-    auto y = parse_coord(msg, R"("y":)");
-    if (!x || !y) return true; // malformed, ignore
-    float r = std::sqrt((*x * *x) + (*y * *y));
-    constexpr float speed = 40.0;
-    sim::Velocity vel =
-        (r > 0.0) ? sim::Velocity{-speed * *y / r, speed * *x / r}
-                  : sim::Velocity{speed, 0.0};
-    (void)world_.spawn(sim::Position{*x, *y}, vel);
+    const auto pos = parse_position(msg);
+    if (!pos) return true; // malformed, ignore
+
+    // Aim new point based on its angle from the center, with a fixed speed.
+    const auto [length, direction] = cartesian_to_polar(pos->x, pos->y);
+    const auto vel = Velocity::from_polar(40.0, direction);
+
+    (void)world_.spawn(*pos, vel);
     return true;
+  }
+
+  // Parse an `{x, y}` position from the fixed message shape used by the sim.
+  [[nodiscard]] static std::optional<Position> parse_position(
+      std::string_view msg) {
+    const auto ox = parse_coord(msg, R"("x":)");
+    const auto oy = parse_coord(msg, R"("y":)");
+    if (!ox || !oy) return std::nullopt;
+    return Position{*ox, *oy};
   }
 
   // Find `key` in `msg` and parse the number that follows it.
@@ -169,8 +190,8 @@ private:
           return loop->post([fuse, tick_n]() -> bool {
             auto tx = fuse.get_if_armed();
             if (!tx) return true;
-            return std::static_pointer_cast<sim_ws_transaction>(tx)
-                ->do_tick_fire(tick_n);
+            return std::static_pointer_cast<sim_ws_handler>(tx)->do_tick_fire(
+                tick_n);
           });
         });
   }
@@ -186,6 +207,7 @@ private:
     current_tick_ = world_.tick();
 
     auto snaps = world_.snapshot();
+    auto paths = world_.path_snapshot();
     std::string entities;
     entities.reserve(snaps.size() * 40);
     for (const auto& e : snaps) {
@@ -194,8 +216,22 @@ private:
           static_cast<std::size_t>(e.id), e.pos.x, e.pos.y);
     }
 
-    auto snap_msg =
-        std::format(R"({{"type":"snapshot","entities":[{}]}})", entities);
+    std::string path_json = "[]";
+    if (!paths.empty()) {
+      const auto& path = paths.front();
+      std::string joints;
+      joints.reserve(path.joints.size() * 24);
+      for (const auto& joint : path.joints) {
+        if (!joints.empty()) joints += ',';
+        joints +=
+            std::format(R"({{"x":{:.1f},"y":{:.1f}}})", joint.x, joint.y);
+      }
+      path_json = std::format("[{}]", joints);
+    }
+
+    auto snap_msg = std::format(
+        R"({{"type":"snapshot","entities":[{}],"path":{}}})", entities,
+        path_json);
     if (!websocket().send_text(snap_msg)) return false;
 
     if (tick_n % 20 == 0) {

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -111,14 +111,14 @@ private:
   [[nodiscard]] bool do_ui_canvas(json_object_view msg) {
     const auto input = parseUiCanvasMessage(msg);
     if (!input) return true; // malformed, ignore
-    game_.handle_ui_canvas(*input);
+    game_.handleUiCanvas(*input);
     return true;
   }
 
   [[nodiscard]] bool do_ui_action(json_object_view msg) {
     const auto input = parseUiActionMessage(msg);
     if (!input) return true; // malformed, ignore
-    game_.handle_ui_action(*input);
+    game_.handle_UiAction(*input);
     return true;
   }
 

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -18,11 +18,11 @@
 
 #include <atomic>
 #include <charconv>
-#include <numbers>
 #include <cmath>
 #include <format>
 #include <iostream>
 #include <memory>
+#include <numbers>
 #include <optional>
 #include <vector>
 
@@ -176,7 +176,8 @@ private:
   }
 
   // Called on the loop thread: advance the simulation one frame, send a
-  // snapshot message (20 Hz) and, once per 20 frames, a tick message (1 Hz).
+  // world update message (20 Hz) and, once per 20 frames, a tick message
+  // (1 Hz).
   // Re-arms for the next 50 ms interval. If a fragmented send is in progress,
   // defers by re-arming with the same counter so the sequence has no gaps.
   [[nodiscard]] bool do_tick_fire(Tick tick_n) {
@@ -231,11 +232,13 @@ private:
     (void)game_.extractDelta(
         // Upserts.
         [&it, &wrote_any_upsert](SimWorld::EntityId entityId,
-            const Position& pos) {
+            const Position& pos, const Appearance& app) {
           if (wrote_any_upsert) it = std::format_to(it, ",");
           wrote_any_upsert = true;
-          it = std::format_to(it, R"({{"id":{},"x":{:.1f},"y":{:.1f}}})",
-              *entityId, pos.x, pos.y);
+          it = std::format_to(it,
+              R"({{"pos":{{"id":{},"x":{:.1f},"y":{:.1f}}},"app":{{"glyph":{},"scale":{:.3f},"fg":{},"bg":{},"glow":{}}}}})",
+              *entityId, pos.x, pos.y, static_cast<uint32_t>(app.glyph),
+              app.scale, app.fg_color, app.bg_color, app.glow_color);
           return true;
         },
         // Erasures.

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -17,15 +17,14 @@
 #pragma once
 
 #include <atomic>
-#include <format>
 #include <iostream>
 #include <memory>
-#include <vector>
 
 #include "../proto/http_websocket_transaction.h"
 #include "../strings/any_strings.h"
 #include "sim_game.h"
 #include "sim_json_parse.h"
+#include "sim_json_wire.h"
 
 namespace corvid { inline namespace proto {
 
@@ -91,34 +90,32 @@ private:
   WorldTick current_tick_{};       // updated each frame; loop-thread only
   SimGame game_;                   // all simulation entity state
   update_strategy send_strategy_{update_strategy::full};
-  size_t buffer_high_watermark_ = 16ULL * 1024; // try to avoid resizes
-  size_t erased_ids_high_watermark = 64;        // ditto for erased ID vector
+  sim_game_state_json json_buffer_; // persistent buffer and high-watermark
 
   // Handle an incoming text frame by classifying and forwarding the message.
   [[nodiscard]] bool do_message(http_websocket& ws, std::string&& msg) {
-    switch (classify_sim_client_message(msg)) {
-      case SimClientMessageKind::hello:
-        if (!ws.send_text(R"({"type":"hello_ack","message":"connected"})"))
-          return false;
-        return do_arm_tick();
-      case SimClientMessageKind::ui_canvas:
-        return do_ui_canvas(msg);
-      case SimClientMessageKind::ui_action:
-        return do_ui_action(msg);
-      case SimClientMessageKind::unknown:
-        break;
+    const auto root = parse_sim_client_message_root(msg);
+    if (!root) return true; // malformed, ignore
+
+    switch (classify_sim_client_message(*root)) {
+    case SimClientMessageKind::hello:
+      if (!ws.send_text(build_sim_hello_ack_json())) return false;
+      return do_arm_tick();
+    case SimClientMessageKind::ui_canvas: return do_ui_canvas(*root);
+    case SimClientMessageKind::ui_action: return do_ui_action(*root);
+    case SimClientMessageKind::unknown: break;
     }
     return true;
   }
 
-  [[nodiscard]] bool do_ui_canvas(std::string_view msg) {
+  [[nodiscard]] bool do_ui_canvas(json_object_view msg) {
     const auto input = parse_ui_canvas_message(msg);
     if (!input) return true; // malformed, ignore
     game_.handle_ui_canvas(*input);
     return true;
   }
 
-  [[nodiscard]] bool do_ui_action(std::string_view msg) {
+  [[nodiscard]] bool do_ui_action(json_object_view msg) {
     const auto input = parse_ui_action_message(msg);
     if (!input) return true; // malformed, ignore
     game_.handle_ui_action(*input);
@@ -162,107 +159,16 @@ private:
   // Stream snapshot of game state to the client as JSON. Uses deltas when
   // possible.
   [[nodiscard]] bool send_game_state() {
-    std::string buf;
-    buf.reserve(buffer_high_watermark_);
-    auto it = std::back_inserter(buf);
-    // State to allow comma delimiter management in callbacks.
-    bool wrote_any_path = false;
-    bool wrote_any_joint = false;
-    bool wrote_any_upsert = false;
-    bool wrote_any_erased = false;
-
-    // If full send, wrap in `world_snapshot` envelope and include paths.
-    if (send_strategy_ == update_strategy::full) {
-      (void)game_.markAllDirty(update_strategy::full);
-      it = std::format_to(it, R"({{"type":"world_snapshot","paths":[)");
-      (void)game_.extractPaths(
-          [&it, &wrote_any_path, &wrote_any_joint](auto, const Position& pos) {
-            if (wrote_any_joint) it = std::format_to(it, ",");
-            wrote_any_path = true;
-            wrote_any_joint = true;
-            it = std::format_to(it, R"({{"x":{:.1f},"y":{:.1f}}})", pos.x,
-                pos.y);
-            return true;
-          });
-      buf += R"(],"delta":)";
-      it = std::back_inserter(buf);
-    }
-
-    std::vector<SimWorld::EntityId> erasedIds;
-    erasedIds.reserve(erased_ids_high_watermark);
-
-    // Display state.
-    size_t current_wave{};
-    WaveTick wave_tick{};
-    int lives_count{};
-    int resources_count{};
-    std::string_view phase{};
-
-    it = std::format_to(it, R"({{"type":"world_delta","tick":{}, "upserts":[)",
-        *current_tick_);
-
-    (void)game_.extractDelta(
-        // Upserts.
-        [&it, &wrote_any_upsert,
-            current_tick = current_tick_](SimWorld::EntityId entityId,
-            const Position& pos, const Appearance& app) {
-          if (wrote_any_upsert) it = std::format_to(it, ",");
-          wrote_any_upsert = true;
-          if (app.modified + 1 != current_tick) {
-            it = std::format_to(it,
-                R"({{"pos":{{"id":{},"x":{:.1f},"y":{:.1f}}}}})", *entityId,
-                pos.x, pos.y);
-            return true;
-          }
-
-          const auto glow_color =
-              app.effect_expiry < current_tick ? 0U : app.glow_color;
-          it = std::format_to(it,
-              R"({{"pos":{{"id":{},"x":{:.1f},"y":{:.1f}}},"app":{{"glyph":{},"scale":{:.3f},"fg":{},"bg":{},"glow":{}}}}})",
-              *entityId, pos.x, pos.y, static_cast<uint32_t>(app.glyph),
-              app.scale, app.fg_color, app.bg_color, glow_color);
-          return true;
-        },
-        // Erasures.
-        [&erasedIds](SimWorld::EntityId entityId) {
-          erasedIds.push_back(entityId);
-          return true;
-        },
-        [&current_wave, &wave_tick, &lives_count, &resources_count,
-            &phase](auto currentWave, auto waveTick, auto lives,
-            auto resources, auto currentPhase) {
-          current_wave = currentWave;
-          wave_tick = waveTick;
-          lives_count = lives;
-          resources_count = resources;
-          phase = currentPhase;
-          return true;
-        });
-
-    // Mostly, the future is predicted by the past.
-    erased_ids_high_watermark = erasedIds.size();
-    it = std::format_to(it, R"(],"erased":[)");
-    for (auto entityId : erasedIds) {
-      if (wrote_any_erased) it = std::format_to(it, ",");
-      wrote_any_erased = true;
-      it = std::format_to(it, R"({})", *entityId);
-    }
-    it = std::format_to(it,
-        R"(],"currentWave":{},"waveTick":{},"lives":{},"resources":{},"phase":"{}"}})",
-        current_wave, *wave_tick, lives_count, resources_count, phase);
-
-    if (send_strategy_ == update_strategy::full) buf += "}";
+    (void)build_sim_game_state_json(json_buffer_, game_, current_tick_,
+        send_strategy_);
 
     std::string header_buf;
     (void)ws_frame_lens::build(header_buf,
-        ws_frame_control::text | ws_frame_control::fin, buf.size(),
-        std::nullopt);
+        ws_frame_control::text | ws_frame_control::fin,
+        json_buffer_.body.size(), std::nullopt);
 
-    // The past predicts the future, mostly.
-    buffer_high_watermark_ = buf.size();
-
-    if (!websocket().send_frame(
-            strings::as_vector(std::move(header_buf), std::move(buf))))
+    if (!websocket().send_frame(strings::as_vector(std::move(header_buf),
+            std::move(json_buffer_.body))))
       return false;
 
     return true;

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -96,6 +96,8 @@ private:
   WorldTick current_tick_{};       // updated each frame; loop-thread only
   SimGame game_;                   // all simulation entity state
   update_strategy send_strategy_{update_strategy::full};
+  size_t buffer_high_watermark_ = 16ULL * 1024; // try to avoid resizes
+  size_t erased_ids_high_watermark = 64;        // ditto for erased ID vector
 
   // Handle an incoming text frame. Dispatches on `"type"` by substring search
   // (no parser needed for these fixed message shapes).
@@ -185,9 +187,11 @@ private:
     return do_arm_tick();
   }
 
+  // Stream snapshot of game state to the client as JSON. Uses deltas when
+  // possible.
   [[nodiscard]] bool send_game_state() {
     std::string buf;
-    buf.reserve(16ULL * 1024);
+    buf.reserve(buffer_high_watermark_);
     auto it = std::back_inserter(buf);
     // State to allow comma delimiter management in callbacks.
     bool wrote_any_path = false;
@@ -197,6 +201,7 @@ private:
 
     // If full send, wrap in `world_snapshot` envelope and include paths.
     if (send_strategy_ == update_strategy::full) {
+      (void)game_.markAllDirty(update_strategy::full);
       it = std::format_to(it, R"({{"type":"world_snapshot","paths":[)");
       (void)game_.extractPaths(
           [&it, &wrote_any_path, &wrote_any_joint](auto, const Position& pos) {
@@ -212,7 +217,7 @@ private:
     }
 
     std::vector<SimWorld::EntityId> erasedIds;
-    erasedIds.reserve(64);
+    erasedIds.reserve(erased_ids_high_watermark);
 
     // Display state.
     size_t current_wave{};
@@ -262,6 +267,8 @@ private:
           return true;
         });
 
+    // Mostly, the future is predicted by the past.
+    erased_ids_high_watermark = erasedIds.size();
     it = std::format_to(it, R"(],"erased":[)");
     for (auto entityId : erasedIds) {
       if (wrote_any_erased) it = std::format_to(it, ",");
@@ -278,6 +285,9 @@ private:
     (void)ws_frame_lens::build(header_buf,
         ws_frame_control::text | ws_frame_control::fin, buf.size(),
         std::nullopt);
+
+    // The past predicts the future, mostly.
+    buffer_high_watermark_ = buf.size();
 
     if (!websocket().send_frame(
             strings::as_vector(std::move(header_buf), std::move(buf))))

--- a/corvid/sim/web/index.html
+++ b/corvid/sim/web/index.html
@@ -1,17 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>CorvidSim</title>
   <script type="module" src="/src/main.ts"></script>
 </head>
+
 <body>
   <h1>CorvidSim</h1>
   <p>Status: <span id="status">disconnected</span></p>
   <p>Latest tick: <span id="tick">--</span></p>
+  <canvas id="canvas" width="640" height="480"></canvas>
   <h2>Log</h2>
   <pre id="log" style="height:200px;overflow-y:auto;border:1px solid #ccc;padding:4px"></pre>
-  <canvas id="canvas" width="640" height="480"></canvas>
 </body>
+
 </html>

--- a/corvid/sim/web/index.html
+++ b/corvid/sim/web/index.html
@@ -1,5 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
-<head><meta charset="UTF-8"><title>CorvidSim</title></head>
-<body><h1>CorvidSim</h1><p>Static server is working.</p></body>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CorvidSim</title>
+  <script type="module" crossorigin src="/assets/index-Bla7islB.js"></script>
+</head>
+<body>
+  <h1>CorvidSim</h1>
+  <p>Status: <span id="status">disconnected</span></p>
+  <p>Latest tick: <span id="tick">--</span></p>
+  <h2>Log</h2>
+  <pre id="log" style="height:200px;overflow-y:auto;border:1px solid #ccc;padding:4px"></pre>
+</body>
 </html>

--- a/corvid/sim/web/index.html
+++ b/corvid/sim/web/index.html
@@ -12,6 +12,14 @@
   <h1>CorvidSim</h1>
   <p>Status: <span id="status">disconnected</span></p>
   <p>Latest tick: <span id="tick">--</span></p>
+  <p>
+    Lives: <span id="lives">--</span>
+    Resources: <span id="resources">--</span>
+    Phase: <span id="phase">--</span>
+  </p>
+  <p>
+    <button type="button" data-action="start_wave">Start Wave</button>
+  </p>
   <div
     style="position:relative;width:960px;height:540px;border:1px solid gray"
   >

--- a/corvid/sim/web/index.html
+++ b/corvid/sim/web/index.html
@@ -12,7 +12,7 @@
   <h1>CorvidSim</h1>
   <p>Status: <span id="status">disconnected</span></p>
   <p>Latest tick: <span id="tick">--</span></p>
-  <canvas id="canvas" width="640" height="480"></canvas>
+  <canvas id="canvas" width="960" height="540" style="border:1px solid gray"></canvas>
   <h2>Log</h2>
   <pre id="log" style="height:200px;overflow-y:auto;border:1px solid #ccc;padding:4px"></pre>
 </body>

--- a/corvid/sim/web/index.html
+++ b/corvid/sim/web/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>CorvidSim</title>
-  <script type="module" crossorigin src="/assets/index-Bla7islB.js"></script>
+  <script type="module" src="/src/main.ts"></script>
 </head>
 <body>
   <h1>CorvidSim</h1>

--- a/corvid/sim/web/index.html
+++ b/corvid/sim/web/index.html
@@ -12,7 +12,22 @@
   <h1>CorvidSim</h1>
   <p>Status: <span id="status">disconnected</span></p>
   <p>Latest tick: <span id="tick">--</span></p>
-  <canvas id="canvas" width="960" height="540" style="border:1px solid gray"></canvas>
+  <div
+    style="position:relative;width:960px;height:540px;border:1px solid gray"
+  >
+    <canvas
+      id="background-canvas"
+      width="960"
+      height="540"
+      style="position:absolute;inset:0"
+    ></canvas>
+    <canvas
+      id="foreground-canvas"
+      width="960"
+      height="540"
+      style="position:absolute;inset:0"
+    ></canvas>
+  </div>
   <h2>Log</h2>
   <pre id="log" style="height:200px;overflow-y:auto;border:1px solid #ccc;padding:4px"></pre>
 </body>

--- a/corvid/sim/web/index.html
+++ b/corvid/sim/web/index.html
@@ -12,5 +12,6 @@
   <p>Latest tick: <span id="tick">--</span></p>
   <h2>Log</h2>
   <pre id="log" style="height:200px;overflow-y:auto;border:1px solid #ccc;padding:4px"></pre>
+  <canvas id="canvas" width="640" height="480"></canvas>
 </body>
 </html>

--- a/corvid/sim/web/index.html
+++ b/corvid/sim/web/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>CorvidSim</title></head>
+<body><h1>CorvidSim</h1><p>Static server is working.</p></body>
+</html>

--- a/corvid/sim/web/package-lock.json
+++ b/corvid/sim/web/package-lock.json
@@ -1,0 +1,944 @@
+{
+  "name": "corvid-sim",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "corvid-sim",
+      "version": "0.0.0",
+      "devDependencies": {
+        "typescript": "^5.0.0",
+        "vite": "^5.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/corvid/sim/web/package.json
+++ b/corvid/sim/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "corvid-sim",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -128,9 +128,9 @@ function renderInterpolated(): void {
     const [x, y] = worldToCanvas(wx, wy)
     const radius = 5 * lerp(prevApp.scale, e.app.scale, t)
 
-    drawFilledCircle(x, y, radius * 1.5, e.app.glow)
-    drawFilledCircle(x, y, radius, e.app.bg)
-    drawGlyphInCircle(e.app.glyph, x, y, radius, e.app.fg)
+    if (e.app.glow.alpha !== 0) drawFilledCircle(x, y, radius * 1.5, e.app.glow)
+    if (e.app.bg.alpha !== 0) drawFilledCircle(x, y, radius, e.app.bg)
+    if (e.app.fg.alpha !== 0) drawGlyphInCircle(e.app.glyph, x, y, radius, e.app.fg)
   }
 }
 

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -2,10 +2,16 @@ import type {
   ClientMsg,
   EntityAppearance,
   EntityPosition,
+  EntityRender,
   EntityUpsert,
   ServerMsg,
   WorldDelta,
 } from './types.js'
+
+interface RenderEntityUpsert {
+  pos: EntityPosition
+  app: EntityRender
+}
 
 // --- DOM setup ---
 
@@ -66,10 +72,10 @@ let lastFrameTime = 0
 
 const SNAPSHOT_INTERVAL_MS = 50 // matches server 20 Hz rate
 
-let prevEntities: EntityUpsert[] = []
-let currEntities: EntityUpsert[] = []
+let prevEntities: RenderEntityUpsert[] = []
+let currEntities: RenderEntityUpsert[] = []
 let prevPositionsById = new Map<number, EntityPosition>()
-let prevAppearancesById = new Map<number, EntityAppearance>()
+let prevAppearancesById = new Map<number, EntityRender>()
 let lastSnapshotTime = 0
 let lives = 0
 let resources = 0
@@ -107,16 +113,77 @@ function renderInterpolated(): void {
     const wx = prevPos ? lerp(prevPos.x, e.pos.x, t) : e.pos.x
     const wy = prevPos ? lerp(prevPos.y, e.pos.y, t) : e.pos.y
     const [x, y] = worldToCanvas(wx, wy)
+    const radius = 5 * lerp(prevApp.scale, e.app.scale, t)
 
-    fgCtx.fillStyle = colorToCss(e.app.fg)
-    fgCtx.beginPath()
-    fgCtx.arc(x, y, 5 * lerp(prevApp.scale, e.app.scale, t), 0, Math.PI * 2)
-    fgCtx.fill()
+    drawFilledCircle(x, y, radius * 1.5, e.app.glow)
+    drawFilledCircle(x, y, radius, e.app.bg)
+    drawGlyphInCircle(e.app.glyph, x, y, radius, e.app.fg)
   }
 }
 
-function colorToCss(color: number): string {
-  return `#${(color & 0xffffff).toString(16).padStart(6, '0')}`
+function packedRgbaToCss(color: number): string {
+  const r = (color >>> 24) & 0xff
+  const g = (color >>> 16) & 0xff
+  const b = (color >>> 8) & 0xff
+  const a = (color & 0xff) / 255
+  return `rgba(${r}, ${g}, ${b}, ${a})`
+}
+
+function cssRgbaAlpha(color: string): number {
+  const match = /^rgba\(\d+, \d+, \d+, ([0-9.]+)\)$/.exec(color)
+  return match ? Number(match[1]) : 1
+}
+
+function isTransparent(color: string): boolean {
+  return cssRgbaAlpha(color) === 0
+}
+
+function drawFilledCircle(x: number, y: number, radius: number, color: string): void {
+  if (radius <= 0 || isTransparent(color)) return
+
+  fgCtx.fillStyle = color
+  fgCtx.beginPath()
+  fgCtx.arc(x, y, radius, 0, Math.PI * 2)
+  fgCtx.fill()
+}
+
+function drawGlyphInCircle(glyph: string, x: number, y: number, radius: number, color: string): void {
+  if (!glyph || radius <= 0 || isTransparent(color)) return
+
+  const maxBox = radius * Math.sqrt(2)
+  let fontSize = maxBox
+  fgCtx.font = `${fontSize}px monospace`
+
+  const metrics = fgCtx.measureText(glyph)
+  const width = metrics.width || 1
+  const height = (metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent) || fontSize
+  const scale = Math.min(maxBox / width, maxBox / height, 1) * 0.9
+  fontSize *= scale
+
+  fgCtx.save()
+  fgCtx.fillStyle = color
+  fgCtx.font = `${fontSize}px monospace`
+  fgCtx.textAlign = 'center'
+  fgCtx.textBaseline = 'middle'
+  fgCtx.fillText(glyph, x, y)
+  fgCtx.restore()
+}
+
+function appearanceToRender(app: EntityAppearance): EntityRender {
+  return {
+    glyph: String.fromCodePoint(app.glyph),
+    scale: app.scale,
+    fg: packedRgbaToCss(app.fg),
+    bg: packedRgbaToCss(app.bg),
+    glow: packedRgbaToCss(app.glow),
+  }
+}
+
+function upsertToRenderEntity(upsert: EntityUpsert): RenderEntityUpsert {
+  return {
+    pos: upsert.pos,
+    app: appearanceToRender(upsert.app),
+  }
 }
 
 function drawFps(): void {
@@ -223,14 +290,14 @@ function getDeltaPhase(delta: WorldDelta): string {
   return delta.phase
 }
 
-function beginSnapshotUpdate(): Map<number, EntityUpsert> {
+function beginSnapshotUpdate(): Map<number, RenderEntityUpsert> {
   prevEntities = currEntities
   prevPositionsById = new Map(prevEntities.map((e) => [e.pos.id, e.pos]))
   prevAppearancesById = new Map(prevEntities.map((e) => [e.pos.id, e.app]))
   return new Map(currEntities.map((e) => [e.pos.id, e]))
 }
 
-function finishSnapshotUpdate(nextEntities: Map<number, EntityUpsert>): void {
+function finishSnapshotUpdate(nextEntities: Map<number, RenderEntityUpsert>): void {
   currEntities = [...nextEntities.values()]
   lastSnapshotTime = performance.now()
 }
@@ -238,7 +305,8 @@ function finishSnapshotUpdate(nextEntities: Map<number, EntityUpsert>): void {
 function applyWorldDelta(delta: WorldDelta): void {
   const nextEntities = beginSnapshotUpdate()
 
-  for (const entity of delta.upserts) nextEntities.set(entity.pos.id, entity)
+  for (const entity of delta.upserts)
+    nextEntities.set(entity.pos.id, upsertToRenderEntity(entity))
   for (const entityId of delta.erased) nextEntities.delete(entityId)
 
   finishSnapshotUpdate(nextEntities)

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -1,29 +1,69 @@
 import type { ServerMsg, ClientMsg, SnapshotEntity } from './types.js'
 
-const statusEl = document.getElementById('status')!
-const tickEl = document.getElementById('tick')!
-const logEl = document.getElementById('log')!
-const canvas = document.getElementById('canvas') as HTMLCanvasElement
-const ctx = canvas.getContext('2d')!
+// --- DOM setup ---
 
-function render(entities: SnapshotEntity[]): void {
+function requireEl<T extends HTMLElement>(
+  id: string,
+  type: abstract new (...args: any[]) => T,
+): T {
+  const el = document.getElementById(id)
+  if (!(el instanceof type)) throw new Error(`Missing #${id}`)
+  return el
+}
+
+const statusEl = requireEl('status', HTMLElement)
+const tickEl = requireEl('tick', HTMLElement)
+const logEl = requireEl('log', HTMLElement)
+const canvas = requireEl('canvas', HTMLCanvasElement)
+
+const maybeCtx = canvas.getContext('2d')
+if (!maybeCtx) throw new Error('Could not get 2D canvas context')
+const ctx: CanvasRenderingContext2D = maybeCtx
+
+// --- Interpolation state ---
+
+const SNAPSHOT_INTERVAL_MS = 50 // matches server 20 Hz rate
+
+let prevEntities: SnapshotEntity[] = []
+let currEntities: SnapshotEntity[] = []
+let prevById = new Map<number, SnapshotEntity>()
+let lastSnapshotTime = 0
+
+// Linear interpolation calculator
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t
+}
+
+function renderInterpolated(): void {
+  const t = Math.min((performance.now() - lastSnapshotTime) / SNAPSHOT_INTERVAL_MS, 1)
+
   ctx.clearRect(0, 0, canvas.width, canvas.height)
-
-  for (const e of entities) {
+  for (const e of currEntities) {
+    const prev = prevById.get(e.id)
+    const x = prev ? lerp(prev.x, e.x, t) : e.x
+    const y = prev ? lerp(prev.y, e.y, t) : e.y
     ctx.beginPath()
-    ctx.arc(e.x, e.y, 5, 0, Math.PI * 2)
+    ctx.arc(x, y, 5, 0, Math.PI * 2)
     ctx.fill()
   }
 }
+
+function frame(): void {
+  renderInterpolated()
+  requestAnimationFrame(frame)
+}
+
+// --- Logging ---
 
 function log(line: string): void {
   logEl.textContent += line + '\n'
   logEl.scrollTop = logEl.scrollHeight
 }
 
+// --- Message validation ---
+
 function isServerMsg(value: unknown): value is ServerMsg {
   if (!value || typeof value !== 'object') return false
-
   const v = value as Record<string, unknown>
   if (typeof v.type !== 'string') return false
 
@@ -33,18 +73,23 @@ function isServerMsg(value: unknown): value is ServerMsg {
     case 'tick':
       return typeof v.tick === 'number'
     case 'snapshot':
-      return Array.isArray(v.entities) &&
-         v.entities.every(e =>
-           typeof e === 'object' &&
-           e !== null &&
-           typeof (e as any).id === 'number' &&
-           typeof (e as any).x === 'number' &&
-           typeof (e as any).y === 'number'
-         )
+      return (
+        Array.isArray(v.entities) &&
+        v.entities.every(
+          (e) =>
+            typeof e === 'object' &&
+            e !== null &&
+            typeof (e as Record<string, unknown>).id === 'number' &&
+            typeof (e as Record<string, unknown>).x === 'number' &&
+            typeof (e as Record<string, unknown>).y === 'number',
+        )
+      )
     default:
       return false
   }
 }
+
+// --- WebSocket ---
 
 const protocol = location.protocol === 'https:' ? 'wss' : 'ws'
 const ws = new WebSocket(`${protocol}://${location.host}/ws`)
@@ -57,8 +102,6 @@ ws.onopen = () => {
 }
 
 ws.onmessage = (event: MessageEvent<string>) => {
-  log(event.data)
-
   let parsed: unknown
   try {
     parsed = JSON.parse(event.data)
@@ -80,8 +123,11 @@ ws.onmessage = (event: MessageEvent<string>) => {
       tickEl.textContent = String(parsed.tick)
       break
     case 'snapshot':
-      render(parsed.entities)
-    break      
+      prevEntities = currEntities
+      prevById = new Map(prevEntities.map((e) => [e.id, e]))
+      currEntities = parsed.entities
+      lastSnapshotTime = performance.now()
+      break
   }
 }
 
@@ -94,3 +140,16 @@ ws.onerror = () => {
   statusEl.textContent = 'error'
   log('WebSocket error')
 }
+
+canvas.addEventListener('click', (e: MouseEvent) => {
+  if (ws.readyState !== WebSocket.OPEN) return
+  const rect = canvas.getBoundingClientRect()
+  const scaleX = canvas.width / rect.width
+  const scaleY = canvas.height / rect.height
+  const x = Math.round((e.clientX - rect.left) * scaleX)
+  const y = Math.round((e.clientY - rect.top) * scaleY)
+  const msg: ClientMsg = { type: 'spawn', x, y }
+  ws.send(JSON.stringify(msg))
+})
+
+requestAnimationFrame(frame)

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -1,12 +1,49 @@
-import type { ServerMsg, ClientMsg } from './types.js'
+import type { ServerMsg, ClientMsg, SnapshotEntity } from './types.js'
 
 const statusEl = document.getElementById('status')!
 const tickEl = document.getElementById('tick')!
 const logEl = document.getElementById('log')!
+const canvas = document.getElementById('canvas') as HTMLCanvasElement
+const ctx = canvas.getContext('2d')!
+
+function render(entities: SnapshotEntity[]): void {
+  ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+  for (const e of entities) {
+    ctx.beginPath()
+    ctx.arc(e.x, e.y, 5, 0, Math.PI * 2)
+    ctx.fill()
+  }
+}
 
 function log(line: string): void {
   logEl.textContent += line + '\n'
   logEl.scrollTop = logEl.scrollHeight
+}
+
+function isServerMsg(value: unknown): value is ServerMsg {
+  if (!value || typeof value !== 'object') return false
+
+  const v = value as Record<string, unknown>
+  if (typeof v.type !== 'string') return false
+
+  switch (v.type) {
+    case 'hello_ack':
+      return typeof v.message === 'string'
+    case 'tick':
+      return typeof v.tick === 'number'
+    case 'snapshot':
+      return Array.isArray(v.entities) &&
+         v.entities.every(e =>
+           typeof e === 'object' &&
+           e !== null &&
+           typeof (e as any).id === 'number' &&
+           typeof (e as any).x === 'number' &&
+           typeof (e as any).y === 'number'
+         )
+    default:
+      return false
+  }
 }
 
 const protocol = location.protocol === 'https:' ? 'wss' : 'ws'
@@ -21,17 +58,30 @@ ws.onopen = () => {
 
 ws.onmessage = (event: MessageEvent<string>) => {
   log(event.data)
-  let msg: ServerMsg
+
+  let parsed: unknown
   try {
-    msg = JSON.parse(event.data) as ServerMsg
+    parsed = JSON.parse(event.data)
   } catch {
     log('(unparseable message)')
     return
   }
-  if (msg.type === 'hello_ack') {
-    log(`Server says: ${msg.message}`)
-  } else if (msg.type === 'tick') {
-    tickEl.textContent = String(msg.tick)
+
+  if (!isServerMsg(parsed)) {
+    log('(invalid server message shape)')
+    return
+  }
+
+  switch (parsed.type) {
+    case 'hello_ack':
+      log(`Server says: ${parsed.message}`)
+      break
+    case 'tick':
+      tickEl.textContent = String(parsed.tick)
+      break
+    case 'snapshot':
+      render(parsed.entities)
+    break      
   }
 }
 

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -691,6 +691,25 @@ function finishSnapshotUpdate(): void {
   }
 }
 
+function resetClientWorldState(): void {
+  currEntitiesById.clear()
+  prevRenderStateById.clear()
+  glyphFontSizeCache.clear()
+  entitySpriteCache.clear()
+  prevSnapshotTime = 0
+  currSnapshotTime = 0
+  snapshotIntervalMs = 50
+  lives = 0
+  resources = 0
+  lastFpsOverlayUpdateTime = 0
+  hudDirty = true
+
+  bgCtx.clearRect(0, 0, backgroundCanvas.width, backgroundCanvas.height)
+  fgCtx.clearRect(0, 0, foregroundCanvas.width, foregroundCanvas.height)
+  hudCtx.clearRect(0, 0, hudCanvas.width, hudCanvas.height)
+  fpsCtx.clearRect(0, 0, fpsCanvas.width, fpsCanvas.height)
+}
+
 function applyWorldDelta(delta: WorldDelta): void {
   const now = performance.now()
   prevRenderStateById.clear()
@@ -790,6 +809,7 @@ ws.onmessage = (event: MessageEvent<string>) => {
       applyWorldDelta(parsed)
       break
     case 'world_snapshot':
+      resetClientWorldState()
       drawBackground(parsed.paths)
       applyWorldDelta(parsed.delta)
       break

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -70,13 +70,13 @@ let lastFrameTime = 0
 
 // --- Interpolation state ---
 
-const SNAPSHOT_INTERVAL_MS = 50 // matches server 20 Hz rate
-
 let prevEntities: RenderEntityUpsert[] = []
 let currEntities: RenderEntityUpsert[] = []
 let prevPositionsById = new Map<number, EntityPosition>()
 let prevAppearancesById = new Map<number, EntityRender>()
-let lastSnapshotTime = 0
+let prevSnapshotTime = 0
+let currSnapshotTime = 0
+let snapshotIntervalMs = 50
 let lives = 0
 let resources = 0
 
@@ -104,7 +104,8 @@ function drawBackground(pathPoints: Array<{ x: number; y: number }>): void {
 }
 
 function renderInterpolated(): void {
-  const t = Math.min((performance.now() - lastSnapshotTime) / SNAPSHOT_INTERVAL_MS, 1)
+  const interval = Math.max(snapshotIntervalMs, 1)
+  const t = Math.min((performance.now() - currSnapshotTime) / interval, 1)
 
   fgCtx.clearRect(0, 0, foregroundCanvas.width, foregroundCanvas.height)
   for (const e of currEntities) {
@@ -299,7 +300,13 @@ function beginSnapshotUpdate(): Map<number, RenderEntityUpsert> {
 
 function finishSnapshotUpdate(nextEntities: Map<number, RenderEntityUpsert>): void {
   currEntities = [...nextEntities.values()]
-  lastSnapshotTime = performance.now()
+
+  prevSnapshotTime = currSnapshotTime
+  currSnapshotTime = performance.now()
+
+  if (prevSnapshotTime !== 0) {
+    snapshotIntervalMs = currSnapshotTime - prevSnapshotTime
+  }
 }
 
 function applyWorldDelta(delta: WorldDelta): void {

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -1,6 +1,4 @@
-import type { ServerMsg, ClientMsg, EntityPosition, SnapshotMsg, WorldDelta } from './types.js'
-
-type IncomingServerMsg = ServerMsg | SnapshotMsg
+import type { ServerMsg, ClientMsg, EntityPosition, WorldDelta } from './types.js'
 
 // --- DOM setup ---
 
@@ -173,10 +171,6 @@ function isPoint(value: unknown): value is { x: number; y: number } {
   )
 }
 
-function snapshotPathsToPoints(paths: Array<{ points: Array<{ x: number; y: number }> }>): Array<{ x: number; y: number }> {
-  return paths[0]?.points ?? []
-}
-
 function getDeltaPhase(delta: WorldDelta): string {
   const maybePhase = (delta as WorldDelta & { phase?: unknown }).phase
   if (typeof maybePhase === 'string') return maybePhase
@@ -211,7 +205,7 @@ function applyWorldDelta(delta: WorldDelta): void {
 
 // --- Message validation ---
 
-function isServerMsg(value: unknown): value is IncomingServerMsg {
+function isServerMsg(value: unknown): value is ServerMsg {
   if (!value || typeof value !== 'object') return false
   const v = value as Record<string, unknown>
   if (typeof v.type !== 'string') return false
@@ -221,27 +215,6 @@ function isServerMsg(value: unknown): value is IncomingServerMsg {
       return typeof v.message === 'string'
     case 'tick':
       return typeof v.tick === 'number'
-    case 'snapshot':
-      return (
-        Array.isArray(v.entities) &&
-        Array.isArray(v.paths) &&
-        v.entities.every(
-          (e) =>
-            typeof e === 'object' &&
-            e !== null &&
-            typeof (e as Record<string, unknown>).id === 'number' &&
-            typeof (e as Record<string, unknown>).x === 'number' &&
-            typeof (e as Record<string, unknown>).y === 'number',
-        ) &&
-        v.paths.every(
-          (path) =>
-            typeof path === 'object' &&
-            path !== null &&
-            (path as Record<string, unknown>).type === 'path' &&
-            Array.isArray((path as Record<string, unknown>).points) &&
-            ((path as Record<string, unknown>).points as unknown[]).every(isPoint),
-        )
-      )
     case 'world_delta':
       return (
         typeof v.tick === 'number' &&
@@ -303,13 +276,6 @@ ws.onmessage = (event: MessageEvent<string>) => {
       break
     case 'tick':
       tickEl.textContent = String(parsed.tick)
-      break
-    case 'snapshot':
-      prevEntities = currEntities
-      prevById = new Map(prevEntities.map((e) => [e.id, e]))
-      currEntities = parsed.entities
-      drawBackground(snapshotPathsToPoints(parsed.paths))
-      lastSnapshotTime = performance.now()
       break
     case 'world_delta':
       applyWorldDelta(parsed)

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -1,0 +1,46 @@
+import type { ServerMsg, ClientMsg } from './types.js'
+
+const statusEl = document.getElementById('status')!
+const tickEl = document.getElementById('tick')!
+const logEl = document.getElementById('log')!
+
+function log(line: string): void {
+  logEl.textContent += line + '\n'
+  logEl.scrollTop = logEl.scrollHeight
+}
+
+const protocol = location.protocol === 'https:' ? 'wss' : 'ws'
+const ws = new WebSocket(`${protocol}://${location.host}/ws`)
+
+ws.onopen = () => {
+  statusEl.textContent = 'connected'
+  log('Connected')
+  const hello: ClientMsg = { type: 'hello', client: 'browser' }
+  ws.send(JSON.stringify(hello))
+}
+
+ws.onmessage = (event: MessageEvent<string>) => {
+  log(event.data)
+  let msg: ServerMsg
+  try {
+    msg = JSON.parse(event.data) as ServerMsg
+  } catch {
+    log('(unparseable message)')
+    return
+  }
+  if (msg.type === 'hello_ack') {
+    log(`Server says: ${msg.message}`)
+  } else if (msg.type === 'tick') {
+    tickEl.textContent = String(msg.tick)
+  }
+}
+
+ws.onclose = () => {
+  statusEl.textContent = 'disconnected'
+  log('Disconnected')
+}
+
+ws.onerror = () => {
+  statusEl.textContent = 'error'
+  log('WebSocket error')
+}

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -486,8 +486,6 @@ function isServerMsg(value: unknown): value is ServerMsg {
   switch (v.type) {
     case 'hello_ack':
       return typeof v.message === 'string'
-    case 'tick':
-      return typeof v.tick === 'number'
     case 'world_delta':
       return isWorldDelta(v)
     case 'world_snapshot':
@@ -530,9 +528,6 @@ ws.onmessage = (event: MessageEvent<string>) => {
   switch (parsed.type) {
     case 'hello_ack':
       log(`Server says: ${parsed.message}`)
-      break
-    case 'tick':
-      tickEl.textContent = String(parsed.tick)
       break
     case 'world_delta':
       applyWorldDelta(parsed)

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -30,6 +30,25 @@ interface RenderEntityUpsert {
   app: RenderAppearance
 }
 
+interface CanvasPointerState {
+  button: number
+  buttons: number
+  dragging: boolean
+}
+
+interface CanvasPointerSample {
+  button: number
+  buttons: number
+  canvasX: number
+  canvasY: number
+  worldX: number
+  worldY: number
+  shift: boolean
+  ctrl: boolean
+  alt: boolean
+  meta: boolean
+}
+
 const DEFAULT_RENDER_APPEARANCE: RenderAppearance = {
   glyph: '?',
   scale: 1,
@@ -100,6 +119,25 @@ function canvasToWorld(cx: number, cy: number): [number, number] {
   ]
 }
 
+function eventToCanvasSample(event: MouseEvent): CanvasPointerSample {
+  const rect = foregroundCanvas.getBoundingClientRect()
+  const canvasX = (event.clientX - rect.left) * (foregroundCanvas.width / rect.width)
+  const canvasY = (event.clientY - rect.top) * (foregroundCanvas.height / rect.height)
+  const [worldX, worldY] = canvasToWorld(canvasX, canvasY)
+  return {
+    button: event.button,
+    buttons: event.buttons,
+    canvasX: Math.round(canvasX),
+    canvasY: Math.round(canvasY),
+    worldX: Math.round(worldX),
+    worldY: Math.round(worldY),
+    shift: event.shiftKey,
+    ctrl: event.ctrlKey,
+    alt: event.altKey,
+    meta: event.metaKey,
+  }
+}
+
 // --- FPS tracking ---
 
 let fps = 0
@@ -122,6 +160,10 @@ const glyphFontSizeCache = new Map<string, number>()
 // paying per-frame draw costs or maintaining an eviction policy.
 const entitySpriteCache = new Map<string, SpriteCacheEntry>()
 const FPS_OVERLAY_INTERVAL_MS = 100
+let nextClientSeq = 1
+let canvasPointerState: CanvasPointerState | null = null
+let pendingDragMove: CanvasPointerSample | null = null
+let dragMoveFrameRequested = false
 
 // Linear interpolation calculator
 function lerp(a: number, b: number, t: number): number {
@@ -380,6 +422,75 @@ function invalidateHud(): void {
   hudDirty = true
 }
 
+function buttonNameFromNumber(button: number): 'left' | 'middle' | 'right' | 'other' {
+  switch (button) {
+    case 0:
+      return 'left'
+    case 1:
+      return 'middle'
+    case 2:
+      return 'right'
+    default:
+      return 'other'
+  }
+}
+
+function sendClientMsg(msg: ClientMsg): void {
+  if (ws.readyState !== WebSocket.OPEN) return
+  ws.send(JSON.stringify(msg))
+}
+
+function sendCanvasMsg(eventName: 'click' | 'dblclick' | 'contextmenu' | 'dragstart' | 'dragmove' | 'dragend', sample: CanvasPointerSample): void {
+  sendClientMsg({
+    type: 'ui_canvas',
+    seq: nextClientSeq++,
+    event: eventName,
+    button: buttonNameFromNumber(sample.button),
+    buttons: sample.buttons,
+    x: sample.worldX,
+    y: sample.worldY,
+    canvasX: sample.canvasX,
+    canvasY: sample.canvasY,
+    shift: sample.shift,
+    ctrl: sample.ctrl,
+    alt: sample.alt,
+    meta: sample.meta,
+  })
+}
+
+function flushPendingDragMove(): void {
+  dragMoveFrameRequested = false
+  if (!pendingDragMove) return
+  sendCanvasMsg('dragmove', pendingDragMove)
+  pendingDragMove = null
+}
+
+function scheduleDragMoveFlush(): void {
+  if (dragMoveFrameRequested) return
+  dragMoveFrameRequested = true
+  requestAnimationFrame(() => {
+    flushPendingDragMove()
+  })
+}
+
+function formDataToFields(formData: FormData): Record<string, string> | undefined {
+  const fields: Record<string, string> = {}
+  for (const [key, value] of formData.entries()) {
+    if (typeof value === 'string') fields[key] = value
+  }
+  return Object.keys(fields).length === 0 ? undefined : fields
+}
+
+function sendUiAction(action: string, fields?: Record<string, string>): void {
+  const msg: ClientMsg = {
+    type: 'ui_action',
+    seq: nextClientSeq++,
+    action,
+  }
+  if (fields && Object.keys(fields).length > 0) msg.fields = fields
+  sendClientMsg(msg)
+}
+
 function isPoint(value: unknown): value is { x: number; y: number } {
   return (
     typeof value === 'object' &&
@@ -508,7 +619,7 @@ ws.onopen = () => {
   statusEl.textContent = 'connected'
   log('Connected')
   const hello: ClientMsg = { type: 'hello', client: 'browser' }
-  ws.send(JSON.stringify(hello))
+  sendClientMsg(hello)
 }
 
 ws.onmessage = (event: MessageEvent<string>) => {
@@ -549,14 +660,80 @@ ws.onerror = () => {
   log('WebSocket error')
 }
 
-foregroundCanvas.addEventListener('click', (e: MouseEvent) => {
-  if (ws.readyState !== WebSocket.OPEN) return
-  const rect = foregroundCanvas.getBoundingClientRect()
-  const cssX = (e.clientX - rect.left) * (foregroundCanvas.width / rect.width)
-  const cssY = (e.clientY - rect.top) * (foregroundCanvas.height / rect.height)
-  const [x, y] = canvasToWorld(cssX, cssY).map(Math.round) as [number, number]
-  const msg: ClientMsg = { type: 'spawn', x, y }
-  ws.send(JSON.stringify(msg))
+foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
+  const sample = eventToCanvasSample(event)
+  canvasPointerState = {
+    button: sample.button,
+    buttons: sample.buttons,
+    dragging: false,
+  }
+
+  if (sample.button !== 2) sendCanvasMsg('click', sample)
+})
+
+foregroundCanvas.addEventListener('mousemove', (event: MouseEvent) => {
+  if (!canvasPointerState) return
+  const sample = eventToCanvasSample(event)
+
+  if (!canvasPointerState.dragging) {
+    canvasPointerState.dragging = true
+    canvasPointerState.buttons = sample.buttons
+    sendCanvasMsg('dragstart', sample)
+    return
+  }
+
+  canvasPointerState.buttons = sample.buttons
+  pendingDragMove = sample
+  scheduleDragMoveFlush()
+})
+
+window.addEventListener('mouseup', (event: MouseEvent) => {
+  if (!canvasPointerState) return
+  const sample = eventToCanvasSample(event)
+  const wasDragging = canvasPointerState.dragging
+  canvasPointerState = null
+  flushPendingDragMove()
+  if (wasDragging) sendCanvasMsg('dragend', sample)
+})
+
+foregroundCanvas.addEventListener('contextmenu', (event: MouseEvent) => {
+  event.preventDefault()
+  sendCanvasMsg('contextmenu', eventToCanvasSample(event))
+})
+
+foregroundCanvas.addEventListener('dblclick', (event: MouseEvent) => {
+  sendCanvasMsg('dblclick', eventToCanvasSample(event))
+})
+
+document.addEventListener('click', (event: MouseEvent) => {
+  const target = event.target
+  if (!(target instanceof Element)) return
+
+  const actionEl = target.closest<HTMLElement>('[data-action]')
+  if (!actionEl || actionEl instanceof HTMLFormElement) return
+
+  const action = actionEl.dataset.action
+  if (!action) return
+
+  if (actionEl.contains(foregroundCanvas)) return
+
+  const form = actionEl.closest('form')
+  const fields = form ? formDataToFields(new FormData(form)) : undefined
+  if (actionEl instanceof HTMLButtonElement || actionEl instanceof HTMLInputElement) {
+    event.preventDefault()
+  }
+  sendUiAction(action, fields)
+})
+
+document.addEventListener('submit', (event: SubmitEvent) => {
+  const target = event.target
+  if (!(target instanceof HTMLFormElement)) return
+
+  const action = target.dataset.action
+  if (!action) return
+
+  event.preventDefault()
+  sendUiAction(action, formDataToFields(new FormData(target)))
 })
 
 requestAnimationFrame(frame)

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -20,6 +20,33 @@ const maybeCtx = canvas.getContext('2d')
 if (!maybeCtx) throw new Error('Could not get 2D canvas context')
 const ctx: CanvasRenderingContext2D = maybeCtx
 
+// --- World / canvas coordinate mapping ---
+//
+// The server simulation runs in a 1920x1080 world space. The canvas is sized
+// to the same 16:9 aspect ratio so the mapping is a uniform scale with no
+// letterboxing needed.
+const WORLD_W = 1920
+const WORLD_H = 1080
+
+function worldToCanvas(wx: number, wy: number): [number, number] {
+  return [
+    (wx + WORLD_W / 2) * canvas.width / WORLD_W,
+    (wy + WORLD_H / 2) * canvas.height / WORLD_H,
+  ]
+}
+
+function canvasToWorld(cx: number, cy: number): [number, number] {
+  return [
+    (cx - canvas.width / 2) * WORLD_W / canvas.width,
+    (cy - canvas.height / 2) * WORLD_H / canvas.height,
+  ]
+}
+
+// --- FPS tracking ---
+
+let fps = 0
+let lastFrameTime = 0
+
 // --- Interpolation state ---
 
 const SNAPSHOT_INTERVAL_MS = 50 // matches server 20 Hz rate
@@ -40,16 +67,40 @@ function renderInterpolated(): void {
   ctx.clearRect(0, 0, canvas.width, canvas.height)
   for (const e of currEntities) {
     const prev = prevById.get(e.id)
-    const x = prev ? lerp(prev.x, e.x, t) : e.x
-    const y = prev ? lerp(prev.y, e.y, t) : e.y
+    const wx = prev ? lerp(prev.x, e.x, t) : e.x
+    const wy = prev ? lerp(prev.y, e.y, t) : e.y
+    const [x, y] = worldToCanvas(wx, wy)
     ctx.beginPath()
     ctx.arc(x, y, 5, 0, Math.PI * 2)
     ctx.fill()
   }
 }
 
-function frame(): void {
+function drawFps(): void {
+  ctx.save()
+  const label = `${fps.toFixed(1)} FPS`
+  ctx.font = '14px monospace'
+  const pad = 6
+  const w = ctx.measureText(label).width + pad * 2
+  const h = 20
+  const x = canvas.width - w - 4
+  const y = canvas.height - 4 - h
+  ctx.fillStyle = 'rgba(0,0,0,0.5)'
+  ctx.fillRect(x, y, w, h)
+  ctx.fillStyle = 'white'
+  ctx.fillText(label, x + pad, y + 14)
+  ctx.restore()
+}
+
+function frame(now: number): void {
+  if (lastFrameTime !== 0) {
+    const dt = now - lastFrameTime
+    fps = fps * 0.9 + (1000 / dt) * 0.1
+  }
+  lastFrameTime = now
+
   renderInterpolated()
+  drawFps()
   requestAnimationFrame(frame)
 }
 
@@ -144,10 +195,9 @@ ws.onerror = () => {
 canvas.addEventListener('click', (e: MouseEvent) => {
   if (ws.readyState !== WebSocket.OPEN) return
   const rect = canvas.getBoundingClientRect()
-  const scaleX = canvas.width / rect.width
-  const scaleY = canvas.height / rect.height
-  const x = Math.round((e.clientX - rect.left) * scaleX)
-  const y = Math.round((e.clientY - rect.top) * scaleY)
+  const cssX = (e.clientX - rect.left) * (canvas.width / rect.width)
+  const cssY = (e.clientY - rect.top) * (canvas.height / rect.height)
+  const [x, y] = canvasToWorld(cssX, cssY).map(Math.round) as [number, number]
   const msg: ClientMsg = { type: 'spawn', x, y }
   ws.send(JSON.stringify(msg))
 })

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -1,4 +1,6 @@
-import type { ServerMsg, ClientMsg, SnapshotEntity } from './types.js'
+import type { ServerMsg, ClientMsg, EntityPosition, SnapshotMsg, WorldDelta } from './types.js'
+
+type IncomingServerMsg = ServerMsg | SnapshotMsg
 
 // --- DOM setup ---
 
@@ -15,6 +17,9 @@ const statusEl = requireEl('status', HTMLElement)
 const tickEl = requireEl('tick', HTMLElement)
 const logEl = requireEl('log', HTMLElement)
 const canvas = requireEl('canvas', HTMLCanvasElement)
+const livesEl = document.getElementById('lives')
+const resourcesEl = document.getElementById('resources')
+const phaseEl = document.getElementById('phase')
 
 const maybeCtx = canvas.getContext('2d')
 if (!maybeCtx) throw new Error('Could not get 2D canvas context')
@@ -51,9 +56,9 @@ let lastFrameTime = 0
 
 const SNAPSHOT_INTERVAL_MS = 50 // matches server 20 Hz rate
 
-let prevEntities: SnapshotEntity[] = []
-let currEntities: SnapshotEntity[] = []
-let prevById = new Map<number, SnapshotEntity>()
+let prevEntities: EntityPosition[] = []
+let currEntities: EntityPosition[] = []
+let prevById = new Map<number, EntityPosition>()
 let lastSnapshotTime = 0
 let pathPoints: Array<{ x: number; y: number }> = []
 
@@ -126,9 +131,56 @@ function log(line: string): void {
   logEl.scrollTop = logEl.scrollHeight
 }
 
+function setTextIfElement(el: HTMLElement | null, value: string): void {
+  if (el) el.textContent = value
+}
+
+function isPoint(value: unknown): value is { x: number; y: number } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).x === 'number' &&
+    typeof (value as Record<string, unknown>).y === 'number'
+  )
+}
+
+function snapshotPathsToPoints(paths: Array<{ points: Array<{ x: number; y: number }> }>): Array<{ x: number; y: number }> {
+  return paths[0]?.points ?? []
+}
+
+function getDeltaPhase(delta: WorldDelta): string {
+  const maybePhase = (delta as WorldDelta & { phase?: unknown }).phase
+  if (typeof maybePhase === 'string') return maybePhase
+  return delta.phase
+}
+
+function beginSnapshotUpdate(): Map<number, EntityPosition> {
+  prevEntities = currEntities
+  prevById = new Map(prevEntities.map((e) => [e.id, e]))
+  return new Map(currEntities.map((e) => [e.id, e]))
+}
+
+function finishSnapshotUpdate(nextEntities: Map<number, EntityPosition>): void {
+  currEntities = [...nextEntities.values()]
+  lastSnapshotTime = performance.now()
+}
+
+function applyWorldDelta(delta: WorldDelta): void {
+  const nextEntities = beginSnapshotUpdate()
+
+  for (const entity of delta.upserts) nextEntities.set(entity.id, entity)
+  for (const entityId of delta.erased) nextEntities.delete(entityId)
+
+  finishSnapshotUpdate(nextEntities)
+  tickEl.textContent = String(delta.tick)
+  setTextIfElement(livesEl, String(delta.lives))
+  setTextIfElement(resourcesEl, String(delta.resources))
+  setTextIfElement(phaseEl, getDeltaPhase(delta))
+}
+
 // --- Message validation ---
 
-function isServerMsg(value: unknown): value is ServerMsg {
+function isServerMsg(value: unknown): value is IncomingServerMsg {
   if (!value || typeof value !== 'object') return false
   const v = value as Record<string, unknown>
   if (typeof v.type !== 'string') return false
@@ -141,7 +193,7 @@ function isServerMsg(value: unknown): value is ServerMsg {
     case 'snapshot':
       return (
         Array.isArray(v.entities) &&
-        Array.isArray(v.path) &&
+        Array.isArray(v.paths) &&
         v.entities.every(
           (e) =>
             typeof e === 'object' &&
@@ -150,13 +202,38 @@ function isServerMsg(value: unknown): value is ServerMsg {
             typeof (e as Record<string, unknown>).x === 'number' &&
             typeof (e as Record<string, unknown>).y === 'number',
         ) &&
-        v.path.every(
-          (p) =>
-            typeof p === 'object' &&
-            p !== null &&
-            typeof (p as Record<string, unknown>).x === 'number' &&
-            typeof (p as Record<string, unknown>).y === 'number',
+        v.paths.every(
+          (path) =>
+            typeof path === 'object' &&
+            path !== null &&
+            (path as Record<string, unknown>).type === 'path' &&
+            Array.isArray((path as Record<string, unknown>).points) &&
+            ((path as Record<string, unknown>).points as unknown[]).every(isPoint),
         )
+      )
+    case 'world_delta':
+      return (
+        typeof v.tick === 'number' &&
+        Array.isArray(v.upserts) &&
+        Array.isArray(v.erased) &&
+        typeof v.lives === 'number' &&
+        typeof v.resources === 'number' &&
+        typeof v.phase === 'string' &&
+        v.upserts.every(
+          (e) =>
+            typeof e === 'object' &&
+            e !== null &&
+            typeof (e as Record<string, unknown>).id === 'number' &&
+            typeof (e as Record<string, unknown>).x === 'number' &&
+            typeof (e as Record<string, unknown>).y === 'number',
+        ) &&
+        v.erased.every((id) => typeof id === 'number')
+      )
+    case 'world_snapshot':
+      return (
+        Array.isArray(v.paths) &&
+        v.paths.every(isPoint) &&
+        isServerMsg(v.delta)
       )
     default:
       return false
@@ -200,8 +277,15 @@ ws.onmessage = (event: MessageEvent<string>) => {
       prevEntities = currEntities
       prevById = new Map(prevEntities.map((e) => [e.id, e]))
       currEntities = parsed.entities
-      pathPoints = parsed.path
+      pathPoints = snapshotPathsToPoints(parsed.paths)
       lastSnapshotTime = performance.now()
+      break
+    case 'world_delta':
+      applyWorldDelta(parsed)
+      break
+    case 'world_snapshot':
+      pathPoints = parsed.paths
+      applyWorldDelta(parsed.delta)
       break
   }
 }

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -388,9 +388,8 @@ function drawRangeCircle(
   if (fx.rangeRadius <= 0 || isTransparent(fx.range)) return
 
   const radius = worldLengthToCanvas(fx.rangeRadius)
-  const lineWidth = Math.max(2, radius * 0.03)
   fgCtx.save()
-  drawStrokedCircleOnContext(fgCtx, x, y, radius, fx.range, lineWidth)
+  drawFilledCircleOnContext(fgCtx, x, y, radius, fx.range)
   fgCtx.restore()
 }
 

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -55,6 +55,7 @@ let prevEntities: SnapshotEntity[] = []
 let currEntities: SnapshotEntity[] = []
 let prevById = new Map<number, SnapshotEntity>()
 let lastSnapshotTime = 0
+let pathPoints: Array<{ x: number; y: number }> = []
 
 // Linear interpolation calculator
 function lerp(a: number, b: number, t: number): number {
@@ -65,6 +66,20 @@ function renderInterpolated(): void {
   const t = Math.min((performance.now() - lastSnapshotTime) / SNAPSHOT_INTERVAL_MS, 1)
 
   ctx.clearRect(0, 0, canvas.width, canvas.height)
+  if (pathPoints.length > 1) {
+    ctx.save()
+    ctx.strokeStyle = '#3b82f6'
+    ctx.lineWidth = 2
+    ctx.beginPath()
+    const [startX, startY] = worldToCanvas(pathPoints[0].x, pathPoints[0].y)
+    ctx.moveTo(startX, startY)
+    for (const point of pathPoints.slice(1)) {
+      const [x, y] = worldToCanvas(point.x, point.y)
+      ctx.lineTo(x, y)
+    }
+    ctx.stroke()
+    ctx.restore()
+  }
   for (const e of currEntities) {
     const prev = prevById.get(e.id)
     const wx = prev ? lerp(prev.x, e.x, t) : e.x
@@ -126,6 +141,7 @@ function isServerMsg(value: unknown): value is ServerMsg {
     case 'snapshot':
       return (
         Array.isArray(v.entities) &&
+        Array.isArray(v.path) &&
         v.entities.every(
           (e) =>
             typeof e === 'object' &&
@@ -133,6 +149,13 @@ function isServerMsg(value: unknown): value is ServerMsg {
             typeof (e as Record<string, unknown>).id === 'number' &&
             typeof (e as Record<string, unknown>).x === 'number' &&
             typeof (e as Record<string, unknown>).y === 'number',
+        ) &&
+        v.path.every(
+          (p) =>
+            typeof p === 'object' &&
+            p !== null &&
+            typeof (p as Record<string, unknown>).x === 'number' &&
+            typeof (p as Record<string, unknown>).y === 'number',
         )
       )
     default:
@@ -177,6 +200,7 @@ ws.onmessage = (event: MessageEvent<string>) => {
       prevEntities = currEntities
       prevById = new Map(prevEntities.map((e) => [e.id, e]))
       currEntities = parsed.entities
+      pathPoints = parsed.path
       lastSnapshotTime = performance.now()
       break
   }

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -12,6 +12,11 @@ interface RenderColor {
   alpha: number
 }
 
+interface SpriteCacheEntry {
+  canvas: HTMLCanvasElement
+  offset: number
+}
+
 interface RenderAppearance {
   glyph: string
   scale: number
@@ -90,6 +95,10 @@ let snapshotIntervalMs = 50
 let lives = 0
 let resources = 0
 const glyphFontSizeCache = new Map<string, number>()
+// Entity appearances come from a small, mostly fixed set of tower/enemy visuals,
+// so we memoize prerendered sprites for the lifetime of the page instead of
+// paying per-frame draw costs or maintaining an eviction policy.
+const entitySpriteCache = new Map<string, SpriteCacheEntry>()
 
 // Linear interpolation calculator
 function lerp(a: number, b: number, t: number): number {
@@ -127,10 +136,7 @@ function renderInterpolated(): void {
     const wy = prevPos ? lerp(prevPos.y, e.pos.y, t) : e.pos.y
     const [x, y] = worldToCanvas(wx, wy)
     const radius = 5 * lerp(prevApp.scale, e.app.scale, t)
-
-    if (e.app.glow.alpha !== 0) drawFilledCircle(x, y, radius * 1.5, e.app.glow)
-    if (e.app.bg.alpha !== 0) drawFilledCircle(x, y, radius, e.app.bg)
-    if (e.app.fg.alpha !== 0) drawGlyphInCircle(e.app.glyph, x, y, radius, e.app.fg)
+    drawEntitySprite(x, y, radius, e.app)
   }
 }
 
@@ -149,13 +155,19 @@ function isTransparent(color: RenderColor): boolean {
   return color.alpha === 0
 }
 
-function drawFilledCircle(x: number, y: number, radius: number, color: RenderColor): void {
+function drawFilledCircleOnContext(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radius: number,
+  color: RenderColor,
+): void {
   if (radius <= 0 || isTransparent(color)) return
 
-  fgCtx.fillStyle = color.css
-  fgCtx.beginPath()
-  fgCtx.arc(x, y, radius, 0, Math.PI * 2)
-  fgCtx.fill()
+  ctx.fillStyle = color.css
+  ctx.beginPath()
+  ctx.arc(x, y, radius, 0, Math.PI * 2)
+  ctx.fill()
 }
 
 function getGlyphFontSize(glyph: string, radius: number): number {
@@ -178,18 +190,74 @@ function getGlyphFontSize(glyph: string, radius: number): number {
   return fontSize
 }
 
-function drawGlyphInCircle(glyph: string, x: number, y: number, radius: number, color: RenderColor): void {
+function drawGlyphOnContext(
+  ctx: CanvasRenderingContext2D,
+  glyph: string,
+  x: number,
+  y: number,
+  radius: number,
+  color: RenderColor,
+): void {
   if (!glyph || radius <= 0 || isTransparent(color)) return
 
   const fontSize = getGlyphFontSize(glyph, radius)
 
-  fgCtx.save()
-  fgCtx.fillStyle = color.css
-  fgCtx.font = `${fontSize}px monospace`
-  fgCtx.textAlign = 'center'
-  fgCtx.textBaseline = 'middle'
-  fgCtx.fillText(glyph, x, y)
-  fgCtx.restore()
+  ctx.save()
+  ctx.fillStyle = color.css
+  ctx.font = `${fontSize}px monospace`
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(glyph, x, y)
+  ctx.restore()
+}
+
+function getSpriteCacheKey(app: RenderAppearance, radius: number): string {
+  const roundedRadius = Math.max(1, Math.round(radius))
+  return [
+    app.glyph,
+    roundedRadius,
+    app.fg.css,
+    app.bg.css,
+    app.glow.css,
+  ].join('|')
+}
+
+function getEntitySprite(app: RenderAppearance, radius: number): SpriteCacheEntry | null {
+  const roundedRadius = Math.max(1, Math.round(radius))
+  if (roundedRadius <= 0) return null
+
+  const cacheKey = getSpriteCacheKey(app, roundedRadius)
+  const cachedSprite = entitySpriteCache.get(cacheKey)
+  if (cachedSprite) return cachedSprite
+
+  // Cache misses only happen the first time we see a visual variant for this
+  // appearance/radius bucket. After that, renderInterpolated() can reuse the
+  // offscreen canvas with a single drawImage() blit.
+  const glowRadius = app.glow.alpha !== 0 ? roundedRadius * 1.5 : 0
+  const extent = Math.max(glowRadius, roundedRadius)
+  const pad = 2
+  const offset = Math.ceil(extent + pad)
+  const size = offset * 2
+  const canvas = document.createElement('canvas')
+  canvas.width = size
+  canvas.height = size
+
+  const spriteCtx = canvas.getContext('2d')
+  if (!spriteCtx) return null
+
+  if (app.glow.alpha !== 0) drawFilledCircleOnContext(spriteCtx, offset, offset, glowRadius, app.glow)
+  if (app.bg.alpha !== 0) drawFilledCircleOnContext(spriteCtx, offset, offset, roundedRadius, app.bg)
+  if (app.fg.alpha !== 0) drawGlyphOnContext(spriteCtx, app.glyph, offset, offset, roundedRadius, app.fg)
+
+  const sprite = { canvas, offset }
+  entitySpriteCache.set(cacheKey, sprite)
+  return sprite
+}
+
+function drawEntitySprite(x: number, y: number, radius: number, app: RenderAppearance): void {
+  const sprite = getEntitySprite(app, radius)
+  if (!sprite) return
+  fgCtx.drawImage(sprite.canvas, x - sprite.offset, y - sprite.offset)
 }
 
 function appearanceToRender(app: EntityAppearance): RenderAppearance {

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -1,4 +1,11 @@
-import type { ServerMsg, ClientMsg, EntityPosition, WorldDelta } from './types.js'
+import type {
+  ClientMsg,
+  EntityAppearance,
+  EntityPosition,
+  EntityUpsert,
+  ServerMsg,
+  WorldDelta,
+} from './types.js'
 
 // --- DOM setup ---
 
@@ -59,9 +66,10 @@ let lastFrameTime = 0
 
 const SNAPSHOT_INTERVAL_MS = 50 // matches server 20 Hz rate
 
-let prevEntities: EntityPosition[] = []
-let currEntities: EntityPosition[] = []
-let prevById = new Map<number, EntityPosition>()
+let prevEntities: EntityUpsert[] = []
+let currEntities: EntityUpsert[] = []
+let prevPositionsById = new Map<number, EntityPosition>()
+let prevAppearancesById = new Map<number, EntityAppearance>()
 let lastSnapshotTime = 0
 let lives = 0
 let resources = 0
@@ -94,14 +102,21 @@ function renderInterpolated(): void {
 
   fgCtx.clearRect(0, 0, foregroundCanvas.width, foregroundCanvas.height)
   for (const e of currEntities) {
-    const prev = prevById.get(e.id)
-    const wx = prev ? lerp(prev.x, e.x, t) : e.x
-    const wy = prev ? lerp(prev.y, e.y, t) : e.y
+    const prevPos = prevPositionsById.get(e.pos.id)
+    const prevApp = prevAppearancesById.get(e.pos.id) ?? e.app
+    const wx = prevPos ? lerp(prevPos.x, e.pos.x, t) : e.pos.x
+    const wy = prevPos ? lerp(prevPos.y, e.pos.y, t) : e.pos.y
     const [x, y] = worldToCanvas(wx, wy)
+
+    fgCtx.fillStyle = colorToCss(e.app.fg)
     fgCtx.beginPath()
-    fgCtx.arc(x, y, 5, 0, Math.PI * 2)
+    fgCtx.arc(x, y, 5 * lerp(prevApp.scale, e.app.scale, t), 0, Math.PI * 2)
     fgCtx.fill()
   }
+}
+
+function colorToCss(color: number): string {
+  return `#${(color & 0xffffff).toString(16).padStart(6, '0')}`
 }
 
 function drawFps(): void {
@@ -171,19 +186,51 @@ function isPoint(value: unknown): value is { x: number; y: number } {
   )
 }
 
+function isEntityPosition(value: unknown): value is EntityPosition {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).id === 'number' &&
+    typeof (value as Record<string, unknown>).x === 'number' &&
+    typeof (value as Record<string, unknown>).y === 'number'
+  )
+}
+
+function isEntityAppearance(value: unknown): value is EntityAppearance {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).glyph === 'number' &&
+    typeof (value as Record<string, unknown>).scale === 'number' &&
+    typeof (value as Record<string, unknown>).fg === 'number' &&
+    typeof (value as Record<string, unknown>).bg === 'number' &&
+    typeof (value as Record<string, unknown>).glow === 'number'
+  )
+}
+
+function isEntityUpsert(value: unknown): value is EntityUpsert {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    isEntityPosition((value as Record<string, unknown>).pos) &&
+    isEntityAppearance((value as Record<string, unknown>).app)
+  )
+}
+
 function getDeltaPhase(delta: WorldDelta): string {
   const maybePhase = (delta as WorldDelta & { phase?: unknown }).phase
   if (typeof maybePhase === 'string') return maybePhase
   return delta.phase
 }
 
-function beginSnapshotUpdate(): Map<number, EntityPosition> {
+function beginSnapshotUpdate(): Map<number, EntityUpsert> {
   prevEntities = currEntities
-  prevById = new Map(prevEntities.map((e) => [e.id, e]))
-  return new Map(currEntities.map((e) => [e.id, e]))
+  prevPositionsById = new Map(prevEntities.map((e) => [e.pos.id, e.pos]))
+  prevAppearancesById = new Map(prevEntities.map((e) => [e.pos.id, e.app]))
+  return new Map(currEntities.map((e) => [e.pos.id, e]))
 }
 
-function finishSnapshotUpdate(nextEntities: Map<number, EntityPosition>): void {
+function finishSnapshotUpdate(nextEntities: Map<number, EntityUpsert>): void {
   currEntities = [...nextEntities.values()]
   lastSnapshotTime = performance.now()
 }
@@ -191,7 +238,7 @@ function finishSnapshotUpdate(nextEntities: Map<number, EntityPosition>): void {
 function applyWorldDelta(delta: WorldDelta): void {
   const nextEntities = beginSnapshotUpdate()
 
-  for (const entity of delta.upserts) nextEntities.set(entity.id, entity)
+  for (const entity of delta.upserts) nextEntities.set(entity.pos.id, entity)
   for (const entityId of delta.erased) nextEntities.delete(entityId)
 
   finishSnapshotUpdate(nextEntities)
@@ -205,6 +252,22 @@ function applyWorldDelta(delta: WorldDelta): void {
 
 // --- Message validation ---
 
+function isWorldDelta(value: unknown): value is WorldDelta {
+  if (!value || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+
+  return (
+    typeof v.tick === 'number' &&
+    Array.isArray(v.upserts) &&
+    Array.isArray(v.erased) &&
+    typeof v.lives === 'number' &&
+    typeof v.resources === 'number' &&
+    typeof v.phase === 'string' &&
+    v.upserts.every(isEntityUpsert) &&
+    v.erased.every((id) => typeof id === 'number')
+  )
+}
+
 function isServerMsg(value: unknown): value is ServerMsg {
   if (!value || typeof value !== 'object') return false
   const v = value as Record<string, unknown>
@@ -216,28 +279,12 @@ function isServerMsg(value: unknown): value is ServerMsg {
     case 'tick':
       return typeof v.tick === 'number'
     case 'world_delta':
-      return (
-        typeof v.tick === 'number' &&
-        Array.isArray(v.upserts) &&
-        Array.isArray(v.erased) &&
-        typeof v.lives === 'number' &&
-        typeof v.resources === 'number' &&
-        typeof v.phase === 'string' &&
-        v.upserts.every(
-          (e) =>
-            typeof e === 'object' &&
-            e !== null &&
-            typeof (e as Record<string, unknown>).id === 'number' &&
-            typeof (e as Record<string, unknown>).x === 'number' &&
-            typeof (e as Record<string, unknown>).y === 'number',
-        ) &&
-        v.erased.every((id) => typeof id === 'number')
-      )
+      return isWorldDelta(v)
     case 'world_snapshot':
       return (
         Array.isArray(v.paths) &&
         v.paths.every(isPoint) &&
-        isServerMsg(v.delta)
+        isWorldDelta(v.delta)
       )
     default:
       return false

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -30,6 +30,14 @@ interface RenderEntityUpsert {
   app: RenderAppearance
 }
 
+const DEFAULT_RENDER_APPEARANCE: RenderAppearance = {
+  glyph: '?',
+  scale: 1,
+  fg: { css: 'rgba(255, 255, 255, 1)', alpha: 1 },
+  bg: { css: 'rgba(0, 0, 0, 1)', alpha: 1 },
+  glow: { css: 'rgba(0, 0, 0, 0)', alpha: 0 },
+}
+
 // --- DOM setup ---
 
 function requireEl<T extends HTMLElement>(
@@ -301,10 +309,10 @@ function appearanceToRender(app: EntityAppearance): RenderAppearance {
   }
 }
 
-function upsertToRenderEntity(upsert: EntityUpsert): RenderEntityUpsert {
+function upsertToRenderEntity(upsert: EntityUpsert, prevApp?: RenderAppearance): RenderEntityUpsert {
   return {
     pos: upsert.pos,
-    app: appearanceToRender(upsert.app),
+    app: upsert.app ? appearanceToRender(upsert.app) : (prevApp ?? DEFAULT_RENDER_APPEARANCE),
   }
 }
 
@@ -404,11 +412,12 @@ function isEntityAppearance(value: unknown): value is EntityAppearance {
 }
 
 function isEntityUpsert(value: unknown): value is EntityUpsert {
+  const maybeApp = (value as Record<string, unknown>).app
   return (
     typeof value === 'object' &&
     value !== null &&
     isEntityPosition((value as Record<string, unknown>).pos) &&
-    isEntityAppearance((value as Record<string, unknown>).app)
+    (maybeApp === undefined || isEntityAppearance(maybeApp))
   )
 }
 
@@ -431,8 +440,8 @@ function applyWorldDelta(delta: WorldDelta): void {
   prevRenderStateById.clear()
 
   for (const entity of delta.upserts) {
-    const nextEntity = upsertToRenderEntity(entity)
     const prevEntity = currEntitiesById.get(entity.pos.id)
+    const nextEntity = upsertToRenderEntity(entity, prevEntity?.app)
     if (prevEntity) prevRenderStateById.set(entity.pos.id, prevEntity)
     currEntitiesById.set(entity.pos.id, nextEntity)
   }

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -2,15 +2,27 @@ import type {
   ClientMsg,
   EntityAppearance,
   EntityPosition,
-  EntityRender,
   EntityUpsert,
   ServerMsg,
   WorldDelta,
 } from './types.js'
 
+interface RenderColor {
+  css: string
+  alpha: number
+}
+
+interface RenderAppearance {
+  glyph: string
+  scale: number
+  fg: RenderColor
+  bg: RenderColor
+  glow: RenderColor
+}
+
 interface RenderEntityUpsert {
   pos: EntityPosition
-  app: EntityRender
+  app: RenderAppearance
 }
 
 // --- DOM setup ---
@@ -122,27 +134,25 @@ function renderInterpolated(): void {
   }
 }
 
-function packedRgbaToCss(color: number): string {
+function packedRgbaToRenderColor(color: number): RenderColor {
   const r = (color >>> 24) & 0xff
   const g = (color >>> 16) & 0xff
   const b = (color >>> 8) & 0xff
   const a = (color & 0xff) / 255
-  return `rgba(${r}, ${g}, ${b}, ${a})`
+  return {
+    css: `rgba(${r}, ${g}, ${b}, ${a})`,
+    alpha: a,
+  }
 }
 
-function cssRgbaAlpha(color: string): number {
-  const match = /^rgba\(\d+, \d+, \d+, ([0-9.]+)\)$/.exec(color)
-  return match ? Number(match[1]) : 1
+function isTransparent(color: RenderColor): boolean {
+  return color.alpha === 0
 }
 
-function isTransparent(color: string): boolean {
-  return cssRgbaAlpha(color) === 0
-}
-
-function drawFilledCircle(x: number, y: number, radius: number, color: string): void {
+function drawFilledCircle(x: number, y: number, radius: number, color: RenderColor): void {
   if (radius <= 0 || isTransparent(color)) return
 
-  fgCtx.fillStyle = color
+  fgCtx.fillStyle = color.css
   fgCtx.beginPath()
   fgCtx.arc(x, y, radius, 0, Math.PI * 2)
   fgCtx.fill()
@@ -168,13 +178,13 @@ function getGlyphFontSize(glyph: string, radius: number): number {
   return fontSize
 }
 
-function drawGlyphInCircle(glyph: string, x: number, y: number, radius: number, color: string): void {
+function drawGlyphInCircle(glyph: string, x: number, y: number, radius: number, color: RenderColor): void {
   if (!glyph || radius <= 0 || isTransparent(color)) return
 
   const fontSize = getGlyphFontSize(glyph, radius)
 
   fgCtx.save()
-  fgCtx.fillStyle = color
+  fgCtx.fillStyle = color.css
   fgCtx.font = `${fontSize}px monospace`
   fgCtx.textAlign = 'center'
   fgCtx.textBaseline = 'middle'
@@ -182,13 +192,13 @@ function drawGlyphInCircle(glyph: string, x: number, y: number, radius: number, 
   fgCtx.restore()
 }
 
-function appearanceToRender(app: EntityAppearance): EntityRender {
+function appearanceToRender(app: EntityAppearance): RenderAppearance {
   return {
     glyph: String.fromCodePoint(app.glyph),
     scale: app.scale,
-    fg: packedRgbaToCss(app.fg),
-    bg: packedRgbaToCss(app.bg),
-    glow: packedRgbaToCss(app.glow),
+    fg: packedRgbaToRenderColor(app.fg),
+    bg: packedRgbaToRenderColor(app.bg),
+    glow: packedRgbaToRenderColor(app.glow),
   }
 }
 

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -57,6 +57,18 @@ const bgCtx: CanvasRenderingContext2D = maybeBgCtx
 const maybeFgCtx = foregroundCanvas.getContext('2d')
 if (!maybeFgCtx) throw new Error('Could not get 2D foreground canvas context')
 const fgCtx: CanvasRenderingContext2D = maybeFgCtx
+const hudCanvas = document.createElement('canvas')
+hudCanvas.width = foregroundCanvas.width
+hudCanvas.height = foregroundCanvas.height
+const maybeHudCtx = hudCanvas.getContext('2d')
+if (!maybeHudCtx) throw new Error('Could not get 2D HUD canvas context')
+const hudCtx: CanvasRenderingContext2D = maybeHudCtx
+const fpsCanvas = document.createElement('canvas')
+fpsCanvas.width = foregroundCanvas.width
+fpsCanvas.height = foregroundCanvas.height
+const maybeFpsCtx = fpsCanvas.getContext('2d')
+if (!maybeFpsCtx) throw new Error('Could not get 2D FPS canvas context')
+const fpsCtx: CanvasRenderingContext2D = maybeFpsCtx
 
 // --- World / canvas coordinate mapping ---
 //
@@ -94,11 +106,14 @@ let currSnapshotTime = 0
 let snapshotIntervalMs = 50
 let lives = 0
 let resources = 0
+let lastFpsOverlayUpdateTime = 0
+let hudDirty = true
 const glyphFontSizeCache = new Map<string, number>()
 // Entity appearances come from a small, mostly fixed set of tower/enemy visuals,
 // so we memoize prerendered sprites for the lifetime of the page instead of
 // paying per-frame draw costs or maintaining an eviction policy.
 const entitySpriteCache = new Map<string, SpriteCacheEntry>()
+const FPS_OVERLAY_INTERVAL_MS = 100
 
 // Linear interpolation calculator
 function lerp(a: number, b: number, t: number): number {
@@ -138,6 +153,22 @@ function renderInterpolated(): void {
     const radius = 5 * lerp(prevApp.scale, e.app.scale, t)
     drawEntitySprite(x, y, radius, e.app)
   }
+}
+
+function updateHudOverlay(): void {
+  if (!hudDirty) return
+
+  hudCtx.clearRect(0, 0, hudCanvas.width, hudCanvas.height)
+  drawHud(hudCtx)
+  hudDirty = false
+}
+
+function updateFpsOverlay(now: number): void {
+  if (now - lastFpsOverlayUpdateTime < FPS_OVERLAY_INTERVAL_MS) return
+
+  fpsCtx.clearRect(0, 0, fpsCanvas.width, fpsCanvas.height)
+  drawFps(fpsCtx)
+  lastFpsOverlayUpdateTime = now
 }
 
 function packedRgbaToRenderColor(color: number): RenderColor {
@@ -277,38 +308,38 @@ function upsertToRenderEntity(upsert: EntityUpsert): RenderEntityUpsert {
   }
 }
 
-function drawFps(): void {
-  fgCtx.save()
+function drawFps(ctx: CanvasRenderingContext2D): void {
+  ctx.save()
   const label = `${fps.toFixed(1)} FPS`
-  fgCtx.font = '14px monospace'
+  ctx.font = '14px monospace'
   const pad = 6
-  const w = fgCtx.measureText(label).width + pad * 2
+  const w = ctx.measureText(label).width + pad * 2
   const h = 20
-  const x = foregroundCanvas.width - w - 4
-  const y = foregroundCanvas.height - 4 - h
-  fgCtx.fillStyle = 'rgba(0,0,0,0.5)'
-  fgCtx.fillRect(x, y, w, h)
-  fgCtx.fillStyle = 'white'
-  fgCtx.fillText(label, x + pad, y + 14)
-  fgCtx.restore()
+  const x = fpsCanvas.width - w - 4
+  const y = fpsCanvas.height - 4 - h
+  ctx.fillStyle = 'rgba(0,0,0,0.5)'
+  ctx.fillRect(x, y, w, h)
+  ctx.fillStyle = 'white'
+  ctx.fillText(label, x + pad, y + 14)
+  ctx.restore()
 }
 
-function drawHud(): void {
-  fgCtx.save()
-  fgCtx.font = '20px monospace'
-  fgCtx.textBaseline = 'top'
+function drawHud(ctx: CanvasRenderingContext2D): void {
+  ctx.save()
+  ctx.font = '20px monospace'
+  ctx.textBaseline = 'top'
 
   const livesLabel = `${lives}❤️`
   const resourcesLabel = `$${resources}`
   const pad = 4
   const barHeight = 24
 
-  fgCtx.fillStyle = 'rgba(0,0,0,0.55)'
-  fgCtx.fillRect(0, 0, foregroundCanvas.width, barHeight)
+  ctx.fillStyle = 'rgba(0,0,0,0.55)'
+  ctx.fillRect(0, 0, hudCanvas.width, barHeight)
 
-  fgCtx.fillStyle = 'white'
-  fgCtx.fillText(`${livesLabel}   ${resourcesLabel}`, pad, pad)
-  fgCtx.restore()
+  ctx.fillStyle = 'white'
+  ctx.fillText(`${livesLabel}   ${resourcesLabel}`, pad, pad)
+  ctx.restore()
 }
 
 function frame(now: number): void {
@@ -319,8 +350,10 @@ function frame(now: number): void {
   lastFrameTime = now
 
   renderInterpolated()
-  drawHud()
-  drawFps()
+  updateHudOverlay()
+  updateFpsOverlay(now)
+  fgCtx.drawImage(hudCanvas, 0, 0)
+  fgCtx.drawImage(fpsCanvas, 0, 0)
   requestAnimationFrame(frame)
 }
 
@@ -333,6 +366,10 @@ function log(line: string): void {
 
 function setTextIfElement(el: HTMLElement | null, value: string): void {
   if (el) el.textContent = value
+}
+
+function invalidateHud(): void {
+  hudDirty = true
 }
 
 function isPoint(value: unknown): value is { x: number; y: number } {
@@ -408,6 +445,7 @@ function applyWorldDelta(delta: WorldDelta): void {
   tickEl.textContent = String(delta.tick)
   lives = delta.lives
   resources = delta.resources
+  invalidateHud()
   setTextIfElement(livesEl, String(delta.lives))
   setTextIfElement(resourcesEl, String(delta.resources))
   setTextIfElement(phaseEl, getDeltaPhase(delta))

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -489,9 +489,7 @@ function visualEffectsToRender(
   const keepExistingFlashPhase =
     prevFx !== undefined &&
     prevFx.flashExpiry > now &&
-    prevFx.flash.css === flash.css &&
-    flashExpiry > 0 &&
-    flashExpiry <= prevFx.flashExpiry
+    flashExpiry > 0
 
   return {
     selection: packedRgbaToRenderColor(fx.selection),

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -61,6 +61,8 @@ let currEntities: EntityPosition[] = []
 let prevById = new Map<number, EntityPosition>()
 let lastSnapshotTime = 0
 let pathPoints: Array<{ x: number; y: number }> = []
+let lives = 0
+let resources = 0
 
 // Linear interpolation calculator
 function lerp(a: number, b: number, t: number): number {
@@ -112,6 +114,24 @@ function drawFps(): void {
   ctx.restore()
 }
 
+function drawHud(): void {
+  ctx.save()
+  ctx.font = '20px monospace'
+  ctx.textBaseline = 'top'
+
+  const livesLabel = `${lives}❤️`
+  const resourcesLabel = `$${resources}`
+  const pad = 4
+  const barHeight = 24
+
+  ctx.fillStyle = 'rgba(0,0,0,0.55)'
+  ctx.fillRect(0, 0, canvas.width, barHeight)
+
+  ctx.fillStyle = 'white'
+  ctx.fillText(`${livesLabel}   ${resourcesLabel}`, pad, pad)
+  ctx.restore()
+}
+
 function frame(now: number): void {
   if (lastFrameTime !== 0) {
     const dt = now - lastFrameTime
@@ -120,6 +140,7 @@ function frame(now: number): void {
   lastFrameTime = now
 
   renderInterpolated()
+  drawHud()
   drawFps()
   requestAnimationFrame(frame)
 }
@@ -173,6 +194,8 @@ function applyWorldDelta(delta: WorldDelta): void {
 
   finishSnapshotUpdate(nextEntities)
   tickEl.textContent = String(delta.tick)
+  lives = delta.lives
+  resources = delta.resources
   setTextIfElement(livesEl, String(delta.lives))
   setTextIfElement(resourcesEl, String(delta.resources))
   setTextIfElement(phaseEl, getDeltaPhase(delta))

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -20,7 +20,7 @@ interface SpriteCacheEntry {
 
 interface RenderAppearance {
   glyph: string
-  scale: number
+  radius: number
   fg: RenderColor
   bg: RenderColor
 }
@@ -60,7 +60,7 @@ interface CanvasPointerSample {
 
 const DEFAULT_RENDER_APPEARANCE: RenderAppearance = {
   glyph: '?',
-  scale: 1,
+  radius: 5,
   fg: { css: 'rgba(255, 255, 255, 1)', alpha: 1 },
   bg: { css: 'rgba(0, 0, 0, 1)', alpha: 1 },
 }
@@ -225,7 +225,7 @@ function renderInterpolated(now: number): void {
     const wx = prevPos ? lerp(prevPos.x, e.pos.x, t) : e.pos.x
     const wy = prevPos ? lerp(prevPos.y, e.pos.y, t) : e.pos.y
     const [x, y] = worldToCanvas(wx, wy)
-    const radius = 5 * lerp(prevApp.scale, e.app.scale, t)
+    const radius = worldLengthToCanvas(lerp(prevApp.radius, e.app.radius, t))
     drawEntity(x, y, radius, e.app, e.fx, now)
   }
 }
@@ -458,7 +458,7 @@ function drawEntity(
 function appearanceToRender(app: EntityAppearance): RenderAppearance {
   return {
     glyph: app.glyph === 0 ? '' : String.fromCodePoint(app.glyph),
-    scale: app.scale,
+    radius: app.radius,
     fg: packedRgbaToRenderColor(app.fg),
     bg: packedRgbaToRenderColor(app.bg),
   }
@@ -647,7 +647,7 @@ function isEntityAppearance(value: unknown): value is EntityAppearance {
     typeof value === 'object' &&
     value !== null &&
     typeof (value as Record<string, unknown>).glyph === 'number' &&
-    typeof (value as Record<string, unknown>).scale === 'number' &&
+    typeof (value as Record<string, unknown>).radius === 'number' &&
     typeof (value as Record<string, unknown>).fg === 'number' &&
     typeof (value as Record<string, unknown>).bg === 'number'
   )

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -3,6 +3,7 @@ import type {
   EntityAppearance,
   EntityPosition,
   EntityUpsert,
+  EntityVisualEffects,
   ServerMsg,
   WorldDelta,
 } from './types.js'
@@ -22,12 +23,19 @@ interface RenderAppearance {
   scale: number
   fg: RenderColor
   bg: RenderColor
-  glow: RenderColor
+}
+
+interface RenderVisualEffects {
+  selection: RenderColor
+  rangeRadius: number
+  range: RenderColor
+  flash: RenderColor
 }
 
 interface RenderEntityUpsert {
   pos: EntityPosition
   app: RenderAppearance
+  fx: RenderVisualEffects
 }
 
 interface CanvasPointerState {
@@ -54,7 +62,13 @@ const DEFAULT_RENDER_APPEARANCE: RenderAppearance = {
   scale: 1,
   fg: { css: 'rgba(255, 255, 255, 1)', alpha: 1 },
   bg: { css: 'rgba(0, 0, 0, 1)', alpha: 1 },
-  glow: { css: 'rgba(0, 0, 0, 0)', alpha: 0 },
+}
+
+const DEFAULT_RENDER_VISUAL_EFFECTS: RenderVisualEffects = {
+  selection: { css: 'rgba(0, 0, 0, 0)', alpha: 0 },
+  rangeRadius: 0,
+  range: { css: 'rgba(0, 0, 0, 0)', alpha: 0 },
+  flash: { css: 'rgba(0, 0, 0, 0)', alpha: 0 },
 }
 
 // --- DOM setup ---
@@ -117,6 +131,10 @@ function canvasToWorld(cx: number, cy: number): [number, number] {
     (cx - foregroundCanvas.width / 2) * WORLD_W / foregroundCanvas.width,
     (cy - foregroundCanvas.height / 2) * WORLD_H / foregroundCanvas.height,
   ]
+}
+
+function worldLengthToCanvas(length: number): number {
+  return length * foregroundCanvas.width / WORLD_W
 }
 
 function eventToCanvasSample(event: MouseEvent): CanvasPointerSample {
@@ -188,9 +206,9 @@ function drawBackground(pathPoints: Array<{ x: number; y: number }>): void {
   bgCtx.restore()
 }
 
-function renderInterpolated(): void {
+function renderInterpolated(now: number): void {
   const interval = Math.max(snapshotIntervalMs, 1)
-  const t = Math.min((performance.now() - currSnapshotTime) / interval, 1)
+  const t = Math.min((now - currSnapshotTime) / interval, 1)
 
   fgCtx.clearRect(0, 0, foregroundCanvas.width, foregroundCanvas.height)
   for (const e of currEntitiesById.values()) {
@@ -201,7 +219,7 @@ function renderInterpolated(): void {
     const wy = prevPos ? lerp(prevPos.y, e.pos.y, t) : e.pos.y
     const [x, y] = worldToCanvas(wx, wy)
     const radius = 5 * lerp(prevApp.scale, e.app.scale, t)
-    drawEntitySprite(x, y, radius, e.app)
+    drawEntity(x, y, radius, e.app, e.fx, now)
   }
 }
 
@@ -249,6 +267,23 @@ function drawFilledCircleOnContext(
   ctx.beginPath()
   ctx.arc(x, y, radius, 0, Math.PI * 2)
   ctx.fill()
+}
+
+function drawStrokedCircleOnContext(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  radius: number,
+  color: RenderColor,
+  lineWidth: number,
+): void {
+  if (radius <= 0 || lineWidth <= 0 || isTransparent(color)) return
+
+  ctx.strokeStyle = color.css
+  ctx.lineWidth = lineWidth
+  ctx.beginPath()
+  ctx.arc(x, y, radius, 0, Math.PI * 2)
+  ctx.stroke()
 }
 
 function getGlyphFontSize(glyph: string, radius: number): number {
@@ -299,7 +334,6 @@ function getSpriteCacheKey(app: RenderAppearance, radius: number): string {
     roundedRadius,
     app.fg.css,
     app.bg.css,
-    app.glow.css,
   ].join('|')
 }
 
@@ -314,8 +348,7 @@ function getEntitySprite(app: RenderAppearance, radius: number): SpriteCacheEntr
   // Cache misses only happen the first time we see a visual variant for this
   // appearance/radius bucket. After that, renderInterpolated() can reuse the
   // offscreen canvas with a single drawImage() blit.
-  const glowRadius = app.glow.alpha !== 0 ? roundedRadius * 1.5 : 0
-  const extent = Math.max(glowRadius, roundedRadius)
+  const extent = roundedRadius
   const pad = 2
   const offset = Math.ceil(extent + pad)
   const size = offset * 2
@@ -326,7 +359,6 @@ function getEntitySprite(app: RenderAppearance, radius: number): SpriteCacheEntr
   const spriteCtx = canvas.getContext('2d')
   if (!spriteCtx) return null
 
-  if (app.glow.alpha !== 0) drawFilledCircleOnContext(spriteCtx, offset, offset, glowRadius, app.glow)
   if (app.bg.alpha !== 0) drawFilledCircleOnContext(spriteCtx, offset, offset, roundedRadius, app.bg)
   if (app.fg.alpha !== 0) drawGlyphOnContext(spriteCtx, app.glyph, offset, offset, roundedRadius, app.fg)
 
@@ -341,20 +373,100 @@ function drawEntitySprite(x: number, y: number, radius: number, app: RenderAppea
   fgCtx.drawImage(sprite.canvas, x - sprite.offset, y - sprite.offset)
 }
 
+function drawRangeCircle(
+  x: number,
+  y: number,
+  fx: RenderVisualEffects,
+): void {
+  if (fx.rangeRadius <= 0 || isTransparent(fx.range)) return
+
+  const radius = worldLengthToCanvas(fx.rangeRadius)
+  const lineWidth = Math.max(2, radius * 0.03)
+  fgCtx.save()
+  drawStrokedCircleOnContext(fgCtx, x, y, radius, fx.range, lineWidth)
+  fgCtx.restore()
+}
+
+function drawSelectionOutline(
+  x: number,
+  y: number,
+  radius: number,
+  fx: RenderVisualEffects,
+): void {
+  if (radius <= 0 || isTransparent(fx.selection)) return
+
+  const lineWidth = Math.max(3, radius * 0.35)
+  fgCtx.save()
+  drawStrokedCircleOnContext(
+    fgCtx,
+    x,
+    y,
+    radius + lineWidth * 0.5,
+    fx.selection,
+    lineWidth,
+  )
+  fgCtx.restore()
+}
+
+function isFlashVisible(now: number): boolean {
+  return Math.floor(now / 125) % 2 === 0
+}
+
+function drawFlashOverlay(
+  x: number,
+  y: number,
+  radius: number,
+  fx: RenderVisualEffects,
+  now: number,
+): void {
+  if (radius <= 0 || isTransparent(fx.flash) || !isFlashVisible(now)) return
+
+  fgCtx.save()
+  drawFilledCircleOnContext(fgCtx, x, y, radius, fx.flash)
+  fgCtx.restore()
+}
+
+function drawEntity(
+  x: number,
+  y: number,
+  radius: number,
+  app: RenderAppearance,
+  fx: RenderVisualEffects,
+  now: number,
+): void {
+  drawRangeCircle(x, y, fx)
+  drawEntitySprite(x, y, radius, app)
+  drawSelectionOutline(x, y, radius, fx)
+  drawFlashOverlay(x, y, radius, fx, now)
+}
+
 function appearanceToRender(app: EntityAppearance): RenderAppearance {
   return {
-    glyph: String.fromCodePoint(app.glyph),
+    glyph: app.glyph === 0 ? '' : String.fromCodePoint(app.glyph),
     scale: app.scale,
     fg: packedRgbaToRenderColor(app.fg),
     bg: packedRgbaToRenderColor(app.bg),
-    glow: packedRgbaToRenderColor(app.glow),
   }
 }
 
-function upsertToRenderEntity(upsert: EntityUpsert, prevApp?: RenderAppearance): RenderEntityUpsert {
+function visualEffectsToRender(fx: EntityVisualEffects): RenderVisualEffects {
+  return {
+    selection: packedRgbaToRenderColor(fx.selection),
+    rangeRadius: fx.rangeRadius,
+    range: packedRgbaToRenderColor(fx.range),
+    flash: packedRgbaToRenderColor(fx.flash),
+  }
+}
+
+function upsertToRenderEntity(
+  upsert: EntityUpsert,
+  prevApp?: RenderAppearance,
+  prevFx?: RenderVisualEffects,
+): RenderEntityUpsert {
   return {
     pos: upsert.pos,
     app: upsert.app ? appearanceToRender(upsert.app) : (prevApp ?? DEFAULT_RENDER_APPEARANCE),
+    fx: upsert.vfx ? visualEffectsToRender(upsert.vfx) : (prevFx ?? DEFAULT_RENDER_VISUAL_EFFECTS),
   }
 }
 
@@ -379,7 +491,7 @@ function drawHud(ctx: CanvasRenderingContext2D): void {
   ctx.font = '20px monospace'
   ctx.textBaseline = 'top'
 
-  const livesLabel = `${lives}❤️`
+  const livesLabel = `${lives.toString().padStart(4, ' ')}❤️`;
   const resourcesLabel = `$${resources}`
   const pad = 4
   const barHeight = 24
@@ -399,7 +511,7 @@ function frame(now: number): void {
   }
   lastFrameTime = now
 
-  renderInterpolated()
+  renderInterpolated(now)
   updateHudOverlay()
   updateFpsOverlay(now)
   fgCtx.drawImage(hudCanvas, 0, 0)
@@ -517,18 +629,30 @@ function isEntityAppearance(value: unknown): value is EntityAppearance {
     typeof (value as Record<string, unknown>).glyph === 'number' &&
     typeof (value as Record<string, unknown>).scale === 'number' &&
     typeof (value as Record<string, unknown>).fg === 'number' &&
-    typeof (value as Record<string, unknown>).bg === 'number' &&
-    typeof (value as Record<string, unknown>).glow === 'number'
+    typeof (value as Record<string, unknown>).bg === 'number'
+  )
+}
+
+function isEntityVisualEffects(value: unknown): value is EntityVisualEffects {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).selection === 'number' &&
+    typeof (value as Record<string, unknown>).rangeRadius === 'number' &&
+    typeof (value as Record<string, unknown>).range === 'number' &&
+    typeof (value as Record<string, unknown>).flash === 'number'
   )
 }
 
 function isEntityUpsert(value: unknown): value is EntityUpsert {
   const maybeApp = (value as Record<string, unknown>).app
+  const maybeVfx = (value as Record<string, unknown>).vfx
   return (
     typeof value === 'object' &&
     value !== null &&
     isEntityPosition((value as Record<string, unknown>).pos) &&
-    (maybeApp === undefined || isEntityAppearance(maybeApp))
+    (maybeApp === undefined || isEntityAppearance(maybeApp)) &&
+    (maybeVfx === undefined || isEntityVisualEffects(maybeVfx))
   )
 }
 
@@ -552,7 +676,7 @@ function applyWorldDelta(delta: WorldDelta): void {
 
   for (const entity of delta.upserts) {
     const prevEntity = currEntitiesById.get(entity.pos.id)
-    const nextEntity = upsertToRenderEntity(entity, prevEntity?.app)
+    const nextEntity = upsertToRenderEntity(entity, prevEntity?.app, prevEntity?.fx)
     if (prevEntity) prevRenderStateById.set(entity.pos.id, prevEntity)
     currEntitiesById.set(entity.pos.id, nextEntity)
   }

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -16,14 +16,19 @@ function requireEl<T extends HTMLElement>(
 const statusEl = requireEl('status', HTMLElement)
 const tickEl = requireEl('tick', HTMLElement)
 const logEl = requireEl('log', HTMLElement)
-const canvas = requireEl('canvas', HTMLCanvasElement)
+const backgroundCanvas = requireEl('background-canvas', HTMLCanvasElement)
+const foregroundCanvas = requireEl('foreground-canvas', HTMLCanvasElement)
 const livesEl = document.getElementById('lives')
 const resourcesEl = document.getElementById('resources')
 const phaseEl = document.getElementById('phase')
 
-const maybeCtx = canvas.getContext('2d')
-if (!maybeCtx) throw new Error('Could not get 2D canvas context')
-const ctx: CanvasRenderingContext2D = maybeCtx
+const maybeBgCtx = backgroundCanvas.getContext('2d')
+if (!maybeBgCtx) throw new Error('Could not get 2D background canvas context')
+const bgCtx: CanvasRenderingContext2D = maybeBgCtx
+
+const maybeFgCtx = foregroundCanvas.getContext('2d')
+if (!maybeFgCtx) throw new Error('Could not get 2D foreground canvas context')
+const fgCtx: CanvasRenderingContext2D = maybeFgCtx
 
 // --- World / canvas coordinate mapping ---
 //
@@ -35,15 +40,15 @@ const WORLD_H = 1080
 
 function worldToCanvas(wx: number, wy: number): [number, number] {
   return [
-    (wx + WORLD_W / 2) * canvas.width / WORLD_W,
-    (wy + WORLD_H / 2) * canvas.height / WORLD_H,
+    (wx + WORLD_W / 2) * foregroundCanvas.width / WORLD_W,
+    (wy + WORLD_H / 2) * foregroundCanvas.height / WORLD_H,
   ]
 }
 
 function canvasToWorld(cx: number, cy: number): [number, number] {
   return [
-    (cx - canvas.width / 2) * WORLD_W / canvas.width,
-    (cy - canvas.height / 2) * WORLD_H / canvas.height,
+    (cx - foregroundCanvas.width / 2) * WORLD_W / foregroundCanvas.width,
+    (cy - foregroundCanvas.height / 2) * WORLD_H / foregroundCanvas.height,
   ]
 }
 
@@ -60,7 +65,6 @@ let prevEntities: EntityPosition[] = []
 let currEntities: EntityPosition[] = []
 let prevById = new Map<number, EntityPosition>()
 let lastSnapshotTime = 0
-let pathPoints: Array<{ x: number; y: number }> = []
 let lives = 0
 let resources = 0
 
@@ -69,67 +73,71 @@ function lerp(a: number, b: number, t: number): number {
   return a + (b - a) * t
 }
 
+function drawBackground(pathPoints: Array<{ x: number; y: number }>): void {
+  bgCtx.clearRect(0, 0, backgroundCanvas.width, backgroundCanvas.height)
+  if (pathPoints.length <= 1) return
+
+  bgCtx.save()
+  bgCtx.strokeStyle = '#3b82f6'
+  bgCtx.lineWidth = 2
+  bgCtx.beginPath()
+  const [startX, startY] = worldToCanvas(pathPoints[0].x, pathPoints[0].y)
+  bgCtx.moveTo(startX, startY)
+  for (const point of pathPoints.slice(1)) {
+    const [x, y] = worldToCanvas(point.x, point.y)
+    bgCtx.lineTo(x, y)
+  }
+  bgCtx.stroke()
+  bgCtx.restore()
+}
+
 function renderInterpolated(): void {
   const t = Math.min((performance.now() - lastSnapshotTime) / SNAPSHOT_INTERVAL_MS, 1)
 
-  ctx.clearRect(0, 0, canvas.width, canvas.height)
-  if (pathPoints.length > 1) {
-    ctx.save()
-    ctx.strokeStyle = '#3b82f6'
-    ctx.lineWidth = 2
-    ctx.beginPath()
-    const [startX, startY] = worldToCanvas(pathPoints[0].x, pathPoints[0].y)
-    ctx.moveTo(startX, startY)
-    for (const point of pathPoints.slice(1)) {
-      const [x, y] = worldToCanvas(point.x, point.y)
-      ctx.lineTo(x, y)
-    }
-    ctx.stroke()
-    ctx.restore()
-  }
+  fgCtx.clearRect(0, 0, foregroundCanvas.width, foregroundCanvas.height)
   for (const e of currEntities) {
     const prev = prevById.get(e.id)
     const wx = prev ? lerp(prev.x, e.x, t) : e.x
     const wy = prev ? lerp(prev.y, e.y, t) : e.y
     const [x, y] = worldToCanvas(wx, wy)
-    ctx.beginPath()
-    ctx.arc(x, y, 5, 0, Math.PI * 2)
-    ctx.fill()
+    fgCtx.beginPath()
+    fgCtx.arc(x, y, 5, 0, Math.PI * 2)
+    fgCtx.fill()
   }
 }
 
 function drawFps(): void {
-  ctx.save()
+  fgCtx.save()
   const label = `${fps.toFixed(1)} FPS`
-  ctx.font = '14px monospace'
+  fgCtx.font = '14px monospace'
   const pad = 6
-  const w = ctx.measureText(label).width + pad * 2
+  const w = fgCtx.measureText(label).width + pad * 2
   const h = 20
-  const x = canvas.width - w - 4
-  const y = canvas.height - 4 - h
-  ctx.fillStyle = 'rgba(0,0,0,0.5)'
-  ctx.fillRect(x, y, w, h)
-  ctx.fillStyle = 'white'
-  ctx.fillText(label, x + pad, y + 14)
-  ctx.restore()
+  const x = foregroundCanvas.width - w - 4
+  const y = foregroundCanvas.height - 4 - h
+  fgCtx.fillStyle = 'rgba(0,0,0,0.5)'
+  fgCtx.fillRect(x, y, w, h)
+  fgCtx.fillStyle = 'white'
+  fgCtx.fillText(label, x + pad, y + 14)
+  fgCtx.restore()
 }
 
 function drawHud(): void {
-  ctx.save()
-  ctx.font = '20px monospace'
-  ctx.textBaseline = 'top'
+  fgCtx.save()
+  fgCtx.font = '20px monospace'
+  fgCtx.textBaseline = 'top'
 
   const livesLabel = `${lives}❤️`
   const resourcesLabel = `$${resources}`
   const pad = 4
   const barHeight = 24
 
-  ctx.fillStyle = 'rgba(0,0,0,0.55)'
-  ctx.fillRect(0, 0, canvas.width, barHeight)
+  fgCtx.fillStyle = 'rgba(0,0,0,0.55)'
+  fgCtx.fillRect(0, 0, foregroundCanvas.width, barHeight)
 
-  ctx.fillStyle = 'white'
-  ctx.fillText(`${livesLabel}   ${resourcesLabel}`, pad, pad)
-  ctx.restore()
+  fgCtx.fillStyle = 'white'
+  fgCtx.fillText(`${livesLabel}   ${resourcesLabel}`, pad, pad)
+  fgCtx.restore()
 }
 
 function frame(now: number): void {
@@ -300,14 +308,14 @@ ws.onmessage = (event: MessageEvent<string>) => {
       prevEntities = currEntities
       prevById = new Map(prevEntities.map((e) => [e.id, e]))
       currEntities = parsed.entities
-      pathPoints = snapshotPathsToPoints(parsed.paths)
+      drawBackground(snapshotPathsToPoints(parsed.paths))
       lastSnapshotTime = performance.now()
       break
     case 'world_delta':
       applyWorldDelta(parsed)
       break
     case 'world_snapshot':
-      pathPoints = parsed.paths
+      drawBackground(parsed.paths)
       applyWorldDelta(parsed.delta)
       break
   }
@@ -323,11 +331,11 @@ ws.onerror = () => {
   log('WebSocket error')
 }
 
-canvas.addEventListener('click', (e: MouseEvent) => {
+foregroundCanvas.addEventListener('click', (e: MouseEvent) => {
   if (ws.readyState !== WebSocket.OPEN) return
-  const rect = canvas.getBoundingClientRect()
-  const cssX = (e.clientX - rect.left) * (canvas.width / rect.width)
-  const cssY = (e.clientY - rect.top) * (canvas.height / rect.height)
+  const rect = foregroundCanvas.getBoundingClientRect()
+  const cssX = (e.clientX - rect.left) * (foregroundCanvas.width / rect.width)
+  const cssY = (e.clientY - rect.top) * (foregroundCanvas.height / rect.height)
   const [x, y] = canvasToWorld(cssX, cssY).map(Math.round) as [number, number]
   const msg: ClientMsg = { type: 'spawn', x, y }
   ws.send(JSON.stringify(msg))

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -31,6 +31,7 @@ interface RenderVisualEffects {
   range: RenderColor
   flash: RenderColor
   flashExpiry: number
+  flashStartedAt: number
 }
 
 interface RenderEntityUpsert {
@@ -76,6 +77,7 @@ const DEFAULT_RENDER_VISUAL_EFFECTS: RenderVisualEffects = {
   range: TRANSPARENT_RENDER_COLOR,
   flash: TRANSPARENT_RENDER_COLOR,
   flashExpiry: 0,
+  flashStartedAt: 0,
 }
 
 // --- DOM setup ---
@@ -163,6 +165,18 @@ function eventToCanvasSample(event: MouseEvent): CanvasPointerSample {
   }
 }
 
+function withPointerButton(
+  sample: CanvasPointerSample,
+  button: number,
+  buttons = sample.buttons,
+): CanvasPointerSample {
+  return {
+    ...sample,
+    button,
+    buttons,
+  }
+}
+
 // --- FPS tracking ---
 
 let fps = 0
@@ -185,6 +199,7 @@ const glyphFontSizeCache = new Map<string, number>()
 // paying per-frame draw costs or maintaining an eviction policy.
 const entitySpriteCache = new Map<string, SpriteCacheEntry>()
 const FPS_OVERLAY_INTERVAL_MS = 100
+const FLASH_FLICKER_INTERVAL_MS = 62.5
 let nextClientSeq = 1
 let canvasPointerState: CanvasPointerState | null = null
 let pendingDragMove: CanvasPointerSample | null = null
@@ -414,8 +429,9 @@ function drawSelectionOutline(
   fgCtx.restore()
 }
 
-function isFlashVisible(now: number): boolean {
-  return Math.floor(now / 125) % 2 === 0
+function isFlashVisible(fx: RenderVisualEffects, now: number): boolean {
+  const elapsed = Math.max(now - fx.flashStartedAt, 0)
+  return Math.floor(elapsed / FLASH_FLICKER_INTERVAL_MS) % 2 === 0
 }
 
 function drawFlashOverlay(
@@ -433,7 +449,7 @@ function drawFlashOverlay(
     return
   }
 
-  if (radius <= 0 || isTransparent(fx.flash) || !isFlashVisible(now)) return
+  if (radius <= 0 || isTransparent(fx.flash) || !isFlashVisible(fx, now)) return
 
   fgCtx.save()
   drawFilledCircleOnContext(fgCtx, x, y, radius, fx.flash)
@@ -466,13 +482,26 @@ function appearanceToRender(app: EntityAppearance): RenderAppearance {
 function visualEffectsToRender(
   fx: EntityVisualEffects,
   now: number,
+  prevFx?: RenderVisualEffects,
 ): RenderVisualEffects {
+  const flash = packedRgbaToRenderColor(fx.flash)
+  const flashExpiry = fx.flashExpiryMs <= 0 ? 0 : now + fx.flashExpiryMs
+  const keepExistingFlashPhase =
+    prevFx !== undefined &&
+    prevFx.flashExpiry > now &&
+    prevFx.flash.css === flash.css &&
+    flashExpiry > 0 &&
+    flashExpiry <= prevFx.flashExpiry
+
   return {
     selection: packedRgbaToRenderColor(fx.selection),
     rangeRadius: fx.rangeRadius,
     range: packedRgbaToRenderColor(fx.range),
-    flash: packedRgbaToRenderColor(fx.flash),
-    flashExpiry: fx.flashExpiryMs <= 0 ? 0 : now + fx.flashExpiryMs,
+    flash,
+    flashExpiry,
+    flashStartedAt: flashExpiry > 0
+      ? (keepExistingFlashPhase ? prevFx.flashStartedAt : now)
+      : 0,
   }
 }
 
@@ -485,7 +514,9 @@ function upsertToRenderEntity(
   return {
     pos: upsert.pos,
     app: upsert.app ? appearanceToRender(upsert.app) : (prevApp ?? DEFAULT_RENDER_APPEARANCE),
-    fx: upsert.vfx ? visualEffectsToRender(upsert.vfx, now) : (prevFx ?? DEFAULT_RENDER_VISUAL_EFFECTS),
+    fx: upsert.vfx
+      ? visualEffectsToRender(upsert.vfx, now, prevFx)
+      : (prevFx ?? DEFAULT_RENDER_VISUAL_EFFECTS),
   }
 }
 
@@ -840,22 +871,28 @@ foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
 foregroundCanvas.addEventListener('mousemove', (event: MouseEvent) => {
   if (!canvasPointerState) return
   const sample = eventToCanvasSample(event)
+  canvasPointerState.buttons = sample.buttons
+
+  if (canvasPointerState.button !== 0) return
+
+  const dragSample = withPointerButton(sample, canvasPointerState.button)
 
   if (!canvasPointerState.dragging) {
     canvasPointerState.dragging = true
-    canvasPointerState.buttons = sample.buttons
-    sendCanvasMsg('dragstart', sample)
+    sendCanvasMsg('dragstart', dragSample)
     return
   }
 
-  canvasPointerState.buttons = sample.buttons
-  pendingDragMove = sample
+  pendingDragMove = dragSample
   scheduleDragMoveFlush()
 })
 
 window.addEventListener('mouseup', (event: MouseEvent) => {
   if (!canvasPointerState) return
-  const sample = eventToCanvasSample(event)
+  const sample = withPointerButton(
+    eventToCanvasSample(event),
+    canvasPointerState.button,
+  )
   const wasDragging = canvasPointerState.dragging
   canvasPointerState = null
   flushPendingDragMove()
@@ -864,7 +901,7 @@ window.addEventListener('mouseup', (event: MouseEvent) => {
 
 foregroundCanvas.addEventListener('contextmenu', (event: MouseEvent) => {
   event.preventDefault()
-  sendCanvasMsg('contextmenu', eventToCanvasSample(event))
+  sendCanvasMsg('click', withPointerButton(eventToCanvasSample(event), 2, 2))
 })
 
 foregroundCanvas.addEventListener('dblclick', (event: MouseEvent) => {

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -70,10 +70,8 @@ let lastFrameTime = 0
 
 // --- Interpolation state ---
 
-let prevEntities: RenderEntityUpsert[] = []
-let currEntities: RenderEntityUpsert[] = []
-let prevPositionsById = new Map<number, EntityPosition>()
-let prevAppearancesById = new Map<number, EntityRender>()
+const currEntitiesById = new Map<number, RenderEntityUpsert>()
+const prevRenderStateById = new Map<number, RenderEntityUpsert>()
 let prevSnapshotTime = 0
 let currSnapshotTime = 0
 let snapshotIntervalMs = 50
@@ -108,9 +106,10 @@ function renderInterpolated(): void {
   const t = Math.min((performance.now() - currSnapshotTime) / interval, 1)
 
   fgCtx.clearRect(0, 0, foregroundCanvas.width, foregroundCanvas.height)
-  for (const e of currEntities) {
-    const prevPos = prevPositionsById.get(e.pos.id)
-    const prevApp = prevAppearancesById.get(e.pos.id) ?? e.app
+  for (const e of currEntitiesById.values()) {
+    const prevState = prevRenderStateById.get(e.pos.id)
+    const prevPos = prevState?.pos
+    const prevApp = prevState?.app ?? e.app
     const wx = prevPos ? lerp(prevPos.x, e.pos.x, t) : e.pos.x
     const wy = prevPos ? lerp(prevPos.y, e.pos.y, t) : e.pos.y
     const [x, y] = worldToCanvas(wx, wy)
@@ -291,16 +290,7 @@ function getDeltaPhase(delta: WorldDelta): string {
   return delta.phase
 }
 
-function beginSnapshotUpdate(): Map<number, RenderEntityUpsert> {
-  prevEntities = currEntities
-  prevPositionsById = new Map(prevEntities.map((e) => [e.pos.id, e.pos]))
-  prevAppearancesById = new Map(prevEntities.map((e) => [e.pos.id, e.app]))
-  return new Map(currEntities.map((e) => [e.pos.id, e]))
-}
-
-function finishSnapshotUpdate(nextEntities: Map<number, RenderEntityUpsert>): void {
-  currEntities = [...nextEntities.values()]
-
+function finishSnapshotUpdate(): void {
   prevSnapshotTime = currSnapshotTime
   currSnapshotTime = performance.now()
 
@@ -310,13 +300,20 @@ function finishSnapshotUpdate(nextEntities: Map<number, RenderEntityUpsert>): vo
 }
 
 function applyWorldDelta(delta: WorldDelta): void {
-  const nextEntities = beginSnapshotUpdate()
+  prevRenderStateById.clear()
 
-  for (const entity of delta.upserts)
-    nextEntities.set(entity.pos.id, upsertToRenderEntity(entity))
-  for (const entityId of delta.erased) nextEntities.delete(entityId)
+  for (const entity of delta.upserts) {
+    const nextEntity = upsertToRenderEntity(entity)
+    const prevEntity = currEntitiesById.get(entity.pos.id)
+    if (prevEntity) prevRenderStateById.set(entity.pos.id, prevEntity)
+    currEntitiesById.set(entity.pos.id, nextEntity)
+  }
+  for (const entityId of delta.erased) {
+    currEntitiesById.delete(entityId)
+    prevRenderStateById.delete(entityId)
+  }
 
-  finishSnapshotUpdate(nextEntities)
+  finishSnapshotUpdate()
   tickEl.textContent = String(delta.tick)
   lives = delta.lives
   resources = delta.resources

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -30,6 +30,7 @@ interface RenderVisualEffects {
   rangeRadius: number
   range: RenderColor
   flash: RenderColor
+  flashExpiry: number
 }
 
 interface RenderEntityUpsert {
@@ -64,11 +65,17 @@ const DEFAULT_RENDER_APPEARANCE: RenderAppearance = {
   bg: { css: 'rgba(0, 0, 0, 1)', alpha: 1 },
 }
 
+const TRANSPARENT_RENDER_COLOR: RenderColor = {
+  css: 'rgba(0, 0, 0, 0)',
+  alpha: 0,
+}
+
 const DEFAULT_RENDER_VISUAL_EFFECTS: RenderVisualEffects = {
-  selection: { css: 'rgba(0, 0, 0, 0)', alpha: 0 },
+  selection: TRANSPARENT_RENDER_COLOR,
   rangeRadius: 0,
-  range: { css: 'rgba(0, 0, 0, 0)', alpha: 0 },
-  flash: { css: 'rgba(0, 0, 0, 0)', alpha: 0 },
+  range: TRANSPARENT_RENDER_COLOR,
+  flash: TRANSPARENT_RENDER_COLOR,
+  flashExpiry: 0,
 }
 
 // --- DOM setup ---
@@ -419,6 +426,14 @@ function drawFlashOverlay(
   fx: RenderVisualEffects,
   now: number,
 ): void {
+  if (fx.flashExpiry == 0) return
+
+  if (now >= fx.flashExpiry) {
+    fx.flash = TRANSPARENT_RENDER_COLOR
+    fx.flashExpiry = 0
+    return
+  }
+
   if (radius <= 0 || isTransparent(fx.flash) || !isFlashVisible(now)) return
 
   fgCtx.save()
@@ -449,24 +464,29 @@ function appearanceToRender(app: EntityAppearance): RenderAppearance {
   }
 }
 
-function visualEffectsToRender(fx: EntityVisualEffects): RenderVisualEffects {
+function visualEffectsToRender(
+  fx: EntityVisualEffects,
+  now: number,
+): RenderVisualEffects {
   return {
     selection: packedRgbaToRenderColor(fx.selection),
     rangeRadius: fx.rangeRadius,
     range: packedRgbaToRenderColor(fx.range),
     flash: packedRgbaToRenderColor(fx.flash),
+    flashExpiry: fx.flashExpiryMs <= 0 ? 0 : now + fx.flashExpiryMs,
   }
 }
 
 function upsertToRenderEntity(
   upsert: EntityUpsert,
+  now: number,
   prevApp?: RenderAppearance,
   prevFx?: RenderVisualEffects,
 ): RenderEntityUpsert {
   return {
     pos: upsert.pos,
     app: upsert.app ? appearanceToRender(upsert.app) : (prevApp ?? DEFAULT_RENDER_APPEARANCE),
-    fx: upsert.vfx ? visualEffectsToRender(upsert.vfx) : (prevFx ?? DEFAULT_RENDER_VISUAL_EFFECTS),
+    fx: upsert.vfx ? visualEffectsToRender(upsert.vfx, now) : (prevFx ?? DEFAULT_RENDER_VISUAL_EFFECTS),
   }
 }
 
@@ -640,7 +660,8 @@ function isEntityVisualEffects(value: unknown): value is EntityVisualEffects {
     typeof (value as Record<string, unknown>).selection === 'number' &&
     typeof (value as Record<string, unknown>).rangeRadius === 'number' &&
     typeof (value as Record<string, unknown>).range === 'number' &&
-    typeof (value as Record<string, unknown>).flash === 'number'
+    typeof (value as Record<string, unknown>).flash === 'number' &&
+    typeof (value as Record<string, unknown>).flashExpiryMs === 'number'
   )
 }
 
@@ -672,11 +693,13 @@ function finishSnapshotUpdate(): void {
 }
 
 function applyWorldDelta(delta: WorldDelta): void {
+  const now = performance.now()
   prevRenderStateById.clear()
 
   for (const entity of delta.upserts) {
     const prevEntity = currEntitiesById.get(entity.pos.id)
-    const nextEntity = upsertToRenderEntity(entity, prevEntity?.app, prevEntity?.fx)
+    const nextEntity =
+      upsertToRenderEntity(entity, now, prevEntity?.app, prevEntity?.fx)
     if (prevEntity) prevRenderStateById.set(entity.pos.id, prevEntity)
     currEntitiesById.set(entity.pos.id, nextEntity)
   }

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -77,6 +77,7 @@ let currSnapshotTime = 0
 let snapshotIntervalMs = 50
 let lives = 0
 let resources = 0
+const glyphFontSizeCache = new Map<string, number>()
 
 // Linear interpolation calculator
 function lerp(a: number, b: number, t: number): number {
@@ -147,10 +148,13 @@ function drawFilledCircle(x: number, y: number, radius: number, color: string): 
   fgCtx.fill()
 }
 
-function drawGlyphInCircle(glyph: string, x: number, y: number, radius: number, color: string): void {
-  if (!glyph || radius <= 0 || isTransparent(color)) return
+function getGlyphFontSize(glyph: string, radius: number): number {
+  const roundedRadius = Math.max(1, Math.round(radius))
+  const cacheKey = `${glyph}:${roundedRadius}`
+  const cachedFontSize = glyphFontSizeCache.get(cacheKey)
+  if (cachedFontSize !== undefined) return cachedFontSize
 
-  const maxBox = radius * Math.sqrt(2)
+  const maxBox = roundedRadius * Math.sqrt(2)
   let fontSize = maxBox
   fgCtx.font = `${fontSize}px monospace`
 
@@ -159,6 +163,15 @@ function drawGlyphInCircle(glyph: string, x: number, y: number, radius: number, 
   const height = (metrics.actualBoundingBoxAscent + metrics.actualBoundingBoxDescent) || fontSize
   const scale = Math.min(maxBox / width, maxBox / height, 1) * 0.9
   fontSize *= scale
+
+  glyphFontSizeCache.set(cacheKey, fontSize)
+  return fontSize
+}
+
+function drawGlyphInCircle(glyph: string, x: number, y: number, radius: number, color: string): void {
+  if (!glyph || radius <= 0 || isTransparent(color)) return
+
+  const fontSize = getGlyphFontSize(glyph, radius)
 
   fgCtx.save()
   fgCtx.fillStyle = color

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -34,6 +34,14 @@ export interface EntityUpsert {
   app: EntityAppearance
 }
 
+export interface EntityRender {
+  glyph: string
+  scale: number
+  fg: string // CSS rgba(...), unpacked from a packed RGBA number
+  bg: string // CSS rgba(...), unpacked from a packed RGBA number
+  glow: string // CSS rgba(...), unpacked from a packed RGBA number
+}
+
 interface PathPoint {
   x: number
   y: number

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -21,11 +21,16 @@ export interface SnapshotEntity {
   y: number
 }
 
+interface PathPoint {
+  x: number
+  y: number
+}
+
 export interface SnapshotMsg {
   type: 'snapshot'
   entities: SnapshotEntity[]
+  path: PathPoint[]
 }
-
 
 export interface SpawnMsg {
   type: 'spawn'

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -10,11 +10,6 @@ export interface HelloAckMsg {
   message: string;
 }
 
-export interface TickMsg {
-  type: 'tick';
-  tick: number;
-}
-
 export interface EntityPosition {
   id: number
   x: number
@@ -69,5 +64,5 @@ export interface WorldSnapshot {
   delta: WorldDelta
 }
 
-export type ServerMsg = HelloAckMsg | TickMsg | WorldDelta | WorldSnapshot;
+export type ServerMsg = HelloAckMsg | WorldDelta | WorldSnapshot;
 export type ClientMsg = HelloMsg | SpawnMsg;

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -28,7 +28,7 @@ export interface EntityPosition {
 
 export interface EntityAppearance {
   glyph: number
-  scale: number
+  radius: number
   fg: number
   bg: number
 }

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -15,5 +15,17 @@ export interface TickMsg {
   tick: number;
 }
 
-export type ServerMsg = HelloAckMsg | TickMsg;
+export interface SnapshotEntity {
+  id: number
+  x: number
+  y: number
+}
+
+export interface SnapshotMsg {
+  type: 'snapshot'
+  entities: SnapshotEntity[]
+}
+
+
+export type ServerMsg = HelloAckMsg | TickMsg | SnapshotMsg;
 export type ClientMsg = HelloMsg;

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -27,5 +27,11 @@ export interface SnapshotMsg {
 }
 
 
+export interface SpawnMsg {
+  type: 'spawn'
+  x: number
+  y: number
+}
+
 export type ServerMsg = HelloAckMsg | TickMsg | SnapshotMsg;
-export type ClientMsg = HelloMsg;
+export type ClientMsg = HelloMsg | SpawnMsg;

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -38,6 +38,7 @@ export interface EntityVisualEffects {
   rangeRadius: number
   range: number
   flash: number
+  flashExpiryMs: number
 }
 
 interface PathPoint {

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -10,6 +10,16 @@ export interface HelloAckMsg {
   message: string;
 }
 
+export type UiCanvasEvent =
+  | 'click'
+  | 'dblclick'
+  | 'contextmenu'
+  | 'dragstart'
+  | 'dragmove'
+  | 'dragend'
+
+export type UiButton = 'left' | 'middle' | 'right' | 'other'
+
 export interface EntityPosition {
   id: number
   x: number
@@ -42,10 +52,27 @@ interface PathPoint {
   y: number
 }
 
-export interface SpawnMsg {
-  type: 'spawn'
+export interface UiCanvasMsg {
+  type: 'ui_canvas'
+  seq: number
+  event: UiCanvasEvent
+  button: UiButton
+  buttons: number
   x: number
   y: number
+  canvasX: number
+  canvasY: number
+  shift: boolean
+  ctrl: boolean
+  alt: boolean
+  meta: boolean
+}
+
+export interface UiActionMsg {
+  type: 'ui_action'
+  seq: number
+  action: string
+  fields?: Record<string, string>
 }
 
 export interface WorldDelta {
@@ -65,4 +92,4 @@ export interface WorldSnapshot {
 }
 
 export type ServerMsg = HelloAckMsg | WorldDelta | WorldSnapshot;
-export type ClientMsg = HelloMsg | SpawnMsg;
+export type ClientMsg = HelloMsg | UiCanvasMsg | UiActionMsg;

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -15,7 +15,7 @@ export interface TickMsg {
   tick: number;
 }
 
-export interface SnapshotEntity {
+export interface EntityPosition {
   id: number
   x: number
   y: number
@@ -26,10 +26,15 @@ interface PathPoint {
   y: number
 }
 
+interface Path {
+  type: 'path'
+  points: PathPoint[]
+}
+
 export interface SnapshotMsg {
   type: 'snapshot'
-  entities: SnapshotEntity[]
-  path: PathPoint[]
+  entities: EntityPosition[]
+  paths: Path[]
 }
 
 export interface SpawnMsg {
@@ -38,5 +43,21 @@ export interface SpawnMsg {
   y: number
 }
 
-export type ServerMsg = HelloAckMsg | TickMsg | SnapshotMsg;
+export interface WorldDelta {
+  type: 'world_delta'
+  tick: number
+  upserts: EntityPosition[]
+  erased: number[]
+  lives: number
+  resources: number
+  phase: string
+}
+
+export interface WorldSnapshot {
+  type: 'world_snapshot'
+  paths: PathPoint[]
+  delta: WorldDelta
+}
+
+export type ServerMsg = HelloAckMsg | TickMsg | WorldDelta | WorldSnapshot;
 export type ClientMsg = HelloMsg | SpawnMsg;

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -21,6 +21,19 @@ export interface EntityPosition {
   y: number
 }
 
+export interface EntityAppearance {
+  glyph: number
+  scale: number
+  fg: number
+  bg: number
+  glow: number
+}
+
+export interface EntityUpsert {
+  pos: EntityPosition
+  app: EntityAppearance
+}
+
 interface PathPoint {
   x: number
   y: number
@@ -35,7 +48,7 @@ export interface SpawnMsg {
 export interface WorldDelta {
   type: 'world_delta'
   tick: number
-  upserts: EntityPosition[]
+  upserts: EntityUpsert[]
   erased: number[]
   lives: number
   resources: number

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -31,25 +31,24 @@ export interface EntityAppearance {
   scale: number
   fg: number
   bg: number
-  glow: number
 }
 
-export interface EntityUpsert {
-  pos: EntityPosition
-  app?: EntityAppearance
-}
-
-export interface EntityRender {
-  glyph: string
-  scale: number
-  fg: string // CSS rgba(...), unpacked from a packed RGBA number
-  bg: string // CSS rgba(...), unpacked from a packed RGBA number
-  glow: string // CSS rgba(...), unpacked from a packed RGBA number
+export interface EntityVisualEffects {
+  selection: number
+  rangeRadius: number
+  range: number
+  flash: number
 }
 
 interface PathPoint {
   x: number
   y: number
+}
+
+export interface EntityUpsert {
+  pos: EntityPosition
+  app?: EntityAppearance
+  vfx?: EntityVisualEffects
 }
 
 export interface UiCanvasMsg {

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -31,7 +31,7 @@ export interface EntityAppearance {
 
 export interface EntityUpsert {
   pos: EntityPosition
-  app: EntityAppearance
+  app?: EntityAppearance
 }
 
 export interface EntityRender {

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -26,17 +26,6 @@ interface PathPoint {
   y: number
 }
 
-interface Path {
-  type: 'path'
-  points: PathPoint[]
-}
-
-export interface SnapshotMsg {
-  type: 'snapshot'
-  entities: EntityPosition[]
-  paths: Path[]
-}
-
 export interface SpawnMsg {
   type: 'spawn'
   x: number

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -1,0 +1,19 @@
+// Client -> server
+export interface HelloMsg {
+  type: 'hello';
+  client: string;
+}
+
+// Server -> client
+export interface HelloAckMsg {
+  type: 'hello_ack';
+  message: string;
+}
+
+export interface TickMsg {
+  type: 'tick';
+  tick: number;
+}
+
+export type ServerMsg = HelloAckMsg | TickMsg;
+export type ClientMsg = HelloMsg;

--- a/corvid/sim/web/tsconfig.json
+++ b/corvid/sim/web/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/corvid/sim/web/vite.config.ts
+++ b/corvid/sim/web/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite'
 
 export default defineConfig({
   build: {
-    outDir: '.',
-    emptyOutDir: false,
+    outDir: 'dist',
+    emptyOutDir: true,
   },
 })

--- a/corvid/sim/web/vite.config.ts
+++ b/corvid/sim/web/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    outDir: '.',
+    emptyOutDir: false,
+  },
+})

--- a/corvid/sim/ws_handler.h
+++ b/corvid/sim/ws_handler.h
@@ -1,0 +1,126 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <atomic>
+#include <format>
+#include <iostream>
+#include <memory>
+
+#include "../proto/http_websocket_transaction.h"
+
+// WebSocket handler for the CorvidSim /ws route.
+//
+// Provides `make_ws_factory(loop, wheel)`, which returns a
+// `transaction_factory` suitable for use with `http_server::add_route`.
+//
+// Protocol:
+//   Client sends: {"type":"hello","client":"browser"}
+//   Server replies: {"type":"hello_ack","message":"connected"}
+//   Server then sends once per second: {"type":"tick","tick":N}
+//
+// Tick scheduling follows the same `timer_fuse` double-check pattern used by
+// `http_websocket_transaction::do_arm_ping_interval`: the wheel-thread
+// callback only calls `loop->post()`, and the loop-thread callback performs
+// the definitive liveness check before sending and re-arming.
+namespace corvid { inline namespace proto {
+
+using namespace std::chrono_literals;
+
+// Forward declaration: `arm_tick`'s fire lambda calls `arm_tick` recursively,
+// so the definition below must be preceded by a declaration.
+[[nodiscard]] inline bool arm_tick(std::weak_ptr<epoll_loop>,
+    std::weak_ptr<timing_wheel>, std::weak_ptr<http_transaction>,
+    std::shared_ptr<std::atomic_uint64_t>, uint64_t);
+
+// Schedule a tick to be sent after 1 second on the connection identified by
+// `tx_w`. On fire, posts to the event loop thread, sends the tick JSON, then
+// re-arms for the next tick. Stops automatically when the connection is
+// destroyed (fuse fizzles) or when `is_close_started()` is true.
+//
+// `tick_seq` is the per-connection sequencer held as a `shared_ptr` so that
+// every lambda copy keeps the underlying `atomic_uint64_t` alive (required
+// because `timer_fuse` stores a raw pointer to it).
+[[nodiscard]] inline bool arm_tick(std::weak_ptr<epoll_loop> loop_w,
+    std::weak_ptr<timing_wheel> wheel_w, std::weak_ptr<http_transaction> tx_w,
+    std::shared_ptr<std::atomic_uint64_t> tick_seq, uint64_t tick_n) {
+  using fuse_t = timer_fuse<http_transaction>;
+  auto wheel = wheel_w.lock();
+  if (!wheel) return true;
+  return fuse_t::set_timeout(*wheel, *tick_seq, tx_w, 1000ms,
+      [loop_w, wheel_w, tick_seq, tick_n](const fuse_t& fuse) -> bool {
+        // Wheel thread: pre-check only.
+        auto tx = fuse.get_if_armed();
+        auto loop = loop_w.lock();
+        if (!tx || !loop) return true;
+        return loop->post([fuse, loop_w, wheel_w, tick_seq, tick_n]() -> bool {
+          // Loop thread: definitive check, send, re-arm.
+          auto tx = fuse.get_if_armed();
+          if (!tx) return true;
+          auto wstx = std::static_pointer_cast<http_websocket_transaction>(tx);
+          if (wstx->websocket().is_close_started()) return true;
+          auto payload = std::format(R"({{"type":"tick","tick":{}}})", tick_n);
+          if (!wstx->websocket().send_text(payload)) return false;
+          return arm_tick(loop_w, wheel_w, tx, tick_seq, tick_n + 1);
+        });
+      });
+}
+
+// Returns a `transaction_factory` for the `/ws` route.
+//
+// Each accepted WebSocket connection receives `on_message` and `on_close`
+// callbacks. On a `hello` message, the server replies with `hello_ack` and
+// arms the 1-second recurring tick timer for that connection.
+[[nodiscard]] inline transaction_factory make_ws_factory(
+    std::shared_ptr<epoll_loop> loop, std::shared_ptr<timing_wheel> wheel) {
+  return http_websocket_transaction::make_factory(
+      [loop = std::move(loop), wheel = std::move(wheel)](
+          http_websocket_transaction& tx) -> bool {
+        std::cout << "WebSocket client connected\n";
+
+        tx.websocket().on_close =
+            [](http_websocket&, uint16_t, std::string_view) {
+              std::cout << "WebSocket client disconnected\n";
+            };
+
+        // Per-connection tick sequencer. Held as `shared_ptr` so every lambda
+        // copy keeps the `atomic_uint64_t` alive (see `arm_tick` comment).
+        auto tick_seq = std::make_shared<std::atomic_uint64_t>(0);
+
+        tx.websocket().on_message =
+            [loop_w = std::weak_ptr{loop}, wheel_w = std::weak_ptr{wheel},
+                tx_w = std::weak_ptr<http_transaction>{tx.shared_from_this()},
+                tick_seq](http_websocket& ws, std::string&& msg,
+                ws_frame_control) -> bool {
+          // No JSON parser: detect `hello` by searching the raw string.
+          // Accept both compact and spaced key/value.
+          const bool is_hello =
+              msg.find(R"("type":"hello")") != std::string::npos ||
+              msg.find(R"("type": "hello")") != std::string::npos;
+          if (!is_hello) return true;
+
+          if (!ws.send_text(R"({"type":"hello_ack","message":"connected"})"))
+            return false;
+
+          return arm_tick(loop_w, wheel_w, tx_w, tick_seq, 1);
+        };
+
+        return true;
+      });
+}
+
+}} // namespace corvid::proto

--- a/corvid/sim/ws_handler.h
+++ b/corvid/sim/ws_handler.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <atomic>
+#include <cmath>
 #include <format>
 #include <iostream>
 #include <memory>
@@ -35,7 +36,8 @@ using namespace std::chrono_literals;
 // Protocol:
 //   Client sends: {"type":"hello","client":"browser"}
 //   Server replies: {"type":"hello_ack","message":"connected"}
-//   Server then sends once per second: {"type":"tick","tick":N}
+//   Server then sends at 20 Hz: {"type":"snapshot","entities":[...]}
+//   Server also sends at 1 Hz: {"type":"tick","tick":N}
 //
 // Keepalive (20s ping / 5s pong timeout) is enabled so that browser pong
 // replies reset the HTTP server's 30s read timeout; the constraint
@@ -103,7 +105,7 @@ private:
     auto wheel = keepalive_wheel_.lock();
     if (!wheel) return true;
     return fuse_t::set_timeout(*wheel, tick_seq_,
-        std::weak_ptr<http_transaction>{shared_from_this()}, 1000ms,
+        std::weak_ptr<http_transaction>{shared_from_this()}, 50ms,
         [loop_w = keepalive_loop_, tick_n](const fuse_t& fuse) -> bool {
           auto tx = fuse.get_if_armed();
           auto loop = loop_w.lock();
@@ -117,14 +119,55 @@ private:
         });
   }
 
-  // Called on the loop thread: send the tick message and re-arm for the next.
-  // If a fragmented send is in progress, defer this tick by re-arming with
-  // the same counter so the sequence has no gaps.
+  // Called on the loop thread: send a snapshot message (20 Hz) and, once per
+  // 20 frames, a tick message (1 Hz). Re-arms for the next 50 ms interval.
+  // If a fragmented send is in progress, defer by re-arming with the same
+  // counter so the sequence has no gaps.
+  //
+  // Five entities orbit the canvas center (320, 240) at varying radii,
+  // angular speeds (radians per 50 ms frame), and initial phases, so no two
+  // are ever in the same position or in sync.
   [[nodiscard]] bool do_tick_fire(uint64_t tick_n) {
     if (websocket().is_close_started()) return true;
     if (websocket().is_send_in_fragment()) return do_arm_tick(tick_n);
-    auto payload = std::format(R"({{"type":"tick","tick":{}}})", tick_n);
-    if (!websocket().send_text(payload)) return false;
+
+    struct orbit {
+      int id;
+      double radius;
+      double speed; // rad/frame (frame = 50 ms)
+      double phase; // initial angle (rad)
+    };
+    static constexpr orbit orbits[] = {
+        {1, 80.0, 0.05, 0.00},
+        {2, 140.0, 0.035, 1.05},
+        {3, 200.0, 0.025, 2.09},
+        {4, 80.0, -0.065, 0.52},
+        {5, 170.0, -0.04, 3.67},
+    };
+
+    const double cx = 320.0;
+    const double cy = 240.0;
+    auto t = static_cast<double>(tick_n);
+
+    std::string entities;
+    for (const auto& o : orbits) {
+      double angle = o.phase + (o.speed * t);
+      double x = cx + (o.radius * std::cos(angle));
+      double y = cy + (o.radius * std::sin(angle));
+      if (!entities.empty()) entities += ',';
+      entities +=
+          std::format(R"({{"id":{},"x":{:.1f},"y":{:.1f}}})", o.id, x, y);
+    }
+    auto snapshot =
+        std::format(R"({{"type":"snapshot","entities":[{}]}})", entities);
+    if (!websocket().send_text(snapshot)) return false;
+
+    if (tick_n % 20 == 0) {
+      auto tick_msg =
+          std::format(R"({{"type":"tick","tick":{}}})", tick_n / 20);
+      if (!websocket().send_text(tick_msg)) return false;
+    }
+
     return do_arm_tick(tick_n + 1);
   }
 };

--- a/corvid/sim/ws_handler.h
+++ b/corvid/sim/ws_handler.h
@@ -118,8 +118,11 @@ private:
   }
 
   // Called on the loop thread: send the tick message and re-arm for the next.
+  // If a fragmented send is in progress, defer this tick by re-arming with
+  // the same counter so the sequence has no gaps.
   [[nodiscard]] bool do_tick_fire(uint64_t tick_n) {
     if (websocket().is_close_started()) return true;
+    if (websocket().is_send_in_fragment()) return do_arm_tick(tick_n);
     auto payload = std::format(R"({{"type":"tick","tick":{}}})", tick_n);
     if (!websocket().send_text(payload)) return false;
     return do_arm_tick(tick_n + 1);

--- a/corvid/sim/ws_handler.h
+++ b/corvid/sim/ws_handler.h
@@ -17,10 +17,12 @@
 #pragma once
 
 #include <atomic>
+#include <charconv>
 #include <cmath>
 #include <format>
 #include <iostream>
 #include <memory>
+#include <vector>
 
 #include "../proto/http_websocket_transaction.h"
 
@@ -36,6 +38,7 @@ using namespace std::chrono_literals;
 // Protocol:
 //   Client sends: {"type":"hello","client":"browser"}
 //   Server replies: {"type":"hello_ack","message":"connected"}
+//   Client sends: {"type":"spawn","x":N,"y":N}
 //   Server then sends at 20 Hz: {"type":"snapshot","entities":[...]}
 //   Server also sends at 1 Hz: {"type":"tick","tick":N}
 //
@@ -82,18 +85,70 @@ public:
 private:
   using fuse_t = timer_fuse<http_transaction>;
 
-  std::atomic_uint64_t tick_seq_;
+  // A user-spawned entity orbiting the canvas centre.
+  //
+  // The click coordinates become the entity's initial position, so the dot
+  // appears exactly under the cursor at spawn and then sweeps in a circle.
+  struct dynamic_orbit {
+    int id;
+    double radius;
+    double speed;   // rad/frame (frame = 50 ms)
+    double phase;   // initial angle (rad) so position at birth == click point
+    uint64_t birth; // tick_n when spawned
+  };
 
-  // Handle an incoming text frame. Detects `hello` by searching the raw JSON
-  // string (no parser needed for these fixed message shapes), replies with
-  // `hello_ack`, then arms the tick timer.
+  std::atomic_uint64_t tick_seq_;
+  uint64_t current_tick_{0};  // updated each frame; loop-thread only
+  int next_id_{6};            // ids 1-5 reserved for static orbits
+  std::vector<dynamic_orbit> spawned_;
+
+  // Handle an incoming text frame. Dispatches on `"type"` by substring search
+  // (no parser needed for these fixed message shapes).
   [[nodiscard]] bool do_message(http_websocket& ws, std::string&& msg) {
-    if (!msg.contains(R"("type":"hello")") &&
-        !msg.contains(R"("type": "hello")"))
-      return true;
-    if (!ws.send_text(R"({"type":"hello_ack","message":"connected"})"))
-      return false;
-    return do_arm_tick(1);
+    if (msg.contains(R"("type":"hello")") ||
+        msg.contains(R"("type": "hello")")) {
+      if (!ws.send_text(R"({"type":"hello_ack","message":"connected"})"))
+        return false;
+      return do_arm_tick(1);
+    }
+    if (msg.contains(R"("type":"spawn")") ||
+        msg.contains(R"("type": "spawn")")) {
+      return do_spawn(msg);
+    }
+    return true;
+  }
+
+  // Parse a `spawn` message and add a new orbiting entity.
+  //
+  // The click point becomes the entity's position at birth: radius and phase
+  // are derived from the click's distance and angle to the canvas centre
+  // (320, 240), so the dot appears exactly under the cursor at spawn.
+  [[nodiscard]] bool do_spawn(std::string_view msg) {
+    auto x = parse_coord(msg, R"("x":)");
+    auto y = parse_coord(msg, R"("y":)");
+    if (!x || !y) return true; // malformed, ignore
+    constexpr double kCx = 320.0;
+    constexpr double kCy = 240.0;
+    double dx = *x - kCx;
+    double dy = *y - kCy;
+    double radius = std::sqrt((dx * dx) + (dy * dy));
+    double phase = std::atan2(dy, dx);
+    spawned_.push_back({next_id_++, radius, 0.04, phase, current_tick_});
+    return true;
+  }
+
+  // Find `key` in `msg` and parse the number that follows it.
+  [[nodiscard]] static std::optional<double> parse_coord(
+      std::string_view msg, std::string_view key) {
+    auto pos = msg.find(key);
+    if (pos == std::string_view::npos) return std::nullopt;
+    pos += key.size();
+    while (pos < msg.size() && msg[pos] == ' ') ++pos;
+    double val{};
+    auto [ptr, ec] =
+        std::from_chars(msg.data() + pos, msg.data() + msg.size(), val);
+    if (ec != std::errc{}) return std::nullopt;
+    return val;
   }
 
   static void do_close() { std::cout << "WebSocket client disconnected\n"; }
@@ -131,6 +186,8 @@ private:
     if (websocket().is_close_started()) return true;
     if (websocket().is_send_in_fragment()) return do_arm_tick(tick_n);
 
+    current_tick_ = tick_n;
+
     struct orbit {
       int id;
       double radius;
@@ -158,6 +215,15 @@ private:
       entities +=
           std::format(R"({{"id":{},"x":{:.1f},"y":{:.1f}}})", o.id, x, y);
     }
+    for (const auto& s : spawned_) {
+      double angle = s.phase + (s.speed * static_cast<double>(tick_n - s.birth));
+      double x = cx + (s.radius * std::cos(angle));
+      double y = cy + (s.radius * std::sin(angle));
+      if (!entities.empty()) entities += ',';
+      entities +=
+          std::format(R"({{"id":{},"x":{:.1f},"y":{:.1f}}})", s.id, x, y);
+    }
+
     auto snapshot =
         std::format(R"({{"type":"snapshot","entities":[{}]}})", entities);
     if (!websocket().send_text(snapshot)) return false;

--- a/corvid/sim/ws_handler.h
+++ b/corvid/sim/ws_handler.h
@@ -80,7 +80,7 @@ public:
     constexpr float kStep = 2.0 * std::numbers::pi / kCount;
     for (int i = 0; i < kCount; ++i)
       (void)world_.spawn(sim::Position{0.0, 0.0},
-          sim::Velocity::from_polar(kSpeed, i * kStep));
+          sim::Velocity::from_polar(kSpeed, static_cast<float>(i) * kStep));
 
     std::cout << "WebSocket client connected\n";
   }

--- a/corvid/sim/ws_handler.h
+++ b/corvid/sim/ws_handler.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <charconv>
+#include <numbers>
 #include <cmath>
 #include <format>
 #include <iostream>
@@ -25,6 +26,7 @@
 #include <vector>
 
 #include "../proto/http_websocket_transaction.h"
+#include "sim_world.h"
 
 namespace corvid { inline namespace proto {
 
@@ -70,6 +72,16 @@ public:
     // `enable_keepalive` stores weak_ptrs and sets `on_pong`; it always
     // returns `true`, so voiding the result is safe here.
     (void)enable_keepalive(loop, wheel, 20s, 5s);
+
+    // Populate the world with five entities at the origin, evenly fanned
+    // around the full circle at the same speed.
+    constexpr int kCount = 5000;
+    constexpr float kSpeed = 40.0;
+    constexpr float kStep = 2.0 * std::numbers::pi / kCount;
+    for (int i = 0; i < kCount; ++i)
+      (void)world_.spawn(sim::Position{0.0, 0.0},
+          sim::Velocity::from_polar(kSpeed, i * kStep));
+
     std::cout << "WebSocket client connected\n";
   }
 
@@ -85,66 +97,55 @@ public:
 private:
   using fuse_t = timer_fuse<http_transaction>;
 
-  // A user-spawned entity orbiting the canvas centre.
-  //
-  // The click coordinates become the entity's initial position, so the dot
-  // appears exactly under the cursor at spawn and then sweeps in a circle.
-  struct dynamic_orbit {
-    int id;
-    double radius;
-    double speed;   // rad/frame (frame = 50 ms)
-    double phase;   // initial angle (rad) so position at birth == click point
-    uint64_t birth; // tick_n when spawned
-  };
-
-  std::atomic_uint64_t tick_seq_;
-  uint64_t current_tick_{0};  // updated each frame; loop-thread only
-  int next_id_{6};            // ids 1-5 reserved for static orbits
-  std::vector<dynamic_orbit> spawned_;
+  std::atomic<tick_t> tick_seq_; // Uses for sequencing tick timers
+  tick_t current_tick_{0};       // updated each frame; loop-thread only
+  sim::sim_world world_;         // all simulation entity state
 
   // Handle an incoming text frame. Dispatches on `"type"` by substring search
   // (no parser needed for these fixed message shapes).
   [[nodiscard]] bool do_message(http_websocket& ws, std::string&& msg) {
     if (msg.contains(R"("type":"hello")") ||
-        msg.contains(R"("type": "hello")")) {
+        msg.contains(R"("type": "hello")"))
+    {
       if (!ws.send_text(R"({"type":"hello_ack","message":"connected"})"))
         return false;
       return do_arm_tick(1);
     }
     if (msg.contains(R"("type":"spawn")") ||
-        msg.contains(R"("type": "spawn")")) {
+        msg.contains(R"("type": "spawn")"))
+    {
       return do_spawn(msg);
     }
     return true;
   }
 
-  // Parse a `spawn` message and add a new orbiting entity.
+  // Parse a `spawn` message and add a new entity at the click position.
   //
-  // The click point becomes the entity's position at birth: radius and phase
-  // are derived from the click's distance and angle to the canvas centre
-  // (320, 240), so the dot appears exactly under the cursor at spawn.
+  // The entity travels in a straight line; velocity is set perpendicular to
+  // the vector from the canvas centre to the click point (tangential), with
+  // a fixed speed of 40 pixels per frame. If the click is exactly on-centre,
+  // the entity moves rightward.
   [[nodiscard]] bool do_spawn(std::string_view msg) {
     auto x = parse_coord(msg, R"("x":)");
     auto y = parse_coord(msg, R"("y":)");
     if (!x || !y) return true; // malformed, ignore
-    constexpr double kCx = 320.0;
-    constexpr double kCy = 240.0;
-    double dx = *x - kCx;
-    double dy = *y - kCy;
-    double radius = std::sqrt((dx * dx) + (dy * dy));
-    double phase = std::atan2(dy, dx);
-    spawned_.push_back({next_id_++, radius, 0.04, phase, current_tick_});
+    float r = std::sqrt((*x * *x) + (*y * *y));
+    constexpr float speed = 40.0;
+    sim::Velocity vel =
+        (r > 0.0) ? sim::Velocity{-speed * *y / r, speed * *x / r}
+                  : sim::Velocity{speed, 0.0};
+    (void)world_.spawn(sim::Position{*x, *y}, vel);
     return true;
   }
 
   // Find `key` in `msg` and parse the number that follows it.
-  [[nodiscard]] static std::optional<double> parse_coord(
-      std::string_view msg, std::string_view key) {
+  [[nodiscard]] static std::optional<float>
+  parse_coord(std::string_view msg, std::string_view key) {
     auto pos = msg.find(key);
     if (pos == std::string_view::npos) return std::nullopt;
     pos += key.size();
     while (pos < msg.size() && msg[pos] == ' ') ++pos;
-    double val{};
+    float val{};
     auto [ptr, ec] =
         std::from_chars(msg.data() + pos, msg.data() + msg.size(), val);
     if (ec != std::errc{}) return std::nullopt;
@@ -156,7 +157,7 @@ private:
   // Schedule the next tick. Uses the `timer_fuse` double-check pattern:
   // the wheel-thread callback pre-checks liveness and posts to the loop
   // thread, which performs the definitive check and calls `do_tick_fire`.
-  [[nodiscard]] bool do_arm_tick(uint64_t tick_n) {
+  [[nodiscard]] bool do_arm_tick(tick_t tick_n) {
     auto wheel = keepalive_wheel_.lock();
     if (!wheel) return true;
     return fuse_t::set_timeout(*wheel, tick_seq_,
@@ -174,59 +175,28 @@ private:
         });
   }
 
-  // Called on the loop thread: send a snapshot message (20 Hz) and, once per
-  // 20 frames, a tick message (1 Hz). Re-arms for the next 50 ms interval.
-  // If a fragmented send is in progress, defer by re-arming with the same
-  // counter so the sequence has no gaps.
-  //
-  // Five entities orbit the canvas center (320, 240) at varying radii,
-  // angular speeds (radians per 50 ms frame), and initial phases, so no two
-  // are ever in the same position or in sync.
-  [[nodiscard]] bool do_tick_fire(uint64_t tick_n) {
+  // Called on the loop thread: advance the simulation one frame, send a
+  // snapshot message (20 Hz) and, once per 20 frames, a tick message (1 Hz).
+  // Re-arms for the next 50 ms interval. If a fragmented send is in progress,
+  // defers by re-arming with the same counter so the sequence has no gaps.
+  [[nodiscard]] bool do_tick_fire(tick_t tick_n) {
     if (websocket().is_close_started()) return true;
     if (websocket().is_send_in_fragment()) return do_arm_tick(tick_n);
 
-    current_tick_ = tick_n;
+    current_tick_ = world_.tick();
 
-    struct orbit {
-      int id;
-      double radius;
-      double speed; // rad/frame (frame = 50 ms)
-      double phase; // initial angle (rad)
-    };
-    static constexpr orbit orbits[] = {
-        {1, 80.0, 0.05, 0.00},
-        {2, 140.0, 0.035, 1.05},
-        {3, 200.0, 0.025, 2.09},
-        {4, 80.0, -0.065, 0.52},
-        {5, 170.0, -0.04, 3.67},
-    };
-
-    const double cx = 320.0;
-    const double cy = 240.0;
-    auto t = static_cast<double>(tick_n);
-
+    auto snaps = world_.snapshot();
     std::string entities;
-    for (const auto& o : orbits) {
-      double angle = o.phase + (o.speed * t);
-      double x = cx + (o.radius * std::cos(angle));
-      double y = cy + (o.radius * std::sin(angle));
+    entities.reserve(snaps.size() * 40);
+    for (const auto& e : snaps) {
       if (!entities.empty()) entities += ',';
-      entities +=
-          std::format(R"({{"id":{},"x":{:.1f},"y":{:.1f}}})", o.id, x, y);
-    }
-    for (const auto& s : spawned_) {
-      double angle = s.phase + (s.speed * static_cast<double>(tick_n - s.birth));
-      double x = cx + (s.radius * std::cos(angle));
-      double y = cy + (s.radius * std::sin(angle));
-      if (!entities.empty()) entities += ',';
-      entities +=
-          std::format(R"({{"id":{},"x":{:.1f},"y":{:.1f}}})", s.id, x, y);
+      entities += std::format(R"({{"id":{},"x":{:.1f},"y":{:.1f}}})",
+          static_cast<std::size_t>(e.id), e.pos.x, e.pos.y);
     }
 
-    auto snapshot =
+    auto snap_msg =
         std::format(R"({{"type":"snapshot","entities":[{}]}})", entities);
-    if (!websocket().send_text(snapshot)) return false;
+    if (!websocket().send_text(snap_msg)) return false;
 
     if (tick_n % 20 == 0) {
       auto tick_msg =

--- a/corvid/sim/ws_handler.h
+++ b/corvid/sim/ws_handler.h
@@ -23,104 +23,107 @@
 
 #include "../proto/http_websocket_transaction.h"
 
-// WebSocket handler for the CorvidSim /ws route.
+namespace corvid { inline namespace proto {
+
+using namespace std::chrono_literals;
+
+// WebSocket transaction for the CorvidSim `/ws` route.
 //
-// Provides `make_ws_factory(loop, wheel)`, which returns a
-// `transaction_factory` suitable for use with `http_server::add_route`.
+// Inherits from `http_websocket_transaction` and wires up all callbacks in the
+// constructor so behaviour lives in named private methods rather than lambdas.
 //
 // Protocol:
 //   Client sends: {"type":"hello","client":"browser"}
 //   Server replies: {"type":"hello_ack","message":"connected"}
 //   Server then sends once per second: {"type":"tick","tick":N}
 //
+// Keepalive (20s ping / 5s pong timeout) is enabled so that browser pong
+// replies reset the HTTP server's 30s read timeout; the constraint
+// ping_interval (20s) + pong_timeout (5s) = 25s < read_timeout (30s) is
+// satisfied.
+//
 // Tick scheduling follows the same `timer_fuse` double-check pattern used by
-// `http_websocket_transaction::do_arm_ping_interval`: the wheel-thread
-// callback only calls `loop->post()`, and the loop-thread callback performs
-// the definitive liveness check before sending and re-arming.
-namespace corvid { inline namespace proto {
-
-using namespace std::chrono_literals;
-
-// Forward declaration: `arm_tick`'s fire lambda calls `arm_tick` recursively,
-// so the definition below must be preceded by a declaration.
-[[nodiscard]] inline bool arm_tick(std::weak_ptr<epoll_loop>,
-    std::weak_ptr<timing_wheel>, std::weak_ptr<http_transaction>,
-    std::shared_ptr<std::atomic_uint64_t>, uint64_t);
-
-// Schedule a tick to be sent after 1 second on the connection identified by
-// `tx_w`. On fire, posts to the event loop thread, sends the tick JSON, then
-// re-arms for the next tick. Stops automatically when the connection is
-// destroyed (fuse fizzles) or when `is_close_started()` is true.
-//
-// `tick_seq` is the per-connection sequencer held as a `shared_ptr` so that
-// every lambda copy keeps the underlying `atomic_uint64_t` alive (required
-// because `timer_fuse` stores a raw pointer to it).
-[[nodiscard]] inline bool arm_tick(std::weak_ptr<epoll_loop> loop_w,
-    std::weak_ptr<timing_wheel> wheel_w, std::weak_ptr<http_transaction> tx_w,
-    std::shared_ptr<std::atomic_uint64_t> tick_seq, uint64_t tick_n) {
-  using fuse_t = timer_fuse<http_transaction>;
-  auto wheel = wheel_w.lock();
-  if (!wheel) return true;
-  return fuse_t::set_timeout(*wheel, *tick_seq, tx_w, 1000ms,
-      [loop_w, wheel_w, tick_seq, tick_n](const fuse_t& fuse) -> bool {
-        // Wheel thread: pre-check only.
-        auto tx = fuse.get_if_armed();
-        auto loop = loop_w.lock();
-        if (!tx || !loop) return true;
-        return loop->post([fuse, loop_w, wheel_w, tick_seq, tick_n]() -> bool {
-          // Loop thread: definitive check, send, re-arm.
-          auto tx = fuse.get_if_armed();
-          if (!tx) return true;
-          auto wstx = std::static_pointer_cast<http_websocket_transaction>(tx);
-          if (wstx->websocket().is_close_started()) return true;
-          auto payload = std::format(R"({{"type":"tick","tick":{}}})", tick_n);
-          if (!wstx->websocket().send_text(payload)) return false;
-          return arm_tick(loop_w, wheel_w, tx, tick_seq, tick_n + 1);
-        });
-      });
-}
-
-// Returns a `transaction_factory` for the `/ws` route.
-//
-// Each accepted WebSocket connection receives `on_message` and `on_close`
-// callbacks. On a `hello` message, the server replies with `hello_ack` and
-// arms the 1-second recurring tick timer for that connection.
-[[nodiscard]] inline transaction_factory make_ws_factory(
-    std::shared_ptr<epoll_loop> loop, std::shared_ptr<timing_wheel> wheel) {
-  return http_websocket_transaction::make_factory(
-      [loop = std::move(loop), wheel = std::move(wheel)](
-          http_websocket_transaction& tx) -> bool {
-        std::cout << "WebSocket client connected\n";
-
-        tx.websocket().on_close =
-            [](http_websocket&, uint16_t, std::string_view) {
-              std::cout << "WebSocket client disconnected\n";
-            };
-
-        // Per-connection tick sequencer. Held as `shared_ptr` so every lambda
-        // copy keeps the `atomic_uint64_t` alive (see `arm_tick` comment).
-        auto tick_seq = std::make_shared<std::atomic_uint64_t>(0);
-
-        tx.websocket().on_message =
-            [loop_w = std::weak_ptr{loop}, wheel_w = std::weak_ptr{wheel},
-                tx_w = std::weak_ptr<http_transaction>{tx.shared_from_this()},
-                tick_seq](http_websocket& ws, std::string&& msg,
-                ws_frame_control) -> bool {
-          // No JSON parser: detect `hello` by searching the raw string.
-          // Accept both compact and spaced key/value.
-          const bool is_hello =
-              msg.find(R"("type":"hello")") != std::string::npos ||
-              msg.find(R"("type": "hello")") != std::string::npos;
-          if (!is_hello) return true;
-
-          if (!ws.send_text(R"({"type":"hello_ack","message":"connected"})"))
-            return false;
-
-          return arm_tick(loop_w, wheel_w, tx_w, tick_seq, 1);
+// the base class: the wheel-thread callback only calls `loop->post()`, and the
+// loop-thread callback performs the definitive liveness check before sending
+// and re-arming. `tick_seq_` is a plain member (like `ping_interval_seq_` in
+// the base) because `timer_fuse::get_if_armed` locks the `weak_ptr` before
+// dereferencing the sequencer, so the sequencer is never accessed after the
+// transaction is destroyed.
+class sim_ws_transaction final: public http_websocket_transaction {
+public:
+  sim_ws_transaction(request_head&& req,
+      const std::shared_ptr<epoll_loop>& loop,
+      const std::shared_ptr<timing_wheel>& wheel)
+      : http_websocket_transaction{std::move(req)} {
+    websocket().on_message =
+        [this](http_websocket& ws, std::string&& msg, ws_frame_control) {
+          return do_message(ws, std::move(msg));
         };
+    websocket().on_close = [](http_websocket&, uint16_t, std::string_view) {
+      do_close();
+    };
+    // `enable_keepalive` stores weak_ptrs and sets `on_pong`; it always
+    // returns `true`, so voiding the result is safe here.
+    (void)enable_keepalive(loop, wheel, 20s, 5s);
+    std::cout << "WebSocket client connected\n";
+  }
 
-        return true;
-      });
-}
+  // Returns a `transaction_factory` for use with `http_server::add_route`.
+  [[nodiscard]] static transaction_factory make_factory(
+      std::shared_ptr<epoll_loop> loop, std::shared_ptr<timing_wheel> wheel) {
+    return [loop = std::move(loop), wheel = std::move(wheel)](
+               request_head&& req) -> transaction_ptr {
+      return std::make_shared<sim_ws_transaction>(std::move(req), loop, wheel);
+    };
+  }
+
+private:
+  using fuse_t = timer_fuse<http_transaction>;
+
+  std::atomic_uint64_t tick_seq_;
+
+  // Handle an incoming text frame. Detects `hello` by searching the raw JSON
+  // string (no parser needed for these fixed message shapes), replies with
+  // `hello_ack`, then arms the tick timer.
+  [[nodiscard]] bool do_message(http_websocket& ws, std::string&& msg) {
+    if (!msg.contains(R"("type":"hello")") &&
+        !msg.contains(R"("type": "hello")"))
+      return true;
+    if (!ws.send_text(R"({"type":"hello_ack","message":"connected"})"))
+      return false;
+    return do_arm_tick(1);
+  }
+
+  static void do_close() { std::cout << "WebSocket client disconnected\n"; }
+
+  // Schedule the next tick. Uses the `timer_fuse` double-check pattern:
+  // the wheel-thread callback pre-checks liveness and posts to the loop
+  // thread, which performs the definitive check and calls `do_tick_fire`.
+  [[nodiscard]] bool do_arm_tick(uint64_t tick_n) {
+    auto wheel = keepalive_wheel_.lock();
+    if (!wheel) return true;
+    return fuse_t::set_timeout(*wheel, tick_seq_,
+        std::weak_ptr<http_transaction>{shared_from_this()}, 1000ms,
+        [loop_w = keepalive_loop_, tick_n](const fuse_t& fuse) -> bool {
+          auto tx = fuse.get_if_armed();
+          auto loop = loop_w.lock();
+          if (!tx || !loop) return true;
+          return loop->post([fuse, tick_n]() -> bool {
+            auto tx = fuse.get_if_armed();
+            if (!tx) return true;
+            return std::static_pointer_cast<sim_ws_transaction>(tx)
+                ->do_tick_fire(tick_n);
+          });
+        });
+  }
+
+  // Called on the loop thread: send the tick message and re-arm for the next.
+  [[nodiscard]] bool do_tick_fire(uint64_t tick_n) {
+    if (websocket().is_close_started()) return true;
+    auto payload = std::format(R"({{"type":"tick","tick":{}}})", tick_n);
+    if (!websocket().send_text(payload)) return false;
+    return do_arm_tick(tick_n + 1);
+  }
+};
 
 }} // namespace corvid::proto

--- a/corvid/strings.h
+++ b/corvid/strings.h
@@ -31,6 +31,7 @@
 #include "strings/concat_join.h"
 #include "strings/enum_conversion.h"
 #include "strings/no_zero.h"
+#include "strings/any_strings.h"
 
 // Recommendation: While you can import the entire `corvid::strings` namespace,
 // you may not want to bring in all of these symbols, or you may wish to do so

--- a/corvid/strings/any_strings.h
+++ b/corvid/strings/any_strings.h
@@ -1,0 +1,56 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+#include <string>
+#include <variant>
+#include <vector>
+#include "strings_shared.h"
+
+namespace corvid::strings { inline namespace any_strings_types {
+
+// A single string, a vector of strings, or `std::monostate`.
+using any_strings =
+    std::variant<std::monostate, std::string, std::vector<std::string>>;
+
+// `make_string_vector`: Efficiently fill a vector with strings by moving them
+// in. If no parameters, returns an empty vector.
+template<typename... Strings>
+requires(std::same_as<Strings, std::string> && ...)
+[[nodiscard]] inline std::vector<std::string>
+make_string_vector(Strings&&... strings) {
+  auto result = std::vector<std::string>{};
+  result.reserve(sizeof...(Strings));
+  (result.emplace_back(std::move(strings)), ...);
+  return result;
+}
+
+// `make_any_strings`: Make an `any_strings` out of the parameters, moving them
+// in. If no parameters, returns `std::monostate`.
+template<typename... Strings>
+requires(std::same_as<Strings, std::string> && ...)
+[[nodiscard]] inline any_strings make_any_strings(Strings&&... strings) {
+  if constexpr (sizeof...(Strings) == 0) {
+    return std::monostate{};
+  } else if constexpr (sizeof...(Strings) == 1) {
+    return any_strings{std::in_place_type<std::string>, std::move(strings)...};
+  } else {
+    return any_strings{std::in_place_type<std::vector<std::string>>,
+        make_string_vector(std::move(strings)...)};
+  }
+}
+
+}} // namespace corvid::strings::any_strings_types

--- a/corvid/strings/any_strings.h
+++ b/corvid/strings/any_strings.h
@@ -26,30 +26,29 @@ namespace corvid::strings { inline namespace any_strings_types {
 using any_strings =
     std::variant<std::monostate, std::string, std::vector<std::string>>;
 
-// `make_string_vector`: Efficiently fill a vector with strings by moving them
+// `as_vector`: Efficiently fill a vector with strings by moving them
 // in. If no parameters, returns an empty vector.
 template<typename... Strings>
 requires(std::same_as<Strings, std::string> && ...)
-[[nodiscard]] inline std::vector<std::string>
-make_string_vector(Strings&&... strings) {
+[[nodiscard]] inline std::vector<std::string> as_vector(Strings&&... strings) {
   auto result = std::vector<std::string>{};
   result.reserve(sizeof...(Strings));
   (result.emplace_back(std::move(strings)), ...);
   return result;
 }
 
-// `make_any_strings`: Make an `any_strings` out of the parameters, moving them
+// `as_any`: Make an `any_strings` out of the parameters, moving them
 // in. If no parameters, returns `std::monostate`.
 template<typename... Strings>
 requires(std::same_as<Strings, std::string> && ...)
-[[nodiscard]] inline any_strings make_any_strings(Strings&&... strings) {
+[[nodiscard]] inline any_strings as_any(Strings&&... strings) {
   if constexpr (sizeof...(Strings) == 0) {
     return std::monostate{};
   } else if constexpr (sizeof...(Strings) == 1) {
     return any_strings{std::in_place_type<std::string>, std::move(strings)...};
   } else {
     return any_strings{std::in_place_type<std::vector<std::string>>,
-        make_string_vector(std::move(strings)...)};
+        as_vector(std::move(strings)...)};
   }
 }
 

--- a/corvid/strings/conversion.h
+++ b/corvid/strings/conversion.h
@@ -21,67 +21,6 @@
 
 namespace corvid::strings { inline namespace conversion {
 
-inline namespace cvt_fix_from_chars {
-
-#if __cpp_lib_to_chars < 202306L
-
-// Ugly workaround for the fact that `std::from_chars` is not available in
-// libstdc++. Does not honor `fmt`.
-template<typename T>
-std::from_chars_result std_from_chars(const char* first, const char* last,
-    T& value, std::chars_format fmt = std::chars_format::general) {
-  // Format isn't supported.
-  (void)fmt;
-
-  // Default to failure.
-  std::from_chars_result result{.ptr = first,
-      .ec = std::errc::invalid_argument};
-
-  // Sanity check.
-  static_assert(std::is_same_v<T, float> || std::is_same_v<T, double>,
-      "Unsupported type. Only float and double are supported.");
-  if (!first || !last || first >= last) return result;
-
-  // Copy into buffer and use that.
-  char buffer[128];
-  const std::string_view view(first, last);
-  const auto copied = std::min(view.size(), sizeof(buffer) - 1);
-  view.copy(buffer, copied);
-  buffer[copied] = '\0';
-
-  // Assume failure.
-  result.ec = std::errc::result_out_of_range;
-  char* endptr = buffer;
-  T parsed_value{};
-  errno = 0;
-
-  // Select the correct parsing function based on the type `T`.
-  if constexpr (std::is_same_v<T, float>) {
-    parsed_value = std::strtof(buffer, &endptr);
-  } else if constexpr (std::is_same_v<T, double>) {
-    parsed_value = std::strtod(buffer, &endptr);
-  }
-  if (errno == ERANGE) return result;
-
-  result.ptr = first + (endptr - buffer);
-  result.ec = {};
-  value = parsed_value;
-
-  return result;
-}
-#else
-
-// Passthrough for conforming implementations, such as gcc.
-template<typename T>
-std::from_chars_result std_from_chars(const char* first, const char* last,
-    T& value, std::chars_format fmt = std::chars_format::general) {
-  return std::from_chars(first, last, value, fmt);
-}
-
-#endif
-
-} // namespace cvt_fix_from_chars
-
 //
 // Numerical conversions
 //
@@ -209,7 +148,7 @@ template<std::chars_format fmt = std::chars_format::general>
 constexpr bool extract_num(std::floating_point auto& t, std::string_view& sv) {
   const auto save_sv = sv;
   sv = trim_left(sv);
-  auto [ptr, ec] = std_from_chars(sv.data(), sv.data() + sv.size(), t, fmt);
+  auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), t, fmt);
   sv.remove_prefix(ptr - sv.data());
   if (ec == std::errc{}) return true;
   sv = save_sv;

--- a/corvid/strings/token_parser.h
+++ b/corvid/strings/token_parser.h
@@ -59,6 +59,28 @@ public:
     return token;
   }
 
+  // Overload for `char` separator; skips empty-separator check and uses the
+  // `char` overload of `find` for efficiency.
+  [[nodiscard]] static std::string_view
+  next_delimited(char separator, std::string_view& text) {
+    // If no input, nothing to parse.
+    if (text.empty()) return {};
+
+    // If delimiter not found, consume the rest of the input.
+    const auto pos = text.find(separator);
+    if (pos == npos) {
+      const auto token = text;
+      text = {};
+      return token;
+    }
+
+    // Delimiter found; return the token before it and update input to after
+    // it.
+    const auto token = text.substr(0, pos);
+    text.remove_prefix(pos + 1);
+    return token;
+  }
+
   // See static method.
   [[nodiscard]] std::string_view next_delimited(std::string_view& text) const {
     return next_delimited(separator_, text);
@@ -84,6 +106,24 @@ public:
     // it.
     const auto token = text.substr(0, pos);
     text.remove_prefix(pos + separator.size());
+    return token;
+  }
+
+  // Overload for `char` separator; skips empty-separator check and uses the
+  // `char` overload of `find` for efficiency.
+  [[nodiscard]] static std::optional<std::string_view>
+  next_terminated(char separator, std::string_view& text) {
+    // If no input, nothing to parse.
+    if (text.empty()) return {};
+
+    // If terminator not found, fail.
+    const auto pos = text.find(separator);
+    if (pos == npos) return std::nullopt;
+
+    // Terminator found; return the token before it and update input to after
+    // it.
+    const auto token = text.substr(0, pos);
+    text.remove_prefix(pos + 1);
     return token;
   }
 

--- a/start_sim.sh
+++ b/start_sim.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Build and run the CorvidSim server.
+#
+# Safe to run from a fresh clone: installs npm dependencies, builds the
+# TypeScript frontend, compiles the C++ server with full optimizations, and
+# launches it on http://localhost:8080/.
+#
+# Subsequent runs skip unchanged work: cmake and npm only rebuild what has
+# changed. The C++ binary goes to tests/build_sim/ (separate from the main
+# test build directory) so this script does not disturb normal dev builds.
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$REPO_ROOT"
+
+# C++ build --------------------------------------------------------------
+
+export CC="/usr/bin/clang-22"
+export CXX="/usr/bin/clang++-22"
+
+BUILD_DIR="tests/build_sim"
+
+echo "--- Configuring C++ build ---"
+cmake -S tests -B "$BUILD_DIR" -G Ninja \
+    -DUSE_LIBSTDCPP=OFF \
+    -DTEST_NAME=corvid_sim.cpp \
+    --log-level=WARNING
+
+echo "--- Building corvid_sim ---"
+cmake --build "$BUILD_DIR" --config Release --target corvid_sim
+
+# Frontend build ---------------------------------------------------------
+
+WEB_DIR="corvid/sim/web"
+
+echo "--- Installing npm dependencies ---"
+npm --prefix "$WEB_DIR" install
+
+echo "--- Building frontend ---"
+npm --prefix "$WEB_DIR" run build
+
+# Launch -----------------------------------------------------------------
+
+BINARY="$BUILD_DIR/release_bin/corvid_sim"
+echo "--- Starting server ---"
+exec "$BINARY"

--- a/tests/corvid_sim.cpp
+++ b/tests/corvid_sim.cpp
@@ -1,0 +1,17 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "../corvid/sim/corvid_sim_main.h"

--- a/tests/ecs_test.cpp
+++ b/tests/ecs_test.cpp
@@ -2064,6 +2064,93 @@ void StableId_MaxId() {
   }
 }
 
+void EntityRegistry_ForEach() {
+  using namespace id_enums;
+  using reg_t = entity_registry<int>;
+  using id_t = reg_t::id_t;
+  using loc_t = reg_t::location_t;
+
+  const loc_t staging{store_id_t{}};
+  const loc_t in_store1{store_id_t{1}, 7U};
+  const loc_t in_store2{store_id_t{2}, 9U};
+
+  // for_each visits only live records in ID order and returns the visit count.
+  if (true) {
+    reg_t r;
+    auto id0 = r.create_id(staging, 10);
+    auto id1 = r.create_id(in_store1, 20);
+    auto id2 = r.create_id(in_store2, 30);
+    EXPECT_TRUE(r.erase(id1));
+
+    std::vector<id_t> ids;
+    std::vector<int> metadata;
+    auto cnt = r.for_each([&](auto id, const auto& rec) {
+      ids.push_back(id);
+      metadata.push_back(rec.metadata);
+      return true;
+    });
+
+    EXPECT_EQ(cnt, 2U);
+    EXPECT_EQ(ids.size(), 2U);
+    EXPECT_EQ(ids[0], id0);
+    EXPECT_EQ(ids[1], id2);
+    EXPECT_EQ(metadata[0], 10);
+    EXPECT_EQ(metadata[1], 30);
+  }
+
+  // Returning false stops iteration early; the stop record is still observed.
+  if (true) {
+    reg_t r;
+    auto id0 = r.create_id(staging, 10);
+    auto id1 = r.create_id(in_store1, 20);
+    auto id2 = r.create_id(in_store2, 30);
+
+    std::vector<id_t> ids;
+    auto cnt = r.for_each([&](auto id, const auto& rec) {
+      ids.push_back(id);
+      EXPECT_TRUE(rec.location.contains(
+          id == id0 ? store_id_t{} : id == id1 ? store_id_t{1} : store_id_t{2}));
+      return id != id1;
+    });
+
+    EXPECT_EQ(cnt, 1U);
+    EXPECT_EQ(ids.size(), 2U);
+    EXPECT_EQ(ids[0], id0);
+    EXPECT_EQ(ids[1], id1);
+    EXPECT_NE(ids[1], id2);
+  }
+
+  // for_each on a const registry yields const records and visits all live IDs.
+  if (true) {
+    reg_t r;
+    auto id0 = r.create_id(in_store1, 10);
+    auto id1 = r.create_id(staging, 20);
+    const reg_t& cr = r;
+
+    int sum = 0;
+    auto cnt = cr.for_each([&](auto id, const auto& rec) {
+      static_assert(std::is_const_v<std::remove_reference_t<decltype(rec)>>);
+      sum += rec.metadata;
+      EXPECT_TRUE(rec.location.contains(id == id0 ? store_id_t{1} : store_id_t{}));
+      EXPECT_TRUE(id == id0 || id == id1);
+      return true;
+    });
+
+    EXPECT_EQ(cnt, 2U);
+    EXPECT_EQ(sum, 30);
+  }
+
+  // Empty registry: callback is never called.
+  if (true) {
+    reg_t r;
+    auto cnt = r.for_each([&](auto, const auto&) {
+      EXPECT_TRUE(false);
+      return true;
+    });
+    EXPECT_EQ(cnt, 0U);
+  }
+}
+
 void MonoArchetypeStorage_Basic() {
   using namespace id_enums;
   using reg_t = entity_registry<int>;
@@ -7634,6 +7721,7 @@ MAKE_TEST_LIST(ArchetypeStorage_Basic, ArchetypeStorage_Registry,
     ChunkedArchetypeStorage_RemoveIf, ChunkedArchetypeStorage_SwapAndMove,
     StableId_Basic, StableId_SmallId, StableId_NoThrow, StableId_Fifo,
     StableId_NoGen, StableId_FifoNoGen, StableId_MaxId,
+    EntityRegistry_ForEach,
     StableId_ReservePrefill, MonoArchetypeStorage_Basic,
     MonoArchetypeStorage_Handle, MonoArchetypeStorage_Remove,
     MonoArchetypeStorage_RemoveAll, MonoArchetypeStorage_Erase,

--- a/tests/ecs_test.cpp
+++ b/tests/ecs_test.cpp
@@ -6277,6 +6277,77 @@ void ArchetypeScene_ForEach() {
   }
 }
 
+void ArchetypeScene_TryGetComponent() {
+  // Returns non-null for a component the entity's archetype has.
+  if (true) {
+    three_storage_scene_t s;
+    auto h =
+        s.store_new_entity<scene_sid_t{1}>({}, Position{3.f, 0.f}, Velocity{});
+    auto* pos = s.try_get_component<Position>(h.id());
+    ASSERT_TRUE(pos != nullptr);
+    EXPECT_EQ(pos->x, 3.f);
+  }
+
+  // Returns null for a component the entity's archetype lacks.
+  if (true) {
+    three_storage_scene_t s;
+    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{}, Velocity{});
+    EXPECT_TRUE(s.try_get_component<Health>(h.id()) == nullptr);
+  }
+
+  // Works across all three storage archetypes.
+  if (true) {
+    three_storage_scene_t s;
+    auto h1 =
+        s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 0.f}, Velocity{});
+    auto h2 = s.store_new_entity<scene_sid_t{2}>({}, Position{2.f, 0.f},
+        Velocity{}, Health{});
+    auto h3 = s.store_new_entity<scene_sid_t{3}>({}, Health{99});
+
+    // arch_pv_t: Position yes, Health no.
+    EXPECT_TRUE(s.try_get_component<Position>(h1.id()) != nullptr);
+    EXPECT_TRUE(s.try_get_component<Health>(h1.id()) == nullptr);
+
+    // arch_pvh_t: Position yes, Health yes.
+    EXPECT_TRUE(s.try_get_component<Position>(h2.id()) != nullptr);
+    EXPECT_TRUE(s.try_get_component<Health>(h2.id()) != nullptr);
+    EXPECT_EQ(s.try_get_component<Health>(h2.id())->hp, 100);
+
+    // arch_h_t: Health yes, Velocity no.
+    EXPECT_EQ(s.try_get_component<Health>(h3.id())->hp, 99);
+    EXPECT_TRUE(s.try_get_component<Velocity>(h3.id()) == nullptr);
+  }
+
+  // Returns null for an invalid entity ID.
+  if (true) {
+    three_storage_scene_t s;
+    EXPECT_TRUE(
+        s.try_get_component<Position>(scene_reg_t::id_t::invalid) == nullptr);
+  }
+
+  // On a const scene returns `const C*`; pointer is still non-null and
+  // readable.
+  if (true) {
+    three_storage_scene_t s;
+    auto h =
+        s.store_new_entity<scene_sid_t{1}>({}, Position{7.f, 0.f}, Velocity{});
+    const auto& cs = s;
+    const Position* pos = cs.try_get_component<Position>(h.id());
+    ASSERT_TRUE(pos != nullptr);
+    EXPECT_EQ(pos->x, 7.f);
+  }
+
+  // Mutation through the returned pointer is reflected in the stored data.
+  if (true) {
+    three_storage_scene_t s;
+    auto h =
+        s.store_new_entity<scene_sid_t{1}>({}, Position{0.f, 0.f}, Velocity{});
+    s.try_get_component<Position>(h.id())->x = 42.f;
+    EXPECT_EQ(s.storage<scene_sid_t{1}>()[h.id()].component<Position>().x,
+        42.f);
+  }
+}
+
 void ComponentScene_StageNewEntity() {
   // stage_new_entity() creates a staged entity and returns its handle.
   if (true) {
@@ -7501,8 +7572,9 @@ MAKE_TEST_LIST(ArchetypeStorage_Basic, ArchetypeStorage_Registry,
     ArchetypeScene_StorageTypeAccess, ArchetypeScene_CreateHandleId,
     ArchetypeScene_AddNewRuntime, ArchetypeScene_StoreEntity,
     ArchetypeScene_EntityLifecycle, ArchetypeScene_MigrateEdgeCases,
-    ArchetypeScene_ForEach, ComponentIndex_Flat, ComponentIndex_Sorted,
-    ComponentIndex_Paged, ComponentStorage_Basic, ComponentStorage_MultiStore,
+    ArchetypeScene_ForEach, ArchetypeScene_TryGetComponent,
+    ComponentIndex_Flat, ComponentIndex_Sorted, ComponentIndex_Paged,
+    ComponentStorage_Basic, ComponentStorage_MultiStore,
     ComponentStorage_Remove, ComponentStorage_Erase, ComponentStorage_EraseIf,
     ComponentStorage_Iterator, ComponentStorage_IndexVariants,
     ComponentStorage_AddNew, ComponentStorage_SwapMoveReserve,

--- a/tests/ecs_test.cpp
+++ b/tests/ecs_test.cpp
@@ -2115,7 +2115,7 @@ void EntityRegistry_ForEach() {
       return id != id1;
     });
 
-    EXPECT_EQ(cnt, 1U);
+    EXPECT_EQ(cnt, 2U);
     EXPECT_EQ(ids.size(), 2U);
     EXPECT_EQ(ids[0], id0);
     EXPECT_EQ(ids[1], id1);

--- a/tests/ecs_test.cpp
+++ b/tests/ecs_test.cpp
@@ -6348,6 +6348,81 @@ void ArchetypeScene_TryGetComponent() {
   }
 }
 
+void ArchetypeScene_TryGetComponents() {
+  // Returns non-null pointers for all requested components when the archetype
+  // contains them.
+  if (true) {
+    three_storage_scene_t s;
+    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{2.f, 3.f},
+        Velocity{4.f, 5.f}, Health{77});
+    auto [pos, vel, hp] =
+        s.try_get_components<Position, Velocity, Health>(h.id());
+    ASSERT_TRUE(pos != nullptr);
+    ASSERT_TRUE(vel != nullptr);
+    ASSERT_TRUE(hp != nullptr);
+    EXPECT_EQ(pos->x, 2.f);
+    EXPECT_EQ(vel->vx, 4.f);
+    EXPECT_EQ(hp->hp, 77);
+  }
+
+  // Returns all null pointers when any requested component is missing from
+  // the entity's archetype.
+  if (true) {
+    three_storage_scene_t s;
+    auto h =
+        s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 0.f}, Velocity{});
+    auto [pos, hp] = s.try_get_components<Position, Health>(h.id());
+    EXPECT_TRUE(pos == nullptr);
+    EXPECT_TRUE(hp == nullptr);
+  }
+
+  // Returns all null pointers for a staged entity and for an invalid ID.
+  if (true) {
+    three_storage_scene_t s;
+    auto staged = s.stage_new_entity().id();
+    auto [staged_pos, staged_vel] =
+        s.try_get_components<Position, Velocity>(staged);
+    EXPECT_TRUE(staged_pos == nullptr);
+    EXPECT_TRUE(staged_vel == nullptr);
+
+    auto [bad_pos, bad_vel] =
+        s.try_get_components<Position, Velocity>(scene_reg_t::id_t::invalid);
+    EXPECT_TRUE(bad_pos == nullptr);
+    EXPECT_TRUE(bad_vel == nullptr);
+  }
+
+  // On a const scene returns const-qualified pointers.
+  if (true) {
+    three_storage_scene_t s;
+    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{7.f, 8.f},
+        Velocity{9.f, 10.f}, Health{});
+    const auto& cs = s;
+    auto [pos, vel] = cs.try_get_components<Position, Velocity>(h.id());
+    static_assert(std::is_same_v<decltype(pos), const Position*>);
+    static_assert(std::is_same_v<decltype(vel), const Velocity*>);
+    ASSERT_TRUE(pos != nullptr);
+    ASSERT_TRUE(vel != nullptr);
+    EXPECT_EQ(pos->x, 7.f);
+    EXPECT_EQ(vel->vx, 9.f);
+  }
+
+  // Mutation through returned pointers updates stored data.
+  if (true) {
+    three_storage_scene_t s;
+    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{0.f, 0.f},
+        Velocity{1.f, 2.f}, Health{});
+    auto [pos, vel] = s.try_get_components<Position, Velocity>(h.id());
+    ASSERT_TRUE(pos != nullptr);
+    ASSERT_TRUE(vel != nullptr);
+    pos->x = 42.f;
+    vel->vx = 24.f;
+    EXPECT_EQ(s.storage<scene_sid_t{2}>()[h.id()].component<Position>().x,
+        42.f);
+    EXPECT_EQ(s.storage<scene_sid_t{2}>()[h.id()].component<Velocity>().vx,
+        24.f);
+  }
+}
+
 void ComponentScene_StageNewEntity() {
   // stage_new_entity() creates a staged entity and returns its handle.
   if (true) {
@@ -7573,9 +7648,10 @@ MAKE_TEST_LIST(ArchetypeStorage_Basic, ArchetypeStorage_Registry,
     ArchetypeScene_AddNewRuntime, ArchetypeScene_StoreEntity,
     ArchetypeScene_EntityLifecycle, ArchetypeScene_MigrateEdgeCases,
     ArchetypeScene_ForEach, ArchetypeScene_TryGetComponent,
-    ComponentIndex_Flat, ComponentIndex_Sorted, ComponentIndex_Paged,
-    ComponentStorage_Basic, ComponentStorage_MultiStore,
-    ComponentStorage_Remove, ComponentStorage_Erase, ComponentStorage_EraseIf,
+    ArchetypeScene_TryGetComponents, ComponentIndex_Flat,
+    ComponentIndex_Sorted, ComponentIndex_Paged, ComponentStorage_Basic,
+    ComponentStorage_MultiStore, ComponentStorage_Remove,
+    ComponentStorage_Erase, ComponentStorage_EraseIf,
     ComponentStorage_Iterator, ComponentStorage_IndexVariants,
     ComponentStorage_AddNew, ComponentStorage_SwapMoveReserve,
     ComponentStorage_At, ComponentScene_Basic, ComponentScene_StoreEntity,

--- a/tests/ecs_test.cpp
+++ b/tests/ecs_test.cpp
@@ -2109,7 +2109,9 @@ void EntityRegistry_ForEach() {
     auto cnt = r.for_each([&](auto id, const auto& rec) {
       ids.push_back(id);
       EXPECT_TRUE(rec.location.contains(
-          id == id0 ? store_id_t{} : id == id1 ? store_id_t{1} : store_id_t{2}));
+          id == id0   ? store_id_t{}
+          : id == id1 ? store_id_t{1}
+                      : store_id_t{2}));
       return id != id1;
     });
 
@@ -2131,7 +2133,8 @@ void EntityRegistry_ForEach() {
     auto cnt = cr.for_each([&](auto id, const auto& rec) {
       static_assert(std::is_const_v<std::remove_reference_t<decltype(rec)>>);
       sum += rec.metadata;
-      EXPECT_TRUE(rec.location.contains(id == id0 ? store_id_t{1} : store_id_t{}));
+      EXPECT_TRUE(
+          rec.location.contains(id == id0 ? store_id_t{1} : store_id_t{}));
       EXPECT_TRUE(id == id0 || id == id1);
       return true;
     });
@@ -7720,8 +7723,7 @@ MAKE_TEST_LIST(ArchetypeStorage_Basic, ArchetypeStorage_Registry,
     ChunkedArchetypeStorage_ChunkBoundary, ChunkedArchetypeStorage_At,
     ChunkedArchetypeStorage_RemoveIf, ChunkedArchetypeStorage_SwapAndMove,
     StableId_Basic, StableId_SmallId, StableId_NoThrow, StableId_Fifo,
-    StableId_NoGen, StableId_FifoNoGen, StableId_MaxId,
-    EntityRegistry_ForEach,
+    StableId_NoGen, StableId_FifoNoGen, StableId_MaxId, EntityRegistry_ForEach,
     StableId_ReservePrefill, MonoArchetypeStorage_Basic,
     MonoArchetypeStorage_Handle, MonoArchetypeStorage_Remove,
     MonoArchetypeStorage_RemoveAll, MonoArchetypeStorage_Erase,

--- a/tests/filesys_test.cpp
+++ b/tests/filesys_test.cpp
@@ -736,8 +736,8 @@ void NetSocket_FactoryMethods() {
   // create_ipv4 with blocking + datagram gives a blocking UDP socket.
   if (true) {
     if (!is_codex()) {
-      auto s =
-          net_socket::create_ipv4(execution::blocking, message_style::datagram);
+      auto s = net_socket::create_ipv4(execution::blocking,
+          message_style::datagram);
       EXPECT_TRUE(s.is_open());
       EXPECT_FALSE(s.get_flags().value_or(0) & O_NONBLOCK);
       auto dom = s.get_option<int>(SOL_SOCKET, SO_DOMAIN);

--- a/tests/filesys_test.cpp
+++ b/tests/filesys_test.cpp
@@ -23,12 +23,19 @@
 #include "../corvid/proto/net_endpoint.h"
 #include "minitest.h"
 
+#include <cstdlib>
 #include <fcntl.h>
+#include <string_view>
 #include <unistd.h>
 #include <system_error>
 #include <sys/socket.h>
 
 using namespace corvid;
+
+bool is_codex() {
+  const char* value = std::getenv("CODEX_SANDBOX_NETWORK_DISABLED");
+  return value && std::string_view{value} == "1";
+}
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 // NOLINTBEGIN(bugprone-unchecked-optional-access)
@@ -166,6 +173,8 @@ void OsFile_WriteRead() {
 }
 
 void NetSocket_Lifecycle() {
+  if (is_codex()) return;
+
   // Default-constructed socket is invalid.
   if (true) {
     net_socket s;
@@ -513,6 +522,8 @@ void EventFd_NonblockingEmptyRead() {
 }
 
 void NetSocket_Move() {
+  if (is_codex()) return;
+
   // Move constructor transfers ownership; source becomes invalid.
   if (true) {
     net_socket a{AF_INET, SOCK_STREAM, 0};
@@ -548,6 +559,8 @@ void NetSocket_Move() {
 }
 
 void NetSocket_Release() {
+  if (is_codex()) return;
+
   // `release()` yields the handle without closing it; socket becomes invalid.
   if (true) {
     net_socket s{AF_INET, SOCK_STREAM, 0};
@@ -559,6 +572,8 @@ void NetSocket_Release() {
 }
 
 void NetSocket_Options() {
+  if (is_codex()) return;
+
   // Named option helpers round-trip through `get_option`.
   if (true) {
     net_socket s{AF_INET, SOCK_STREAM, 0};
@@ -593,6 +608,8 @@ void NetSocket_Options() {
 }
 
 void NetSocket_Nonblocking() {
+  if (is_codex()) return;
+
   if (true) {
     net_socket s{AF_INET, SOCK_STREAM, 0};
 
@@ -665,6 +682,8 @@ void NetSocket_RecvAtContract() {
 }
 
 void NetSocket_BindListenAccept() {
+  if (is_codex()) return;
+
   // Bind a listening socket to a free loopback port.
   net_socket listener{AF_INET, SOCK_STREAM, 0};
   EXPECT_TRUE(listener.is_open());
@@ -701,41 +720,47 @@ void NetSocket_FactoryMethods() {
 
   // create_ipv4 defaults to non-blocking TCP.
   if (true) {
-    auto s = net_socket::create_ipv4();
-    EXPECT_TRUE(s.is_open());
-    EXPECT_TRUE(s.get_flags().value_or(0) & O_NONBLOCK);
-    auto dom = s.get_option<int>(SOL_SOCKET, SO_DOMAIN);
-    EXPECT_TRUE(dom.has_value());
-    EXPECT_EQ(*dom, AF_INET);
-    auto type = s.get_option<int>(SOL_SOCKET, SO_TYPE);
-    EXPECT_TRUE(type.has_value());
-    EXPECT_EQ(*type, SOCK_STREAM);
+    if (!is_codex()) {
+      auto s = net_socket::create_ipv4();
+      EXPECT_TRUE(s.is_open());
+      EXPECT_TRUE(s.get_flags().value_or(0) & O_NONBLOCK);
+      auto dom = s.get_option<int>(SOL_SOCKET, SO_DOMAIN);
+      EXPECT_TRUE(dom.has_value());
+      EXPECT_EQ(*dom, AF_INET);
+      auto type = s.get_option<int>(SOL_SOCKET, SO_TYPE);
+      EXPECT_TRUE(type.has_value());
+      EXPECT_EQ(*type, SOCK_STREAM);
+    }
   }
 
   // create_ipv4 with blocking + datagram gives a blocking UDP socket.
   if (true) {
-    auto s =
-        net_socket::create_ipv4(execution::blocking, message_style::datagram);
-    EXPECT_TRUE(s.is_open());
-    EXPECT_FALSE(s.get_flags().value_or(0) & O_NONBLOCK);
-    auto dom = s.get_option<int>(SOL_SOCKET, SO_DOMAIN);
-    EXPECT_EQ(*dom, AF_INET);
-    auto type = s.get_option<int>(SOL_SOCKET, SO_TYPE);
-    EXPECT_TRUE(type.has_value());
-    EXPECT_EQ(*type, SOCK_DGRAM);
+    if (!is_codex()) {
+      auto s =
+          net_socket::create_ipv4(execution::blocking, message_style::datagram);
+      EXPECT_TRUE(s.is_open());
+      EXPECT_FALSE(s.get_flags().value_or(0) & O_NONBLOCK);
+      auto dom = s.get_option<int>(SOL_SOCKET, SO_DOMAIN);
+      EXPECT_EQ(*dom, AF_INET);
+      auto type = s.get_option<int>(SOL_SOCKET, SO_TYPE);
+      EXPECT_TRUE(type.has_value());
+      EXPECT_EQ(*type, SOCK_DGRAM);
+    }
   }
 
   // create_ipv6 defaults to non-blocking TCP.
   if (true) {
-    auto s = net_socket::create_ipv6();
-    EXPECT_TRUE(s.is_open());
-    EXPECT_TRUE(s.get_flags().value_or(0) & O_NONBLOCK);
-    auto dom = s.get_option<int>(SOL_SOCKET, SO_DOMAIN);
-    EXPECT_TRUE(dom.has_value());
-    EXPECT_EQ(*dom, AF_INET6);
-    auto type = s.get_option<int>(SOL_SOCKET, SO_TYPE);
-    EXPECT_TRUE(type.has_value());
-    EXPECT_EQ(*type, SOCK_STREAM);
+    if (!is_codex()) {
+      auto s = net_socket::create_ipv6();
+      EXPECT_TRUE(s.is_open());
+      EXPECT_TRUE(s.get_flags().value_or(0) & O_NONBLOCK);
+      auto dom = s.get_option<int>(SOL_SOCKET, SO_DOMAIN);
+      EXPECT_TRUE(dom.has_value());
+      EXPECT_EQ(*dom, AF_INET6);
+      auto type = s.get_option<int>(SOL_SOCKET, SO_TYPE);
+      EXPECT_TRUE(type.has_value());
+      EXPECT_EQ(*type, SOCK_STREAM);
+    }
   }
 
   // create_uds defaults to non-blocking stream.

--- a/tests/json_parser_test.cpp
+++ b/tests/json_parser_test.cpp
@@ -23,7 +23,7 @@
 #include "minitest.h"
 
 using namespace corvid;
-
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 void JsonParser_ParseScalarsAndKinds() {
   json_value_view value;
 
@@ -145,8 +145,8 @@ void JsonWriter_FormatsFloatsAndRoundTrips() {
 
   {
     auto root = writer.object();
-    root->member("x", 20.0f, std::chars_format::fixed, 1)
-        .member("scale", 2.0f, std::chars_format::fixed, 3);
+    root->member("x", 20.0F, std::chars_format::fixed, 1)
+        .member("scale", 2.0F, std::chars_format::fixed, 3);
     {
       auto items = root->member_array("items");
       items->value(1).value("two");
@@ -234,3 +234,4 @@ MAKE_TEST_LIST(JsonParser_ParseScalarsAndKinds,
     JsonParser_RejectsInvalidJson, JsonParser_RespectsDepthLimit,
     JsonWriter_EscapesAndTrustedStrings, JsonWriter_FormatsFloatsAndRoundTrips,
     JsonWriter_WritesToOstreamTargets, JsonWriter_ScopedContainersAutoClose);
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/json_parser_test.cpp
+++ b/tests/json_parser_test.cpp
@@ -1,0 +1,236 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../corvid/proto.h"
+
+#include <sstream>
+#include <string>
+
+#include "minitest.h"
+
+using namespace corvid;
+
+void JsonParser_ParseScalarsAndKinds() {
+  json_value_view value;
+
+  ASSERT_TRUE(parse_json("null", value));
+  EXPECT_TRUE(value.is_null());
+
+  ASSERT_TRUE(parse_json(" true ", value));
+  ASSERT_TRUE(value.is_bool());
+  const auto bool_value = value.as_bool();
+  ASSERT_TRUE(bool_value.has_value());
+  EXPECT_TRUE(*bool_value);
+
+  ASSERT_TRUE(parse_json("-12.5e2", value));
+  ASSERT_TRUE(value.is_number());
+  const auto number_value = value.as_number<double>();
+  ASSERT_TRUE(number_value.has_value());
+  EXPECT_NEAR(*number_value, -1250.0, 1e-6);
+
+  ASSERT_TRUE(parse_json(R"("plain")", value));
+  ASSERT_TRUE(value.is_string());
+  const auto plain_value = value.string_view_if_plain();
+  ASSERT_TRUE(plain_value.has_value());
+  EXPECT_EQ(*plain_value, std::string_view{"plain"});
+}
+
+void JsonParser_ParseNestedViewsAndLookup() {
+  json_value_view root;
+  ASSERT_TRUE(parse_json(
+      R"({"a\/b":[1,{"nested":false}],"plain":"value","count":2})", root));
+
+  const auto obj = root.as_object();
+  ASSERT_TRUE(obj);
+
+  const auto plain = obj.get_string_view_if_plain("plain");
+  ASSERT_TRUE(plain.has_value());
+  EXPECT_EQ(*plain, std::string_view{"value"});
+  const auto count_value = obj.get_number<int>("count");
+  ASSERT_TRUE(count_value.has_value());
+  EXPECT_EQ(*count_value, 2);
+
+  const auto arr = obj.get_array("a/b");
+  ASSERT_TRUE(arr);
+
+  size_t count = 0;
+  for (const auto item : arr) {
+    if (count == 0) {
+      const auto item_value = item.as_number<int>();
+      ASSERT_TRUE(item_value.has_value());
+      EXPECT_EQ(*item_value, 1);
+    } else {
+      const auto nested = item.as_object();
+      ASSERT_TRUE(nested);
+      const auto nested_value = nested.get_bool("nested");
+      ASSERT_TRUE(nested_value.has_value());
+      EXPECT_FALSE(*nested_value);
+    }
+    ++count;
+  }
+  EXPECT_EQ(count, 2U);
+}
+
+void JsonParser_DecodesEscapesAndUnicode() {
+  json_value_view value;
+  ASSERT_TRUE(parse_json(R"("line\nA\uD83D\uDE00")", value));
+
+  EXPECT_FALSE(value.string_view_if_plain().has_value());
+
+  std::string decoded;
+  ASSERT_TRUE(value.decode_string(decoded));
+  std::string expected = "line\nA";
+  expected += "\xF0\x9F\x98\x80";
+  EXPECT_EQ(decoded, expected);
+}
+
+void JsonParser_RejectsInvalidJson() {
+  json_value_view value;
+  json_error err;
+
+  EXPECT_FALSE(parse_json("01", value, &err));
+  EXPECT_EQ(err.code, json_errc::invalid_number);
+
+  EXPECT_FALSE(parse_json("1.", value, &err));
+  EXPECT_EQ(err.code, json_errc::invalid_number);
+
+  EXPECT_FALSE(parse_json(R"({"a":1,})", value, &err));
+  EXPECT_EQ(err.code, json_errc::expected_key);
+
+  EXPECT_FALSE(parse_json("true false", value, &err));
+  EXPECT_EQ(err.code, json_errc::trailing_data);
+
+  EXPECT_FALSE(parse_json("NaN", value, &err));
+  EXPECT_EQ(err.code, json_errc::invalid_token);
+}
+
+void JsonParser_RespectsDepthLimit() {
+  json_value_view value;
+  json_error err;
+
+  EXPECT_FALSE(parse_json("[[[0]]]", value, &err, {.max_depth = 2}));
+  EXPECT_EQ(err.code, json_errc::depth_exceeded);
+}
+
+void JsonWriter_EscapesAndTrustedStrings() {
+  std::string out;
+  json_writer writer{out};
+
+  {
+    auto root = writer.object();
+    root->member("escaped", "a/b")
+        .member(json_trusted{"trusted"}, json_trusted{"a/b"});
+  }
+
+  EXPECT_EQ(out, R"({"escaped":"a\/b","trusted":"a/b"})");
+}
+
+void JsonWriter_FormatsFloatsAndRoundTrips() {
+  std::string out;
+  json_writer writer{out};
+
+  {
+    auto root = writer.object();
+    root->member("x", 20.0f, std::chars_format::fixed, 1)
+        .member("scale", 2.0f, std::chars_format::fixed, 3);
+    {
+      auto items = root->member_array("items");
+      items->value(1).value("two");
+      {
+        auto item = items->object();
+        item->member("ok", true);
+      }
+    }
+  }
+
+  EXPECT_EQ(out, R"({"x":20.0,"scale":2.000,"items":[1,"two",{"ok":true}]})");
+
+  json_value_view root;
+  ASSERT_TRUE(parse_json(out, root));
+  const auto obj = root.as_object();
+  ASSERT_TRUE(obj);
+  const auto x = obj.get_number<float>("x");
+  const auto scale = obj.get_number<float>("scale");
+  ASSERT_TRUE(x.has_value());
+  ASSERT_TRUE(scale.has_value());
+  EXPECT_NEAR(*x, 20.0, 1e-6);
+  EXPECT_NEAR(*scale, 2.0, 1e-6);
+
+  const auto items = obj.get_array("items");
+  ASSERT_TRUE(items);
+  size_t count = 0;
+  for (const auto item : items) {
+    if (count == 2) {
+      const auto nested = item.as_object();
+      ASSERT_TRUE(nested);
+      const auto ok = nested.get_bool("ok");
+      ASSERT_TRUE(ok.has_value());
+      EXPECT_TRUE(*ok);
+    }
+    ++count;
+  }
+  EXPECT_EQ(count, 3U);
+}
+
+void JsonWriter_WritesToOstreamTargets() {
+  std::ostringstream out;
+  json_writer writer{out};
+
+  {
+    auto root = writer.object();
+    root->member("ok", true);
+
+    auto items = root->member_array("items");
+    items->value(nullptr).value(json_trusted{"raw"});
+  }
+
+  EXPECT_EQ(out.str(), R"({"ok":true,"items":[null,"raw"]})");
+}
+
+void JsonWriter_ScopedContainersAutoClose() {
+  std::string out;
+  json_writer writer{out};
+
+  {
+    auto root = writer.object();
+    root->member("kind", "demo");
+
+    {
+      auto meta = root->member_object("meta");
+      meta->member("ok", true);
+    }
+
+    {
+      auto items = root->member_array("items");
+      items->value(1);
+
+      {
+        auto item = items->object();
+        item->member("name", "two");
+      }
+    }
+  }
+
+  EXPECT_EQ(out,
+      R"({"kind":"demo","meta":{"ok":true},"items":[1,{"name":"two"}]})");
+}
+
+MAKE_TEST_LIST(JsonParser_ParseScalarsAndKinds,
+    JsonParser_ParseNestedViewsAndLookup, JsonParser_DecodesEscapesAndUnicode,
+    JsonParser_RejectsInvalidJson, JsonParser_RespectsDepthLimit,
+    JsonWriter_EscapesAndTrustedStrings, JsonWriter_FormatsFloatsAndRoundTrips,
+    JsonWriter_WritesToOstreamTargets, JsonWriter_ScopedContainersAutoClose);

--- a/tests/proto_http_test.cpp
+++ b/tests/proto_http_test.cpp
@@ -426,21 +426,22 @@ struct padded_page_transaction: public http_transaction {
   explicit padded_page_transaction(request_head&& req)
       : http_transaction{std::move(req)} {}
 
-  [[nodiscard]] stream_claim handle_drain(const send_fn& send) override {
+  [[nodiscard]] stream_claim handle_drain(const send_fn& send_cb) override {
     const auto& req = request_headers;
 
     if (req.method != http_method::GET) {
       close_after = after_response::close;
-      (void)send(response_head::make_error_response(close_after, req.version,
-          http_status_code::METHOD_NOT_ALLOWED, "Method Not Allowed"));
+      (void)send_cb(response_head::make_error_response(close_after,
+          req.version, http_status_code::METHOD_NOT_ALLOWED,
+          "Method Not Allowed"));
       return stream_claim::release;
     }
 
     const size_t pad_count = parse_pad_count(req.target);
     if (pad_count > max_pad) {
       close_after = after_response::close;
-      (void)send(response_head::make_error_response(close_after, req.version,
-          http_status_code::BAD_REQUEST, "Bad Request"));
+      (void)send_cb(response_head::make_error_response(close_after,
+          req.version, http_status_code::BAD_REQUEST, "Bad Request"));
       return stream_claim::release;
     }
 
@@ -452,7 +453,7 @@ struct padded_page_transaction: public http_transaction {
     body += "</body></html>";
 
     if (req.version == http_version::http_0_9) {
-      (void)send(std::move(body));
+      (void)send_cb(std::move(body));
       return stream_claim::release;
     }
 
@@ -463,8 +464,8 @@ struct padded_page_transaction: public http_transaction {
     response_headers.options.content_length = body.size();
     response_headers.options.connection = close_after;
 
-    (void)send(response_headers.serialize());
-    (void)send(std::move(body));
+    (void)send_cb(response_headers.serialize());
+    (void)send_cb(std::move(body));
     return stream_claim::release;
   }
 
@@ -486,11 +487,13 @@ private:
     http_server::timing_wheel_ptr wheel = nullptr,
     http_server::duration_t request_timeout = 30s,
     http_server::duration_t write_timeout = 5s) {
-  return http_server::create(endpoint,
+  return http_server::create(
+      endpoint,
       [](http_server& s) {
-        return s.add_route({"", "/"}, [](request_head&& req) -> transaction_ptr {
-          return std::make_shared<padded_page_transaction>(std::move(req));
-        });
+        return s.add_route({"", "/"},
+            [](request_head&& req) -> transaction_ptr {
+              return std::make_shared<padded_page_transaction>(std::move(req));
+            });
       },
       std::move(loop), std::move(wheel), request_timeout, write_timeout);
 }
@@ -1795,7 +1798,7 @@ void WebSocket_FrameCodec_RoundTrip() {
 void WebSocket_Feed_SingleText() {
   std::string got_msg;
   ws_frame_control got_op{};
-  http_websocket ws{[](std::string&&) { return true; },
+  http_websocket ws{[](any_strings&&) { return true; },
       connection_role::client};
   ws.on_message = [&](http_websocket&, std::string&& p, ws_frame_control op) {
     got_msg = std::move(p);
@@ -1814,8 +1817,8 @@ void WebSocket_Feed_SingleText() {
 // Invalid UTF-8 in a text frame fails the connection with close code 1007.
 void WebSocket_Feed_SingleTextInvalidUtf8() {
   std::string sent_frame;
-  http_websocket ws{[&](std::string&& f) {
-    sent_frame = std::move(f);
+  http_websocket ws{[&](any_strings&& f) {
+    sent_frame = std::get<std::string>(std::move(f));
     return true;
   }};
   bool msg_fired{};
@@ -1848,7 +1851,7 @@ void WebSocket_Feed_SingleTextInvalidUtf8Disabled() {
   std::string got_msg;
   ws_frame_control got_op{};
   bool msg_fired{};
-  http_websocket ws{[](std::string&&) { return true; }};
+  http_websocket ws{[](any_strings&&) { return true; }};
   ws.validate_utf8 = false;
   ws.on_message = [&](http_websocket&, std::string&& p, ws_frame_control op) {
     got_msg = std::move(p);
@@ -1870,7 +1873,7 @@ void WebSocket_Feed_SingleTextInvalidUtf8Disabled() {
 void WebSocket_Feed_MaskedBinary() {
   std::string got_msg;
   ws_frame_control got_op{};
-  http_websocket ws{[](std::string&&) { return true; }};
+  http_websocket ws{[](any_strings&&) { return true; }};
   ws.on_message = [&](http_websocket&, std::string&& p, ws_frame_control op) {
     got_msg = std::move(p);
     got_op = op;
@@ -1890,8 +1893,8 @@ void WebSocket_Feed_MaskedBinary() {
 void WebSocket_Feed_Ping() {
   std::string sent_frame;
   bool msg_fired{};
-  http_websocket ws_server{[&](std::string&& f) {
-    sent_frame = std::move(f);
+  http_websocket ws_server{[&](any_strings&& f) {
+    sent_frame = std::get<std::string>(std::move(f));
     return true;
   }};
   ws_server.on_message =
@@ -1901,8 +1904,8 @@ void WebSocket_Feed_Ping() {
       };
   std::string received_frame;
   http_websocket ws_client{
-      [&](std::string&& frame) {
-        received_frame = std::move(frame);
+      [&](any_strings&& frame) {
+        received_frame = std::get<std::string>(std::move(frame));
         return true;
       },
       connection_role::client};
@@ -1928,7 +1931,7 @@ void WebSocket_Feed_Ping() {
 void WebSocket_Feed_Close() {
   uint16_t got_code{};
   std::string got_reason;
-  http_websocket ws_server{[](std::string&&) { return true; }};
+  http_websocket ws_server{[](any_strings&&) { return true; }};
   ws_server.on_close =
       [&](http_websocket&, uint16_t code, std::string_view reason) {
         got_code = code;
@@ -1936,8 +1939,8 @@ void WebSocket_Feed_Close() {
       };
   std::string received_frame;
   http_websocket ws_client{
-      [&](std::string&& frame) {
-        received_frame = std::move(frame);
+      [&](any_strings&& frame) {
+        received_frame = std::get<std::string>(std::move(frame));
         return true;
       },
       connection_role::client};
@@ -1954,8 +1957,8 @@ void WebSocket_Feed_Close() {
 void WebSocket_Feed_CloseInvalidUtf8Reason() {
   std::string sent_frame;
   bool close_fired{};
-  http_websocket ws_server{[&](std::string&& f) {
-    sent_frame = std::move(f);
+  http_websocket ws_server{[&](any_strings&& f) {
+    sent_frame = std::get<std::string>(std::move(f));
     return true;
   }};
   ws_server.on_close = [&](http_websocket&, uint16_t, std::string_view) {
@@ -1991,7 +1994,7 @@ void WebSocket_Feed_Fragmented() {
   std::string got_msg;
   ws_frame_control got_op{};
   int msg_count{};
-  http_websocket ws{[](std::string&&) { return true; }};
+  http_websocket ws{[](any_strings&&) { return true; }};
   ws.on_message = [&](http_websocket&, std::string&& p, ws_frame_control op) {
     got_msg = std::move(p);
     got_op = op;
@@ -2000,8 +2003,8 @@ void WebSocket_Feed_Fragmented() {
   };
   std::string received_frame;
   http_websocket ws_client{
-      [&](std::string&& frame) {
-        received_frame = std::move(frame);
+      [&](any_strings&& frame) {
+        received_frame = std::get<std::string>(std::move(frame));
         return true;
       },
       connection_role::client};
@@ -2041,7 +2044,7 @@ void WebSocket_Feed_FragmentedDelivery() {
     ws_frame_control op{};
   };
   std::vector<Call> calls;
-  http_websocket ws{[](std::string&&) { return true; }};
+  http_websocket ws{[](any_strings&&) { return true; }};
   ws.deliver_fragments = true;
   ws.on_message = [&](http_websocket&, std::string&& p, ws_frame_control op) {
     calls.push_back({std::move(p), op});
@@ -2049,8 +2052,8 @@ void WebSocket_Feed_FragmentedDelivery() {
   };
   std::string received_frame;
   http_websocket ws_client{
-      [&](std::string&& frame) {
-        received_frame = std::move(frame);
+      [&](any_strings&& frame) {
+        received_frame = std::get<std::string>(std::move(frame));
         return true;
       },
       connection_role::client};
@@ -2092,7 +2095,7 @@ void WebSocket_Feed_FragmentedDeliverySplitUtf8() {
     ws_frame_control op{};
   };
   std::vector<Call> calls;
-  http_websocket ws{[](std::string&&) { return true; }};
+  http_websocket ws{[](any_strings&&) { return true; }};
   ws.deliver_fragments = true;
   ws.on_message = [&](http_websocket&, std::string&& p, ws_frame_control op) {
     calls.push_back({std::move(p), op});
@@ -2100,8 +2103,8 @@ void WebSocket_Feed_FragmentedDeliverySplitUtf8() {
   };
   std::string received_frame;
   http_websocket ws_client{
-      [&](std::string&& frame) {
-        received_frame = std::move(frame);
+      [&](any_strings&& frame) {
+        received_frame = std::get<std::string>(std::move(frame));
         return true;
       },
       connection_role::client};
@@ -2126,15 +2129,15 @@ void WebSocket_Feed_FragmentedDeliverySplitUtf8() {
 // In fragment-delivery mode, invalid UTF-8 across frames fails with 1007.
 void WebSocket_Feed_FragmentedDeliveryInvalidUtf8() {
   std::string sent_frame;
-  http_websocket ws{[&](std::string&& f) {
-    sent_frame = std::move(f);
+  http_websocket ws{[&](any_strings&& f) {
+    sent_frame = std::get<std::string>(std::move(f));
     return true;
   }};
   ws.deliver_fragments = true;
   std::string received_frame;
   http_websocket ws_client{
-      [&](std::string&& frame) {
-        received_frame = std::move(frame);
+      [&](any_strings&& frame) {
+        received_frame = std::get<std::string>(std::move(frame));
         return true;
       },
       connection_role::client};
@@ -2166,15 +2169,15 @@ void WebSocket_Feed_FragmentedDeliveryInvalidUtf8() {
 // mid-code-point.
 void WebSocket_Feed_FragmentedDeliveryInvalidUtf8EmptyFinal() {
   std::string sent_frame;
-  http_websocket ws{[&](std::string&& f) {
-    sent_frame = std::move(f);
+  http_websocket ws{[&](any_strings&& f) {
+    sent_frame = std::get<std::string>(std::move(f));
     return true;
   }};
   ws.deliver_fragments = true;
   std::string received_frame;
   http_websocket ws_client{
-      [&](std::string&& frame) {
-        received_frame = std::move(frame);
+      [&](any_strings&& frame) {
+        received_frame = std::get<std::string>(std::move(frame));
         return true;
       },
       connection_role::client};
@@ -2209,7 +2212,7 @@ void WebSocket_Feed_FragmentedDeliveryInvalidUtf8Disabled() {
     ws_frame_control op{};
   };
   std::vector<Call> calls;
-  http_websocket ws{[](std::string&&) { return true; }};
+  http_websocket ws{[](any_strings&&) { return true; }};
   ws.deliver_fragments = true;
   ws.validate_utf8 = false;
   ws.on_message = [&](http_websocket&, std::string&& p, ws_frame_control op) {
@@ -2218,8 +2221,8 @@ void WebSocket_Feed_FragmentedDeliveryInvalidUtf8Disabled() {
   };
   std::string received_frame;
   http_websocket ws_client{
-      [&](std::string&& frame) {
-        received_frame = std::move(frame);
+      [&](any_strings&& frame) {
+        received_frame = std::get<std::string>(std::move(frame));
         return true;
       },
       connection_role::client};
@@ -2244,7 +2247,7 @@ void WebSocket_Feed_FragmentedDeliveryInvalidUtf8Disabled() {
 // Feeding only the header bytes of a frame returns true (awaiting payload).
 void WebSocket_Feed_PartialFrame() {
   bool msg_fired{};
-  http_websocket ws{[](std::string&&) { return true; }};
+  http_websocket ws{[](any_strings&&) { return true; }};
   ws.on_message = [&](http_websocket&, std::string&&, ws_frame_control) {
     msg_fired = true;
     return true;
@@ -2316,7 +2319,7 @@ void WebSocket_Feed_RecvBufferViewRequestsFrameSizedGrowth() {
           resume_new_size = n;
           resume_last_seen_end = lse;
         }};
-    http_websocket ws{[](std::string&&) { return true; }};
+    http_websocket ws{[](any_strings&&) { return true; }};
     EXPECT_TRUE(ws.feed(view));
   }
 
@@ -2327,7 +2330,7 @@ void WebSocket_Feed_RecvBufferViewRequestsFrameSizedGrowth() {
 // Two complete frames in one buffer each fire on_message.
 void WebSocket_Feed_MultipleFrames() {
   std::vector<std::string> msgs;
-  http_websocket ws{[](std::string&&) { return true; }};
+  http_websocket ws{[](any_strings&&) { return true; }};
   ws.on_message = [&](http_websocket&, std::string&& p, ws_frame_control) {
     msgs.emplace_back(std::move(p));
     return true;
@@ -2349,7 +2352,7 @@ void WebSocket_Feed_MultipleFrames() {
 // `feed(std::string_view&)` overload.
 void WebSocket_Feed_MultipleFramesViaView() {
   std::vector<std::string> msgs;
-  http_websocket ws{[](std::string&&) { return true; }};
+  http_websocket ws{[](any_strings&&) { return true; }};
   ws.on_message = [&](http_websocket&, std::string&& p, ws_frame_control) {
     msgs.emplace_back(std::move(p));
     return true;
@@ -2373,7 +2376,7 @@ void WebSocket_Feed_MultipleFramesViaView() {
 
 // A continuation frame without a prior start fragment is a protocol error.
 void WebSocket_Feed_BadContinuation() {
-  http_websocket ws{[](std::string&&) { return true; }};
+  http_websocket ws{[](any_strings&&) { return true; }};
   std::string buf = ws_frame_lens::serialize_frame(
       ws_frame_control::fin | ws_frame_control::continuation, "data");
   std::string_view wire{buf};
@@ -2382,7 +2385,7 @@ void WebSocket_Feed_BadContinuation() {
 
 // A non-continuation data frame arriving mid-fragment is a protocol error.
 void WebSocket_Feed_InterleavedData() {
-  http_websocket ws{[](std::string&&) { return true; }};
+  http_websocket ws{[](any_strings&&) { return true; }};
   std::string buf =
       ws_frame_lens::serialize_frame(ws_frame_control::text, "start", 0);
   std::string_view wire{buf};
@@ -2400,7 +2403,7 @@ void WebSocket_Feed_InterleavedData() {
 // `insatiable`).
 void WebSocket_Feed_DataAfterSentClose() {
   bool msg_fired{};
-  http_websocket ws{[](std::string&&) { return true; }};
+  http_websocket ws{[](any_strings&&) { return true; }};
   ws.on_message = [&](http_websocket&, std::string&&, ws_frame_control) {
     msg_fired = true;
     return true;
@@ -2423,8 +2426,8 @@ void WebSocket_Feed_DataAfterSentClose() {
 void WebSocket_Feed_DataAfterReceivedClose() {
   bool msg_fired{};
   std::string sent_frame;
-  http_websocket ws{[&](std::string&& f) {
-    sent_frame = std::move(f);
+  http_websocket ws{[&](any_strings&& f) {
+    sent_frame = std::get<std::string>(std::move(f));
     return true;
   }};
   ws.on_message = [&](http_websocket&, std::string&&, ws_frame_control) {
@@ -2451,8 +2454,8 @@ void WebSocket_Feed_DataAfterReceivedClose() {
 // Server pump sends unmasked frames.
 void WebSocket_Send_Server() {
   std::string sent;
-  http_websocket ws{[&](std::string&& f) {
-    sent = std::move(f);
+  http_websocket ws{[&](any_strings&& f) {
+    sent = std::get<std::string>(std::move(f));
     return true;
   }};
   EXPECT_TRUE(ws.send_text("hi"));
@@ -2471,8 +2474,8 @@ void WebSocket_Send_Server() {
 void WebSocket_Send_Client() {
   std::string sent;
   http_websocket ws{
-      [&](std::string&& f) {
-        sent = std::move(f);
+      [&](any_strings&& f) {
+        sent = std::get<std::string>(std::move(f));
         return true;
       },
       connection_role::client};
@@ -2610,8 +2613,8 @@ void WebSocket_FrameWrapper_MaskPayloadCopyByteOrder() {
 // `send_binary` sends a FIN+binary frame with the correct opcode.
 void WebSocket_Send_Binary() {
   std::string sent;
-  http_websocket ws{[&](std::string&& f) {
-    sent = std::move(f);
+  http_websocket ws{[&](any_strings&& f) {
+    sent = std::get<std::string>(std::move(f));
     return true;
   }};
   EXPECT_TRUE(ws.send_binary("data"));
@@ -2629,8 +2632,8 @@ void WebSocket_Send_Binary() {
 // block outbound data.
 void WebSocket_Send_Pong_Direct() {
   std::string sent;
-  http_websocket ws{[&](std::string&& f) {
-    sent = std::move(f);
+  http_websocket ws{[&](any_strings&& f) {
+    sent = std::get<std::string>(std::move(f));
     return true;
   }};
   ASSERT_TRUE(ws.send_close(1000));
@@ -2648,8 +2651,8 @@ void WebSocket_Send_Pong_Direct() {
 // send callback.
 void WebSocket_Send_Frame_Prebuilt() {
   std::string sent;
-  http_websocket ws{[&](std::string&& f) {
-    sent = std::move(f);
+  http_websocket ws{[&](any_strings&& f) {
+    sent = std::get<std::string>(std::move(f));
     return true;
   }};
   std::string frame = ws_frame_lens::serialize_frame(
@@ -2662,18 +2665,18 @@ void WebSocket_Send_Frame_Prebuilt() {
   EXPECT_EQ(hdr.payload_length(), 3ULL);
 }
 
-// `hangup` invokes the send callback with an empty string to signal RST.
+// `hangup` invokes the send callback with `std::monostate` to signal RST.
 void WebSocket_Hangup() {
   bool called{};
-  std::string sent{"initial"};
-  http_websocket ws{[&](std::string&& f) {
+  bool got_monostate{};
+  http_websocket ws{[&](any_strings&& f) {
     called = true;
-    sent = std::move(f);
+    got_monostate = std::holds_alternative<std::monostate>(f);
     return true;
   }};
   EXPECT_FALSE(ws.hangup());
   EXPECT_TRUE(called);
-  EXPECT_TRUE(sent.empty());
+  EXPECT_TRUE(got_monostate);
 }
 
 // `fail` sends a close frame and returns false. `fail_proto` wraps `fail` with
@@ -2683,8 +2686,8 @@ void WebSocket_Fail() {
   // `fail` with no prior close sends a close frame.
   {
     std::string sent;
-    http_websocket ws{[&](std::string&& f) {
-      sent = std::move(f);
+    http_websocket ws{[&](any_strings&& f) {
+      sent = std::get<std::string>(std::move(f));
       return true;
     }};
     EXPECT_FALSE(ws.fail(1001, "bye"));
@@ -2697,8 +2700,8 @@ void WebSocket_Fail() {
   // `fail_proto` sends close code 1002 with a prefixed reason string.
   {
     std::string sent;
-    http_websocket ws{[&](std::string&& f) {
-      sent = std::move(f);
+    http_websocket ws{[&](any_strings&& f) {
+      sent = std::get<std::string>(std::move(f));
       return true;
     }};
     EXPECT_FALSE(ws.fail_proto("test reason"));
@@ -2717,7 +2720,7 @@ void WebSocket_Fail() {
 
   // `fail_insatiable` returns `insatiable`.
   {
-    http_websocket ws{[](std::string&&) { return true; }};
+    http_websocket ws{[](any_strings&&) { return true; }};
     EXPECT_EQ(ws.fail_insatiable(1000, "error"), http_websocket::insatiable);
   }
 }
@@ -2739,7 +2742,7 @@ wstx_make_view(recv_buffer& buf, std::string_view data = {}) {
 // Build a well-formed WebSocket upgrade `request_head` without parsing.
 [[nodiscard]] request_head wstx_make_upgrade_req(
     std::string* accept_key_ptr = nullptr) {
-  http_websocket hws{[](std::string&&) { return true; }};
+  http_websocket hws{[](any_strings&&) { return true; }};
   std::string accept_key;
   request_head req =
       http_websocket::generate_upgrade_request("/ws", accept_key);
@@ -2770,7 +2773,7 @@ void WebSocketTransaction_OnDrain() {
     ASSERT_EQ(tx->handle_data(view), stream_claim::claim);
   }
 
-  http_transaction::send_fn send_fn{[](std::string&&) { return true; }};
+  http_transaction::send_fn send_fn{[](any_strings&&) { return true; }};
   // First drain flushes the 101 response, then falls through to `on_drain`.
   EXPECT_EQ(tx->handle_drain(send_fn), stream_claim::claim);
   EXPECT_EQ(drain_count, 1);
@@ -2801,8 +2804,8 @@ void WebSocketTransaction_DrainSendsResponse() {
   }
 
   std::string sent;
-  http_transaction::send_fn send_fn{[&](std::string&& data) {
-    sent = std::move(data);
+  http_transaction::send_fn send_fn{[&](any_strings&& data) {
+    sent = std::get<std::string>(std::move(data));
     return true;
   }};
   EXPECT_EQ(tx->handle_drain(send_fn), stream_claim::claim);
@@ -2822,7 +2825,7 @@ void WebSocketTransaction_DrainSendsResponse() {
 void WebSocketTransaction_DrainBeforeUpgrade() {
   auto tx =
       std::make_shared<http_websocket_transaction>(wstx_make_upgrade_req());
-  http_transaction::send_fn send_fn{[](std::string&&) { return true; }};
+  http_transaction::send_fn send_fn{[](any_strings&&) { return true; }};
   EXPECT_EQ(tx->handle_drain(send_fn), stream_claim::release);
 }
 
@@ -2896,8 +2899,8 @@ void WebSocketTransaction_UpgradeRequiredDrain() {
   }
 
   std::string sent;
-  http_transaction::send_fn send_fn{[&](std::string&& data) {
-    sent = std::move(data);
+  http_transaction::send_fn send_fn{[&](any_strings&& data) {
+    sent = std::get<std::string>(std::move(data));
     return true;
   }};
   EXPECT_EQ(tx->handle_drain(send_fn), stream_claim::release);
@@ -2935,8 +2938,8 @@ void WebSocketTransaction_BadRequestDrain() {
   }
 
   std::string sent;
-  http_transaction::send_fn send_fn{[&](std::string&& data) {
-    sent = std::move(data);
+  http_transaction::send_fn send_fn{[&](any_strings&& data) {
+    sent = std::get<std::string>(std::move(data));
     return true;
   }};
   EXPECT_EQ(tx->handle_drain(send_fn), stream_claim::release);
@@ -2966,7 +2969,7 @@ void WebSocketTransaction_FeedAfterUpgrade() {
     auto view = wstx_make_view(buf);
     ASSERT_EQ(tx->handle_data(view), stream_claim::claim);
   }
-  http_transaction::send_fn send_fn{[](std::string&&) { return true; }};
+  http_transaction::send_fn send_fn{[](any_strings&&) { return true; }};
   ASSERT_EQ(tx->handle_drain(send_fn), stream_claim::claim);
 
   const auto frame = ws_frame_lens::serialize_frame(
@@ -2988,7 +2991,7 @@ void WebSocketTransaction_FeedProtocolError() {
     auto view = wstx_make_view(buf);
     ASSERT_EQ(tx->handle_data(view), stream_claim::claim);
   }
-  http_transaction::send_fn send_fn{[](std::string&&) { return true; }};
+  http_transaction::send_fn send_fn{[](any_strings&&) { return true; }};
   ASSERT_EQ(tx->handle_drain(send_fn), stream_claim::claim);
 
   // A continuation frame with no prior start fragment is a protocol error.
@@ -3024,8 +3027,8 @@ void WebSocketTransaction_SubprotocolNegotiation() {
     }
 
     std::string sent;
-    http_transaction::send_fn send_fn{[&](std::string&& data) {
-      sent = std::move(data);
+    http_transaction::send_fn send_fn{[&](any_strings&& data) {
+      sent = std::get<std::string>(std::move(data));
       return true;
     }};
     ASSERT_EQ(tx->handle_drain(send_fn), stream_claim::claim);
@@ -3058,8 +3061,8 @@ void WebSocketTransaction_SubprotocolNegotiation() {
     }
 
     std::string sent;
-    http_transaction::send_fn send_fn{[&](std::string&& data) {
-      sent = std::move(data);
+    http_transaction::send_fn send_fn{[&](any_strings&& data) {
+      sent = std::get<std::string>(std::move(data));
       return true;
     }};
     ASSERT_EQ(tx->handle_drain(send_fn), stream_claim::claim);
@@ -3102,8 +3105,8 @@ void WebSocket_PingCounter() {
 
   std::string sent_frame;
   http_websocket ws{
-      [&](std::string&& f) {
-        sent_frame = std::move(f);
+      [&](any_strings&& f) {
+        sent_frame = std::get<std::string>(std::move(f));
         return true;
       },
       connection_role::server};
@@ -3170,7 +3173,8 @@ void HttpServer_WebSocket_Keepalive() {
   epoll_loop_runner loop_runner;
   timing_wheel_runner wheel_runner;
 
-  auto server = http_server::create(net_endpoint{ipv4_addr::loopback, 0},
+  auto server = http_server::create(
+      net_endpoint{ipv4_addr::loopback, 0},
       [](http_server& s) {
         return s.add_route({"", "/ws"},
             http_websocket_transaction::make_factory(
@@ -3188,8 +3192,8 @@ void HttpServer_WebSocket_Keepalive() {
 
   // Perform WebSocket upgrade.
   std::string accept_key;
-  http_transaction::send_fn send_fn{[&](std::string&& f) {
-    return client.send(f);
+  http_transaction::send_fn send_fn{[&](any_strings&& f) {
+    return client.send(std::get<std::string>(f));
   }};
   http_websocket ws_client{std::move(send_fn), connection_role::client};
   auto req = http_websocket::generate_upgrade_request("/ws", accept_key);
@@ -3258,7 +3262,8 @@ void HttpServer_WebSocket_KeepaliveTimeout() {
   epoll_loop_runner loop_runner;
   timing_wheel_runner wheel_runner;
 
-  auto server = http_server::create(net_endpoint{ipv4_addr::loopback, 0},
+  auto server = http_server::create(
+      net_endpoint{ipv4_addr::loopback, 0},
       [](http_server& s) {
         return s.add_route({"", "/ws"},
             http_websocket_transaction::make_factory(
@@ -3276,8 +3281,8 @@ void HttpServer_WebSocket_KeepaliveTimeout() {
 
   // Perform WebSocket upgrade.
   std::string accept_key;
-  http_transaction::send_fn send_fn{[&](std::string&& f) {
-    return client.send(f);
+  http_transaction::send_fn send_fn{[&](any_strings&& f) {
+    return client.send(std::get<std::string>(f));
   }};
   http_websocket ws_client{std::move(send_fn), connection_role::client};
   auto req = http_websocket::generate_upgrade_request("/ws", accept_key);
@@ -3343,9 +3348,8 @@ void HttpServer_WebSocket() {
             http_websocket_transaction::make_factory(
                 [](http_websocket_transaction& tx) {
                   tx.websocket().on_message =
-                      [](http_websocket& ws, std::string&& p, ws_frame_control) {
-                        return ws.send_text(p);
-                      };
+                      [](http_websocket& ws, std::string&& p,
+                          ws_frame_control) { return ws.send_text(p); };
                   return true;
                 }));
       });
@@ -3381,8 +3385,8 @@ void HttpServer_WebSocket() {
   // Build a client-side WebSocket pump that writes through `client`.
   std::string got_msg;
   ws_frame_control got_op{};
-  http_transaction::send_fn client_send{[&](std::string&& frame) {
-    return client.send(frame);
+  http_transaction::send_fn client_send{[&](any_strings&& frame) {
+    return client.send(std::get<std::string>(frame));
   }};
   http_websocket ws_client{std::move(client_send), connection_role::client};
   ws_client.on_message =
@@ -3415,9 +3419,8 @@ void HttpServer_WebSocket_QueryAndFragmentRoute() {
             http_websocket_transaction::make_factory(
                 [](http_websocket_transaction& tx) {
                   tx.websocket().on_message =
-                      [](http_websocket& ws, std::string&& p, ws_frame_control) {
-                        return ws.send_text(p);
-                      };
+                      [](http_websocket& ws, std::string&& p,
+                          ws_frame_control) { return ws.send_text(p); };
                   return true;
                 }));
       });
@@ -3471,9 +3474,8 @@ void HttpServer_WebSocket_Frames() {
             http_websocket_transaction::make_factory(
                 [](http_websocket_transaction& tx) {
                   tx.websocket().on_message =
-                      [](http_websocket& ws, std::string&& p, ws_frame_control) {
-                        return ws.send_text(p);
-                      };
+                      [](http_websocket& ws, std::string&& p,
+                          ws_frame_control) { return ws.send_text(p); };
                   return true;
                 }));
       });
@@ -3482,8 +3484,8 @@ void HttpServer_WebSocket_Frames() {
   auto client = stream_sync::connect(web_server->local_endpoint(), 1s);
   ASSERT_TRUE(client);
 
-  http_transaction::send_fn client_send{[&](std::string&& frame) {
-    return client.send(frame);
+  http_transaction::send_fn client_send{[&](any_strings&& frame) {
+    return client.send(std::get<std::string>(frame));
   }};
   http_websocket ws_client{std::move(client_send), connection_role::client};
 

--- a/tests/sequence_enum_test.cpp
+++ b/tests/sequence_enum_test.cpp
@@ -876,11 +876,22 @@ void SequentialEnumTest_Int64() {
   }
 }
 
+void SequentialEnumTest_AsView() {
+  if (true) {
+    EXPECT_EQ(enum_as_view(e0_3(0)), "a");
+    EXPECT_EQ(enum_as_view(e0_3(1)), "(unknown)");
+    EXPECT_EQ(enum_as_view(e0_3(2)), "c");
+    EXPECT_EQ(enum_as_view(e0_3(3)), "(unknown)");
+    EXPECT_EQ(enum_as_view(e0_3(4)), "(unknown)");
+  }
+}
+
 MAKE_TEST_LIST(SequentialEnumTest_Registry, SequentialEnumTest_Ops,
     SequentialEnumTest_MakeSafely, SequentialEnumTest_SafeOps,
     SequentialEnumTest_SubtleBugRepro, SequentialEnumTest_StreamingOut,
     SequentialEnumTest_Missing, SequentialEnumTest_Intervals,
-    SequentialEnumTest_ExtractEnum, SequentialEnumTest_Int64);
+    SequentialEnumTest_ExtractEnum, SequentialEnumTest_Int64,
+    SequentialEnumTest_AsView);
 
 // NOLINTEND(readability-function-cognitive-complexity,
 // readability-function-size)

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -17,11 +17,14 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
 
 #include "../corvid/sim/sim_game.h"
+#include "../corvid/sim/sim_json_parse.h"
+#include "../corvid/sim/sim_json_wire.h"
 #include "minitest.h"
 
 using namespace corvid;
@@ -616,6 +619,144 @@ void SimGame_ExtractFullIncludesPathsAndState() {
   EXPECT_EQ(phase, std::string_view{"build"});
 }
 
+void SimJson_ParseUiCanvasMessage() {
+  const auto msg = parse_sim_client_message_root(R"({
+    "type": "ui_canvas",
+    "seq": 42,
+    "event": "dragmove",
+    "button": "right",
+    "buttons": 2,
+    "x": 10.5,
+    "y": -3.25,
+    "canvasX": 100.0,
+    "canvasY": 200.5,
+    "shift": true,
+    "ctrl": false,
+    "alt": true,
+    "meta": false
+  })");
+
+  ASSERT_TRUE(msg.has_value());
+  EXPECT_EQ(classify_sim_client_message(*msg),
+      SimClientMessageKind::ui_canvas);
+
+  const auto input = parse_ui_canvas_message(*msg);
+  ASSERT_TRUE(input.has_value());
+  EXPECT_EQ(input->seq, 42U);
+  EXPECT_EQ(input->event, UiCanvasEvent::dragmove);
+  EXPECT_EQ(input->button, UiMouseButton::right);
+  EXPECT_EQ(input->buttons, 2U);
+  EXPECT_NEAR(input->x, 10.5, 1e-6);
+  EXPECT_NEAR(input->y, -3.25, 1e-6);
+  EXPECT_NEAR(input->canvasX, 100.0, 1e-6);
+  EXPECT_NEAR(input->canvasY, 200.5, 1e-6);
+  EXPECT_TRUE(input->shift);
+  EXPECT_FALSE(input->ctrl);
+  EXPECT_TRUE(input->alt);
+  EXPECT_FALSE(input->meta);
+}
+
+void SimJson_ParseUiActionMessageFields() {
+  const auto input = parse_ui_action_message(
+      R"({"type":"ui_action","seq":7,"action":"start_wave","fields":{"tower\/kind":"ice","note":"line\nbreak"}})");
+
+  ASSERT_TRUE(input.has_value());
+  EXPECT_EQ(input->seq, 7U);
+  EXPECT_EQ(input->action, "start_wave");
+  ASSERT_EQ(input->fields.size(), 2U);
+  EXPECT_EQ(input->fields[0].key, "tower/kind");
+  EXPECT_EQ(input->fields[0].value, "ice");
+  EXPECT_EQ(input->fields[1].key, "note");
+  EXPECT_EQ(input->fields[1].value, std::string("line\nbreak"));
+}
+
+void SimJson_BuildHelloAckJson() {
+  EXPECT_EQ(build_sim_hello_ack_json(),
+      std::string(R"({"type":"hello_ack","message":"connected"})"));
+}
+
+void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
+  SimGame game;
+  game.loadMap();
+  game.start_wave();
+  (void)game.step();
+  const auto tick = game.step();
+
+  sim_game_state_json state;
+  (void)build_sim_game_state_json(state, game, tick);
+  EXPECT_TRUE(state.body_highwater >= state.body.size());
+  EXPECT_TRUE(state.body.contains(R"("x":20.0)"));
+  EXPECT_TRUE(state.body.contains(R"("scale":2.000)"));
+
+  json_value_view root;
+  ASSERT_TRUE(parse_json(state.body, root));
+  const auto obj = root.as_object();
+  ASSERT_TRUE(obj);
+  const auto tick_value = obj.get_number<uint32_t>("tick");
+  const auto wave_tick_value = obj.get_number<uint32_t>("waveTick");
+  const auto phase_value = obj.get_string_view_if_plain("phase");
+  ASSERT_TRUE(tick_value.has_value());
+  ASSERT_TRUE(wave_tick_value.has_value());
+  ASSERT_TRUE(phase_value.has_value());
+  EXPECT_EQ(*tick_value, 2U);
+  EXPECT_EQ(*wave_tick_value, 2U);
+  EXPECT_EQ(*phase_value, std::string_view{"wave"});
+
+  const auto upserts = obj.get_array("upserts");
+  ASSERT_TRUE(upserts);
+  size_t count = 0;
+  for (const auto item : upserts) {
+    const auto entry = item.as_object();
+    ASSERT_TRUE(entry);
+    const auto pos = entry.get_object("pos");
+    ASSERT_TRUE(pos);
+    const auto x = pos.get_number<float>("x");
+    ASSERT_TRUE(x.has_value());
+    EXPECT_NEAR(*x, 20.0, 1e-6);
+    ++count;
+  }
+  EXPECT_EQ(count, 1U);
+}
+
+void SimJson_BuildWorldSnapshotJsonShape() {
+  SimGame game;
+  game.loadMap();
+
+  sim_game_state_json state;
+  (void)build_sim_game_state_json(state, game, WorldTick{}, update_strategy::full);
+  EXPECT_TRUE(state.body.contains(R"("type":"world_snapshot")"));
+  EXPECT_TRUE(state.body.contains(R"("x":0.0)"));
+
+  json_value_view root;
+  ASSERT_TRUE(parse_json(state.body, root));
+  const auto obj = root.as_object();
+  ASSERT_TRUE(obj);
+  const auto root_type = obj.get_string_view_if_plain("type");
+  ASSERT_TRUE(root_type.has_value());
+  EXPECT_EQ(*root_type, std::string_view{"world_snapshot"});
+
+  const auto paths = obj.get_array("paths");
+  ASSERT_TRUE(paths);
+  size_t path_points = 0;
+  for (const auto point : paths) {
+    const auto entry = point.as_object();
+    ASSERT_TRUE(entry);
+    ASSERT_TRUE(entry.get_number<float>("x").has_value());
+    ASSERT_TRUE(entry.get_number<float>("y").has_value());
+    ++path_points;
+  }
+  EXPECT_GT(path_points, 0U);
+
+  const auto delta = obj.get_object("delta");
+  ASSERT_TRUE(delta);
+  const auto delta_type = delta.get_string_view_if_plain("type");
+  const auto delta_phase = delta.get_string_view_if_plain("phase");
+  ASSERT_TRUE(delta_type.has_value());
+  EXPECT_EQ(*delta_type, std::string_view{"world_delta"});
+  ASSERT_TRUE(delta_phase.has_value());
+  EXPECT_EQ(*delta_phase, std::string_view{"build"});
+}
+
 // NOLINTEND(readability-function-cognitive-complexity)
 
 MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_TickMovesMover,
@@ -632,4 +773,7 @@ MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_TickMovesMover,
     SimGame_HandleUiCanvasDoesNotChangeStateYet,
     SimGame_StartWaveSpawnsFirstEnemyOnFirstStep,
     SimGame_ExtractDeltaConsumesWorldUpdatesButNotState,
-    SimGame_ExtractFullIncludesPathsAndState)
+    SimGame_ExtractFullIncludesPathsAndState, SimJson_ParseUiCanvasMessage,
+    SimJson_ParseUiActionMessageFields, SimJson_BuildHelloAckJson,
+    SimJson_BuildWorldDeltaJsonShapeAndFormatting,
+    SimJson_BuildWorldSnapshotJsonShape)

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -58,7 +58,7 @@ struct GameSnapshot {
   std::vector<EntitySnapshot> snaps;
   (void)world.markAllDirty();
   (void)world.extractUpdatedEntities(
-      [&snaps](SimWorld::EntityId id, const Position& pos) {
+      [&snaps](SimWorld::EntityId id, const Position& pos, const Appearance&) {
         const auto it = std::ranges::find(snaps, id, &EntitySnapshot::id);
         if (it == snaps.end())
           snaps.push_back({id, pos});
@@ -96,7 +96,7 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
 [[nodiscard]] WorldDelta extractWorldDelta(SimWorld& world) {
   WorldDelta delta;
   (void)world.extractUpdatedEntities(
-      [&delta](SimWorld::EntityId id, const Position& pos) {
+      [&delta](SimWorld::EntityId id, const Position& pos, const Appearance&) {
         delta.upserts.emplace_back(id, pos);
       },
       [&delta](SimWorld::EntityId id) { delta.erased.push_back(id); });
@@ -113,7 +113,7 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
         if (pathsById.size() <= ndx) pathsById.resize(ndx + 1);
         pathsById[ndx].joints.push_back({pos});
       },
-      [&snap](SimWorld::EntityId id, const Position& pos) {
+      [&snap](SimWorld::EntityId id, const Position& pos, const Appearance&) {
         snap.entities.push_back({id, pos});
       },
       [](SimWorld::EntityId) {},
@@ -126,7 +126,7 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
 [[nodiscard]] GameDelta extractGameDelta(SimGame& game) {
   GameDelta delta;
   (void)game.extractDelta(
-      [&delta](SimWorld::EntityId id, const Position& pos) {
+      [&delta](SimWorld::EntityId id, const Position& pos, const Appearance&) {
         delta.upserts.emplace_back(id, pos);
       },
       [&delta](SimWorld::EntityId id) { delta.erased.push_back(id); },
@@ -559,7 +559,9 @@ void SimGame_ExtractFullIncludesPathsAndState() {
 
   (void)game.extractFull(
       [&path_points](PathId, const Position&) { ++path_points; },
-      [&upserts](SimWorld::EntityId, const Position&) { ++upserts; },
+      [&upserts](SimWorld::EntityId, const Position&, const Appearance&) {
+        ++upserts;
+      },
       [&erased](SimWorld::EntityId) { ++erased; },
       [&currentWave, &waveTick, &lives, &resources, &phase](size_t wave,
           Tick tick, int newLives, int newResources,

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -31,11 +31,11 @@ void SimWorld_SpawnDespawn() {
   SimWorld w;
   EXPECT_EQ(w.size(), 0U);
 
-  auto h = w.spawn(Position{10.0, 20.0}, Velocity{1.0, 2.0});
+  auto h = w.spawnMover(Position{10.0, 20.0}, Velocity{1.0, 2.0});
   EXPECT_TRUE(w.is_alive(h));
   EXPECT_EQ(w.size(), 1U);
 
-  auto h2 = w.spawn(Position{30.0, 40.0}, Velocity{-1.0, 0.0});
+  auto h2 = w.spawnMover(Position{30.0, 40.0}, Velocity{-1.0, 0.0});
   EXPECT_EQ(w.size(), 2U);
 
   EXPECT_TRUE(w.despawn(h));
@@ -49,7 +49,7 @@ void SimWorld_SpawnDespawn() {
 // Despawning a stale handle returns false without crashing.
 void SimWorld_DespawnStale() {
   SimWorld w;
-  auto h = w.spawn(Position{}, Velocity{});
+  auto h = w.spawnMover(Position{}, Velocity{});
   EXPECT_TRUE(w.despawn(h));
   EXPECT_FALSE(w.despawn(h)); // second call: handle is dead
 }
@@ -57,7 +57,7 @@ void SimWorld_DespawnStale() {
 // tick() advances position by velocity.
 void SimWorld_Tick() {
   SimWorld w;
-  auto h = w.spawn(Position{100.0, 200.0}, Velocity{3.0, -5.0});
+  auto h = w.spawnMover(Position{100.0, 200.0}, Velocity{3.0, -5.0});
   (void)w.tick();
 
   auto snaps = w.snapshot();
@@ -70,11 +70,11 @@ void SimWorld_Tick() {
 // tick() with a non-null out-vector appends changed entity IDs.
 void SimWorld_TickOutParam() {
   SimWorld w;
-  auto h1 = w.spawn(Position{100.0, 100.0}, Velocity{1.0, 0.0});
-  auto h2 = w.spawn(Position{200.0, 200.0}, Velocity{0.0, 1.0});
+  auto h1 = w.spawnMover(Position{100.0, 100.0}, Velocity{1.0, 0.0});
+  auto h2 = w.spawnMover(Position{200.0, 200.0}, Velocity{0.0, 1.0});
 
   std::vector<SimWorld::EntityId> changed;
-  (void)w.tick(&changed);
+  (void)w.tick();
 
   EXPECT_EQ(changed.size(), 2U);
   (void)h1;
@@ -84,8 +84,8 @@ void SimWorld_TickOutParam() {
 // tick() with nullptr out-param does not allocate (just advance state).
 void SimWorld_TickNullOut() {
   SimWorld w;
-  (void)w.spawn(Position{50.0, 50.0}, Velocity{1.0, 1.0});
-  (void)w.tick(nullptr); // must not crash
+  (void)w.spawnMover(Position{50.0, 50.0}, Velocity{1.0, 1.0});
+  (void)w.tick(); // must not crash
   auto snaps = w.snapshot();
   ASSERT_EQ(snaps.size(), 1U);
   EXPECT_NEAR(snaps[0].pos.x, 51.0, 1e-9);
@@ -94,9 +94,9 @@ void SimWorld_TickNullOut() {
 // Entities bounce off the left/top boundary.
 void SimWorld_BounceMinEdge() {
   SimWorld w;
-  const float half_w = SimWorld::world_width * 0.5F;
-  const float half_h = SimWorld::world_height * 0.5F;
-  (void)w.spawn(Position{-half_w + 0.5F, -half_h + 0.5F},
+  const float half_w = SimWorld::widthOfWorld * 0.5F;
+  const float half_h = SimWorld::heightOfWorld * 0.5F;
+  (void)w.spawnMover(Position{-half_w + 0.5F, -half_h + 0.5F},
       Velocity{-2.0F, -2.0F});
   (void)w.tick();
 
@@ -109,9 +109,10 @@ void SimWorld_BounceMinEdge() {
 // Entities bounce off the right/bottom boundary.
 void SimWorld_BounceMaxEdge() {
   SimWorld w;
-  const float half_w = SimWorld::world_width * 0.5F;
-  const float half_h = SimWorld::world_height * 0.5F;
-  (void)w.spawn(Position{half_w - 0.5F, half_h - 0.5F}, Velocity{2.0F, 2.0F});
+  const float half_w = SimWorld::widthOfWorld * 0.5F;
+  const float half_h = SimWorld::heightOfWorld * 0.5F;
+  (void)w.spawnMover(Position{half_w - 0.5F, half_h - 0.5F},
+      Velocity{2.0F, 2.0F});
   (void)w.tick();
 
   auto snaps = w.snapshot();
@@ -123,8 +124,8 @@ void SimWorld_BounceMaxEdge() {
 // snapshot() with default since_tick returns all entities.
 void SimWorld_SnapshotAll() {
   SimWorld w;
-  (void)w.spawn(Position{1.0, 2.0}, Velocity{});
-  (void)w.spawn(Position{3.0, 4.0}, Velocity{});
+  (void)w.spawnMover(Position{1.0, 2.0}, Velocity{});
+  (void)w.spawnMover(Position{3.0, 4.0}, Velocity{});
 
   auto snaps = w.snapshot();
   EXPECT_EQ(snaps.size(), 2U);
@@ -134,8 +135,8 @@ void SimWorld_SnapshotAll() {
 void SimWorld_SnapshotSince() {
   SimWorld w;
   // Spawn two entities before any tick (their last-change tick = 0).
-  (void)w.spawn(Position{10.0, 10.0}, Velocity{1.0, 0.0});
-  (void)w.spawn(Position{20.0, 20.0}, Velocity{1.0, 0.0});
+  (void)w.spawnMover(Position{10.0, 10.0}, Velocity{1.0, 0.0});
+  (void)w.spawnMover(Position{20.0, 20.0}, Velocity{1.0, 0.0});
 
   (void)w.tick(); // tick 1: both entities move, metadata set to 1
 
@@ -157,9 +158,9 @@ void SimWorld_SnapshotSince() {
 // snapshot(ids) returns only the requested entities.
 void SimWorld_SnapshotByIds() {
   SimWorld w;
-  auto h1 = w.spawn(Position{1.0, 1.0}, Velocity{});
-  auto h2 = w.spawn(Position{2.0, 2.0}, Velocity{});
-  auto h3 = w.spawn(Position{3.0, 3.0}, Velocity{});
+  auto h1 = w.spawnMover(Position{1.0, 1.0}, Velocity{});
+  auto h2 = w.spawnMover(Position{2.0, 2.0}, Velocity{});
+  auto h3 = w.spawnMover(Position{3.0, 3.0}, Velocity{});
 
   std::vector<SimWorld::EntityId> ids{h1.id(), h3.id()};
   auto snaps = w.snapshot(ids);
@@ -173,7 +174,7 @@ void SimWorld_SnapshotByIds() {
 // snapshot(ids) silently skips dead entity IDs.
 void SimWorld_SnapshotByIdsSkipsDead() {
   SimWorld w;
-  auto h = w.spawn(Position{5.0, 5.0}, Velocity{});
+  auto h = w.spawnMover(Position{5.0, 5.0}, Velocity{});
   auto dead_id = h.id();
   EXPECT_TRUE(w.despawn(h));
 
@@ -185,7 +186,7 @@ void SimWorld_SnapshotByIdsSkipsDead() {
 // spawn_background adds a P-only entity visible in snapshots.
 void SimWorld_Background() {
   SimWorld w;
-  auto hb = w.spawn_background(Position{50.0, 60.0});
+  auto hb = w.spawnBackground(Position{50.0, 60.0});
   EXPECT_TRUE(w.is_alive(hb));
   EXPECT_EQ(w.size(), 1U);
 
@@ -205,7 +206,7 @@ void SimWorld_Background() {
 // because its metadata was never updated beyond its spawn tick (0).
 void SimWorld_BackgroundNotInDeltaAfterTick() {
   SimWorld w;
-  (void)w.spawn_background(Position{50.0, 60.0});
+  (void)w.spawnBackground(Position{50.0, 60.0});
   (void)w.tick(); // tick 1; background entity metadata stays at 0
   EXPECT_EQ(w.snapshot(1).size(), 0U);
 }
@@ -216,11 +217,11 @@ void SimWorld_BackgroundNotInDeltaAfterTick() {
 void BakePath_TwoJoints() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{3.F, 4.F}}};
-  const auto bp = SegmentedPath::from_joints(p);
+  const auto bp = SegmentedPath::fromJoints(p);
   ASSERT_EQ(bp.segments.size(), 1U);
-  EXPECT_NEAR(bp.segments[0].cumulative_start, 0.0, 1e-6);
+  EXPECT_NEAR(bp.segments[0].cumulativeStart, 0.0, 1e-6);
   EXPECT_NEAR(bp.segments[0].length, 5.0, 1e-6);
-  EXPECT_NEAR(bp.total_length, 5.0, 1e-6);
+  EXPECT_NEAR(bp.totalLength, 5.0, 1e-6);
 }
 
 // bake_path with three joints produces two segments with correct cumulative
@@ -228,22 +229,22 @@ void BakePath_TwoJoints() {
 void BakePath_ThreeJoints() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{3.F, 4.F}}, {{6.F, 8.F}}};
-  const auto bp = SegmentedPath::from_joints(p);
+  const auto bp = SegmentedPath::fromJoints(p);
   ASSERT_EQ(bp.segments.size(), 2U);
-  EXPECT_NEAR(bp.segments[0].cumulative_start, 0.0, 1e-6);
+  EXPECT_NEAR(bp.segments[0].cumulativeStart, 0.0, 1e-6);
   EXPECT_NEAR(bp.segments[0].length, 5.0, 1e-6);
-  EXPECT_NEAR(bp.segments[1].cumulative_start, 5.0, 1e-6);
+  EXPECT_NEAR(bp.segments[1].cumulativeStart, 5.0, 1e-6);
   EXPECT_NEAR(bp.segments[1].length, 5.0, 1e-6);
-  EXPECT_NEAR(bp.total_length, 10.0, 1e-6);
+  EXPECT_NEAR(bp.totalLength, 10.0, 1e-6);
 }
 
 // bake_path with fewer than two joints returns an empty baked_path.
 void BakePath_Degenerate() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}};
-  const auto bp = SegmentedPath::from_joints(p);
+  const auto bp = SegmentedPath::fromJoints(p);
   EXPECT_TRUE(bp.segments.empty());
-  EXPECT_NEAR(bp.total_length, 0.0, 1e-6);
+  EXPECT_NEAR(bp.totalLength, 0.0, 1e-6);
 }
 
 // path_position at progress 0 returns the first joint; at total_length
@@ -251,13 +252,13 @@ void BakePath_Degenerate() {
 void PathPosition_Endpoints() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
-  const auto bp = SegmentedPath::from_joints(p);
+  const auto bp = SegmentedPath::fromJoints(p);
 
-  const auto start = bp.position_from_progress(0.F);
+  const auto start = bp.calculatePositionFromProgress(0.F);
   EXPECT_NEAR(start.x, 0.0, 1e-6);
   EXPECT_NEAR(start.y, 0.0, 1e-6);
 
-  const auto end = bp.position_from_progress(bp.total_length);
+  const auto end = bp.calculatePositionFromProgress(bp.totalLength);
   EXPECT_NEAR(end.x, 10.0, 1e-6);
   EXPECT_NEAR(end.y, 0.0, 1e-6);
 }
@@ -266,9 +267,9 @@ void PathPosition_Endpoints() {
 void PathPosition_Midpoint() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
-  const auto bp = SegmentedPath::from_joints(p);
+  const auto bp = SegmentedPath::fromJoints(p);
 
-  const auto mid = bp.position_from_progress(5.F);
+  const auto mid = bp.calculatePositionFromProgress(5.F);
   EXPECT_NEAR(mid.x, 5.0, 1e-6);
   EXPECT_NEAR(mid.y, 0.0, 1e-6);
 }
@@ -278,9 +279,9 @@ void SimWorld_EnemyAdvancesOnTick() {
   SimWorld w;
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{100.F, 0.F}}};
-  const auto pid = w.add_path(p);
+  const auto pid = w.addPath(p);
 
-  auto h = w.spawn_enemy(pid, 10.F);
+  auto h = w.spawnEnemy(pid, 10.F);
   EXPECT_TRUE(w.is_alive(h));
 
   (void)w.tick();
@@ -296,10 +297,10 @@ void SimWorld_EnemyDespawnsAtEnd() {
   SimWorld w;
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
-  const auto pid = w.add_path(p);
+  const auto pid = w.addPath(p);
 
   // Start near the end; one tick will push progress past total_length.
-  auto h = w.spawn_enemy(pid, 5.F, 8.F);
+  auto h = w.spawnEnemy(pid, 5.F, 8.F);
   EXPECT_EQ(w.size(), 1U);
 
   (void)w.tick();
@@ -311,14 +312,14 @@ void SimWorld_EnemyDespawnsAtEnd() {
 // get_path returns nullptr for an out-of-range index.
 void SimWorld_GetPathOutOfRange() {
   SimWorld w;
-  EXPECT_TRUE(w.get_path(PathId{0}) == nullptr);
+  EXPECT_TRUE(w.getPath(PathId{0}) == nullptr);
 
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{1.F, 0.F}}};
-  (void)w.add_path(p);
+  (void)w.addPath(p);
 
-  EXPECT_TRUE(w.get_path(PathId{0}) != nullptr);
-  EXPECT_TRUE(w.get_path(PathId{1}) == nullptr);
+  EXPECT_TRUE(w.getPath(PathId{0}) != nullptr);
+  EXPECT_TRUE(w.getPath(PathId{1}) == nullptr);
 }
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -620,7 +620,7 @@ void SimGame_ExtractFullIncludesPathsAndState() {
 }
 
 void SimJson_ParseUiCanvasMessage() {
-  const auto msg = parse_sim_client_message_root(R"({
+  const auto msg = parseSimClientMessageRoot(R"({
     "type": "ui_canvas",
     "seq": 42,
     "event": "dragmove",
@@ -637,10 +637,9 @@ void SimJson_ParseUiCanvasMessage() {
   })");
 
   ASSERT_TRUE(msg.has_value());
-  EXPECT_EQ(classify_sim_client_message(*msg),
-      SimClientMessageKind::ui_canvas);
+  EXPECT_EQ(classifySimClientMessage(*msg), SimClientMessageKind::ui_canvas);
 
-  const auto input = parse_ui_canvas_message(*msg);
+  const auto input = parseUiCanvasMessage(*msg);
   ASSERT_TRUE(input.has_value());
   EXPECT_EQ(input->seq, 42U);
   EXPECT_EQ(input->event, UiCanvasEvent::dragmove);
@@ -723,7 +722,8 @@ void SimJson_BuildWorldSnapshotJsonShape() {
   game.loadMap();
 
   sim_game_state_json state;
-  (void)build_sim_game_state_json(state, game, WorldTick{}, update_strategy::full);
+  (void)build_sim_game_state_json(state, game, WorldTick{},
+      update_strategy::full);
   EXPECT_TRUE(state.body.contains(R"("type":"world_snapshot")"));
   EXPECT_TRUE(state.body.contains(R"("x":0.0)"));
 

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -94,9 +94,10 @@ void SimWorld_TickNullOut() {
 // Entities bounce off the left/top boundary.
 void SimWorld_BounceMinEdge() {
   sim_world w;
-  const double half_w = sim_world::world_width * 0.5;
-  const double half_h = sim_world::world_height * 0.5;
-  (void)w.spawn(Position{-half_w + 0.5, -half_h + 0.5}, Velocity{-2.0, -2.0});
+  const float half_w = sim_world::world_width * 0.5F;
+  const float half_h = sim_world::world_height * 0.5F;
+  (void)w.spawn(Position{-half_w + 0.5F, -half_h + 0.5F},
+      Velocity{-2.0F, -2.0F});
   (void)w.tick();
 
   auto snaps = w.snapshot();
@@ -108,9 +109,9 @@ void SimWorld_BounceMinEdge() {
 // Entities bounce off the right/bottom boundary.
 void SimWorld_BounceMaxEdge() {
   sim_world w;
-  const double half_w = sim_world::world_width * 0.5;
-  const double half_h = sim_world::world_height * 0.5;
-  (void)w.spawn(Position{half_w - 0.5, half_h - 0.5}, Velocity{2.0, 2.0});
+  const float half_w = sim_world::world_width * 0.5F;
+  const float half_h = sim_world::world_height * 0.5F;
+  (void)w.spawn(Position{half_w - 0.5F, half_h - 0.5F}, Velocity{2.0F, 2.0F});
   (void)w.tick();
 
   auto snaps = w.snapshot();
@@ -209,10 +210,125 @@ void SimWorld_BackgroundNotInDeltaAfterTick() {
   EXPECT_EQ(w.snapshot(1).size(), 0U);
 }
 
+// --- Path geometry tests ---
+
+// bake_path with two joints produces one segment with the correct length.
+void BakePath_TwoJoints() {
+  path p;
+  p.joints = {{{0.F, 0.F}}, {{3.F, 4.F}}};
+  const auto bp = baked_path::from_path(p);
+  ASSERT_EQ(bp.segments.size(), 1U);
+  EXPECT_NEAR(bp.segments[0].cumulative_start, 0.0, 1e-6);
+  EXPECT_NEAR(bp.segments[0].length, 5.0, 1e-6);
+  EXPECT_NEAR(bp.total_length, 5.0, 1e-6);
+}
+
+// bake_path with three joints produces two segments with correct cumulative
+// distances.
+void BakePath_ThreeJoints() {
+  path p;
+  p.joints = {{{0.F, 0.F}}, {{3.F, 4.F}}, {{6.F, 8.F}}};
+  const auto bp = baked_path::from_path(p);
+  ASSERT_EQ(bp.segments.size(), 2U);
+  EXPECT_NEAR(bp.segments[0].cumulative_start, 0.0, 1e-6);
+  EXPECT_NEAR(bp.segments[0].length, 5.0, 1e-6);
+  EXPECT_NEAR(bp.segments[1].cumulative_start, 5.0, 1e-6);
+  EXPECT_NEAR(bp.segments[1].length, 5.0, 1e-6);
+  EXPECT_NEAR(bp.total_length, 10.0, 1e-6);
+}
+
+// bake_path with fewer than two joints returns an empty baked_path.
+void BakePath_Degenerate() {
+  path p;
+  p.joints = {{{0.F, 0.F}}};
+  const auto bp = baked_path::from_path(p);
+  EXPECT_TRUE(bp.segments.empty());
+  EXPECT_NEAR(bp.total_length, 0.0, 1e-6);
+}
+
+// path_position at progress 0 returns the first joint; at total_length
+// returns the last joint.
+void PathPosition_Endpoints() {
+  path p;
+  p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
+  const auto bp = baked_path::from_path(p);
+
+  const auto start = bp.position_from_progress(0.F);
+  EXPECT_NEAR(start.x, 0.0, 1e-6);
+  EXPECT_NEAR(start.y, 0.0, 1e-6);
+
+  const auto end = bp.position_from_progress(bp.total_length);
+  EXPECT_NEAR(end.x, 10.0, 1e-6);
+  EXPECT_NEAR(end.y, 0.0, 1e-6);
+}
+
+// path_position at the midpoint returns the correctly interpolated position.
+void PathPosition_Midpoint() {
+  path p;
+  p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
+  const auto bp = baked_path::from_path(p);
+
+  const auto mid = bp.position_from_progress(5.F);
+  EXPECT_NEAR(mid.x, 5.0, 1e-6);
+  EXPECT_NEAR(mid.y, 0.0, 1e-6);
+}
+
+// Spawning an enemy and ticking once advances its position by `speed`.
+void SimWorld_EnemyAdvancesOnTick() {
+  sim_world w;
+  path p;
+  p.joints = {{{0.F, 0.F}}, {{100.F, 0.F}}};
+  const auto pid = w.add_path(p);
+
+  auto h = w.spawn_enemy(pid, 10.F);
+  EXPECT_TRUE(w.is_alive(h));
+
+  (void)w.tick();
+
+  const auto snaps = w.snapshot();
+  ASSERT_EQ(snaps.size(), 1U);
+  EXPECT_NEAR(snaps[0].pos.x, 10.0, 1e-5);
+  EXPECT_NEAR(snaps[0].pos.y, 0.0, 1e-5);
+}
+
+// An enemy that reaches the end of the path is despawned automatically.
+void SimWorld_EnemyDespawnsAtEnd() {
+  sim_world w;
+  path p;
+  p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
+  const auto pid = w.add_path(p);
+
+  // Start near the end; one tick will push progress past total_length.
+  auto h = w.spawn_enemy(pid, 5.F, 8.F);
+  EXPECT_EQ(w.size(), 1U);
+
+  (void)w.tick();
+
+  EXPECT_EQ(w.size(), 0U);
+  EXPECT_FALSE(w.is_alive(h));
+}
+
+// get_path returns nullptr for an out-of-range index.
+void SimWorld_GetPathOutOfRange() {
+  sim_world w;
+  EXPECT_TRUE(w.get_path(0) == nullptr);
+
+  path p;
+  p.joints = {{{0.F, 0.F}}, {{1.F, 0.F}}};
+  (void)w.add_path(p);
+
+  EXPECT_TRUE(w.get_path(0) != nullptr);
+  EXPECT_TRUE(w.get_path(1) == nullptr);
+}
+
 // NOLINTEND(readability-function-cognitive-complexity)
 
 MAKE_TEST_LIST(SimWorld_SpawnDespawn, SimWorld_DespawnStale, SimWorld_Tick,
     SimWorld_TickOutParam, SimWorld_TickNullOut, SimWorld_BounceMinEdge,
     SimWorld_BounceMaxEdge, SimWorld_SnapshotAll, SimWorld_SnapshotSince,
     SimWorld_SnapshotByIds, SimWorld_SnapshotByIdsSkipsDead,
-    SimWorld_Background, SimWorld_BackgroundNotInDeltaAfterTick)
+    SimWorld_Background, SimWorld_BackgroundNotInDeltaAfterTick,
+    BakePath_TwoJoints, BakePath_ThreeJoints, BakePath_Degenerate,
+    PathPosition_Endpoints, PathPosition_Midpoint,
+    SimWorld_EnemyAdvancesOnTick, SimWorld_EnemyDespawnsAtEnd,
+    SimWorld_GetPathOutOfRange)

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -15,221 +15,211 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <cstddef>
+#include <string_view>
+#include <utility>
 #include <vector>
 
-#include "../corvid/sim/sim_world.h"
+#include "../corvid/sim/sim_game.h"
 #include "minitest.h"
 
 using namespace corvid;
 using namespace corvid::sim;
 
+namespace {
+
+struct WorldDelta {
+  std::vector<std::pair<SimWorld::EntityId, Position>> upserts;
+  std::vector<SimWorld::EntityId> erased;
+};
+
+struct GameDelta {
+  std::vector<std::pair<SimWorld::EntityId, Position>> upserts;
+  std::vector<SimWorld::EntityId> erased;
+  size_t currentWave{};
+  Tick waveTick{};
+  int lives{};
+  int resources{};
+  std::string_view phase;
+};
+
+[[nodiscard]] WorldDelta extractWorldDelta(SimWorld& world) {
+  WorldDelta delta;
+  (void)world.extractUpdatedEntities(
+      [&delta](SimWorld::EntityId id, const Position& pos) {
+        delta.upserts.emplace_back(id, pos);
+      },
+      [&delta](SimWorld::EntityId id) { delta.erased.push_back(id); });
+  return delta;
+}
+
+[[nodiscard]] GameDelta extractGameDelta(SimGame& game) {
+  GameDelta delta;
+  (void)game.extractDelta(
+      [&delta](SimWorld::EntityId id, const Position& pos) {
+        delta.upserts.emplace_back(id, pos);
+      },
+      [&delta](SimWorld::EntityId id) { delta.erased.push_back(id); },
+      [&delta](size_t currentWave, Tick waveTick, int lives, int resources,
+          std::string_view phase) {
+        delta.currentWave = currentWave;
+        delta.waveTick = waveTick;
+        delta.lives = lives;
+        delta.resources = resources;
+        delta.phase = phase;
+      });
+  return delta;
+}
+
+[[nodiscard]] bool containsId(const auto& entries, SimWorld::EntityId id) {
+  return std::ranges::any_of(entries,
+      [id](const auto& entry) { return entry.first == id; });
+}
+
+[[nodiscard]] const Position* findPosition(
+    const auto& entries, SimWorld::EntityId id) {
+  const auto it = std::ranges::find_if(
+      entries, [id](const auto& entry) { return entry.first == id; });
+  return it == entries.end() ? nullptr : &it->second;
+}
+
+} // namespace
+
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
-// Spawn, size, and despawn round-trip.
-void SimWorld_SpawnDespawn() {
+void SimWorld_SpawnAndSnapshot() {
   SimWorld w;
   EXPECT_EQ(w.size(), 0U);
 
-  auto h = w.spawnMover(Position{10.0, 20.0}, Velocity{1.0, 2.0});
-  EXPECT_TRUE(w.is_alive(h));
-  EXPECT_EQ(w.size(), 1U);
+  const auto mover = w.spawnMover(Position{10.F, 20.F}, Velocity{1.F, 2.F});
+  const auto background = w.spawnBackground(Position{30.F, 40.F});
 
-  auto h2 = w.spawnMover(Position{30.0, 40.0}, Velocity{-1.0, 0.0});
   EXPECT_EQ(w.size(), 2U);
 
-  EXPECT_TRUE(w.despawn(h));
-  EXPECT_EQ(w.size(), 1U);
-  EXPECT_FALSE(w.is_alive(h)); // handle is invalidated on success
-
-  EXPECT_TRUE(w.despawn(h2));
-  EXPECT_EQ(w.size(), 0U);
+  const auto all = w.snapshot();
+  ASSERT_EQ(all.size(), 2U);
+  EXPECT_EQ(w.snapshot(std::vector<SimWorld::EntityId>{mover.id()}).size(), 1U);
+  EXPECT_EQ(w.snapshot(
+                std::vector<SimWorld::EntityId>{mover.id(), background.id()})
+                .size(),
+      2U);
 }
 
-// Despawning a stale handle returns false without crashing.
-void SimWorld_DespawnStale() {
+void SimWorld_TickMovesMover() {
   SimWorld w;
-  auto h = w.spawnMover(Position{}, Velocity{});
-  EXPECT_TRUE(w.despawn(h));
-  EXPECT_FALSE(w.despawn(h)); // second call: handle is dead
-}
+  const auto mover = w.spawnMover(Position{100.F, 200.F}, Velocity{3.F, -5.F});
 
-// tick() advances position by velocity.
-void SimWorld_Tick() {
-  SimWorld w;
-  auto h = w.spawnMover(Position{100.0, 200.0}, Velocity{3.0, -5.0});
-  (void)w.tick();
+  EXPECT_EQ(w.tick(), 1U);
 
-  auto snaps = w.snapshot();
+  const auto snaps = w.snapshot();
   ASSERT_EQ(snaps.size(), 1U);
-  EXPECT_NEAR(snaps[0].pos.x, 103.0, 1e-9);
-  EXPECT_NEAR(snaps[0].pos.y, 195.0, 1e-9);
-  (void)h;
+  EXPECT_EQ(snaps[0].id, mover.id());
+  EXPECT_NEAR(snaps[0].pos.x, 103.0, 1e-6);
+  EXPECT_NEAR(snaps[0].pos.y, 195.0, 1e-6);
 }
 
-// tick() with a non-null out-vector appends changed entity IDs.
-void SimWorld_TickOutParam() {
+void SimWorld_ExtractUpdatedEntitiesReportsMovedMoverOncePerExtraction() {
   SimWorld w;
-  auto h1 = w.spawnMover(Position{100.0, 100.0}, Velocity{1.0, 0.0});
-  auto h2 = w.spawnMover(Position{200.0, 200.0}, Velocity{0.0, 1.0});
+  const auto mover = w.spawnMover(Position{0.F, 0.F}, Velocity{2.F, 3.F});
 
-  std::vector<SimWorld::EntityId> changed;
   (void)w.tick();
+  const auto delta = extractWorldDelta(w);
 
-  EXPECT_EQ(changed.size(), 2U);
-  (void)h1;
-  (void)h2;
+  EXPECT_TRUE(containsId(delta.upserts, mover.id()));
+  EXPECT_TRUE(delta.erased.empty());
+
+  const auto* pos = findPosition(delta.upserts, mover.id());
+  ASSERT_TRUE(pos != nullptr);
+  EXPECT_NEAR(pos->x, 2.0, 1e-6);
+  EXPECT_NEAR(pos->y, 3.0, 1e-6);
+
+  const auto empty_delta = extractWorldDelta(w);
+  EXPECT_TRUE(empty_delta.upserts.empty());
+  EXPECT_TRUE(empty_delta.erased.empty());
 }
 
-// tick() with nullptr out-param does not allocate (just advance state).
-void SimWorld_TickNullOut() {
-  SimWorld w;
-  (void)w.spawnMover(Position{50.0, 50.0}, Velocity{1.0, 1.0});
-  (void)w.tick(); // must not crash
-  auto snaps = w.snapshot();
-  ASSERT_EQ(snaps.size(), 1U);
-  EXPECT_NEAR(snaps[0].pos.x, 51.0, 1e-9);
-}
-
-// Entities bounce off the left/top boundary.
 void SimWorld_BounceMinEdge() {
   SimWorld w;
   const float half_w = SimWorld::widthOfWorld * 0.5F;
   const float half_h = SimWorld::heightOfWorld * 0.5F;
-  (void)w.spawnMover(Position{-half_w + 0.5F, -half_h + 0.5F},
-      Velocity{-2.0F, -2.0F});
+  const auto mover = w.spawnMover(
+      Position{-half_w + 0.5F, -half_h + 0.5F}, Velocity{-2.F, -2.F});
+
   (void)w.tick();
 
-  auto snaps = w.snapshot();
+  const auto snaps = w.snapshot(std::vector<SimWorld::EntityId>{mover.id()});
   ASSERT_EQ(snaps.size(), 1U);
+  EXPECT_EQ(snaps[0].id, mover.id());
   EXPECT_GE(snaps[0].pos.x, -half_w);
   EXPECT_GE(snaps[0].pos.y, -half_h);
 }
 
-// Entities bounce off the right/bottom boundary.
 void SimWorld_BounceMaxEdge() {
   SimWorld w;
   const float half_w = SimWorld::widthOfWorld * 0.5F;
   const float half_h = SimWorld::heightOfWorld * 0.5F;
-  (void)w.spawnMover(Position{half_w - 0.5F, half_h - 0.5F},
-      Velocity{2.0F, 2.0F});
+  const auto mover = w.spawnMover(
+      Position{half_w - 0.5F, half_h - 0.5F}, Velocity{2.F, 2.F});
+
   (void)w.tick();
 
-  auto snaps = w.snapshot();
+  const auto snaps = w.snapshot(std::vector<SimWorld::EntityId>{mover.id()});
   ASSERT_EQ(snaps.size(), 1U);
+  EXPECT_EQ(snaps[0].id, mover.id());
   EXPECT_LE(snaps[0].pos.x, half_w);
   EXPECT_LE(snaps[0].pos.y, half_h);
 }
 
-// snapshot() with default since_tick returns all entities.
-void SimWorld_SnapshotAll() {
+void SimWorld_SnapshotSinceTracksChanges() {
   SimWorld w;
-  (void)w.spawnMover(Position{1.0, 2.0}, Velocity{});
-  (void)w.spawnMover(Position{3.0, 4.0}, Velocity{});
+  (void)w.spawnMover(Position{10.F, 10.F}, Velocity{1.F, 0.F});
+  (void)w.spawnBackground(Position{20.F, 20.F});
 
-  auto snaps = w.snapshot();
-  EXPECT_EQ(snaps.size(), 2U);
-}
-
-// snapshot(since_tick) returns only entities changed at or after that tick.
-void SimWorld_SnapshotSince() {
-  SimWorld w;
-  // Spawn two entities before any tick (their last-change tick = 0).
-  (void)w.spawnMover(Position{10.0, 10.0}, Velocity{1.0, 0.0});
-  (void)w.spawnMover(Position{20.0, 20.0}, Velocity{1.0, 0.0});
-
-  (void)w.tick(); // tick 1: both entities move, metadata set to 1
-
-  // Everything changed at tick 1 or later -> 2 results.
-  EXPECT_EQ(w.snapshot(1).size(), 2U);
-
-  // Nothing changed at tick 2 or later -> 0 results.
-  EXPECT_EQ(w.snapshot(2).size(), 0U);
-
-  (void)w.tick(); // tick 2: both entities move again, metadata set to 2
-
-  // Now both qualify for since_tick=2.
-  EXPECT_EQ(w.snapshot(2).size(), 2U);
-
-  // Still nothing at tick 3.
-  EXPECT_EQ(w.snapshot(3).size(), 0U);
-}
-
-// snapshot(ids) returns only the requested entities.
-void SimWorld_SnapshotByIds() {
-  SimWorld w;
-  auto h1 = w.spawnMover(Position{1.0, 1.0}, Velocity{});
-  auto h2 = w.spawnMover(Position{2.0, 2.0}, Velocity{});
-  auto h3 = w.spawnMover(Position{3.0, 3.0}, Velocity{});
-
-  std::vector<SimWorld::EntityId> ids{h1.id(), h3.id()};
-  auto snaps = w.snapshot(ids);
-  ASSERT_EQ(snaps.size(), 2U);
-  // The results should be for h1 and h3, not h2.
-  EXPECT_EQ(snaps[0].id, h1.id());
-  EXPECT_EQ(snaps[1].id, h3.id());
-  (void)h2;
-}
-
-// snapshot(ids) silently skips dead entity IDs.
-void SimWorld_SnapshotByIdsSkipsDead() {
-  SimWorld w;
-  auto h = w.spawnMover(Position{5.0, 5.0}, Velocity{});
-  auto dead_id = h.id();
-  EXPECT_TRUE(w.despawn(h));
-
-  std::vector<SimWorld::EntityId> ids{dead_id};
-  auto snaps = w.snapshot(ids);
-  EXPECT_EQ(snaps.size(), 0U);
-}
-
-// spawn_background adds a P-only entity visible in snapshots.
-void SimWorld_Background() {
-  SimWorld w;
-  auto hb = w.spawnBackground(Position{50.0, 60.0});
-  EXPECT_TRUE(w.is_alive(hb));
-  EXPECT_EQ(w.size(), 1U);
-
-  auto snaps = w.snapshot();
-  ASSERT_EQ(snaps.size(), 1U);
-  EXPECT_NEAR(snaps[0].pos.x, 50.0, 1e-9);
-  EXPECT_NEAR(snaps[0].pos.y, 60.0, 1e-9);
-
-  // Background entity does not move on tick.
-  (void)w.tick();
-  snaps = w.snapshot();
-  ASSERT_EQ(snaps.size(), 1U);
-  EXPECT_NEAR(snaps[0].pos.x, 50.0, 1e-9);
-}
-
-// Background entity is excluded from snapshot(since_tick) after a tick
-// because its metadata was never updated beyond its spawn tick (0).
-void SimWorld_BackgroundNotInDeltaAfterTick() {
-  SimWorld w;
-  (void)w.spawnBackground(Position{50.0, 60.0});
-  (void)w.tick(); // tick 1; background entity metadata stays at 0
+  EXPECT_EQ(w.snapshot(0).size(), 2U);
   EXPECT_EQ(w.snapshot(1).size(), 0U);
+
+  (void)w.tick();
+
+  EXPECT_EQ(w.snapshot(1).size(), 1U);
+  EXPECT_EQ(w.snapshot(2).size(), 0U);
 }
 
-// --- Path geometry tests ---
+void SimWorld_BackgroundDoesNotAppearAsChangedAfterTick() {
+  SimWorld w;
+  (void)w.spawnBackground(Position{50.F, 60.F});
 
-// bake_path with two joints produces one segment with the correct length.
+  (void)w.tick();
+
+  const auto snaps = w.snapshot();
+  ASSERT_EQ(snaps.size(), 1U);
+  EXPECT_NEAR(snaps[0].pos.x, 50.0, 1e-6);
+  EXPECT_NEAR(snaps[0].pos.y, 60.0, 1e-6);
+  EXPECT_EQ(w.snapshot(1).size(), 0U);
+
+  const auto delta = extractWorldDelta(w);
+  EXPECT_TRUE(delta.upserts.empty());
+  EXPECT_TRUE(delta.erased.empty());
+}
+
 void BakePath_TwoJoints() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{3.F, 4.F}}};
+
   const auto bp = SegmentedPath::fromJoints(p);
+
   ASSERT_EQ(bp.segments.size(), 1U);
   EXPECT_NEAR(bp.segments[0].cumulativeStart, 0.0, 1e-6);
   EXPECT_NEAR(bp.segments[0].length, 5.0, 1e-6);
   EXPECT_NEAR(bp.totalLength, 5.0, 1e-6);
 }
 
-// bake_path with three joints produces two segments with correct cumulative
-// distances.
 void BakePath_ThreeJoints() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{3.F, 4.F}}, {{6.F, 8.F}}};
+
   const auto bp = SegmentedPath::fromJoints(p);
+
   ASSERT_EQ(bp.segments.size(), 2U);
   EXPECT_NEAR(bp.segments[0].cumulativeStart, 0.0, 1e-6);
   EXPECT_NEAR(bp.segments[0].length, 5.0, 1e-6);
@@ -238,78 +228,124 @@ void BakePath_ThreeJoints() {
   EXPECT_NEAR(bp.totalLength, 10.0, 1e-6);
 }
 
-// bake_path with fewer than two joints returns an empty baked_path.
 void BakePath_Degenerate() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}};
+
   const auto bp = SegmentedPath::fromJoints(p);
+
   EXPECT_TRUE(bp.segments.empty());
   EXPECT_NEAR(bp.totalLength, 0.0, 1e-6);
 }
 
-// path_position at progress 0 returns the first joint; at total_length
-// returns the last joint.
 void PathPosition_Endpoints() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
   const auto bp = SegmentedPath::fromJoints(p);
 
   const auto start = bp.calculatePositionFromProgress(0.F);
+  const auto end = bp.calculatePositionFromProgress(bp.totalLength);
+
   EXPECT_NEAR(start.x, 0.0, 1e-6);
   EXPECT_NEAR(start.y, 0.0, 1e-6);
-
-  const auto end = bp.calculatePositionFromProgress(bp.totalLength);
   EXPECT_NEAR(end.x, 10.0, 1e-6);
   EXPECT_NEAR(end.y, 0.0, 1e-6);
 }
 
-// path_position at the midpoint returns the correctly interpolated position.
 void PathPosition_Midpoint() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
   const auto bp = SegmentedPath::fromJoints(p);
 
   const auto mid = bp.calculatePositionFromProgress(5.F);
+
   EXPECT_NEAR(mid.x, 5.0, 1e-6);
   EXPECT_NEAR(mid.y, 0.0, 1e-6);
 }
 
-// Spawning an enemy and ticking once advances its position by `speed`.
 void SimWorld_EnemyAdvancesOnTick() {
   SimWorld w;
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{100.F, 0.F}}};
   const auto pid = w.addPath(p);
+  const auto enemy = w.spawnEnemy(pid, 10.F);
 
-  auto h = w.spawnEnemy(pid, 10.F);
-  EXPECT_TRUE(w.is_alive(h));
+  EXPECT_TRUE(static_cast<bool>(enemy));
+  EXPECT_EQ(w.size(), 1U);
 
   (void)w.tick();
 
   const auto snaps = w.snapshot();
   ASSERT_EQ(snaps.size(), 1U);
+  EXPECT_EQ(snaps[0].id, enemy.id());
   EXPECT_NEAR(snaps[0].pos.x, 10.0, 1e-5);
   EXPECT_NEAR(snaps[0].pos.y, 0.0, 1e-5);
+
+  const auto delta = extractWorldDelta(w);
+  EXPECT_TRUE(containsId(delta.upserts, enemy.id()));
 }
 
-// An enemy that reaches the end of the path is despawned automatically.
-void SimWorld_EnemyDespawnsAtEnd() {
+void SimWorld_ResolveEscapeesVisitsEscapedEnemy() {
   SimWorld w;
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
   const auto pid = w.addPath(p);
+  const auto enemy = w.spawnEnemy(pid, 5.F, 8.F);
 
-  // Start near the end; one tick will push progress past total_length.
-  auto h = w.spawnEnemy(pid, 5.F, 8.F);
+  (void)w.tick();
   EXPECT_EQ(w.size(), 1U);
+
+  size_t resolved = 0;
+  (void)w.resolveEscapees([&](SimWorld::EntityId id, const Position& pos,
+                               const PathFollower& pf) {
+    ++resolved;
+    EXPECT_EQ(id, enemy.id());
+    EXPECT_NEAR(pos.x, 8.0, 1e-6);
+    EXPECT_NEAR(pos.y, 0.0, 1e-6);
+    EXPECT_NEAR(pf.progress, 13.0, 1e-6);
+    EXPECT_NEAR(pf.speed, 5.0, 1e-6);
+    return true;
+  });
+
+  EXPECT_EQ(resolved, 1U);
+  EXPECT_EQ(w.size(), 1U);
+
+  const auto delta = extractWorldDelta(w);
+  EXPECT_TRUE(containsId(delta.upserts, enemy.id()));
+  EXPECT_TRUE(delta.erased.empty());
+
+  const auto snaps = w.snapshot();
+  ASSERT_EQ(snaps.size(), 1U);
+  EXPECT_EQ(snaps[0].id, enemy.id());
+  EXPECT_NEAR(snaps[0].pos.x, 8.0, 1e-6);
+}
+
+void SimWorld_ResolveEscapeesCanLeaveEnemyAlive() {
+  SimWorld w;
+  PathJoints p;
+  p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
+  const auto pid = w.addPath(p);
+  const auto enemy = w.spawnEnemy(pid, 5.F, 8.F);
 
   (void)w.tick();
 
-  EXPECT_EQ(w.size(), 0U);
-  EXPECT_FALSE(w.is_alive(h));
+  size_t resolved = 0;
+  (void)w.resolveEscapees([&](SimWorld::EntityId id, const Position&,
+                               const PathFollower&) {
+    ++resolved;
+    EXPECT_EQ(id, enemy.id());
+    return false;
+  });
+
+  EXPECT_EQ(resolved, 1U);
+  EXPECT_EQ(w.size(), 1U);
+
+  const auto snaps = w.snapshot();
+  ASSERT_EQ(snaps.size(), 1U);
+  EXPECT_EQ(snaps[0].id, enemy.id());
+  EXPECT_NEAR(snaps[0].pos.x, 8.0, 1e-6);
 }
 
-// get_path returns nullptr for an out-of-range index.
 void SimWorld_GetPathOutOfRange() {
   SimWorld w;
   EXPECT_TRUE(w.getPath(PathId{0}) == nullptr);
@@ -322,14 +358,120 @@ void SimWorld_GetPathOutOfRange() {
   EXPECT_TRUE(w.getPath(PathId{1}) == nullptr);
 }
 
+void SimGame_LoadMapInitialSnapshotAndState() {
+  SimGame game;
+  game.loadMap();
+
+  const auto snap = game.snapshot();
+  ASSERT_EQ(snap.entities.size(), 0U);
+  ASSERT_EQ(snap.path_points.size(), 1U);
+  EXPECT_EQ(snap.path_points[0].joints.front().p.x, 0.F);
+  EXPECT_EQ(snap.path_points[0].joints.front().p.y, 0.F);
+  EXPECT_GT(snap.path_points[0].joints.size(), 2U);
+
+  const auto delta = extractGameDelta(game);
+  EXPECT_EQ(delta.currentWave, 0U);
+  EXPECT_EQ(delta.waveTick, 0U);
+  EXPECT_EQ(delta.lives, 20);
+  EXPECT_EQ(delta.resources, 100);
+  EXPECT_EQ(delta.phase, std::string_view{"build"});
+  EXPECT_TRUE(delta.upserts.empty());
+  EXPECT_TRUE(delta.erased.empty());
+}
+
+void SimGame_StartWaveSpawnsFirstEnemyOnFirstStep() {
+  SimGame game;
+  game.loadMap();
+  game.start_wave();
+
+  EXPECT_EQ(game.step(), 1U);
+
+  const auto snap = game.snapshot();
+  ASSERT_EQ(snap.entities.size(), 1U);
+  EXPECT_NEAR(snap.entities[0].pos.x, 0.0, 1e-6);
+  EXPECT_NEAR(snap.entities[0].pos.y, 0.0, 1e-6);
+
+  const auto delta = extractGameDelta(game);
+  EXPECT_EQ(delta.currentWave, 0U);
+  EXPECT_EQ(delta.waveTick, 1U);
+  EXPECT_EQ(delta.lives, 20);
+  EXPECT_EQ(delta.resources, 100);
+  EXPECT_EQ(delta.phase, std::string_view{"wave"});
+}
+
+void SimGame_ExtractDeltaConsumesWorldUpdatesButNotState() {
+  SimGame game;
+  game.loadMap();
+  game.start_wave();
+
+  (void)game.step();
+  (void)game.step();
+
+  const auto delta = extractGameDelta(game);
+  EXPECT_TRUE(!delta.upserts.empty());
+  EXPECT_EQ(delta.erased.size(), 0U);
+  EXPECT_EQ(delta.waveTick, 2U);
+  EXPECT_EQ(delta.phase, std::string_view{"wave"});
+
+  const auto* pos = findPosition(delta.upserts, delta.upserts.front().first);
+  ASSERT_TRUE(pos != nullptr);
+  EXPECT_GT(pos->x, 0.F);
+
+  const auto empty_world_delta = extractGameDelta(game);
+  EXPECT_TRUE(empty_world_delta.upserts.empty());
+  EXPECT_TRUE(empty_world_delta.erased.empty());
+  EXPECT_EQ(empty_world_delta.waveTick, 2U);
+  EXPECT_EQ(empty_world_delta.phase, std::string_view{"wave"});
+}
+
+void SimGame_ExtractFullIncludesPathsAndState() {
+  SimGame game;
+  game.loadMap();
+
+  size_t path_points = 0;
+  size_t upserts = 0;
+  size_t erased = 0;
+  size_t currentWave = 99;
+  Tick waveTick = 99;
+  int lives = -1;
+  int resources = -1;
+  std::string_view phase = "unknown";
+
+  (void)game.extractFull(
+      [&path_points](PathId, const Position&) { ++path_points; },
+      [&upserts](SimWorld::EntityId, const Position&) { ++upserts; },
+      [&erased](SimWorld::EntityId) { ++erased; },
+      [&currentWave, &waveTick, &lives, &resources, &phase](size_t wave,
+          Tick tick, int newLives, int newResources, std::string_view newPhase) {
+        currentWave = wave;
+        waveTick = tick;
+        lives = newLives;
+        resources = newResources;
+        phase = newPhase;
+      });
+
+  EXPECT_GT(path_points, 0U);
+  EXPECT_EQ(upserts, 0U);
+  EXPECT_EQ(erased, 0U);
+  EXPECT_EQ(currentWave, 0U);
+  EXPECT_EQ(waveTick, 0U);
+  EXPECT_EQ(lives, 20);
+  EXPECT_EQ(resources, 100);
+  EXPECT_EQ(phase, std::string_view{"build"});
+}
+
 // NOLINTEND(readability-function-cognitive-complexity)
 
-MAKE_TEST_LIST(SimWorld_SpawnDespawn, SimWorld_DespawnStale, SimWorld_Tick,
-    SimWorld_TickOutParam, SimWorld_TickNullOut, SimWorld_BounceMinEdge,
-    SimWorld_BounceMaxEdge, SimWorld_SnapshotAll, SimWorld_SnapshotSince,
-    SimWorld_SnapshotByIds, SimWorld_SnapshotByIdsSkipsDead,
-    SimWorld_Background, SimWorld_BackgroundNotInDeltaAfterTick,
-    BakePath_TwoJoints, BakePath_ThreeJoints, BakePath_Degenerate,
-    PathPosition_Endpoints, PathPosition_Midpoint,
-    SimWorld_EnemyAdvancesOnTick, SimWorld_EnemyDespawnsAtEnd,
-    SimWorld_GetPathOutOfRange)
+MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_TickMovesMover,
+    SimWorld_ExtractUpdatedEntitiesReportsMovedMoverOncePerExtraction,
+    SimWorld_BounceMinEdge, SimWorld_BounceMaxEdge,
+    SimWorld_SnapshotSinceTracksChanges,
+    SimWorld_BackgroundDoesNotAppearAsChangedAfterTick, BakePath_TwoJoints,
+    BakePath_ThreeJoints, BakePath_Degenerate, PathPosition_Endpoints,
+    PathPosition_Midpoint, SimWorld_EnemyAdvancesOnTick,
+    SimWorld_ResolveEscapeesVisitsEscapedEnemy,
+    SimWorld_ResolveEscapeesCanLeaveEnemyAlive, SimWorld_GetPathOutOfRange,
+    SimGame_LoadMapInitialSnapshotAndState,
+    SimGame_StartWaveSpawnsFirstEnemyOnFirstStep,
+    SimGame_ExtractDeltaConsumesWorldUpdatesButNotState,
+    SimGame_ExtractFullIncludesPathsAndState)

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -518,7 +518,7 @@ void SimGame_HandleUiCanvasSpawnsTowerButKeepsBuildPhase() {
   const auto before = extractGameDelta(game);
 
   game.handleUiCanvas(UiCanvasInput{.seq = 1,
-      .event = UiCanvasEvent::click,
+      .event = UiCanvasEvent::dblclick,
       .button = UiMouseButton::left,
       .buttons = 1,
       .x = 10.F,
@@ -679,7 +679,7 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
   SimGame game;
   game.loadMap();
   game.handleUiCanvas(UiCanvasInput{.seq = 1,
-      .event = UiCanvasEvent::click,
+      .event = UiCanvasEvent::dblclick,
       .button = UiMouseButton::left,
       .buttons = 1,
       .x = 10.F,
@@ -692,7 +692,7 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
   (void)build_sim_game_state_json(state, game, tick);
   EXPECT_TRUE(state.body_highwater >= state.body.size());
   EXPECT_TRUE(state.body.contains(R"("x":10.0)"));
-  EXPECT_TRUE(state.body.contains(R"("scale":4.000)"));
+  EXPECT_TRUE(state.body.contains(R"("radius":20.000)"));
   EXPECT_FALSE(state.body.contains(R"("vfx")"));
   EXPECT_FALSE(state.body.contains(R"("flashExpiryMs")"));
   EXPECT_FALSE(state.body.contains(R"("modified")"));
@@ -728,7 +728,7 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
     const auto app = entry.get_object("app");
     ASSERT_TRUE(app);
     ASSERT_TRUE(app.get_number<uint32_t>("glyph").has_value());
-    ASSERT_TRUE(app.get_number<float>("scale").has_value());
+    ASSERT_TRUE(app.get_number<float>("radius").has_value());
     ASSERT_TRUE(!app.get_number<uint32_t>("modified").has_value());
 
     const auto vfx = entry.get_object("vfx");

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -44,6 +44,43 @@ struct GameDelta {
   std::string_view phase;
 };
 
+struct EntitySnapshot {
+  SimWorld::EntityId id;
+  Position pos;
+};
+
+struct GameSnapshot {
+  std::vector<EntitySnapshot> entities;
+  std::vector<PathJoints> path_points;
+};
+
+[[nodiscard]] std::vector<EntitySnapshot> snapshot(SimWorld& world) {
+  std::vector<EntitySnapshot> snaps;
+  (void)world.markAllDirty();
+  (void)world.extractUpdatedEntities(
+      [&snaps](SimWorld::EntityId id, const Position& pos) {
+        const auto it = std::ranges::find(snaps, id, &EntitySnapshot::id);
+        if (it == snaps.end())
+          snaps.push_back({id, pos});
+        else
+          it->pos = pos;
+      },
+      [](SimWorld::EntityId) {});
+  return snaps;
+}
+
+[[nodiscard]] std::vector<EntitySnapshot>
+snapshot(SimWorld& world, const std::vector<SimWorld::EntityId>& ids) {
+  const auto all = snapshot(world);
+  std::vector<EntitySnapshot> filtered;
+  filtered.reserve(ids.size());
+  std::ranges::copy_if(all, std::back_inserter(filtered),
+      [&ids](const EntitySnapshot& snap) {
+        return std::ranges::find(ids, snap.id) != ids.end();
+      });
+  return filtered;
+}
+
 [[nodiscard]] WorldDelta extractWorldDelta(SimWorld& world) {
   WorldDelta delta;
   (void)world.extractUpdatedEntities(
@@ -52,6 +89,26 @@ struct GameDelta {
       },
       [&delta](SimWorld::EntityId id) { delta.erased.push_back(id); });
   return delta;
+}
+
+[[nodiscard]] GameSnapshot snapshot(SimGame& game) {
+  GameSnapshot snap;
+  std::vector<PathJoints> pathsById;
+
+  (void)game.extractFull(
+      [&pathsById](PathId pathId, const Position& pos) {
+        const auto ndx = static_cast<size_t>(*pathId);
+        if (pathsById.size() <= ndx) pathsById.resize(ndx + 1);
+        pathsById[ndx].joints.push_back({pos});
+      },
+      [&snap](SimWorld::EntityId id, const Position& pos) {
+        snap.entities.push_back({id, pos});
+      },
+      [](SimWorld::EntityId) {},
+      [](size_t, Tick, int, int, std::string_view) {});
+
+  snap.path_points = std::move(pathsById);
+  return snap;
 }
 
 [[nodiscard]] GameDelta extractGameDelta(SimGame& game) {
@@ -73,14 +130,16 @@ struct GameDelta {
 }
 
 [[nodiscard]] bool containsId(const auto& entries, SimWorld::EntityId id) {
-  return std::ranges::any_of(entries,
-      [id](const auto& entry) { return entry.first == id; });
+  return std::ranges::any_of(entries, [id](const auto& entry) {
+    return entry.first == id;
+  });
 }
 
-[[nodiscard]] const Position* findPosition(
-    const auto& entries, SimWorld::EntityId id) {
-  const auto it = std::ranges::find_if(
-      entries, [id](const auto& entry) { return entry.first == id; });
+[[nodiscard]] const Position*
+findPosition(const auto& entries, SimWorld::EntityId id) {
+  const auto it = std::ranges::find_if(entries, [id](const auto& entry) {
+    return entry.first == id;
+  });
   return it == entries.end() ? nullptr : &it->second;
 }
 
@@ -97,12 +156,13 @@ void SimWorld_SpawnAndSnapshot() {
 
   EXPECT_EQ(w.size(), 2U);
 
-  const auto all = w.snapshot();
+  const auto all = snapshot(w);
   ASSERT_EQ(all.size(), 2U);
-  EXPECT_EQ(w.snapshot(std::vector<SimWorld::EntityId>{mover.id()}).size(), 1U);
-  EXPECT_EQ(w.snapshot(
-                std::vector<SimWorld::EntityId>{mover.id(), background.id()})
-                .size(),
+  EXPECT_EQ(snapshot(w, std::vector<SimWorld::EntityId>{mover.id()}).size(),
+      1U);
+  EXPECT_EQ(
+      snapshot(w, std::vector<SimWorld::EntityId>{mover.id(), background.id()})
+          .size(),
       2U);
 }
 
@@ -112,7 +172,7 @@ void SimWorld_TickMovesMover() {
 
   EXPECT_EQ(w.tick(), 1U);
 
-  const auto snaps = w.snapshot();
+  const auto snaps = snapshot(w);
   ASSERT_EQ(snaps.size(), 1U);
   EXPECT_EQ(snaps[0].id, mover.id());
   EXPECT_NEAR(snaps[0].pos.x, 103.0, 1e-6);
@@ -143,12 +203,12 @@ void SimWorld_BounceMinEdge() {
   SimWorld w;
   const float half_w = SimWorld::widthOfWorld * 0.5F;
   const float half_h = SimWorld::heightOfWorld * 0.5F;
-  const auto mover = w.spawnMover(
-      Position{-half_w + 0.5F, -half_h + 0.5F}, Velocity{-2.F, -2.F});
+  const auto mover = w.spawnMover(Position{-half_w + 0.5F, -half_h + 0.5F},
+      Velocity{-2.F, -2.F});
 
   (void)w.tick();
 
-  const auto snaps = w.snapshot(std::vector<SimWorld::EntityId>{mover.id()});
+  const auto snaps = snapshot(w, std::vector<SimWorld::EntityId>{mover.id()});
   ASSERT_EQ(snaps.size(), 1U);
   EXPECT_EQ(snaps[0].id, mover.id());
   EXPECT_GE(snaps[0].pos.x, -half_w);
@@ -159,12 +219,12 @@ void SimWorld_BounceMaxEdge() {
   SimWorld w;
   const float half_w = SimWorld::widthOfWorld * 0.5F;
   const float half_h = SimWorld::heightOfWorld * 0.5F;
-  const auto mover = w.spawnMover(
-      Position{half_w - 0.5F, half_h - 0.5F}, Velocity{2.F, 2.F});
+  const auto mover =
+      w.spawnMover(Position{half_w - 0.5F, half_h - 0.5F}, Velocity{2.F, 2.F});
 
   (void)w.tick();
 
-  const auto snaps = w.snapshot(std::vector<SimWorld::EntityId>{mover.id()});
+  const auto snaps = snapshot(w, std::vector<SimWorld::EntityId>{mover.id()});
   ASSERT_EQ(snaps.size(), 1U);
   EXPECT_EQ(snaps[0].id, mover.id());
   EXPECT_LE(snaps[0].pos.x, half_w);
@@ -176,13 +236,22 @@ void SimWorld_SnapshotSinceTracksChanges() {
   (void)w.spawnMover(Position{10.F, 10.F}, Velocity{1.F, 0.F});
   (void)w.spawnBackground(Position{20.F, 20.F});
 
-  EXPECT_EQ(w.snapshot(0).size(), 2U);
-  EXPECT_EQ(w.snapshot(1).size(), 0U);
+  const auto initial = snapshot(w);
+  EXPECT_EQ(initial.size(), 2U);
+
+  const auto unchanged = extractWorldDelta(w);
+  EXPECT_TRUE(unchanged.upserts.empty());
+  EXPECT_TRUE(unchanged.erased.empty());
 
   (void)w.tick();
 
-  EXPECT_EQ(w.snapshot(1).size(), 1U);
-  EXPECT_EQ(w.snapshot(2).size(), 0U);
+  const auto moved = extractWorldDelta(w);
+  EXPECT_EQ(moved.upserts.size(), 1U);
+  EXPECT_TRUE(moved.erased.empty());
+
+  const auto stable = extractWorldDelta(w);
+  EXPECT_TRUE(stable.upserts.empty());
+  EXPECT_TRUE(stable.erased.empty());
 }
 
 void SimWorld_BackgroundDoesNotAppearAsChangedAfterTick() {
@@ -191,11 +260,10 @@ void SimWorld_BackgroundDoesNotAppearAsChangedAfterTick() {
 
   (void)w.tick();
 
-  const auto snaps = w.snapshot();
+  const auto snaps = snapshot(w);
   ASSERT_EQ(snaps.size(), 1U);
   EXPECT_NEAR(snaps[0].pos.x, 50.0, 1e-6);
   EXPECT_NEAR(snaps[0].pos.y, 60.0, 1e-6);
-  EXPECT_EQ(w.snapshot(1).size(), 0U);
 
   const auto delta = extractWorldDelta(w);
   EXPECT_TRUE(delta.upserts.empty());
@@ -275,14 +343,11 @@ void SimWorld_EnemyAdvancesOnTick() {
 
   (void)w.tick();
 
-  const auto snaps = w.snapshot();
-  ASSERT_EQ(snaps.size(), 1U);
-  EXPECT_EQ(snaps[0].id, enemy.id());
-  EXPECT_NEAR(snaps[0].pos.x, 10.0, 1e-5);
-  EXPECT_NEAR(snaps[0].pos.y, 0.0, 1e-5);
-
   const auto delta = extractWorldDelta(w);
   EXPECT_TRUE(containsId(delta.upserts, enemy.id()));
+  ASSERT_EQ(delta.upserts.size(), 1U);
+  EXPECT_NEAR(delta.upserts[0].second.x, 10.0, 1e-5);
+  EXPECT_NEAR(delta.upserts[0].second.y, 0.0, 1e-5);
 }
 
 void SimWorld_ResolveEscapeesVisitsEscapedEnemy() {
@@ -296,28 +361,27 @@ void SimWorld_ResolveEscapeesVisitsEscapedEnemy() {
   EXPECT_EQ(w.size(), 1U);
 
   size_t resolved = 0;
-  (void)w.resolveEscapees([&](SimWorld::EntityId id, const Position& pos,
-                               const PathFollower& pf) {
-    ++resolved;
-    EXPECT_EQ(id, enemy.id());
-    EXPECT_NEAR(pos.x, 8.0, 1e-6);
-    EXPECT_NEAR(pos.y, 0.0, 1e-6);
-    EXPECT_NEAR(pf.progress, 13.0, 1e-6);
-    EXPECT_NEAR(pf.speed, 5.0, 1e-6);
-    return true;
-  });
+  (void)w.resolveEscapees(
+      [&](SimWorld::EntityId id, const Position& pos, const PathFollower& pf) {
+        ++resolved;
+        EXPECT_EQ(id, enemy.id());
+        EXPECT_NEAR(pos.x, 8.0, 1e-6);
+        EXPECT_NEAR(pos.y, 0.0, 1e-6);
+        EXPECT_NEAR(pf.progress, 13.0, 1e-6);
+        EXPECT_NEAR(pf.speed, 5.0, 1e-6);
+        return true;
+      });
 
   EXPECT_EQ(resolved, 1U);
-  EXPECT_EQ(w.size(), 1U);
+  EXPECT_EQ(w.size(), 0U);
 
   const auto delta = extractWorldDelta(w);
-  EXPECT_TRUE(containsId(delta.upserts, enemy.id()));
-  EXPECT_TRUE(delta.erased.empty());
+  EXPECT_TRUE(delta.upserts.empty());
+  EXPECT_EQ(delta.erased.size(), 1U);
+  EXPECT_EQ(delta.erased[0], enemy.id());
 
-  const auto snaps = w.snapshot();
-  ASSERT_EQ(snaps.size(), 1U);
-  EXPECT_EQ(snaps[0].id, enemy.id());
-  EXPECT_NEAR(snaps[0].pos.x, 8.0, 1e-6);
+  const auto snaps = snapshot(w);
+  EXPECT_TRUE(snaps.empty());
 }
 
 void SimWorld_ResolveEscapeesCanLeaveEnemyAlive() {
@@ -330,17 +394,17 @@ void SimWorld_ResolveEscapeesCanLeaveEnemyAlive() {
   (void)w.tick();
 
   size_t resolved = 0;
-  (void)w.resolveEscapees([&](SimWorld::EntityId id, const Position&,
-                               const PathFollower&) {
-    ++resolved;
-    EXPECT_EQ(id, enemy.id());
-    return false;
-  });
+  (void)w.resolveEscapees(
+      [&](SimWorld::EntityId id, const Position&, const PathFollower&) {
+        ++resolved;
+        EXPECT_EQ(id, enemy.id());
+        return false;
+      });
 
   EXPECT_EQ(resolved, 1U);
   EXPECT_EQ(w.size(), 1U);
 
-  const auto snaps = w.snapshot();
+  const auto snaps = snapshot(w);
   ASSERT_EQ(snaps.size(), 1U);
   EXPECT_EQ(snaps[0].id, enemy.id());
   EXPECT_NEAR(snaps[0].pos.x, 8.0, 1e-6);
@@ -362,7 +426,7 @@ void SimGame_LoadMapInitialSnapshotAndState() {
   SimGame game;
   game.loadMap();
 
-  const auto snap = game.snapshot();
+  const auto snap = snapshot(game);
   ASSERT_EQ(snap.entities.size(), 0U);
   ASSERT_EQ(snap.path_points.size(), 1U);
   EXPECT_EQ(snap.path_points[0].joints.front().p.x, 0.F);
@@ -386,7 +450,7 @@ void SimGame_StartWaveSpawnsFirstEnemyOnFirstStep() {
 
   EXPECT_EQ(game.step(), 1U);
 
-  const auto snap = game.snapshot();
+  const auto snap = snapshot(game);
   ASSERT_EQ(snap.entities.size(), 1U);
   EXPECT_NEAR(snap.entities[0].pos.x, 0.0, 1e-6);
   EXPECT_NEAR(snap.entities[0].pos.y, 0.0, 1e-6);
@@ -442,7 +506,8 @@ void SimGame_ExtractFullIncludesPathsAndState() {
       [&upserts](SimWorld::EntityId, const Position&) { ++upserts; },
       [&erased](SimWorld::EntityId) { ++erased; },
       [&currentWave, &waveTick, &lives, &resources, &phase](size_t wave,
-          Tick tick, int newLives, int newResources, std::string_view newPhase) {
+          Tick tick, int newLives, int newResources,
+          std::string_view newPhase) {
         currentWave = wave;
         waveTick = tick;
         lives = newLives;

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -506,7 +506,7 @@ void SimGame_HandleUiActionStartWaveTransitionsToWavePhase() {
   SimGame game;
   game.loadMap();
 
-  game.handle_ui_action(
+  game.handle_UiAction(
       UiActionInput{.seq = 1, .action = "start_wave", .fields = {}});
 
   const auto delta = extractGameDelta(game);
@@ -519,7 +519,7 @@ void SimGame_HandleUiCanvasDoesNotChangeStateYet() {
   game.loadMap();
   const auto before = extractGameDelta(game);
 
-  game.handle_ui_canvas(UiCanvasInput{.seq = 1,
+  game.handleUiCanvas(UiCanvasInput{.seq = 1,
       .event = UiCanvasEvent::click,
       .button = UiMouseButton::left,
       .buttons = 1,

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -473,7 +473,7 @@ void SimWorld_ObtainPathIncludesTerminalJoint() {
 
 void SimWorld_FromJointsThrowsWhenJointIsOutOfBounds() {
   PathJoints p;
-  p.joints = {{{0.F, 0.F}}, {{SimWorld::widthOfWorld / 2.F + 1.F, 0.F}}};
+  p.joints = {{{0.F, 0.F}}, {{(SimWorld::widthOfWorld / 2.F) + 1.F, 0.F}}};
 
   EXPECT_THROW(SegmentedPath::fromJoints(p), std::runtime_error);
 }

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -214,9 +214,9 @@ void SimWorld_BackgroundNotInDeltaAfterTick() {
 
 // bake_path with two joints produces one segment with the correct length.
 void BakePath_TwoJoints() {
-  path p;
+  path_joints p;
   p.joints = {{{0.F, 0.F}}, {{3.F, 4.F}}};
-  const auto bp = baked_path::from_path(p);
+  const auto bp = segmented_path::from_joints(p);
   ASSERT_EQ(bp.segments.size(), 1U);
   EXPECT_NEAR(bp.segments[0].cumulative_start, 0.0, 1e-6);
   EXPECT_NEAR(bp.segments[0].length, 5.0, 1e-6);
@@ -226,9 +226,9 @@ void BakePath_TwoJoints() {
 // bake_path with three joints produces two segments with correct cumulative
 // distances.
 void BakePath_ThreeJoints() {
-  path p;
+  path_joints p;
   p.joints = {{{0.F, 0.F}}, {{3.F, 4.F}}, {{6.F, 8.F}}};
-  const auto bp = baked_path::from_path(p);
+  const auto bp = segmented_path::from_joints(p);
   ASSERT_EQ(bp.segments.size(), 2U);
   EXPECT_NEAR(bp.segments[0].cumulative_start, 0.0, 1e-6);
   EXPECT_NEAR(bp.segments[0].length, 5.0, 1e-6);
@@ -239,9 +239,9 @@ void BakePath_ThreeJoints() {
 
 // bake_path with fewer than two joints returns an empty baked_path.
 void BakePath_Degenerate() {
-  path p;
+  path_joints p;
   p.joints = {{{0.F, 0.F}}};
-  const auto bp = baked_path::from_path(p);
+  const auto bp = segmented_path::from_joints(p);
   EXPECT_TRUE(bp.segments.empty());
   EXPECT_NEAR(bp.total_length, 0.0, 1e-6);
 }
@@ -249,9 +249,9 @@ void BakePath_Degenerate() {
 // path_position at progress 0 returns the first joint; at total_length
 // returns the last joint.
 void PathPosition_Endpoints() {
-  path p;
+  path_joints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
-  const auto bp = baked_path::from_path(p);
+  const auto bp = segmented_path::from_joints(p);
 
   const auto start = bp.position_from_progress(0.F);
   EXPECT_NEAR(start.x, 0.0, 1e-6);
@@ -264,9 +264,9 @@ void PathPosition_Endpoints() {
 
 // path_position at the midpoint returns the correctly interpolated position.
 void PathPosition_Midpoint() {
-  path p;
+  path_joints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
-  const auto bp = baked_path::from_path(p);
+  const auto bp = segmented_path::from_joints(p);
 
   const auto mid = bp.position_from_progress(5.F);
   EXPECT_NEAR(mid.x, 5.0, 1e-6);
@@ -276,7 +276,7 @@ void PathPosition_Midpoint() {
 // Spawning an enemy and ticking once advances its position by `speed`.
 void SimWorld_EnemyAdvancesOnTick() {
   sim_world w;
-  path p;
+  path_joints p;
   p.joints = {{{0.F, 0.F}}, {{100.F, 0.F}}};
   const auto pid = w.add_path(p);
 
@@ -294,7 +294,7 @@ void SimWorld_EnemyAdvancesOnTick() {
 // An enemy that reaches the end of the path is despawned automatically.
 void SimWorld_EnemyDespawnsAtEnd() {
   sim_world w;
-  path p;
+  path_joints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
   const auto pid = w.add_path(p);
 
@@ -313,7 +313,7 @@ void SimWorld_GetPathOutOfRange() {
   sim_world w;
   EXPECT_TRUE(w.get_path(0) == nullptr);
 
-  path p;
+  path_joints p;
   p.joints = {{{0.F, 0.F}}, {{1.F, 0.F}}};
   (void)w.add_path(p);
 

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -38,7 +38,7 @@ struct GameDelta {
   std::vector<std::pair<SimWorld::EntityId, Position>> upserts;
   std::vector<SimWorld::EntityId> erased;
   size_t currentWave{};
-  Tick waveTick{};
+  WaveTick waveTick{};
   int lives{};
   int resources{};
   std::string_view phase;
@@ -117,7 +117,7 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
         snap.entities.push_back({id, pos});
       },
       [](SimWorld::EntityId) {},
-      [](size_t, Tick, int, int, std::string_view) {});
+      [](size_t, WaveTick, int, int, std::string_view) {});
 
   snap.path_points = std::move(pathsById);
   return snap;
@@ -130,7 +130,7 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
         delta.upserts.emplace_back(id, pos);
       },
       [&delta](SimWorld::EntityId id) { delta.erased.push_back(id); },
-      [&delta](size_t currentWave, Tick waveTick, int lives, int resources,
+      [&delta](size_t currentWave, WaveTick waveTick, int lives, int resources,
           std::string_view phase) {
         delta.currentWave = currentWave;
         delta.waveTick = waveTick;
@@ -491,7 +491,7 @@ void SimGame_LoadMapInitialSnapshotAndState() {
 
   const auto delta = extractGameDelta(game);
   EXPECT_EQ(delta.currentWave, 0U);
-  EXPECT_EQ(delta.waveTick, 0U);
+  EXPECT_EQ(delta.waveTick, WaveTick{});
   EXPECT_EQ(delta.lives, 20);
   EXPECT_EQ(delta.resources, 100);
   EXPECT_EQ(delta.phase, std::string_view{"build"});
@@ -508,7 +508,7 @@ void SimGame_HandleUiActionStartWaveTransitionsToWavePhase() {
 
   const auto delta = extractGameDelta(game);
   EXPECT_EQ(delta.phase, std::string_view{"wave"});
-  EXPECT_EQ(delta.waveTick, 0U);
+  EXPECT_EQ(delta.waveTick, WaveTick{0});
 }
 
 void SimGame_HandleUiCanvasDoesNotChangeStateYet() {
@@ -544,7 +544,7 @@ void SimGame_StartWaveSpawnsFirstEnemyOnFirstStep() {
 
   const auto delta = extractGameDelta(game);
   EXPECT_EQ(delta.currentWave, 0U);
-  EXPECT_EQ(delta.waveTick, 1U);
+  EXPECT_EQ(delta.waveTick, WaveTick{1});
   EXPECT_EQ(delta.lives, 20);
   EXPECT_EQ(delta.resources, 100);
   EXPECT_EQ(delta.phase, std::string_view{"wave"});
@@ -563,7 +563,7 @@ void SimGame_ExtractDeltaConsumesWorldUpdatesButNotState() {
   const auto delta = extractGameDelta(game);
   EXPECT_TRUE(!delta.upserts.empty());
   EXPECT_EQ(delta.erased.size(), 0U);
-  EXPECT_EQ(delta.waveTick, 2U);
+  EXPECT_EQ(delta.waveTick, WaveTick{2});
   EXPECT_EQ(delta.phase, std::string_view{"wave"});
 
   const auto* pos = findPosition(delta.upserts, delta.upserts.front().first);
@@ -573,7 +573,7 @@ void SimGame_ExtractDeltaConsumesWorldUpdatesButNotState() {
   const auto empty_world_delta = extractGameDelta(game);
   EXPECT_TRUE(empty_world_delta.upserts.empty());
   EXPECT_TRUE(empty_world_delta.erased.empty());
-  EXPECT_EQ(empty_world_delta.waveTick, 2U);
+  EXPECT_EQ(empty_world_delta.waveTick, WaveTick{2});
   EXPECT_EQ(empty_world_delta.phase, std::string_view{"wave"});
 }
 
@@ -585,7 +585,7 @@ void SimGame_ExtractFullIncludesPathsAndState() {
   size_t upserts = 0;
   size_t erased = 0;
   size_t currentWave = 99;
-  Tick waveTick = 99;
+  WaveTick waveTick{99};
   int lives = -1;
   int resources = -1;
   std::string_view phase = "unknown";
@@ -597,7 +597,7 @@ void SimGame_ExtractFullIncludesPathsAndState() {
       },
       [&erased](SimWorld::EntityId) { ++erased; },
       [&currentWave, &waveTick, &lives, &resources, &phase](size_t wave,
-          Tick tick, int newLives, int newResources,
+          WaveTick tick, int newLives, int newResources,
           std::string_view newPhase) {
         currentWave = wave;
         waveTick = tick;
@@ -610,7 +610,7 @@ void SimGame_ExtractFullIncludesPathsAndState() {
   EXPECT_EQ(upserts, 0U);
   EXPECT_EQ(erased, 0U);
   EXPECT_EQ(currentWave, 0U);
-  EXPECT_EQ(waveTick, 0U);
+  EXPECT_EQ(waveTick, WaveTick{0});
   EXPECT_EQ(lives, 20);
   EXPECT_EQ(resources, 100);
   EXPECT_EQ(phase, std::string_view{"build"});

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -768,6 +768,7 @@ void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
 
   sim_game_state_json initial_state;
   (void)build_sim_game_state_json(initial_state, game);
+  (void)game.tick();
 
   game.handleUiCanvas(UiCanvasInput{.seq = 2,
       .event = UiCanvasEvent::click,
@@ -804,8 +805,8 @@ void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
     const auto flash_expiry_ms = vfx.get_number<uint32_t>("flashExpiryMs");
     ASSERT_TRUE(flash.has_value());
     ASSERT_TRUE(flash_expiry_ms.has_value());
-    EXPECT_EQ(*flash, 0xFFFF007FU);
-    EXPECT_EQ(*flash_expiry_ms, 20000U);
+    EXPECT_EQ(*flash, 0xFF7F7FAFU);
+    EXPECT_EQ(*flash_expiry_ms, 250U);
     ++count;
   }
   EXPECT_EQ(count, 1U);

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -81,8 +81,8 @@ snapshot(SimWorld& world, const std::vector<SimWorld::EntityId>& ids) {
   return filtered;
 }
 
-[[nodiscard]] std::vector<EntitySnapshot> filterSnapshot(
-    const std::vector<EntitySnapshot>& all,
+[[nodiscard]] std::vector<EntitySnapshot>
+filterSnapshot(const std::vector<EntitySnapshot>& all,
     const std::vector<SimWorld::EntityId>& ids) {
   std::vector<EntitySnapshot> filtered;
   filtered.reserve(ids.size());
@@ -170,12 +170,12 @@ void SimWorld_SpawnAndSnapshot() {
 
   const auto all = snapshot(w);
   ASSERT_EQ(all.size(), 2U);
-  EXPECT_EQ(filterSnapshot(all, std::vector<SimWorld::EntityId>{mover.id()})
-                .size(),
+  EXPECT_EQ(
+      filterSnapshot(all, std::vector<SimWorld::EntityId>{mover.id()}).size(),
       1U);
   EXPECT_EQ(
-      filterSnapshot(
-          all, std::vector<SimWorld::EntityId>{mover.id(), background.id()})
+      filterSnapshot(all,
+          std::vector<SimWorld::EntityId>{mover.id(), background.id()})
           .size(),
       2U);
 }
@@ -455,10 +455,12 @@ void SimWorld_ObtainPathIncludesTerminalJoint() {
   const auto pid = w.addPath(p);
 
   std::vector<Position> points;
-  (void)w.obtainPath([&points](PathId, const Position& pos) {
-    points.push_back(pos);
-    return true;
-  }, pid);
+  (void)w.obtainPath(
+      [&points](PathId, const Position& pos) {
+        points.push_back(pos);
+        return true;
+      },
+      pid);
 
   ASSERT_EQ(points.size(), 3U);
   EXPECT_NEAR(points[0].x, 0.0, 1e-6);

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -184,7 +184,7 @@ void SimWorld_TickMovesMover() {
   SimWorld w;
   const auto mover = w.spawnMover(Position{100.F, 200.F}, Velocity{3.F, -5.F});
 
-  EXPECT_EQ(w.tick(), 1U);
+  EXPECT_EQ(*w.tick(), 1U);
 
   const auto snaps = snapshot(w);
   ASSERT_EQ(snaps.size(), 1U);
@@ -504,7 +504,7 @@ void SimGame_StartWaveSpawnsFirstEnemyOnFirstStep() {
   game.loadMap();
   game.start_wave();
 
-  EXPECT_EQ(game.step(), 1U);
+  EXPECT_EQ(*game.step(), 1U);
 
   const auto snap = snapshot(game);
   EXPECT_TRUE(snap.entities.empty());

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -499,6 +499,39 @@ void SimGame_LoadMapInitialSnapshotAndState() {
   EXPECT_TRUE(delta.erased.empty());
 }
 
+void SimGame_HandleUiActionStartWaveTransitionsToWavePhase() {
+  SimGame game;
+  game.loadMap();
+
+  game.handle_ui_action(
+      UiActionInput{.seq = 1, .action = "start_wave", .fields = {}});
+
+  const auto delta = extractGameDelta(game);
+  EXPECT_EQ(delta.phase, std::string_view{"wave"});
+  EXPECT_EQ(delta.waveTick, 0U);
+}
+
+void SimGame_HandleUiCanvasDoesNotChangeStateYet() {
+  SimGame game;
+  game.loadMap();
+  const auto before = extractGameDelta(game);
+
+  game.handle_ui_canvas(UiCanvasInput{.seq = 1,
+      .event = UiCanvasEvent::click,
+      .button = UiMouseButton::left,
+      .buttons = 1,
+      .x = 10.F,
+      .y = 20.F,
+      .canvasX = 100.F,
+      .canvasY = 200.F});
+
+  const auto after = extractGameDelta(game);
+  EXPECT_EQ(before.phase, std::string_view{"build"});
+  EXPECT_EQ(after.phase, std::string_view{"build"});
+  EXPECT_TRUE(after.upserts.empty());
+  EXPECT_TRUE(after.erased.empty());
+}
+
 void SimGame_StartWaveSpawnsFirstEnemyOnFirstStep() {
   SimGame game;
   game.loadMap();
@@ -595,6 +628,8 @@ MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_TickMovesMover,
     SimWorld_ResolveEscapeesVisitsEscapedEnemy,
     SimWorld_ResolveEscapeesCanLeaveEnemyAlive, SimWorld_GetPathOutOfRange,
     SimGame_LoadMapInitialSnapshotAndState,
+    SimGame_HandleUiActionStartWaveTransitionsToWavePhase,
+    SimGame_HandleUiCanvasDoesNotChangeStateYet,
     SimGame_StartWaveSpawnsFirstEnemyOnFirstStep,
     SimGame_ExtractDeltaConsumesWorldUpdatesButNotState,
     SimGame_ExtractFullIncludesPathsAndState)

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -436,6 +436,34 @@ void SimWorld_GetPathOutOfRange() {
   EXPECT_TRUE(w.getPath(PathId{1}) == nullptr);
 }
 
+void SimWorld_ObtainPathIncludesTerminalJoint() {
+  SimWorld w;
+  PathJoints p;
+  p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}, {{10.F, 5.F}}};
+  const auto pid = w.addPath(p);
+
+  std::vector<Position> points;
+  (void)w.obtainPath([&points](PathId, const Position& pos) {
+    points.push_back(pos);
+    return true;
+  }, pid);
+
+  ASSERT_EQ(points.size(), 3U);
+  EXPECT_NEAR(points[0].x, 0.0, 1e-6);
+  EXPECT_NEAR(points[0].y, 0.0, 1e-6);
+  EXPECT_NEAR(points[1].x, 10.0, 1e-6);
+  EXPECT_NEAR(points[1].y, 0.0, 1e-6);
+  EXPECT_NEAR(points[2].x, 10.0, 1e-6);
+  EXPECT_NEAR(points[2].y, 5.0, 1e-6);
+}
+
+void SimWorld_FromJointsThrowsWhenJointIsOutOfBounds() {
+  PathJoints p;
+  p.joints = {{{0.F, 0.F}}, {{SimWorld::widthOfWorld / 2.F + 1.F, 0.F}}};
+
+  EXPECT_THROW(SegmentedPath::fromJoints(p), std::runtime_error);
+}
+
 void SimGame_LoadMapInitialSnapshotAndState() {
   SimGame game;
   game.loadMap();

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -28,7 +28,7 @@ using namespace corvid::sim;
 
 // Spawn, size, and despawn round-trip.
 void SimWorld_SpawnDespawn() {
-  sim_world w;
+  SimWorld w;
   EXPECT_EQ(w.size(), 0U);
 
   auto h = w.spawn(Position{10.0, 20.0}, Velocity{1.0, 2.0});
@@ -48,7 +48,7 @@ void SimWorld_SpawnDespawn() {
 
 // Despawning a stale handle returns false without crashing.
 void SimWorld_DespawnStale() {
-  sim_world w;
+  SimWorld w;
   auto h = w.spawn(Position{}, Velocity{});
   EXPECT_TRUE(w.despawn(h));
   EXPECT_FALSE(w.despawn(h)); // second call: handle is dead
@@ -56,7 +56,7 @@ void SimWorld_DespawnStale() {
 
 // tick() advances position by velocity.
 void SimWorld_Tick() {
-  sim_world w;
+  SimWorld w;
   auto h = w.spawn(Position{100.0, 200.0}, Velocity{3.0, -5.0});
   (void)w.tick();
 
@@ -69,11 +69,11 @@ void SimWorld_Tick() {
 
 // tick() with a non-null out-vector appends changed entity IDs.
 void SimWorld_TickOutParam() {
-  sim_world w;
+  SimWorld w;
   auto h1 = w.spawn(Position{100.0, 100.0}, Velocity{1.0, 0.0});
   auto h2 = w.spawn(Position{200.0, 200.0}, Velocity{0.0, 1.0});
 
-  std::vector<sim_world::entity_id_t> changed;
+  std::vector<SimWorld::EntityId> changed;
   (void)w.tick(&changed);
 
   EXPECT_EQ(changed.size(), 2U);
@@ -83,7 +83,7 @@ void SimWorld_TickOutParam() {
 
 // tick() with nullptr out-param does not allocate (just advance state).
 void SimWorld_TickNullOut() {
-  sim_world w;
+  SimWorld w;
   (void)w.spawn(Position{50.0, 50.0}, Velocity{1.0, 1.0});
   (void)w.tick(nullptr); // must not crash
   auto snaps = w.snapshot();
@@ -93,9 +93,9 @@ void SimWorld_TickNullOut() {
 
 // Entities bounce off the left/top boundary.
 void SimWorld_BounceMinEdge() {
-  sim_world w;
-  const float half_w = sim_world::world_width * 0.5F;
-  const float half_h = sim_world::world_height * 0.5F;
+  SimWorld w;
+  const float half_w = SimWorld::world_width * 0.5F;
+  const float half_h = SimWorld::world_height * 0.5F;
   (void)w.spawn(Position{-half_w + 0.5F, -half_h + 0.5F},
       Velocity{-2.0F, -2.0F});
   (void)w.tick();
@@ -108,9 +108,9 @@ void SimWorld_BounceMinEdge() {
 
 // Entities bounce off the right/bottom boundary.
 void SimWorld_BounceMaxEdge() {
-  sim_world w;
-  const float half_w = sim_world::world_width * 0.5F;
-  const float half_h = sim_world::world_height * 0.5F;
+  SimWorld w;
+  const float half_w = SimWorld::world_width * 0.5F;
+  const float half_h = SimWorld::world_height * 0.5F;
   (void)w.spawn(Position{half_w - 0.5F, half_h - 0.5F}, Velocity{2.0F, 2.0F});
   (void)w.tick();
 
@@ -122,7 +122,7 @@ void SimWorld_BounceMaxEdge() {
 
 // snapshot() with default since_tick returns all entities.
 void SimWorld_SnapshotAll() {
-  sim_world w;
+  SimWorld w;
   (void)w.spawn(Position{1.0, 2.0}, Velocity{});
   (void)w.spawn(Position{3.0, 4.0}, Velocity{});
 
@@ -132,7 +132,7 @@ void SimWorld_SnapshotAll() {
 
 // snapshot(since_tick) returns only entities changed at or after that tick.
 void SimWorld_SnapshotSince() {
-  sim_world w;
+  SimWorld w;
   // Spawn two entities before any tick (their last-change tick = 0).
   (void)w.spawn(Position{10.0, 10.0}, Velocity{1.0, 0.0});
   (void)w.spawn(Position{20.0, 20.0}, Velocity{1.0, 0.0});
@@ -156,12 +156,12 @@ void SimWorld_SnapshotSince() {
 
 // snapshot(ids) returns only the requested entities.
 void SimWorld_SnapshotByIds() {
-  sim_world w;
+  SimWorld w;
   auto h1 = w.spawn(Position{1.0, 1.0}, Velocity{});
   auto h2 = w.spawn(Position{2.0, 2.0}, Velocity{});
   auto h3 = w.spawn(Position{3.0, 3.0}, Velocity{});
 
-  std::vector<sim_world::entity_id_t> ids{h1.id(), h3.id()};
+  std::vector<SimWorld::EntityId> ids{h1.id(), h3.id()};
   auto snaps = w.snapshot(ids);
   ASSERT_EQ(snaps.size(), 2U);
   // The results should be for h1 and h3, not h2.
@@ -172,19 +172,19 @@ void SimWorld_SnapshotByIds() {
 
 // snapshot(ids) silently skips dead entity IDs.
 void SimWorld_SnapshotByIdsSkipsDead() {
-  sim_world w;
+  SimWorld w;
   auto h = w.spawn(Position{5.0, 5.0}, Velocity{});
   auto dead_id = h.id();
   EXPECT_TRUE(w.despawn(h));
 
-  std::vector<sim_world::entity_id_t> ids{dead_id};
+  std::vector<SimWorld::EntityId> ids{dead_id};
   auto snaps = w.snapshot(ids);
   EXPECT_EQ(snaps.size(), 0U);
 }
 
 // spawn_background adds a P-only entity visible in snapshots.
 void SimWorld_Background() {
-  sim_world w;
+  SimWorld w;
   auto hb = w.spawn_background(Position{50.0, 60.0});
   EXPECT_TRUE(w.is_alive(hb));
   EXPECT_EQ(w.size(), 1U);
@@ -204,7 +204,7 @@ void SimWorld_Background() {
 // Background entity is excluded from snapshot(since_tick) after a tick
 // because its metadata was never updated beyond its spawn tick (0).
 void SimWorld_BackgroundNotInDeltaAfterTick() {
-  sim_world w;
+  SimWorld w;
   (void)w.spawn_background(Position{50.0, 60.0});
   (void)w.tick(); // tick 1; background entity metadata stays at 0
   EXPECT_EQ(w.snapshot(1).size(), 0U);
@@ -214,9 +214,9 @@ void SimWorld_BackgroundNotInDeltaAfterTick() {
 
 // bake_path with two joints produces one segment with the correct length.
 void BakePath_TwoJoints() {
-  path_joints p;
+  PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{3.F, 4.F}}};
-  const auto bp = segmented_path::from_joints(p);
+  const auto bp = SegmentedPath::from_joints(p);
   ASSERT_EQ(bp.segments.size(), 1U);
   EXPECT_NEAR(bp.segments[0].cumulative_start, 0.0, 1e-6);
   EXPECT_NEAR(bp.segments[0].length, 5.0, 1e-6);
@@ -226,9 +226,9 @@ void BakePath_TwoJoints() {
 // bake_path with three joints produces two segments with correct cumulative
 // distances.
 void BakePath_ThreeJoints() {
-  path_joints p;
+  PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{3.F, 4.F}}, {{6.F, 8.F}}};
-  const auto bp = segmented_path::from_joints(p);
+  const auto bp = SegmentedPath::from_joints(p);
   ASSERT_EQ(bp.segments.size(), 2U);
   EXPECT_NEAR(bp.segments[0].cumulative_start, 0.0, 1e-6);
   EXPECT_NEAR(bp.segments[0].length, 5.0, 1e-6);
@@ -239,9 +239,9 @@ void BakePath_ThreeJoints() {
 
 // bake_path with fewer than two joints returns an empty baked_path.
 void BakePath_Degenerate() {
-  path_joints p;
+  PathJoints p;
   p.joints = {{{0.F, 0.F}}};
-  const auto bp = segmented_path::from_joints(p);
+  const auto bp = SegmentedPath::from_joints(p);
   EXPECT_TRUE(bp.segments.empty());
   EXPECT_NEAR(bp.total_length, 0.0, 1e-6);
 }
@@ -249,9 +249,9 @@ void BakePath_Degenerate() {
 // path_position at progress 0 returns the first joint; at total_length
 // returns the last joint.
 void PathPosition_Endpoints() {
-  path_joints p;
+  PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
-  const auto bp = segmented_path::from_joints(p);
+  const auto bp = SegmentedPath::from_joints(p);
 
   const auto start = bp.position_from_progress(0.F);
   EXPECT_NEAR(start.x, 0.0, 1e-6);
@@ -264,9 +264,9 @@ void PathPosition_Endpoints() {
 
 // path_position at the midpoint returns the correctly interpolated position.
 void PathPosition_Midpoint() {
-  path_joints p;
+  PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
-  const auto bp = segmented_path::from_joints(p);
+  const auto bp = SegmentedPath::from_joints(p);
 
   const auto mid = bp.position_from_progress(5.F);
   EXPECT_NEAR(mid.x, 5.0, 1e-6);
@@ -275,8 +275,8 @@ void PathPosition_Midpoint() {
 
 // Spawning an enemy and ticking once advances its position by `speed`.
 void SimWorld_EnemyAdvancesOnTick() {
-  sim_world w;
-  path_joints p;
+  SimWorld w;
+  PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{100.F, 0.F}}};
   const auto pid = w.add_path(p);
 
@@ -293,8 +293,8 @@ void SimWorld_EnemyAdvancesOnTick() {
 
 // An enemy that reaches the end of the path is despawned automatically.
 void SimWorld_EnemyDespawnsAtEnd() {
-  sim_world w;
-  path_joints p;
+  SimWorld w;
+  PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
   const auto pid = w.add_path(p);
 
@@ -310,15 +310,15 @@ void SimWorld_EnemyDespawnsAtEnd() {
 
 // get_path returns nullptr for an out-of-range index.
 void SimWorld_GetPathOutOfRange() {
-  sim_world w;
-  EXPECT_TRUE(w.get_path(path_id_t{0}) == nullptr);
+  SimWorld w;
+  EXPECT_TRUE(w.get_path(PathId{0}) == nullptr);
 
-  path_joints p;
+  PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{1.F, 0.F}}};
   (void)w.add_path(p);
 
-  EXPECT_TRUE(w.get_path(path_id_t{0}) != nullptr);
-  EXPECT_TRUE(w.get_path(path_id_t{1}) == nullptr);
+  EXPECT_TRUE(w.get_path(PathId{0}) != nullptr);
+  EXPECT_TRUE(w.get_path(PathId{1}) == nullptr);
 }
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -325,8 +325,9 @@ void PathPosition_Endpoints() {
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
   const auto bp = SegmentedPath::fromJoints(p);
 
-  const auto start = bp.calculatePositionFromProgress(0.F);
-  const auto end = bp.calculatePositionFromProgress(bp.totalLength);
+  const auto start = bp.calculatePositionFromProgress(0.F, 0.F);
+  const auto end =
+      bp.calculatePositionFromProgress(bp.totalLength, bp.totalLength);
 
   EXPECT_NEAR(start.x, 0.0, 1e-6);
   EXPECT_NEAR(start.y, 0.0, 1e-6);
@@ -339,10 +340,21 @@ void PathPosition_Midpoint() {
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
   const auto bp = SegmentedPath::fromJoints(p);
 
-  const auto mid = bp.calculatePositionFromProgress(5.F);
+  const auto mid = bp.calculatePositionFromProgress(5.F, 5.F);
 
   EXPECT_NEAR(mid.x, 5.0, 1e-6);
   EXPECT_NEAR(mid.y, 0.0, 1e-6);
+}
+
+void PathPosition_CrossingSegmentBoundaryEmitsJoint() {
+  PathJoints p;
+  p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}, {{10.F, 10.F}}};
+  const auto bp = SegmentedPath::fromJoints(p);
+
+  const auto corner = bp.calculatePositionFromProgress(12.F, 8.F);
+
+  EXPECT_NEAR(corner.x, 10.0, 1e-6);
+  EXPECT_NEAR(corner.y, 0.0, 1e-6);
 }
 
 void SimWorld_EnemyAdvancesOnTick() {

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -61,7 +61,8 @@ struct GameSnapshot {
   std::vector<EntitySnapshot> snaps;
   (void)world.markAllDirty();
   (void)world.extractUpdatedEntities(
-      [&snaps](SimWorld::EntityId id, const Position& pos, const Appearance&) {
+      [&snaps](SimWorld::EntityId id, const Position& pos, const Appearance&,
+          const VisualEffects&) {
         const auto it = std::ranges::find(snaps, id, &EntitySnapshot::id);
         if (it == snaps.end())
           snaps.push_back({id, pos});
@@ -99,9 +100,8 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
 [[nodiscard]] WorldDelta extractWorldDelta(SimWorld& world) {
   WorldDelta delta;
   (void)world.extractUpdatedEntities(
-      [&delta](SimWorld::EntityId id, const Position& pos, const Appearance&) {
-        delta.upserts.emplace_back(id, pos);
-      },
+      [&delta](SimWorld::EntityId id, const Position& pos, const Appearance&,
+          const VisualEffects&) { delta.upserts.emplace_back(id, pos); },
       [&delta](SimWorld::EntityId id) { delta.erased.push_back(id); });
   return delta;
 }
@@ -116,9 +116,8 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
         if (pathsById.size() <= ndx) pathsById.resize(ndx + 1);
         pathsById[ndx].joints.push_back({pos});
       },
-      [&snap](SimWorld::EntityId id, const Position& pos, const Appearance&) {
-        snap.entities.push_back({id, pos});
-      },
+      [&snap](SimWorld::EntityId id, const Position& pos, const Appearance&,
+          const VisualEffects&) { snap.entities.push_back({id, pos}); },
       [](SimWorld::EntityId) {},
       [](size_t, WaveTick, int, int, std::string_view) {});
 
@@ -129,9 +128,8 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
 [[nodiscard]] GameDelta extractGameDelta(SimGame& game) {
   GameDelta delta;
   (void)game.extractDelta(
-      [&delta](SimWorld::EntityId id, const Position& pos, const Appearance&) {
-        delta.upserts.emplace_back(id, pos);
-      },
+      [&delta](SimWorld::EntityId id, const Position& pos, const Appearance&,
+          const VisualEffects&) { delta.upserts.emplace_back(id, pos); },
       [&delta](SimWorld::EntityId id) { delta.erased.push_back(id); },
       [&delta](size_t currentWave, WaveTick waveTick, int lives, int resources,
           std::string_view phase) {
@@ -374,7 +372,7 @@ void SimWorld_EnemyAdvancesOnTick() {
 
   const auto delta = extractWorldDelta(w);
   EXPECT_TRUE(containsId(delta.upserts, enemy.id()));
-  ASSERT_EQ(delta.upserts.size(), 1U);
+  ASSERT_EQ(delta.upserts.size(), 2U);
   EXPECT_NEAR(delta.upserts[0].second.x, 10.0, 1e-5);
   EXPECT_NEAR(delta.upserts[0].second.y, 0.0, 1e-5);
 }
@@ -514,7 +512,7 @@ void SimGame_HandleUiActionStartWaveTransitionsToWavePhase() {
   EXPECT_EQ(delta.waveTick, WaveTick{0});
 }
 
-void SimGame_HandleUiCanvasDoesNotChangeStateYet() {
+void SimGame_HandleUiCanvasSpawnsTowerButKeepsBuildPhase() {
   SimGame game;
   game.loadMap();
   const auto before = extractGameDelta(game);
@@ -531,7 +529,9 @@ void SimGame_HandleUiCanvasDoesNotChangeStateYet() {
   const auto after = extractGameDelta(game);
   EXPECT_EQ(before.phase, std::string_view{"build"});
   EXPECT_EQ(after.phase, std::string_view{"build"});
-  EXPECT_TRUE(after.upserts.empty());
+  ASSERT_EQ(after.upserts.size(), 1U);
+  EXPECT_NEAR(after.upserts[0].second.x, 10.0, 1e-6);
+  EXPECT_NEAR(after.upserts[0].second.y, 20.0, 1e-6);
   EXPECT_TRUE(after.erased.empty());
 }
 
@@ -543,7 +543,9 @@ void SimGame_StartWaveSpawnsFirstEnemyOnFirstStep() {
   EXPECT_EQ(*game.step(), 1U);
 
   const auto snap = snapshot(game);
-  EXPECT_TRUE(snap.entities.empty());
+  ASSERT_EQ(snap.entities.size(), 1U);
+  EXPECT_NEAR(snap.entities[0].pos.x, 0.0, 1e-6);
+  EXPECT_NEAR(snap.entities[0].pos.y, 0.0, 1e-6);
 
   const auto delta = extractGameDelta(game);
   EXPECT_EQ(delta.currentWave, 0U);
@@ -595,9 +597,8 @@ void SimGame_ExtractFullIncludesPathsAndState() {
 
   (void)game.extractFull(
       [&path_points](PathId, const Position&) { ++path_points; },
-      [&upserts](SimWorld::EntityId, const Position&, const Appearance&) {
-        ++upserts;
-      },
+      [&upserts](SimWorld::EntityId, const Position&, const Appearance&,
+          const VisualEffects&) { ++upserts; },
       [&erased](SimWorld::EntityId) { ++erased; },
       [&currentWave, &waveTick, &lives, &resources, &phase](size_t wave,
           WaveTick tick, int newLives, int newResources,
@@ -677,15 +678,25 @@ void SimJson_BuildHelloAckJson() {
 void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
   SimGame game;
   game.loadMap();
-  game.start_wave();
-  (void)game.step();
+  game.handleUiCanvas(UiCanvasInput{.seq = 1,
+      .event = UiCanvasEvent::click,
+      .button = UiMouseButton::left,
+      .buttons = 1,
+      .x = 10.F,
+      .y = 20.F,
+      .canvasX = 100.F,
+      .canvasY = 200.F});
   const auto tick = game.step();
 
   sim_game_state_json state;
   (void)build_sim_game_state_json(state, game, tick);
   EXPECT_TRUE(state.body_highwater >= state.body.size());
-  EXPECT_TRUE(state.body.contains(R"("x":20.0)"));
-  EXPECT_TRUE(state.body.contains(R"("scale":2.000)"));
+  EXPECT_TRUE(state.body.contains(R"("x":10.0)"));
+  EXPECT_TRUE(state.body.contains(R"("scale":4.000)"));
+  EXPECT_FALSE(state.body.contains(R"("vfx")"));
+  EXPECT_FALSE(state.body.contains(R"("modified")"));
+  EXPECT_FALSE(state.body.contains(R"("flash_expiry")"));
+  EXPECT_FALSE(state.body.contains(R"("glow")"));
 
   json_value_view root;
   ASSERT_TRUE(parse_json(state.body, root));
@@ -697,9 +708,9 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
   ASSERT_TRUE(tick_value.has_value());
   ASSERT_TRUE(wave_tick_value.has_value());
   ASSERT_TRUE(phase_value.has_value());
-  EXPECT_EQ(*tick_value, 2U);
-  EXPECT_EQ(*wave_tick_value, 2U);
-  EXPECT_EQ(*phase_value, std::string_view{"wave"});
+  EXPECT_EQ(*tick_value, 1U);
+  EXPECT_EQ(*wave_tick_value, 0U);
+  EXPECT_EQ(*phase_value, std::string_view{"build"});
 
   const auto upserts = obj.get_array("upserts");
   ASSERT_TRUE(upserts);
@@ -711,7 +722,16 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
     ASSERT_TRUE(pos);
     const auto x = pos.get_number<float>("x");
     ASSERT_TRUE(x.has_value());
-    EXPECT_NEAR(*x, 20.0, 1e-6);
+    EXPECT_NEAR(*x, 10.0, 1e-6);
+
+    const auto app = entry.get_object("app");
+    ASSERT_TRUE(app);
+    ASSERT_TRUE(app.get_number<uint32_t>("glyph").has_value());
+    ASSERT_TRUE(app.get_number<float>("scale").has_value());
+    ASSERT_TRUE(!app.get_number<uint32_t>("modified").has_value());
+
+    const auto vfx = entry.get_object("vfx");
+    EXPECT_TRUE(!vfx);
     ++count;
   }
   EXPECT_EQ(count, 1U);
@@ -770,7 +790,7 @@ MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_TickMovesMover,
     SimWorld_ResolveEscapeesCanLeaveEnemyAlive, SimWorld_GetPathOutOfRange,
     SimGame_LoadMapInitialSnapshotAndState,
     SimGame_HandleUiActionStartWaveTransitionsToWavePhase,
-    SimGame_HandleUiCanvasDoesNotChangeStateYet,
+    SimGame_HandleUiCanvasSpawnsTowerButKeepsBuildPhase,
     SimGame_StartWaveSpawnsFirstEnemyOnFirstStep,
     SimGame_ExtractDeltaConsumesWorldUpdatesButNotState,
     SimGame_ExtractFullIncludesPathsAndState, SimJson_ParseUiCanvasMessage,

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -1,0 +1,218 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstddef>
+#include <vector>
+
+#include "../corvid/sim/sim_world.h"
+#include "minitest.h"
+
+using namespace corvid;
+using namespace corvid::sim;
+
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+
+// Spawn, size, and despawn round-trip.
+void SimWorld_SpawnDespawn() {
+  sim_world w;
+  EXPECT_EQ(w.size(), 0U);
+
+  auto h = w.spawn(Position{10.0, 20.0}, Velocity{1.0, 2.0});
+  EXPECT_TRUE(w.is_alive(h));
+  EXPECT_EQ(w.size(), 1U);
+
+  auto h2 = w.spawn(Position{30.0, 40.0}, Velocity{-1.0, 0.0});
+  EXPECT_EQ(w.size(), 2U);
+
+  EXPECT_TRUE(w.despawn(h));
+  EXPECT_EQ(w.size(), 1U);
+  EXPECT_FALSE(w.is_alive(h)); // handle is invalidated on success
+
+  EXPECT_TRUE(w.despawn(h2));
+  EXPECT_EQ(w.size(), 0U);
+}
+
+// Despawning a stale handle returns false without crashing.
+void SimWorld_DespawnStale() {
+  sim_world w;
+  auto h = w.spawn(Position{}, Velocity{});
+  EXPECT_TRUE(w.despawn(h));
+  EXPECT_FALSE(w.despawn(h)); // second call: handle is dead
+}
+
+// tick() advances position by velocity.
+void SimWorld_Tick() {
+  sim_world w;
+  auto h = w.spawn(Position{100.0, 200.0}, Velocity{3.0, -5.0});
+  (void)w.tick();
+
+  auto snaps = w.snapshot();
+  ASSERT_EQ(snaps.size(), 1U);
+  EXPECT_NEAR(snaps[0].pos.x, 103.0, 1e-9);
+  EXPECT_NEAR(snaps[0].pos.y, 195.0, 1e-9);
+  (void)h;
+}
+
+// tick() with a non-null out-vector appends changed entity IDs.
+void SimWorld_TickOutParam() {
+  sim_world w;
+  auto h1 = w.spawn(Position{100.0, 100.0}, Velocity{1.0, 0.0});
+  auto h2 = w.spawn(Position{200.0, 200.0}, Velocity{0.0, 1.0});
+
+  std::vector<sim_world::entity_id_t> changed;
+  (void)w.tick(&changed);
+
+  EXPECT_EQ(changed.size(), 2U);
+  (void)h1;
+  (void)h2;
+}
+
+// tick() with nullptr out-param does not allocate (just advance state).
+void SimWorld_TickNullOut() {
+  sim_world w;
+  (void)w.spawn(Position{50.0, 50.0}, Velocity{1.0, 1.0});
+  (void)w.tick(nullptr); // must not crash
+  auto snaps = w.snapshot();
+  ASSERT_EQ(snaps.size(), 1U);
+  EXPECT_NEAR(snaps[0].pos.x, 51.0, 1e-9);
+}
+
+// Entities bounce off the left/top boundary.
+void SimWorld_BounceMinEdge() {
+  sim_world w;
+  const double half_w = sim_world::world_width * 0.5;
+  const double half_h = sim_world::world_height * 0.5;
+  (void)w.spawn(Position{-half_w + 0.5, -half_h + 0.5}, Velocity{-2.0, -2.0});
+  (void)w.tick();
+
+  auto snaps = w.snapshot();
+  ASSERT_EQ(snaps.size(), 1U);
+  EXPECT_GE(snaps[0].pos.x, -half_w);
+  EXPECT_GE(snaps[0].pos.y, -half_h);
+}
+
+// Entities bounce off the right/bottom boundary.
+void SimWorld_BounceMaxEdge() {
+  sim_world w;
+  const double half_w = sim_world::world_width * 0.5;
+  const double half_h = sim_world::world_height * 0.5;
+  (void)w.spawn(Position{half_w - 0.5, half_h - 0.5}, Velocity{2.0, 2.0});
+  (void)w.tick();
+
+  auto snaps = w.snapshot();
+  ASSERT_EQ(snaps.size(), 1U);
+  EXPECT_LE(snaps[0].pos.x, half_w);
+  EXPECT_LE(snaps[0].pos.y, half_h);
+}
+
+// snapshot() with default since_tick returns all entities.
+void SimWorld_SnapshotAll() {
+  sim_world w;
+  (void)w.spawn(Position{1.0, 2.0}, Velocity{});
+  (void)w.spawn(Position{3.0, 4.0}, Velocity{});
+
+  auto snaps = w.snapshot();
+  EXPECT_EQ(snaps.size(), 2U);
+}
+
+// snapshot(since_tick) returns only entities changed at or after that tick.
+void SimWorld_SnapshotSince() {
+  sim_world w;
+  // Spawn two entities before any tick (their last-change tick = 0).
+  (void)w.spawn(Position{10.0, 10.0}, Velocity{1.0, 0.0});
+  (void)w.spawn(Position{20.0, 20.0}, Velocity{1.0, 0.0});
+
+  (void)w.tick(); // tick 1: both entities move, metadata set to 1
+
+  // Everything changed at tick 1 or later -> 2 results.
+  EXPECT_EQ(w.snapshot(1).size(), 2U);
+
+  // Nothing changed at tick 2 or later -> 0 results.
+  EXPECT_EQ(w.snapshot(2).size(), 0U);
+
+  (void)w.tick(); // tick 2: both entities move again, metadata set to 2
+
+  // Now both qualify for since_tick=2.
+  EXPECT_EQ(w.snapshot(2).size(), 2U);
+
+  // Still nothing at tick 3.
+  EXPECT_EQ(w.snapshot(3).size(), 0U);
+}
+
+// snapshot(ids) returns only the requested entities.
+void SimWorld_SnapshotByIds() {
+  sim_world w;
+  auto h1 = w.spawn(Position{1.0, 1.0}, Velocity{});
+  auto h2 = w.spawn(Position{2.0, 2.0}, Velocity{});
+  auto h3 = w.spawn(Position{3.0, 3.0}, Velocity{});
+
+  std::vector<sim_world::entity_id_t> ids{h1.id(), h3.id()};
+  auto snaps = w.snapshot(ids);
+  ASSERT_EQ(snaps.size(), 2U);
+  // The results should be for h1 and h3, not h2.
+  EXPECT_EQ(snaps[0].id, h1.id());
+  EXPECT_EQ(snaps[1].id, h3.id());
+  (void)h2;
+}
+
+// snapshot(ids) silently skips dead entity IDs.
+void SimWorld_SnapshotByIdsSkipsDead() {
+  sim_world w;
+  auto h = w.spawn(Position{5.0, 5.0}, Velocity{});
+  auto dead_id = h.id();
+  EXPECT_TRUE(w.despawn(h));
+
+  std::vector<sim_world::entity_id_t> ids{dead_id};
+  auto snaps = w.snapshot(ids);
+  EXPECT_EQ(snaps.size(), 0U);
+}
+
+// spawn_background adds a P-only entity visible in snapshots.
+void SimWorld_Background() {
+  sim_world w;
+  auto hb = w.spawn_background(Position{50.0, 60.0});
+  EXPECT_TRUE(w.is_alive(hb));
+  EXPECT_EQ(w.size(), 1U);
+
+  auto snaps = w.snapshot();
+  ASSERT_EQ(snaps.size(), 1U);
+  EXPECT_NEAR(snaps[0].pos.x, 50.0, 1e-9);
+  EXPECT_NEAR(snaps[0].pos.y, 60.0, 1e-9);
+
+  // Background entity does not move on tick.
+  (void)w.tick();
+  snaps = w.snapshot();
+  ASSERT_EQ(snaps.size(), 1U);
+  EXPECT_NEAR(snaps[0].pos.x, 50.0, 1e-9);
+}
+
+// Background entity is excluded from snapshot(since_tick) after a tick
+// because its metadata was never updated beyond its spawn tick (0).
+void SimWorld_BackgroundNotInDeltaAfterTick() {
+  sim_world w;
+  (void)w.spawn_background(Position{50.0, 60.0});
+  (void)w.tick(); // tick 1; background entity metadata stays at 0
+  EXPECT_EQ(w.snapshot(1).size(), 0U);
+}
+
+// NOLINTEND(readability-function-cognitive-complexity)
+
+MAKE_TEST_LIST(SimWorld_SpawnDespawn, SimWorld_DespawnStale, SimWorld_Tick,
+    SimWorld_TickOutParam, SimWorld_TickNullOut, SimWorld_BounceMinEdge,
+    SimWorld_BounceMaxEdge, SimWorld_SnapshotAll, SimWorld_SnapshotSince,
+    SimWorld_SnapshotByIds, SimWorld_SnapshotByIdsSkipsDead,
+    SimWorld_Background, SimWorld_BackgroundNotInDeltaAfterTick)

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -185,9 +185,10 @@ void SimWorld_TickMovesMover() {
   SimWorld w;
   const auto mover = w.spawnMover(Position{100.F, 200.F}, Velocity{3.F, -5.F});
 
-  EXPECT_EQ(*w.tick(), 1U);
+  (void)w.next();
 
   const auto snaps = snapshot(w);
+  EXPECT_EQ(*w.tick(), 1U);
   ASSERT_EQ(snaps.size(), 1U);
   EXPECT_EQ(snaps[0].id, mover.id());
   EXPECT_NEAR(snaps[0].pos.x, 103.0, 1e-6);
@@ -198,6 +199,7 @@ void SimWorld_ExtractUpdatedEntitiesReportsMovedMoverOncePerExtraction() {
   SimWorld w;
   const auto mover = w.spawnMover(Position{0.F, 0.F}, Velocity{2.F, 3.F});
 
+  (void)w.next();
   (void)w.tick();
   const auto delta = extractWorldDelta(w);
 
@@ -221,9 +223,10 @@ void SimWorld_BounceMinEdge() {
   const auto mover = w.spawnMover(Position{-half_w + 0.5F, -half_h + 0.5F},
       Velocity{-2.F, -2.F});
 
-  (void)w.tick();
+  (void)w.next();
 
   const auto snaps = snapshot(w, std::vector<SimWorld::EntityId>{mover.id()});
+  (void)w.tick();
   ASSERT_EQ(snaps.size(), 1U);
   EXPECT_EQ(snaps[0].id, mover.id());
   EXPECT_GE(snaps[0].pos.x, -half_w);
@@ -237,9 +240,10 @@ void SimWorld_BounceMaxEdge() {
   const auto mover =
       w.spawnMover(Position{half_w - 0.5F, half_h - 0.5F}, Velocity{2.F, 2.F});
 
-  (void)w.tick();
+  (void)w.next();
 
   const auto snaps = snapshot(w, std::vector<SimWorld::EntityId>{mover.id()});
+  (void)w.tick();
   ASSERT_EQ(snaps.size(), 1U);
   EXPECT_EQ(snaps[0].id, mover.id());
   EXPECT_LE(snaps[0].pos.x, half_w);
@@ -251,18 +255,24 @@ void SimWorld_SnapshotSinceTracksChanges() {
   (void)w.spawnMover(Position{10.F, 10.F}, Velocity{1.F, 0.F});
   (void)w.spawnBackground(Position{20.F, 20.F});
 
-  const auto initial = snapshot(w);
-  EXPECT_EQ(initial.size(), 2U);
+  // Drain the spawn-time dirty list; both entities visible at tick_=0.
+  const auto initial = extractWorldDelta(w);
+  EXPECT_EQ(initial.upserts.size(), 2U);
 
   const auto unchanged = extractWorldDelta(w);
   EXPECT_TRUE(unchanged.upserts.empty());
   EXPECT_TRUE(unchanged.erased.empty());
 
+  // Advance tick first so next() physics runs at a new tick value and can
+  // re-mark the mover (last_updated=0 != tick_=1).
   (void)w.tick();
+  (void)w.next();
 
   const auto moved = extractWorldDelta(w);
   EXPECT_EQ(moved.upserts.size(), 1U);
   EXPECT_TRUE(moved.erased.empty());
+
+  (void)w.tick();
 
   const auto stable = extractWorldDelta(w);
   EXPECT_TRUE(stable.upserts.empty());
@@ -273,9 +283,10 @@ void SimWorld_BackgroundDoesNotAppearAsChangedAfterTick() {
   SimWorld w;
   (void)w.spawnBackground(Position{50.F, 60.F});
 
-  (void)w.tick();
+  (void)w.next();
 
   const auto snaps = snapshot(w);
+  (void)w.tick();
   ASSERT_EQ(snaps.size(), 1U);
   EXPECT_NEAR(snaps[0].pos.x, 50.0, 1e-6);
   EXPECT_NEAR(snaps[0].pos.y, 60.0, 1e-6);
@@ -368,11 +379,12 @@ void SimWorld_EnemyAdvancesOnTick() {
   EXPECT_TRUE(static_cast<bool>(enemy));
   EXPECT_EQ(w.size(), 1U);
 
+  (void)w.next();
   (void)w.tick();
 
   const auto delta = extractWorldDelta(w);
   EXPECT_TRUE(containsId(delta.upserts, enemy.id()));
-  ASSERT_EQ(delta.upserts.size(), 2U);
+  ASSERT_EQ(delta.upserts.size(), 1U);
   EXPECT_NEAR(delta.upserts[0].second.x, 10.0, 1e-5);
   EXPECT_NEAR(delta.upserts[0].second.y, 0.0, 1e-5);
 }
@@ -384,7 +396,7 @@ void SimWorld_ResolveEscapeesVisitsEscapedEnemy() {
   const auto pid = w.addPath(p);
   const auto enemy = w.spawnEnemy(pid, 5.F, 8.F);
 
-  (void)w.tick();
+  (void)w.next();
   EXPECT_EQ(w.size(), 1U);
 
   size_t resolved = 0;
@@ -409,6 +421,7 @@ void SimWorld_ResolveEscapeesVisitsEscapedEnemy() {
 
   const auto snaps = snapshot(w);
   EXPECT_TRUE(snaps.empty());
+  (void)w.tick();
 }
 
 void SimWorld_ResolveEscapeesCanLeaveEnemyAlive() {
@@ -418,7 +431,7 @@ void SimWorld_ResolveEscapeesCanLeaveEnemyAlive() {
   const auto pid = w.addPath(p);
   const auto enemy = w.spawnEnemy(pid, 5.F, 8.F);
 
-  (void)w.tick();
+  (void)w.next();
 
   size_t resolved = 0;
   (void)w.resolveEscapees(
@@ -435,6 +448,7 @@ void SimWorld_ResolveEscapeesCanLeaveEnemyAlive() {
   ASSERT_EQ(snaps.size(), 1U);
   EXPECT_EQ(snaps[0].id, enemy.id());
   EXPECT_NEAR(snaps[0].pos.x, 8.0, 1e-6);
+  (void)w.tick();
 }
 
 void SimWorld_GetPathOutOfRange() {
@@ -540,9 +554,10 @@ void SimGame_StartWaveSpawnsFirstEnemyOnFirstStep() {
   game.loadMap();
   game.start_wave();
 
-  EXPECT_EQ(*game.step(), 1U);
+  (void)game.next();
 
   const auto snap = snapshot(game);
+  EXPECT_EQ(*game.tick(), 1U);
   ASSERT_EQ(snap.entities.size(), 1U);
   EXPECT_NEAR(snap.entities[0].pos.x, 0.0, 1e-6);
   EXPECT_NEAR(snap.entities[0].pos.y, 0.0, 1e-6);
@@ -562,8 +577,10 @@ void SimGame_ExtractDeltaConsumesWorldUpdatesButNotState() {
   game.loadMap();
   game.start_wave();
 
-  (void)game.step();
-  (void)game.step();
+  (void)game.next();
+  (void)game.tick();
+  (void)game.next();
+  (void)game.tick();
 
   const auto delta = extractGameDelta(game);
   EXPECT_TRUE(!delta.upserts.empty());
@@ -686,11 +703,10 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
       .y = 20.F,
       .canvasX = 100.F,
       .canvasY = 200.F});
-  const auto tick = game.step();
+  (void)game.next();
 
   sim_game_state_json state;
-  (void)build_sim_game_state_json(state, game, tick);
-  EXPECT_TRUE(state.body_highwater >= state.body.size());
+  (void)build_sim_game_state_json(state, game);
   EXPECT_TRUE(state.body.contains(R"("x":10.0)"));
   EXPECT_TRUE(state.body.contains(R"("radius":20.000)"));
   EXPECT_FALSE(state.body.contains(R"("vfx")"));
@@ -709,7 +725,7 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
   ASSERT_TRUE(tick_value.has_value());
   ASSERT_TRUE(wave_tick_value.has_value());
   ASSERT_TRUE(phase_value.has_value());
-  EXPECT_EQ(*tick_value, 1U);
+  EXPECT_EQ(*tick_value, 0U);
   EXPECT_EQ(*wave_tick_value, 0U);
   EXPECT_EQ(*phase_value, std::string_view{"build"});
 
@@ -761,8 +777,7 @@ void SimJson_BuildWorldSnapshotJsonShape() {
   game.loadMap();
 
   sim_game_state_json state;
-  (void)build_sim_game_state_json(state, game, WorldTick{},
-      update_strategy::full);
+  (void)build_sim_game_state_json(state, game, update_strategy::full);
   EXPECT_TRUE(state.body.contains(R"("type":"world_snapshot")"));
   EXPECT_TRUE(state.body.contains(R"("x":0.0)"));
 

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -754,6 +754,63 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
   EXPECT_EQ(count, 1U);
 }
 
+void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
+  SimGame game;
+  game.loadMap();
+  game.handleUiCanvas(UiCanvasInput{.seq = 1,
+      .event = UiCanvasEvent::dblclick,
+      .button = UiMouseButton::left,
+      .buttons = 1,
+      .x = 10.F,
+      .y = 20.F,
+      .canvasX = 100.F,
+      .canvasY = 200.F});
+
+  sim_game_state_json initial_state;
+  (void)build_sim_game_state_json(initial_state, game);
+
+  game.handleUiCanvas(UiCanvasInput{.seq = 2,
+      .event = UiCanvasEvent::click,
+      .button = UiMouseButton::right,
+      .buttons = 2,
+      .x = 10.F,
+      .y = 20.F,
+      .canvasX = 100.F,
+      .canvasY = 200.F});
+
+  sim_game_state_json state;
+  (void)build_sim_game_state_json(state, game);
+
+  json_value_view root;
+  ASSERT_TRUE(parse_json(state.body, root));
+  const auto obj = root.as_object();
+  ASSERT_TRUE(obj);
+
+  const auto upserts = obj.get_array("upserts");
+  ASSERT_TRUE(upserts);
+  size_t count = 0;
+  for (const auto item : upserts) {
+    const auto entry = item.as_object();
+    ASSERT_TRUE(entry);
+    const auto pos = entry.get_object("pos");
+    ASSERT_TRUE(pos);
+    const auto x = pos.get_number<float>("x");
+    ASSERT_TRUE(x.has_value());
+    EXPECT_NEAR(*x, 10.0, 1e-6);
+
+    const auto vfx = entry.get_object("vfx");
+    ASSERT_TRUE(vfx);
+    const auto flash = vfx.get_number<uint32_t>("flash");
+    const auto flash_expiry_ms = vfx.get_number<uint32_t>("flashExpiryMs");
+    ASSERT_TRUE(flash.has_value());
+    ASSERT_TRUE(flash_expiry_ms.has_value());
+    EXPECT_EQ(*flash, 0xFFFF007FU);
+    EXPECT_EQ(*flash_expiry_ms, 20000U);
+    ++count;
+  }
+  EXPECT_EQ(count, 1U);
+}
+
 void SimJson_FlashExpiryDelayMsUsesCurrentTickRelativeTiming() {
   VisualEffects fx{
       .modified = WorldTick{12},
@@ -830,5 +887,6 @@ MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_TickMovesMover,
     SimGame_ExtractFullIncludesPathsAndState, SimJson_ParseUiCanvasMessage,
     SimJson_ParseUiActionMessageFields, SimJson_BuildHelloAckJson,
     SimJson_BuildWorldDeltaJsonShapeAndFormatting,
+    SimJson_BuildWorldDeltaIncludesFlashVisualEffects,
     SimJson_FlashExpiryDelayMsUsesCurrentTickRelativeTiming,
     SimJson_BuildWorldSnapshotJsonShape)

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -656,7 +656,7 @@ void SimJson_ParseUiCanvasMessage() {
 }
 
 void SimJson_ParseUiActionMessageFields() {
-  const auto input = parse_ui_action_message(
+  const auto input = parseUiActionMessage(
       R"({"type":"ui_action","seq":7,"action":"start_wave","fields":{"tower\/kind":"ice","note":"line\nbreak"}})");
 
   ASSERT_TRUE(input.has_value());

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -694,6 +694,7 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
   EXPECT_TRUE(state.body.contains(R"("x":10.0)"));
   EXPECT_TRUE(state.body.contains(R"("scale":4.000)"));
   EXPECT_FALSE(state.body.contains(R"("vfx")"));
+  EXPECT_FALSE(state.body.contains(R"("flashExpiryMs")"));
   EXPECT_FALSE(state.body.contains(R"("modified")"));
   EXPECT_FALSE(state.body.contains(R"("flash_expiry")"));
   EXPECT_FALSE(state.body.contains(R"("glow")"));
@@ -735,6 +736,24 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
     ++count;
   }
   EXPECT_EQ(count, 1U);
+}
+
+void SimJson_FlashExpiryDelayMsUsesCurrentTickRelativeTiming() {
+  VisualEffects fx{
+      .modified = WorldTick{12},
+      .selection_color = 0,
+      .range_radius = 0.F,
+      .range_color = 0,
+      .flash_color = 0xFF0000FF,
+      .flash_expiry = WorldTick{15},
+  };
+
+  EXPECT_EQ(flash_expiry_delay_ms(fx, WorldTick{10}), 250U);
+  EXPECT_EQ(flash_expiry_delay_ms(fx, WorldTick{15}), 0U);
+  EXPECT_EQ(flash_expiry_delay_ms(fx, WorldTick{16}), 0U);
+
+  fx.flash_color = 0;
+  EXPECT_EQ(flash_expiry_delay_ms(fx, WorldTick{10}), 0U);
 }
 
 void SimJson_BuildWorldSnapshotJsonShape() {
@@ -796,4 +815,5 @@ MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_TickMovesMover,
     SimGame_ExtractFullIncludesPathsAndState, SimJson_ParseUiCanvasMessage,
     SimJson_ParseUiActionMessageFields, SimJson_BuildHelloAckJson,
     SimJson_BuildWorldDeltaJsonShapeAndFormatting,
+    SimJson_FlashExpiryDelayMsUsesCurrentTickRelativeTiming,
     SimJson_BuildWorldSnapshotJsonShape)

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -81,6 +81,18 @@ snapshot(SimWorld& world, const std::vector<SimWorld::EntityId>& ids) {
   return filtered;
 }
 
+[[nodiscard]] std::vector<EntitySnapshot> filterSnapshot(
+    const std::vector<EntitySnapshot>& all,
+    const std::vector<SimWorld::EntityId>& ids) {
+  std::vector<EntitySnapshot> filtered;
+  filtered.reserve(ids.size());
+  std::ranges::copy_if(all, std::back_inserter(filtered),
+      [&ids](const EntitySnapshot& snap) {
+        return std::ranges::find(ids, snap.id) != ids.end();
+      });
+  return filtered;
+}
+
 [[nodiscard]] WorldDelta extractWorldDelta(SimWorld& world) {
   WorldDelta delta;
   (void)world.extractUpdatedEntities(
@@ -158,10 +170,12 @@ void SimWorld_SpawnAndSnapshot() {
 
   const auto all = snapshot(w);
   ASSERT_EQ(all.size(), 2U);
-  EXPECT_EQ(snapshot(w, std::vector<SimWorld::EntityId>{mover.id()}).size(),
+  EXPECT_EQ(filterSnapshot(all, std::vector<SimWorld::EntityId>{mover.id()})
+                .size(),
       1U);
   EXPECT_EQ(
-      snapshot(w, std::vector<SimWorld::EntityId>{mover.id(), background.id()})
+      filterSnapshot(
+          all, std::vector<SimWorld::EntityId>{mover.id(), background.id()})
           .size(),
       2U);
 }
@@ -451,9 +465,7 @@ void SimGame_StartWaveSpawnsFirstEnemyOnFirstStep() {
   EXPECT_EQ(game.step(), 1U);
 
   const auto snap = snapshot(game);
-  ASSERT_EQ(snap.entities.size(), 1U);
-  EXPECT_NEAR(snap.entities[0].pos.x, 0.0, 1e-6);
-  EXPECT_NEAR(snap.entities[0].pos.y, 0.0, 1e-6);
+  EXPECT_TRUE(snap.entities.empty());
 
   const auto delta = extractGameDelta(game);
   EXPECT_EQ(delta.currentWave, 0U);
@@ -461,6 +473,8 @@ void SimGame_StartWaveSpawnsFirstEnemyOnFirstStep() {
   EXPECT_EQ(delta.lives, 20);
   EXPECT_EQ(delta.resources, 100);
   EXPECT_EQ(delta.phase, std::string_view{"wave"});
+  EXPECT_TRUE(delta.upserts.empty());
+  EXPECT_TRUE(delta.erased.empty());
 }
 
 void SimGame_ExtractDeltaConsumesWorldUpdatesButNotState() {

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -311,14 +311,14 @@ void SimWorld_EnemyDespawnsAtEnd() {
 // get_path returns nullptr for an out-of-range index.
 void SimWorld_GetPathOutOfRange() {
   sim_world w;
-  EXPECT_TRUE(w.get_path(0) == nullptr);
+  EXPECT_TRUE(w.get_path(path_id_t{0}) == nullptr);
 
   path_joints p;
   p.joints = {{{0.F, 0.F}}, {{1.F, 0.F}}};
   (void)w.add_path(p);
 
-  EXPECT_TRUE(w.get_path(0) != nullptr);
-  EXPECT_TRUE(w.get_path(1) == nullptr);
+  EXPECT_TRUE(w.get_path(path_id_t{0}) != nullptr);
+  EXPECT_TRUE(w.get_path(path_id_t{1}) == nullptr);
 }
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/strings_test.cpp
+++ b/tests/strings_test.cpp
@@ -2134,6 +2134,7 @@ void StringUtilsTest_StdFromChars() {
     sv = "abc";
     result = std::from_chars(sv.data(), sv.data() + sv.size(), fvalue);
     EXPECT_EQ(result.ptr, sv.data());
+    EXPECT_EQ(result.ec, std::errc::invalid_argument);
   }
   // Test extract_num float wrappers (which use std::from_chars internally).
   if (true) {
@@ -2151,11 +2152,6 @@ void StringUtilsTest_StdFromChars() {
     EXPECT_TRUE(strings::extract_num(f, sv));
     EXPECT_TRUE(f > 6e23f);
     EXPECT_TRUE(sv.empty());
-
-    // Note: The fallback std::from_chars implementation has a limitation where
-    // invalid input like "xyz" returns success with value 0.0 and ptr at
-    // start. The extract_num wrapper checks for character consumption, so it
-    // may still fail in some cases.
   }
   // Test parse_num float wrappers.
   if (true) {

--- a/tests/strings_test.cpp
+++ b/tests/strings_test.cpp
@@ -2521,6 +2521,66 @@ void StringUtilsTest_TokenParser() {
   input = {};
   token = p.next_terminated(input);
   ASSERT_FALSE(token.has_value());
+
+  // Char-separator overloads for next_delimited.
+  input = "one,two,three";
+  EXPECT_EQ(token_parser::next_delimited(',', input), "one");
+  EXPECT_EQ(token_parser::next_delimited(',', input), "two");
+  EXPECT_EQ(token_parser::next_delimited(',', input), "three");
+  EXPECT_EQ(token_parser::next_delimited(',', input), "");
+  EXPECT_TRUE(input.empty());
+
+  // Char-separator overloads for next_terminated.
+  input = "one,two,three";
+  auto ctoken = token_parser::next_terminated(',', input);
+  ASSERT_TRUE(ctoken.has_value());
+  EXPECT_EQ(*ctoken, "one");
+  ctoken = token_parser::next_terminated(',', input);
+  ASSERT_TRUE(ctoken.has_value());
+  EXPECT_EQ(*ctoken, "two");
+  // No trailing terminator; expect nullopt but input unchanged.
+  ctoken = token_parser::next_terminated(',', input);
+  ASSERT_FALSE(ctoken.has_value());
+  EXPECT_EQ(input, "three");
+}
+
+// Test any_strings, make_string_vector, and make_any_strings.
+void StringUtilsTest_AnyStrings() {
+  using strings::any_strings;
+  using strings::make_any_strings;
+  using strings::make_string_vector;
+
+  // make_string_vector: zero, one, and multiple strings.
+  auto v0 = make_string_vector();
+  EXPECT_TRUE(v0.empty());
+
+  auto v1 = make_string_vector(std::string{"hello"});
+  ASSERT_EQ(v1.size(), 1u);
+  EXPECT_EQ(v1[0], "hello");
+
+  auto v2 =
+      make_string_vector(std::string{"a"}, std::string{"b"}, std::string{"c"});
+  ASSERT_EQ(v2.size(), 3u);
+  EXPECT_EQ(v2[0], "a");
+  EXPECT_EQ(v2[1], "b");
+  EXPECT_EQ(v2[2], "c");
+
+  // make_any_strings: zero args -> monostate.
+  auto a0 = make_any_strings();
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(a0));
+
+  // make_any_strings: one arg -> string.
+  auto a1 = make_any_strings(std::string{"hello"});
+  ASSERT_TRUE(std::holds_alternative<std::string>(a1));
+  EXPECT_EQ(std::get<std::string>(a1), "hello");
+
+  // make_any_strings: multiple args -> vector.
+  auto a2 = make_any_strings(std::string{"x"}, std::string{"y"});
+  ASSERT_TRUE(std::holds_alternative<std::vector<std::string>>(a2));
+  const auto& sv = std::get<std::vector<std::string>>(a2);
+  ASSERT_EQ(sv.size(), 2u);
+  EXPECT_EQ(sv[0], "x");
+  EXPECT_EQ(sv[1], "y");
 }
 
 MAKE_TEST_LIST(StringUtilsTest_ExtractPiece, StringUtilsTest_MorePieces,
@@ -2534,7 +2594,7 @@ MAKE_TEST_LIST(StringUtilsTest_ExtractPiece, StringUtilsTest_MorePieces,
     StringUtilsTest_Streams, StringUtilsTest_AppendEnum,
     StringUtilsTest_AppendStream, StringUtilsTest_AppendJson,
     StringUtilsTest_StdFromChars, StringUtilsTest_NoZero,
-    StringUtilsTest_TokenParser);
+    StringUtilsTest_TokenParser, StringUtilsTest_AnyStrings);
 
 // NOLINTEND(readability-function-cognitive-complexity,
 // readability-function-size)

--- a/tests/strings_test.cpp
+++ b/tests/strings_test.cpp
@@ -2544,38 +2544,36 @@ void StringUtilsTest_TokenParser() {
   EXPECT_EQ(input, "three");
 }
 
-// Test any_strings, make_string_vector, and make_any_strings.
+// Test any_strings, strings::as_vector, and strings::as_any.
 void StringUtilsTest_AnyStrings() {
   using strings::any_strings;
-  using strings::make_any_strings;
-  using strings::make_string_vector;
 
-  // make_string_vector: zero, one, and multiple strings.
-  auto v0 = make_string_vector();
+  // strings::as_vector: zero, one, and multiple strings.
+  auto v0 = strings::as_vector();
   EXPECT_TRUE(v0.empty());
 
-  auto v1 = make_string_vector(std::string{"hello"});
+  auto v1 = strings::as_vector(std::string{"hello"});
   ASSERT_EQ(v1.size(), 1u);
   EXPECT_EQ(v1[0], "hello");
 
   auto v2 =
-      make_string_vector(std::string{"a"}, std::string{"b"}, std::string{"c"});
+      strings::as_vector(std::string{"a"}, std::string{"b"}, std::string{"c"});
   ASSERT_EQ(v2.size(), 3u);
   EXPECT_EQ(v2[0], "a");
   EXPECT_EQ(v2[1], "b");
   EXPECT_EQ(v2[2], "c");
 
-  // make_any_strings: zero args -> monostate.
-  auto a0 = make_any_strings();
+  // strings::as_any: zero args -> monostate.
+  auto a0 = strings::as_any();
   EXPECT_TRUE(std::holds_alternative<std::monostate>(a0));
 
-  // make_any_strings: one arg -> string.
-  auto a1 = make_any_strings(std::string{"hello"});
+  // strings::as_any: one arg -> string.
+  auto a1 = strings::as_any(std::string{"hello"});
   ASSERT_TRUE(std::holds_alternative<std::string>(a1));
   EXPECT_EQ(std::get<std::string>(a1), "hello");
 
-  // make_any_strings: multiple args -> vector.
-  auto a2 = make_any_strings(std::string{"x"}, std::string{"y"});
+  // strings::as_any: multiple args -> vector.
+  auto a2 = strings::as_any(std::string{"x"}, std::string{"y"});
   ASSERT_TRUE(std::holds_alternative<std::vector<std::string>>(a2));
   const auto& sv = std::get<std::vector<std::string>>(a2);
   ASSERT_EQ(sv.size(), 2u);

--- a/tests/strings_test.cpp
+++ b/tests/strings_test.cpp
@@ -2126,11 +2126,6 @@ void StringUtilsTest_StdFromChars() {
     auto result = std::from_chars(sv.data(), sv.data() + sv.size(), fvalue);
     EXPECT_NE(result.ec, std::errc{});
 
-    // first >= last - properly returns error.
-    sv = "123";
-    result = std::from_chars(sv.data() + 2, sv.data(), fvalue);
-    EXPECT_NE(result.ec, std::errc{});
-
     sv = "abc";
     result = std::from_chars(sv.data(), sv.data() + sv.size(), fvalue);
     EXPECT_EQ(result.ptr, sv.data());

--- a/tests/strings_test.cpp
+++ b/tests/strings_test.cpp
@@ -1999,122 +1999,120 @@ void StringUtilsTest_AppendJson() {
 }
 
 void StringUtilsTest_StdFromChars() {
-  // Test std_from_chars directly for float.
+  // Test std::from_chars directly for float.
   if (true) {
     float value{};
     std::string_view sv;
 
     // Basic positive float.
     sv = "3.14";
-    auto result =
-        strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    auto result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_TRUE(value > 3.13f && value < 3.15f);
     EXPECT_EQ(result.ptr, sv.data() + sv.size());
 
     // Basic negative float.
     sv = "-2.5";
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_EQ(value, -2.5f);
     EXPECT_EQ(result.ptr, sv.data() + sv.size());
 
     // Integer parsed as float.
     sv = "42";
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_EQ(value, 42.0f);
 
     // Zero.
     sv = "0.0";
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_EQ(value, 0.0f);
 
     // Negative zero.
     sv = "-0.0";
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     // Negative zero should be equal to positive zero.
     EXPECT_EQ(value, 0.0f);
 
     // Scientific notation.
     sv = "1.5e3";
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_EQ(value, 1500.0f);
 
     // Negative exponent.
     sv = "1.5e-2";
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_TRUE(value > 0.014f && value < 0.016f);
 
     // Large positive exponent.
     sv = "1e30";
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_TRUE(value > 9e29f);
 
     // Very small positive number.
     sv = "1e-30";
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_TRUE(value > 0.0f && value < 1e-29f);
 
     // Partial parse (stops at non-numeric).
     sv = "3.14abc";
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_TRUE(value > 3.13f && value < 3.15f);
     EXPECT_EQ(result.ptr, sv.data() + 4); // Stops at 'a'.
   }
-  // Test std_from_chars directly for double.
+  // Test std::from_chars directly for double.
   if (true) {
     double value{};
     std::string_view sv;
 
     // Basic positive double.
     sv = "3.141592653589793";
-    auto result =
-        strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    auto result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_TRUE(value > 3.14159265358979 && value < 3.14159265358980);
     EXPECT_EQ(result.ptr, sv.data() + sv.size());
 
     // Basic negative double.
     sv = "-2.718281828";
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_TRUE(value < -2.71828182 && value > -2.71828183);
 
     // Large double.
     sv = "1.7976931348623157e308";
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_TRUE(value > 1e307);
 
     // Small positive double.
     sv = "2.2250738585072014e-308";
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_TRUE(value > 0.0 && value < 1e-307);
 
     // Scientific notation with capital E.
     sv = "1.5E10";
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_EQ(value, 1.5e10);
 
     // Leading decimal point.
     sv = ".5";
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_EQ(value, 0.5);
 
     // Trailing decimal point.
     sv = "5.";
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_EQ(value, 5.0);
   }
@@ -2125,17 +2123,12 @@ void StringUtilsTest_StdFromChars() {
 
     // Empty string - properly returns error.
     sv = "";
-    auto result =
-        strings::std_from_chars(sv.data(), sv.data() + sv.size(), fvalue);
-    EXPECT_NE(result.ec, std::errc{});
-
-    // Null first pointer - properly returns error.
-    result = strings::std_from_chars(nullptr, sv.data(), fvalue);
+    auto result = std::from_chars(sv.data(), sv.data() + sv.size(), fvalue);
     EXPECT_NE(result.ec, std::errc{});
 
     // first >= last - properly returns error.
     sv = "123";
-    result = strings::std_from_chars(sv.data() + 2, sv.data(), fvalue);
+    result = std::from_chars(sv.data() + 2, sv.data(), fvalue);
     EXPECT_NE(result.ec, std::errc{});
 
     // Note: Invalid input like "abc" is handled by strtof/strtod which returns
@@ -2143,12 +2136,12 @@ void StringUtilsTest_StdFromChars() {
     // this as an error (it sets value to 0.0 and returns success with ptr at
     // start). This is a known limitation of the fallback implementation.
     sv = "abc";
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), fvalue);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), fvalue);
     // Fallback returns success with value 0 and ptr at start (no chars
     // consumed).
     EXPECT_EQ(result.ptr, sv.data());
   }
-  // Test extract_num float wrappers (which use std_from_chars internally).
+  // Test extract_num float wrappers (which use std::from_chars internally).
   if (true) {
     std::string_view sv;
     float f{};
@@ -2165,7 +2158,7 @@ void StringUtilsTest_StdFromChars() {
     EXPECT_TRUE(f > 6e23f);
     EXPECT_TRUE(sv.empty());
 
-    // Note: The fallback std_from_chars implementation has a limitation where
+    // Note: The fallback std::from_chars implementation has a limitation where
     // invalid input like "xyz" returns success with value 0.0 and ptr at
     // start. The extract_num wrapper checks for character consumption, so it
     // may still fail in some cases.
@@ -2214,7 +2207,7 @@ void StringUtilsTest_StdFromChars() {
     val = strings::parse_num<double>("xyz"sv, -999.0);
     EXPECT_EQ(val, -999.0);
   }
-  // Test edge cases for buffer handling in std_from_chars fallback.
+  // Test edge cases for buffer handling in std::from_chars fallback.
   if (true) {
     double value{};
 
@@ -2222,8 +2215,7 @@ void StringUtilsTest_StdFromChars() {
     std::string long_num = "1.";
     long_num.append(125, '0');
     std::string_view sv = long_num;
-    auto result =
-        strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    auto result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_EQ(value, 1.0);
 
@@ -2231,7 +2223,7 @@ void StringUtilsTest_StdFromChars() {
     long_num = "1.";
     long_num.append(200, '0');
     sv = long_num;
-    result = strings::std_from_chars(sv.data(), sv.data() + sv.size(), value);
+    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     EXPECT_EQ(result.ec, std::errc{});
     EXPECT_EQ(value, 1.0);
   }

--- a/tests/strings_test.cpp
+++ b/tests/strings_test.cpp
@@ -2131,14 +2131,8 @@ void StringUtilsTest_StdFromChars() {
     result = std::from_chars(sv.data() + 2, sv.data(), fvalue);
     EXPECT_NE(result.ec, std::errc{});
 
-    // Note: Invalid input like "abc" is handled by strtof/strtod which returns
-    // 0.0 with endptr at start. The fallback implementation doesn't detect
-    // this as an error (it sets value to 0.0 and returns success with ptr at
-    // start). This is a known limitation of the fallback implementation.
     sv = "abc";
     result = std::from_chars(sv.data(), sv.data() + sv.size(), fvalue);
-    // Fallback returns success with value 0 and ptr at start (no chars
-    // consumed).
     EXPECT_EQ(result.ptr, sv.data());
   }
   // Test extract_num float wrappers (which use std::from_chars internally).
@@ -2206,26 +2200,6 @@ void StringUtilsTest_StdFromChars() {
 
     val = strings::parse_num<double>("xyz"sv, -999.0);
     EXPECT_EQ(val, -999.0);
-  }
-  // Test edge cases for buffer handling in std::from_chars fallback.
-  if (true) {
-    double value{};
-
-    // String exactly at buffer boundary (127 chars).
-    std::string long_num = "1.";
-    long_num.append(125, '0');
-    std::string_view sv = long_num;
-    auto result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
-    EXPECT_EQ(result.ec, std::errc{});
-    EXPECT_EQ(value, 1.0);
-
-    // String longer than internal buffer (should still work, truncated).
-    long_num = "1.";
-    long_num.append(200, '0');
-    sv = long_num;
-    result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
-    EXPECT_EQ(result.ec, std::errc{});
-    EXPECT_EQ(value, 1.0);
   }
 }
 


### PR DESCRIPTION
## Summary

Adds CorvidSim, a browser-based tower defense game hosted by the Corvid library,
under \`corvid/sim/\`. The server is a single-process C++ binary; the client is a
TypeScript/Vite app served as static files from \`web/dist/\`.

### Server side (\`corvid/sim/\`)

**\`corvid_sim_main.h\`** — entry point and HTTP server setup.
- Walks up from the executable to find \`corvid/sim/web/dist\` automatically.
- Serves static files via \`static_file_cache\` on \`localhost:8080\`.
- Intercepts SIGINT/SIGTERM cleanly via \`signal_waiter\` (blocks signals on all
  threads so \`sigwait\` owns delivery).
- Accepts \`-testonly\` to exit immediately, allowing CI to include the binary
  in its test sweep without blocking on a live server.

**\`sim_ws_handler.h\`** — \`SimWsHandler\`, the \`/ws\` WebSocket route.
- Inherits \`http_websocket_transaction\`; wires callbacks in the constructor so
  behavior lives in named private methods rather than lambdas.
- Drives a 20 Hz tick timer using the \`timer_fuse\` double-check pattern: the
  wheel-thread callback only calls \`loop->post()\`; the loop-thread callback
  performs the definitive liveness check before advancing the simulation.
- Enables 20s-ping / 5s-pong keepalive (sum 25s < the 30s read timeout).
- First tick sends a full \`world_snapshot\`; subsequent ticks send incremental
  \`world_delta\` messages.

**\`sim_json_wire.h\`** — JSON serialization using \`json_writer\`.
- \`build_sim_hello_ack_json()\` — \`{"type":"hello_ack","message":"connected"}\`.
- \`build_sim_game_state_json()\` — on full strategy, emits
  \`{"type":"world_snapshot","paths":[...],"delta":{...}}\`; on incremental,
  emits \`{"type":"world_delta",...}\` with only entities whose \`Appearance\` or
  \`VisualEffects\` changed this tick. Includes \`currentWave\`, \`waveTick\`,
  \`lives\`, \`resources\`, and \`phase\` in every delta.
- \`sim_game_state_json\` is a reusable struct with high-watermark \`reserve()\`
  to avoid repeated allocations across frames.

**\`sim_json_parse.h\`** — JSON parsing for client messages.
- Classifies \`hello\`, \`ui_canvas\`, and \`ui_action\` by \`"type"\` field using
  Corvid enum reflection.
- \`parseUiCanvasMessage()\` decodes pointer position, button, modifier keys,
  and event kind (\`click\`, \`dblclick\`, \`contextmenu\`, \`dragstart\`, \`dragmove\`,
  \`dragend\`).
- \`parseUiActionMessage()\` decodes action name and key-value fields.

**\`sim_world.h\`** — \`SimWorld\`: ECS entity state and physics.
- Five archetypes:
  - \`sidPos\` — static entities (\`Position + Appearance\`).
  - \`sidPosVel\` — velocity-driven movers (\`Position + Velocity + Appearance\`).
  - \`sidEnemy\` — path-following invaders (\`Position + Appearance + VisualEffects + PathFollower + Invader\`).
  - \`sidTower\` — placed towers (\`Position + Appearance + VisualEffects + Tower\`).
  - \`sidBullet\` — bullets (\`Position + Velocity + Bullet\`; archetype defined, not yet wired up).
- \`PathJoints\` → \`SegmentedPath\`: pre-computes cumulative segment distances for
  O(log n) progress-to-position lookup; snaps to the joint position when a fast
  entity crosses a segment boundary in one tick.
- Dirty tracking stores the last-change tick in registry metadata; \`markDirty()\`
  deduplicates within a frame and appends to \`updatedEntities_\`.
- \`markAllDirty(update_strategy::full)\` also stamps \`Appearance.modified\` and
  \`VisualEffects.modified\` so the snapshot serializer emits every component.
- \`towersAttack()\` detects circle-circle overlaps and flashes both tower and
  enemy; actual damage, cooldown, and kill logic is stubbed behind \`#if 0\`.
- \`flashEntity()\` sets \`flash_color\` and \`flash_expiry\` on any entity carrying
  \`VisualEffects\`; \`flash_expiry_delay_ms()\` converts the remaining tick count
  to a millisecond deadline the client uses for its flicker timer.

**\`sim_game.h\`** — \`SimGame\`: game rules and flow on top of \`SimWorld\`.
- \`GamePhase\`: \`build\` → \`wave\` → \`game_over\` (or \`victory\`, not yet reachable).
- \`WaveDefinition\` holds \`EnemySpawn\` records (start tick, enemy type).
  \`doLoadMap1()\` builds one hardcoded spiral path and one wave of 20 enemies
  spaced 20 ticks apart.
- \`next()\`: advances the world, increments \`WaveTick\`, spawns due enemies, calls
  \`resolveEscapees()\` to decrement lives, transitions to \`game_over\` at 0 lives.
- Input handling:
  - Left click — selects tower (paints range circle via \`VisualEffects\`; clears
    the previous selection).
  - Double-click — places a new tower at that world position.
  - Right click — flashes the entity under the cursor.
  - \`ui_action "start_wave"\` — transitions build → wave.

### Client side (\`corvid/sim/web/src/\`)

**\`main.ts\`** — TypeScript client (Vite build, no runtime dependencies).
- Connects via WebSocket; sends \`hello\` on open, starts ticking on \`hello_ack\`.
- Validates every incoming message shape before processing.
- Dual-canvas layout: \`background-canvas\` for the static path (drawn once per
  snapshot reset); \`foreground-canvas\` for live entities + composited overlays.
- 1920×1080 world space mapped to the 960×540 canvas (uniform scale).
- \`requestAnimationFrame\` loop at the display's native refresh rate, with linear
  interpolation between consecutive 20 Hz snapshots for smooth motion.
- Sprite cache: entity appearance (filled circle + Unicode glyph) rendered once
  to an offscreen \`HTMLCanvasElement\` per unique (glyph, radius, fg, bg) bucket
  and blitted via \`drawImage\` on every frame.
- VFX layers per entity: range circle → entity sprite → selection outline →
  flicker flash overlay (62.5 ms flicker period, wall-clock expiry).
- HUD (lives + resources) and FPS counter rendered to separate offscreen canvases
  and composited only when dirty / on a 100 ms timer.
- Drag throttling: \`mousemove\` batches \`dragmove\` messages to one per
  \`requestAnimationFrame\`.
- \`ui_action\` sent for \`data-action\` button clicks and form submits (e.g., the
  "Start Wave" button).

## Known gaps
- Tower damage, cooldown, and kill logic are disabled (\`#if 0\` in \`towersAttack\`).
- Only one hardcoded map and one wave; data-driven loading is not yet wired up.
- \`placeTower()\` in \`SimGame\` is a stub; resource spending and build-slot
  enforcement are not implemented.
- No victory condition when all waves clear with lives remaining.
- Enemy variety: \`enemyType\` is recorded but all enemies share the same speed
  and appearance.
- The \`sidBullet\` archetype exists but no projectile-firing tower type fires into
  it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)