### PR TITLE
Additional sim work

### DIFF
--- a/corvid/concurrency/timing_wheel.h
+++ b/corvid/concurrency/timing_wheel.h
@@ -91,7 +91,7 @@ public:
   // All slots in the wheel, indexed by the tick position.
   using slots_t = std::vector<slot_t>;
 
-  // Default slot count covers ~60 s at 100ms per slot.
+  // Default slot count covers ~60s at 100ms per slot.
   static constexpr size_t default_slot_count{600};
 
   // Default resolution: one 100ms slot per tick.
@@ -121,6 +121,12 @@ public:
   timing_wheel& operator=(const timing_wheel&) = delete;
   timing_wheel& operator=(timing_wheel&&) = delete;
 
+  // Return the maximum delay this wheel can schedule. Attempts to schedule a
+  // delay beyond this value will fail; they will not be capped.
+  [[nodiscard]] duration_t max_delay() const noexcept {
+    return tick_interval_ * static_cast<int>(slots_.size() - 1);
+  }
+
   // Schedule `callback` to fire after `delay`. Thread-safe.
   //
   // Returns false if `delay` exceeds `(slot_count - 1) * tick_interval`;
@@ -131,9 +137,7 @@ public:
   // firing time is rounded to the next slot boundary after that, and only
   // occurs after all previous callbacks have fired.
   [[nodiscard]] bool schedule(eventfn callback, duration_t delay) {
-    const auto max_delay =
-        tick_interval_ * static_cast<int>(slots_.size() - 1);
-    if (delay > max_delay) return false;
+    if (delay > max_delay()) return false;
     delay = std::max(delay, tick_interval_);
     const auto ticks_ahead = static_cast<size_t>(delay / tick_interval_);
 

--- a/corvid/ecs/archetype_scene.h
+++ b/corvid/ecs/archetype_scene.h
@@ -112,7 +112,7 @@ public:
   // `megatuple_t`: one `optional<C>` per unique component type in the scene.
   // Setting an optional encodes component presence; the pattern of set
   // optionals uniquely identifies the archetype, eliminating the need for an
-  // explicit `store_id_t` at the call site of `store_new_entity_from_mega`.
+  // explicit `store_id_t`.
   using megatuple_t = wrap_optionals_t<component_union_t>;
 
   // One bit per unique component type; supports scenes with up to 64 distinct

--- a/corvid/ecs/archetype_scene.h
+++ b/corvid/ecs/archetype_scene.h
@@ -16,7 +16,9 @@
 // limitations under the License.
 #pragma once
 
+#include <array>
 #include <cstddef>
+#include <optional>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -103,6 +105,22 @@ public:
   static_assert(storage_count_v < *store_id_t::invalid,
       "too many storage_ts: store_id_t would overflow into the invalid "
       "sentinel");
+
+  // Deduplicated union of all component types across all storages.
+  using component_union_t = tuple_union_t<typename STORES::tuple_t...>;
+
+  // `megatuple_t`: one `optional<C>` per unique component type in the scene.
+  // Setting an optional encodes component presence; the pattern of set
+  // optionals uniquely identifies the archetype, eliminating the need for an
+  // explicit `store_id_t` at the call site of `store_new_entity_from_mega`.
+  using megatuple_t = wrap_optionals_t<component_union_t>;
+
+  // One bit per unique component type; supports scenes with up to 64 distinct
+  // component types.
+  using bitmap_t = uint64_t;
+  static_assert(std::tuple_size_v<component_union_t> <= 64,
+      "megatuple_t has more than 64 unique component types; bitmap_t too "
+      "narrow");
 
   // Type of the storage with the given `store_id`.
   template<store_id_t SID>
@@ -191,6 +209,32 @@ public:
               std::forward<decltype(cs)>(cs)...);
         },
         std::forward<T>(obj));
+  }
+
+  // Create a new entity from a `megatuple_t`. The set of optionals that have
+  // values must exactly match the component set of one of this scene's
+  // archetypes, as determined by a linear search of the compile-time bitmap
+  // table. Returns a valid handle on success, or an invalid handle if no
+  // archetype matches the bitmap, the registry refused creation, or the
+  // storage limit would be exceeded.
+  //
+  // Note: It's tempting to sort the array and do a binary search, but given
+  // the numbers, it's not likely to be measurably faster, and might even be
+  // slower.
+  [[nodiscard]] handle_t store_new_entity_from_mega(const metadata_t& metadata,
+      const megatuple_t& tpl) {
+    const bitmap_t bm = bitmap_of(tpl);
+    for (const auto& [arch_bm, sid] : bitmap_table_v) {
+      if (arch_bm == bm) {
+        return dispatch_storage<handle_t>(
+            sid,
+            [&](auto& s) -> handle_t {
+              return s.add_new_from_mega(metadata, tpl);
+            },
+            handle_t{});
+      }
+    }
+    return handle_t{};
   }
 
   // Insert an already-staged entity into a storage selected at runtime by
@@ -568,6 +612,39 @@ public:
   }
 
 private:
+  // Bit index of component type C in `component_union_t` / `megatuple_t`.
+  template<typename C>
+  static constexpr size_t component_bit_v =
+      tuple_index_v<C, component_union_t>;
+
+  // Compile-time bitmap for archetype `Store`: bit j is set if component j
+  // (in `component_union_t` order) is in `Store::tuple_t`.
+  template<typename Store>
+  static constexpr bitmap_t arch_bitmap_for() {
+    return []<typename... Cs>(std::tuple<Cs...>*) -> bitmap_t {
+      return ((bitmap_t{1} << component_bit_v<Cs>) | ...);
+    }(static_cast<typename Store::tuple_t*>(nullptr));
+  }
+
+  // Compile-time table mapping each archetype's component bitmap to its SID.
+  // Entries are in storage order (SID 1, 2, ..., `storage_count_v`).
+  static constexpr std::array<std::pair<bitmap_t, store_id_t>, storage_count_v>
+      bitmap_table_v = []<size_t... Is>(std::index_sequence<Is...>) {
+        return std::array{std::pair{
+            arch_bitmap_for<std::tuple_element_t<Is, std::tuple<STORES...>>>(),
+            store_id_t{Is + 1}}...};
+      }(std::index_sequence_for<STORES...>{});
+
+  // Compute the runtime bitmap of a `megatuple_t`: bit j is set if the jth
+  // optional has a value.
+  [[nodiscard]] static bitmap_t bitmap_of(const megatuple_t& tpl) noexcept {
+    return [&]<size_t... Is>(std::index_sequence<Is...>) -> bitmap_t {
+      return (
+          (std::get<Is>(tpl).has_value() ? (bitmap_t{1} << Is) : bitmap_t{}) |
+          ...);
+    }(std::make_index_sequence<std::tuple_size_v<megatuple_t>>{});
+  }
+
   // Count how many storages expose a `tuple_t` equal to `T`.
   template<typename T>
   static constexpr size_t count_stores_with_tuple_v =

--- a/corvid/ecs/archetype_scene.h
+++ b/corvid/ecs/archetype_scene.h
@@ -525,6 +525,15 @@ public:
   // Return a pointer to component `C` for entity `id`, or `nullptr` if the
   // entity is invalid, in staging, or its archetype does not contain `C`.
   // Deduces `const` from the scene: on a `const` scene returns `const C*`.
+  //
+  // Performance: O(S) in the number of storages, but with a very small
+  // constant. The implementation is a fold over a compile-time
+  // `std::index_sequence` that expands to S comparisons of `store_id` against
+  // a compile-time constant, with `if constexpr` eliding the body for any
+  // storage whose `tuple_t` does not contain `C`. In practice, with a small
+  // number of archetypes and an optimizing compiler, this collapses to one or
+  // two branches. The registry lookup (`is_valid` + `get_location`) is O(1)
+  // and runs unconditionally.
   template<typename C>
   [[nodiscard]] auto
   try_get_component(this auto& self, id_t id) noexcept -> std::conditional_t<
@@ -553,6 +562,14 @@ public:
   // the value being `nullptr` if the entity is invalid, in staging, or its
   // archetype does not contain `C`. Deduces `const` from the scene: on a
   // `const` scene returns `const C*`.
+  //
+  // Performance: same O(S) fold as `try_get_component`, but requires that
+  // every requested component `C` in `Cs...` be present in the same storage
+  // (the `has_all_components_v` guard). When a storage matches, all C
+  // pointers are extracted in a single `storage[id]` row access. Compared to
+  // calling `try_get_component` once per component, this avoids repeating the
+  // registry lookup and the S-way fold for each component, making it
+  // preferable when fetching two or more components at once.
   template<typename... Cs>
   [[nodiscard]] auto try_get_components(this auto& self, id_t id) noexcept
       -> std::tuple<std::conditional_t<
@@ -577,6 +594,56 @@ public:
             {
               if (*loc.store_id == Is)
                 found = std::tuple{&storage[id].template component<Cs>()...};
+            }
+          }(std::get<Is>(self.storages_)),
+          ...);
+    }(storage_indices());
+    return found;
+  }
+
+  // Return a tuple of pointers to the components `Cs` for entity `id`.
+  // Unlike `try_get_components`, this does not require all `Cs` to be present
+  // in the same archetype: each pointer is set independently based on whether
+  // the entity's archetype contains that component, and may be `nullptr` even
+  // when others are non-null. Returns all `nullptr`s if the entity is invalid
+  // or in staging. Deduces `const` from the scene: on a `const` scene returns
+  // `const C*` for each element.
+  //
+  // Performance: O(S) in the number of storages (one registry lookup + one
+  // fold to identify the storage), then O(N) in `sizeof...(Cs)` to populate
+  // the result from a single row access. Prefer this over N separate
+  // `try_get_component` calls when the components may or may not all be
+  // present and the single-lookup savings matter.
+  template<typename... Cs>
+  [[nodiscard]] auto try_get_some_components(this auto& self, id_t id) noexcept
+      -> std::tuple<std::conditional_t<
+          std::is_const_v<std::remove_reference_t<decltype(self)>>, const Cs*,
+          Cs*>...> {
+    using self_t = std::remove_reference_t<decltype(self)>;
+    using result_t = std::tuple<
+        std::conditional_t<std::is_const_v<self_t>, const Cs*, Cs*>...>;
+
+    const result_t missing{static_cast<
+        std::conditional_t<std::is_const_v<self_t>, const Cs*, Cs*>>(
+        nullptr)...};
+    if (!self.registry_.is_valid(id)) return missing;
+
+    auto loc = self.registry_.get_location(id);
+    result_t found = missing;
+    [&]<size_t... Is>(std::index_sequence<Is...>) {
+      (
+          [&](auto& storage) {
+            if (*loc.store_id == Is) {
+              using storage_t = std::remove_cvref_t<decltype(storage)>;
+              auto row = storage[id];
+              found = result_t{
+                  [&]() -> std::conditional_t<std::is_const_v<self_t>,
+                            const Cs*, Cs*> {
+                    if constexpr (has_all_components_v<storage_t, Cs>)
+                      return &row.template component<Cs>();
+                    else
+                      return nullptr;
+                  }()...};
             }
           }(std::get<Is>(self.storages_)),
           ...);

--- a/corvid/ecs/archetype_scene.h
+++ b/corvid/ecs/archetype_scene.h
@@ -687,7 +687,7 @@ private:
   // Compile-time bitmap for archetype `Store`: bit j is set if component j
   // (in `component_union_t` order) is in `Store::tuple_t`.
   template<typename Store>
-  static constexpr bitmap_t arch_bitmap_for() {
+  static consteval bitmap_t arch_bitmap_for() {
     return []<typename... Cs>(std::tuple<Cs...>*) -> bitmap_t {
       return ((bitmap_t{1} << component_bit_v<Cs>) | ...);
     }(static_cast<typename Store::tuple_t*>(nullptr));
@@ -696,7 +696,7 @@ private:
   // Compile-time table mapping each archetype's component bitmap to its SID.
   // Entries are in storage order (SID 1, 2, ..., `storage_count_v`).
   static constexpr std::array<std::pair<bitmap_t, store_id_t>, storage_count_v>
-      bitmap_table_v = []<size_t... Is>(std::index_sequence<Is...>) {
+      bitmap_table_v = []<size_t... Is>(std::index_sequence<Is...>) consteval {
         return std::array{std::pair{
             arch_bitmap_for<std::tuple_element_t<Is, std::tuple<STORES...>>>(),
             store_id_t{Is + 1}}...};
@@ -721,7 +721,7 @@ private:
   // Caller must ensure exactly one match (guarded by
   // `count_stores_with_tuple_v`).
   template<typename T, size_t... Is>
-  static constexpr store_id_t
+  static consteval store_id_t
   find_sid_for_tuple(std::index_sequence<Is...>) noexcept {
     store_id_t result = store_id_t::invalid;
     (void)((std::is_same_v<T, typename std::tuple_element_t<Is,
@@ -734,14 +734,14 @@ private:
 
   // Produces `std::index_sequence<Offset, Offset+1, ..., Offset+N-1>`.
   template<size_t Offset, size_t... Is>
-  static constexpr auto make_offset_sequence(std::index_sequence<Is...>)
+  static consteval auto make_offset_sequence(std::index_sequence<Is...>)
       -> std::index_sequence<(Is + Offset)...> {
     return {};
   }
 
   // Index sequence spanning all real storages: 1, 2, ..., `storage_count_v`.
   // Matches `store_id_t` values and tuple indices directly (monostate at 0).
-  static constexpr auto storage_indices() {
+  static consteval auto storage_indices() {
     return make_offset_sequence<1>(
         std::make_index_sequence<storage_count_v>{});
   }

--- a/corvid/ecs/archetype_scene.h
+++ b/corvid/ecs/archetype_scene.h
@@ -693,7 +693,7 @@ private:
   static consteval bitmap_t arch_bitmap_for() {
     return []<typename... Cs>(std::tuple<Cs...>*) -> bitmap_t {
       return ((bitmap_t{1} << component_bit_v<Cs>) | ...);
-    }(static_cast<typename Store::tuple_t*>(nullptr));
+    }(static_cast<Store::tuple_t*>(nullptr));
   }
 
   // Compile-time table mapping each archetype's component bitmap to its SID.

--- a/corvid/ecs/archetype_scene.h
+++ b/corvid/ecs/archetype_scene.h
@@ -558,10 +558,13 @@ public:
     return found;
   }
 
-  // Return a tuple of pointers to the components `Cs` for entity `id`, with
-  // the value being `nullptr` if the entity is invalid, in staging, or its
-  // archetype does not contain `C`. Deduces `const` from the scene: on a
-  // `const` scene returns `const C*`.
+  // Return a tuple of pointers to the components `Cs` for entity `id`.
+  // Because all `Cs...` must reside in the same archetype (enforced by the
+  // `has_all_components_v` guard below), the result is all-or-nothing: either
+  // every pointer is non-null (the entity's archetype contains all of `Cs...`)
+  // or every pointer is null (the entity is invalid, in staging, or its
+  // archetype is missing at least one of `Cs...`). Deduces `const` from the
+  // scene: on a `const` scene returns `const C*`.
   //
   // Performance: same O(S) fold as `try_get_component`, but requires that
   // every requested component `C` in `Cs...` be present in the same storage

--- a/corvid/ecs/archetype_storage.h
+++ b/corvid/ecs/archetype_storage.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <span>
 #include <type_traits>
 #include <tuple>
@@ -160,6 +161,16 @@ public:
         },
         components_);
     return static_cast<size_type>(min_cap);
+  }
+
+  // Create a new entity by extracting this archetype's components from `mega`,
+  // a `megatuple_t` (tuple of optionals). Each `optional<C>` for a component
+  // `C` in this archetype must have a value; the caller is responsible for
+  // ensuring the bitmap matches before calling.
+  template<typename MegaTuple>
+  [[nodiscard]] handle_t
+  add_new_from_mega(const metadata_t& metadata, const MegaTuple& mega) {
+    return this->add_new(metadata, *std::get<std::optional<Cs>>(mega)...);
   }
 
 private:

--- a/corvid/ecs/archetype_storage.h
+++ b/corvid/ecs/archetype_storage.h
@@ -167,11 +167,13 @@ public:
   // a `megatuple_t` (tuple of optionals). Each `optional<C>` for a component
   // `C` in this archetype must have a value; the caller is responsible for
   // ensuring the bitmap matches before calling.
+  // NOLINTBEGIN(bugprone-unchecked-optional-access)
   template<typename MegaTuple>
   [[nodiscard]] handle_t
   add_new_from_mega(const metadata_t& metadata, const MegaTuple& mega) {
     return this->add_new(metadata, *std::get<std::optional<Cs>>(mega)...);
   }
+  // NOLINTEND(bugprone-unchecked-optional-access)
 
 private:
   using base_t::registry_;

--- a/corvid/ecs/component_scene.h
+++ b/corvid/ecs/component_scene.h
@@ -385,7 +385,7 @@ private:
   // Build the union of all storage bits whose `component_t == C`. Used by
   // `for_all` to detect multi-storage presence for a shared component type.
   template<typename C>
-  [[nodiscard]] static constexpr registry_t::store_id_set_t
+  [[nodiscard]] static consteval registry_t::store_id_set_t
   make_union_mask_for() noexcept {
     typename registry_t::store_id_set_t mask{};
     [&]<size_t... Is>(std::index_sequence<Is...>) {
@@ -453,7 +453,7 @@ private:
   // then `tag_t` fallback). The storage at tuple index `I+1` invariantly
   // holds `store_id_t{I+1}` (established by `make_storages`).
   template<typename... Cs>
-  [[nodiscard]] static constexpr registry_t::store_id_set_t
+  [[nodiscard]] static consteval registry_t::store_id_set_t
   make_target_mask() noexcept {
     typename registry_t::store_id_set_t mask{};
     auto set_one = [&]<typename C>() {

--- a/corvid/ecs/ecs_meta.h
+++ b/corvid/ecs/ecs_meta.h
@@ -16,6 +16,7 @@
 // limitations under the License.
 #pragma once
 
+#include <optional>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -144,5 +145,63 @@ template<typename C, typename SrcTuple>
   else
     return C{};
 }
+
+// Helper: append T to Tuple only if T is not already present.
+template<typename T, typename Tuple>
+struct tuple_append_unique;
+template<typename T, typename... Ts>
+struct tuple_append_unique<T, std::tuple<Ts...>> {
+  using type = std::conditional_t<(std::is_same_v<T, Ts> || ...),
+      std::tuple<Ts...>, std::tuple<Ts..., T>>;
+};
+
+// Recursively accumulate types from SrcTuples into AccTuple, skipping
+// duplicates. Handles both type-list and empty-tuple cases.
+template<typename AccTuple, typename... SrcTuples>
+struct tuple_union_impl {
+  using type = AccTuple;
+};
+template<typename AccTuple, typename Head, typename... Tail, typename... Rest>
+struct tuple_union_impl<AccTuple, std::tuple<Head, Tail...>, Rest...> {
+  using type = typename tuple_union_impl<
+      typename tuple_append_unique<Head, AccTuple>::type, std::tuple<Tail...>,
+      Rest...>::type;
+};
+template<typename AccTuple, typename... Rest>
+struct tuple_union_impl<AccTuple, std::tuple<>, Rest...> {
+  using type = typename tuple_union_impl<AccTuple, Rest...>::type;
+};
+
+// Deduplicated union of component types across all `Tuples`. For example,
+// `tuple_union_t<tuple<A,B,C>, tuple<A,D,E>>` yields `tuple<A,B,C,D,E>`.
+template<typename... Tuples>
+using tuple_union_t = typename tuple_union_impl<std::tuple<>, Tuples...>::type;
+
+// 0-based index of T in Tuple. Fails to compile if T is not present.
+template<typename T, typename Tuple, size_t I = 0>
+struct tuple_index_impl;
+template<typename T, size_t I>
+struct tuple_index_impl<T, std::tuple<>, I> {
+  static_assert(dependent_false_v<T>, "type not found in tuple");
+};
+template<typename T, typename Head, typename... Tail, size_t I>
+struct tuple_index_impl<T, std::tuple<Head, Tail...>, I>
+    : std::conditional_t<std::is_same_v<T, Head>,
+          std::integral_constant<size_t, I>,
+          tuple_index_impl<T, std::tuple<Tail...>, I + 1>> {};
+
+template<typename T, typename Tuple>
+inline constexpr size_t tuple_index_v = tuple_index_impl<T, Tuple>::value;
+
+// Transform `std::tuple<C0, C1, ...>` to
+// `std::tuple<std::optional<C0>, std::optional<C1>, ...>`.
+template<typename Tuple>
+struct wrap_optionals;
+template<typename... Cs>
+struct wrap_optionals<std::tuple<Cs...>> {
+  using type = std::tuple<std::optional<Cs>...>;
+};
+template<typename Tuple>
+using wrap_optionals_t = typename wrap_optionals<Tuple>::type;
 
 }}} // namespace corvid::ecs::ecs_metas

--- a/corvid/ecs/ecs_meta.h
+++ b/corvid/ecs/ecs_meta.h
@@ -163,19 +163,19 @@ struct tuple_union_impl {
 };
 template<typename AccTuple, typename Head, typename... Tail, typename... Rest>
 struct tuple_union_impl<AccTuple, std::tuple<Head, Tail...>, Rest...> {
-  using type = typename tuple_union_impl<
-      typename tuple_append_unique<Head, AccTuple>::type, std::tuple<Tail...>,
-      Rest...>::type;
+  using type =
+      tuple_union_impl<typename tuple_append_unique<Head, AccTuple>::type,
+          std::tuple<Tail...>, Rest...>::type;
 };
 template<typename AccTuple, typename... Rest>
 struct tuple_union_impl<AccTuple, std::tuple<>, Rest...> {
-  using type = typename tuple_union_impl<AccTuple, Rest...>::type;
+  using type = tuple_union_impl<AccTuple, Rest...>::type;
 };
 
 // Deduplicated union of component types across all `Tuples`. For example,
 // `tuple_union_t<tuple<A,B,C>, tuple<A,D,E>>` yields `tuple<A,B,C,D,E>`.
 template<typename... Tuples>
-using tuple_union_t = typename tuple_union_impl<std::tuple<>, Tuples...>::type;
+using tuple_union_t = tuple_union_impl<std::tuple<>, Tuples...>::type;
 
 // 0-based index of T in Tuple. Fails to compile if T is not present.
 template<typename T, typename Tuple, size_t I = 0>
@@ -202,6 +202,6 @@ struct wrap_optionals<std::tuple<Cs...>> {
   using type = std::tuple<std::optional<Cs>...>;
 };
 template<typename Tuple>
-using wrap_optionals_t = typename wrap_optionals<Tuple>::type;
+using wrap_optionals_t = wrap_optionals<Tuple>::type;
 
 }}} // namespace corvid::ecs::ecs_metas

--- a/corvid/ecs/stable_ids.h
+++ b/corvid/ecs/stable_ids.h
@@ -78,7 +78,7 @@ namespace corvid { inline namespace ecs { inline namespace stable_id_vector {
 // prefilling constructor) before inserting, ensuring that insertions do not
 // allocate.
 //
-// Motivated by https://github.com/johnBuffer/StableIndexVector. Largely
+// Motivated by https://github.com/johnBuffer/StableIndexVector. Completely
 // obsoleted by `entity_registry` and `component_storage`.
 template<typename T, sequence::SequentialEnum ID = id_enums::id_t,
     generation_scheme GEN = generation_scheme::versioned,

--- a/corvid/enums/bitmask_enum.h
+++ b/corvid/enums/bitmask_enum.h
@@ -604,7 +604,7 @@ consteval auto make_bitmask_enum_spec() {
 // hex, in combination with the known part of the value, if any.
 template<ScopedEnum E, strings::fixed_string bit_names,
     wrapclip bitclip = wrapclip{}>
-[[nodiscard]] constexpr auto make_bitmask_enum_values_spec() {
+[[nodiscard]] consteval auto make_bitmask_enum_values_spec() {
   constexpr auto name_array = strings::fixed_split<bit_names>();
   constexpr auto trimmed_names =
       strings::fixed_split_trim<bit_names, " -?*">();

--- a/corvid/enums/bool_enums.h
+++ b/corvid/enums/bool_enums.h
@@ -79,4 +79,8 @@ enum class exclusivity : bool { exclusive = false, shared = true };
 // Whether to perform a full update or an incremental update.
 enum class update_strategy : bool { full = false, incremental = true };
 
+// Whether the text is already validated as correct (`trusted`) or needs
+// validation and possible encoding (`untrusted`).
+enum class text_validation : bool { untrusted = false, trusted = true };
+
 }}} // namespace corvid::enums::bool_enums

--- a/corvid/enums/sequence_enum.h
+++ b/corvid/enums/sequence_enum.h
@@ -371,7 +371,7 @@ struct sequence_enum_names_spec
 // printed.
 template<ScopedEnum E, strings::fixed_string names,
     wrapclip wrapseq = wrapclip{}, E minseq = E{}>
-[[nodiscard]] constexpr auto make_sequence_enum_spec() {
+[[nodiscard]] consteval auto make_sequence_enum_spec() {
   constexpr auto name_array = strings::fixed_split_trim<names, " -?*">();
   constexpr auto name_count = name_array.size();
   constexpr auto maxseq = E{as_underlying(minseq) + name_count - 1};
@@ -389,7 +389,7 @@ template<ScopedEnum E, strings::fixed_string names,
 //
 // The numerical value is printed.
 template<ScopedEnum E, E maxseq, E minseq = E{}, wrapclip wrapseq = wrapclip{}>
-[[nodiscard]] constexpr auto make_sequence_enum_spec() {
+[[nodiscard]] consteval auto make_sequence_enum_spec() {
   return sequence_enum_spec<E, maxseq, minseq, wrapseq>{};
 }
 

--- a/corvid/proto/http_server.h
+++ b/corvid/proto/http_server.h
@@ -190,8 +190,11 @@ public:
   //
   // If `loop` is non-null, the server shares it; otherwise it constructs
   // and owns an `epoll_loop_runner`. If `wheel` is non-null, the server shares
-  // it; otherwise it constructs and owns a `timing_wheel_runner`. Returns null
-  // if the listen socket cannot be created.
+  // it; otherwise it constructs and owns a `timing_wheel_runner`.
+  //
+  // Throws `std::invalid_argument` if `request_timeout` or `write_timeout`
+  // exceeds the supplied wheel's schedulable range. Returns null if the
+  // listen socket cannot be created.
   [[nodiscard]] static http_server_ptr create(const net_endpoint& endpoint,
       const configure_fn& configure, epoll_loop_ptr loop = nullptr,
       timing_wheel_ptr wheel = nullptr, duration_t request_timeout = 30s,
@@ -211,6 +214,20 @@ public:
       self->wheel_ = self->wheel_runner_->wheel();
     } else
       self->wheel_ = std::move(wheel);
+
+    const auto max_delay = self->wheel_->max_delay();
+    if (request_timeout > 0s && request_timeout > max_delay) {
+      throw std::invalid_argument{std::format(
+          "http_server: request_timeout {}ms exceeds timing "
+          "wheel max delay {}ms",
+          request_timeout.count(), max_delay.count())};
+    }
+    if (write_timeout > 0s && write_timeout > max_delay) {
+      throw std::invalid_argument{std::format(
+          "http_server: write_timeout {}ms exceeds timing "
+          "wheel max delay {}ms",
+          write_timeout.count(), max_delay.count())};
+    }
 
     self->read_timeout_ = request_timeout;
     self->write_timeout_ = write_timeout;

--- a/corvid/proto/json_parser.h
+++ b/corvid/proto/json_parser.h
@@ -29,12 +29,14 @@
 #include <utility>
 #include <vector>
 
+#include "../enums/bool_enums.h"
 #include "../strings/concat_join.h"
 #include "../strings/conversion.h"
 #include "../strings/trimming.h"
 
 // Strict JSON parser, non-owning value views, and compact JSON writer.
 namespace corvid { inline namespace proto { inline namespace json {
+using namespace corvid::enums::bool_enums;
 
 size_t npos = std::string_view::npos;
 
@@ -1058,10 +1060,12 @@ class json_writer {
   template<typename Begin, typename End>
   class scoped_writer {
   public:
-    constexpr scoped_writer(json_writer& writer, Begin&& begin, End&& end)
+    constexpr explicit scoped_writer(json_writer& writer, Begin&& begin,
+        End&& end)
         : writer_{&writer}, end_{std::forward<End>(end)} {
       std::forward<Begin>(begin)(*writer_);
     }
+    constexpr explicit scoped_writer(json_writer&&, Begin&&, End&&) = delete;
 
     scoped_writer(const scoped_writer&) = delete;
     scoped_writer(const scoped_writer&&) = delete;
@@ -1127,6 +1131,7 @@ class json_writer {
 
 public:
   explicit constexpr json_writer(Target& target) : target_{target} {}
+  explicit constexpr json_writer(Target&& target) = delete;
 
   [[nodiscard]] constexpr Target& target() noexcept { return target_; }
 
@@ -1168,12 +1173,12 @@ public:
   template<StringViewConvertible S>
   requires(!SameAs<json_trusted, S>)
   constexpr json_writer& key(const S& key_text) {
-    write_key(std::string_view{key_text}, false);
+    write_key(std::string_view{key_text}, text_validation::untrusted);
     return *this;
   }
 
   constexpr json_writer& key(json_trusted key_text) {
-    write_key(key_text.value, true);
+    write_key(key_text.value, text_validation::trusted);
     return *this;
   }
 
@@ -1210,13 +1215,13 @@ public:
   requires(!SameAs<json_trusted, S>)
   constexpr json_writer& value(const S& s) {
     before_value();
-    write_quoted(std::string_view{s}, false);
+    write_quoted(std::string_view{s}, text_validation::untrusted);
     return *this;
   }
 
   constexpr json_writer& value(json_trusted s) {
     before_value();
-    write_quoted(s.value, true);
+    write_quoted(s.value, text_validation::trusted);
     return *this;
   }
 
@@ -1283,22 +1288,24 @@ private:
   }
 
   // Emit an escaped or trusted object key followed by `:`.
-  constexpr void write_key(std::string_view key_text, bool trusted) {
+  constexpr void write_key(std::string_view key_text,
+      text_validation validated = text_validation::untrusted) {
     if (stack_.empty()) return;
     auto& top = stack_.back();
     if (top.kind != frame_kind::object || top.expect_value) return;
 
     if (!top.first) strings::append(target_, ',');
     top.first = false;
-    write_quoted(key_text, trusted);
+    write_quoted(key_text, validated);
     strings::append(target_, ':');
     top.expect_value = true;
   }
 
   // Emit one quoted JSON string, escaping unless explicitly trusted.
-  constexpr void write_quoted(std::string_view text, bool trusted) {
+  constexpr void write_quoted(std::string_view text,
+      text_validation validated = text_validation::untrusted) {
     strings::append(target_, '"');
-    if (trusted)
+    if (validated == text_validation::trusted)
       strings::append(target_, text);
     else
       strings::append_escaped(target_, text);

--- a/corvid/sim/corvid_sim_main.h
+++ b/corvid/sim/corvid_sim_main.h
@@ -54,6 +54,7 @@ private:
 };
 
 using namespace corvid::proto;
+using namespace corvid::concurrency;
 
 int do_main(int argc, char** argv) {
   // If invoked with "-testonly" (e.g., by the CI build script), skip the
@@ -100,10 +101,22 @@ int do_main(int argc, char** argv) {
 
   signal_waiter signals;
 
-  // Create server (owns its own loop and timing wheel). The cache shared_ptr
-  // is captured by the factory lambda and passed into each transaction, which
-  // holds its own reference to keep the cache alive.
-  auto server = http_server::create(net_endpoint{ipv4_addr::loopback, 8080},
+  epoll_loop_runner loop;
+  // Run the server and sim on a 50ms wheel so the world loop can achieve its
+  // intended 20 Hz cadence. Use 1200 slots so the wheel still spans nearly
+  // 60 seconds, which keeps the HTTP server's default 30s request timeout
+  // within range.
+  timing_wheel_runner wheel{1200, 50ms};
+
+  http_server::duration_t request_timeout = 30s;
+  http_server::duration_t write_timeout = 5s;
+
+  // Create server using the same explicit loop and 50ms timing wheel that the
+  // sim WebSocket route will use. The cache shared_ptr is captured by the
+  // factory lambda and passed into each transaction, which holds its own
+  // reference to keep the cache alive.
+  auto server = http_server::create(
+      net_endpoint{ipv4_addr::loopback, 8080},
       [cache](http_server& s) {
         if (!s.add_route({"", "/"},
                 [cache](request_head&& req) -> transaction_ptr {
@@ -113,7 +126,8 @@ int do_main(int argc, char** argv) {
           return false;
         return s.add_route({"", "/ws"},
             SimWsHandler::make_factory(s.loop(), s.wheel()));
-      });
+      },
+      loop.loop(), wheel.wheel(), request_timeout, write_timeout);
 
   if (!server) {
     std::cerr << "Failed to create HTTP server\n";

--- a/corvid/sim/maps/map1.json
+++ b/corvid/sim/maps/map1.json
@@ -45,53 +45,169 @@
         "bgColor": "0x000000FF"
       },
       "visualEffects": {},
-      "pathing": { "speed": 50.0 },
-      "invader": { "hitCircleRadius": 30.0, "bounty": 10 },
-      "health": { "currentHealth": 50.0, "maxHealth": 50.0, "regen": 10.0 }
+      "pathing": {
+        "speed": 50.0
+      },
+      "invader": {
+        "hitCircleRadius": 30.0,
+        "bounty": 10
+      },
+      "health": {
+        "currentHealth": 50.0,
+        "maxHealth": 50.0,
+        "regen": 10.0
+      }
+    },
+    {
+      "entityName": "InvaderBetaBasic",
+      "position": {},
+      "appearance": {
+        "glyph": 946,
+        "radius": 40.0,
+        "fgColor": "0xFFFFFFFF",
+        "bgColor": "0x000000FF"
+      },
+      "visualEffects": {},
+      "pathing": {
+        "speed": 30.0
+      },
+      "invader": {
+        "hitCircleRadius": 40.0,
+        "bounty": 25
+      },
+      "health": {
+        "currentHealth": 120.0,
+        "maxHealth": 120.0,
+        "regen": 12.0
+      }
     },
     {
       "entityName": "DefenderAoeBasic",
-      "displayName": "Area",
+      "displayName": "Basic Area",
       "category": "area",
       "menuOrder": 1,
       "flavorText": "Damages all enemies in range.",
       "resourceCost": 50,
       "position": {},
       "appearance": {
-        "glyph": 65,
+        "glyph": 66,
         "radius": 30.0,
         "fgColor": "0xFFFFFFFF",
         "bgColor": "0x7F7FFFFF",
         "attackRadius": 100.0
       },
-      "visualEffects": { "flashColor": "0xFF7F7FFF", "flashExpiry": 5 },
+      "visualEffects": {
+        "flashColor": "0xFF7F7FFF",
+        "flashExpiry": 5
+      },
       "defender": {
         "hitCircleRadius": 30.0,
         "attackRadius": 100.0,
         "rangeColor": "0xFFFF00FF",
-        "attackDamage": 5.0,
+        "attackDamage": 6.0,
         "cooldown": 20
       },
       "defenderStats": {},
-      "health": { "currentHealth": 100.0, "maxHealth": 100.0, "regen": 0.0 },
-      "defenderAoe": { "damageType": 1 }
+      "health": {
+        "currentHealth": 100.0,
+        "maxHealth": 100.0,
+        "regen": 0.0
+      },
+      "defenderAoe": {
+        "damageType": 1
+      }
     },
     {
-      "entityName": "DefenderShooterBasic",
-      "displayName": "Shooter",
-      "category": "shooter",
+      "entityName": "DefenderAoeFlasher",
+      "displayName": "Flasher",
+      "category": "area",
       "menuOrder": 2,
+      "flavorText": "Wide range, short cooldown, low damage.",
+      "resourceCost": 75,
+      "position": {},
+      "appearance": {
+        "glyph": 70,
+        "radius": 30.0,
+        "fgColor": "0xFFFFFFFF",
+        "bgColor": "0x7F7FFFFF",
+        "attackRadius": 160.0
+      },
+      "visualEffects": {
+        "flashColor": "0xFF7F7FFF",
+        "flashExpiry": 5
+      },
+      "defender": {
+        "hitCircleRadius": 30.0,
+        "attackRadius": 160.0,
+        "rangeColor": "0xFFFF00FF",
+        "attackDamage": 3.0,
+        "cooldown": 10
+      },
+      "defenderStats": {},
+      "health": {
+        "currentHealth": 100.0,
+        "maxHealth": 100.0,
+        "regen": 0.0
+      },
+      "defenderAoe": {
+        "damageType": 1
+      }
+    },
+    {
+      "entityName": "DefenderAoeMine",
+      "displayName": "Mine",
+      "category": "area",
+      "menuOrder": 3,
+      "flavorText": "Medium range, high cooldown, high damage.",
+      "resourceCost": 100,
+      "position": {},
+      "appearance": {
+        "glyph": 77,
+        "radius": 20.0,
+        "fgColor": "0xFFFFFFFF",
+        "bgColor": "0x7F7FFFFF",
+        "attackRadius": 120.0
+      },
+      "visualEffects": {
+        "flashColor": "0xFF7F7FFF",
+        "flashExpiry": 5
+      },
+      "defender": {
+        "hitCircleRadius": 20.0,
+        "attackRadius": 120.0,
+        "rangeColor": "0xFFFF00FF",
+        "attackDamage": 12.0,
+        "cooldown": 20
+      },
+      "defenderStats": {},
+      "health": {
+        "currentHealth": 100.0,
+        "maxHealth": 100.0,
+        "regen": 0.0
+      },
+      "defenderAoe": {
+        "damageType": 1
+      }
+    },
+    {
+      "entityName": "DefenderShooterPistol",
+      "displayName": "Pistol",
+      "category": "shooter",
+      "menuOrder": 1,
       "flavorText": "Fires projectiles at a single target.",
       "resourceCost": 75,
       "position": {},
       "appearance": {
-        "glyph": 83,
+        "glyph": 80,
         "radius": 25.0,
         "fgColor": "0xFFFFFFFF",
         "bgColor": "0x107F50FF",
         "attackRadius": 150.0
       },
-      "visualEffects": { "flashColor": "0xFF7FFF7F", "flashExpiry": 5 },
+      "visualEffects": {
+        "flashColor": "0xFF7FFF7F",
+        "flashExpiry": 5
+      },
       "defender": {
         "hitCircleRadius": 25.0,
         "attackRadius": 150.0,
@@ -100,7 +216,11 @@
         "cooldown": 30
       },
       "defenderStats": {},
-      "health": { "currentHealth": 80.0, "maxHealth": 80.0, "regen": 0.0 },
+      "health": {
+        "currentHealth": 80.0,
+        "maxHealth": 80.0,
+        "regen": 0.0
+      },
       "defenderShooter": {
         "fireRate": 0.033,
         "bullet": {
@@ -120,11 +240,61 @@
       }
     },
     {
+      "entityName": "DefenderShooterSniper",
+      "displayName": "Sniper",
+      "category": "shooter",
+      "menuOrder": 2,
+      "flavorText": "Long range, slow fire rate, big damage.",
+      "resourceCost": 100,
+      "position": {},
+      "appearance": {
+        "glyph": 83,
+        "radius": 20.0,
+        "fgColor": "0xFFFFFFFF",
+        "bgColor": "0x107F50FF",
+        "attackRadius": 450.0
+      },
+      "visualEffects": {
+        "flashColor": "0xFF7FFF7F",
+        "flashExpiry": 5
+      },
+      "defender": {
+        "hitCircleRadius": 20.0,
+        "attackRadius": 450.0,
+        "rangeColor": "0xFF00FFFF",
+        "attackDamage": 200.0,
+        "cooldown": 120
+      },
+      "defenderStats": {},
+      "health": {
+        "currentHealth": 80.0,
+        "maxHealth": 80.0,
+        "regen": 0.0
+      },
+      "defenderShooter": {
+        "fireRate": 0.033,
+        "bullet": {
+          "hitCircleRadius": 8.0,
+          "speed": 100.0,
+          "directDamage": 25.0,
+          "projectileType": 1,
+          "expiry": 20
+        },
+        "muzzleFlash": {
+          "startDistance": 25.0,
+          "expiry": 3,
+          "primaryColor": "0xFFFFC0FF",
+          "halfAngleDeg": 15.0,
+          "coneRadius": 75.0
+        }
+      }
+    },
+    {
       "entityName": "DefenderHitscanBasic",
-      "displayName": "Laser",
+      "displayName": "Basic Laser",
       "category": "laser",
-      "menuOrder": 3,
-      "flavorText": "Instantly damages a single target with an infrared laser beam.",
+      "menuOrder": 1,
+      "flavorText": "Instantly damages a single target with a laser beam.",
       "resourceCost": 100,
       "position": {},
       "appearance": {
@@ -134,7 +304,10 @@
         "bgColor": "0x7F7F3FFF",
         "attackRadius": 200.0
       },
-      "visualEffects": { "flashColor": "0xFFFF4040", "flashExpiry": 3 },
+      "visualEffects": {
+        "flashColor": "0xFFFF4040",
+        "flashExpiry": 3
+      },
       "defender": {
         "hitCircleRadius": 25.0,
         "attackRadius": 200.0,
@@ -143,7 +316,91 @@
         "cooldown": 25
       },
       "defenderStats": {},
-      "health": { "currentHealth": 75.0, "maxHealth": 75.0, "regen": 0.0 },
+      "health": {
+        "currentHealth": 75.0,
+        "maxHealth": 75.0,
+        "regen": 0.0
+      },
+      "defenderHitscan": {
+        "startDistance": 25.0,
+        "expiry": 3,
+        "primaryColor": "0xFFFF4040",
+        "secondaryColor": "0xFFFFD080",
+        "lineWidth": 8.0
+      }
+    },
+    {
+      "entityName": "DefenderHitscanZapper",
+      "displayName": "Zapper",
+      "category": "laser",
+      "menuOrder": 2,
+      "flavorText": "Short range, fast fire rate, small damage.",
+      "resourceCost": 100,
+      "position": {},
+      "appearance": {
+        "glyph": 90,
+        "radius": 40.0,
+        "fgColor": "0xFFFFFFFF",
+        "bgColor": "0x7F7F3FFF",
+        "attackRadius": 100.0
+      },
+      "visualEffects": {
+        "flashColor": "0xFFFF4040",
+        "flashExpiry": 3
+      },
+      "defender": {
+        "hitCircleRadius": 40.0,
+        "attackRadius": 100.0,
+        "rangeColor": "0xFFFF00FF",
+        "attackDamage": 15.0,
+        "cooldown": 5
+      },
+      "defenderStats": {},
+      "health": {
+        "currentHealth": 75.0,
+        "maxHealth": 75.0,
+        "regen": 0.0
+      },
+      "defenderHitscan": {
+        "startDistance": 40.0,
+        "expiry": 3,
+        "primaryColor": "0xFFFF4040",
+        "secondaryColor": "0xFFFFD080",
+        "lineWidth": 8.0
+      }
+    },
+    {
+      "entityName": "DefenderHitscanCannon",
+      "displayName": "Pulse Cannon",
+      "category": "laser",
+      "menuOrder": 3,
+      "flavorText": "Long range, slow fire rate, big damage.",
+      "resourceCost": 100,
+      "position": {},
+      "appearance": {
+        "glyph": 67,
+        "radius": 25.0,
+        "fgColor": "0xFFFFFFFF",
+        "bgColor": "0x7F7F3FFF",
+        "attackRadius": 250.0
+      },
+      "visualEffects": {
+        "flashColor": "0xFFFF4040",
+        "flashExpiry": 3
+      },
+      "defender": {
+        "hitCircleRadius": 25.0,
+        "attackRadius": 250.0,
+        "rangeColor": "0xFFFF00FF",
+        "attackDamage": 60.0,
+        "cooldown": 15
+      },
+      "defenderStats": {},
+      "health": {
+        "currentHealth": 75.0,
+        "maxHealth": 75.0,
+        "regen": 0.0
+      },
       "defenderHitscan": {
         "startDistance": 25.0,
         "expiry": 3,
@@ -157,24 +414,78 @@
     {
       "width": 40.0,
       "joints": [
-        { "x":     0.00, "y":     0.00 },
-        { "x":   213.33, "y":     0.00 },
-        { "x":   213.33, "y":   120.00 },
-        { "x":  -213.33, "y":   120.00 },
-        { "x":  -213.33, "y":  -120.00 },
-        { "x":   426.67, "y":  -120.00 },
-        { "x":   426.67, "y":   240.00 },
-        { "x":  -426.67, "y":   240.00 },
-        { "x":  -426.67, "y":  -240.00 },
-        { "x":   640.00, "y":  -240.00 },
-        { "x":   640.00, "y":   360.00 },
-        { "x":  -640.00, "y":   360.00 },
-        { "x":  -640.00, "y":  -360.00 },
-        { "x":   853.33, "y":  -360.00 },
-        { "x":   853.33, "y":   480.00 },
-        { "x":  -853.33, "y":   480.00 },
-        { "x":  -853.33, "y":  -480.00 },
-        { "x":   960.00, "y":  -480.00 }
+        {
+          "x": 0.00,
+          "y": 0.00
+        },
+        {
+          "x": 213.33,
+          "y": 0.00
+        },
+        {
+          "x": 213.33,
+          "y": 120.00
+        },
+        {
+          "x": -213.33,
+          "y": 120.00
+        },
+        {
+          "x": -213.33,
+          "y": -120.00
+        },
+        {
+          "x": 426.67,
+          "y": -120.00
+        },
+        {
+          "x": 426.67,
+          "y": 240.00
+        },
+        {
+          "x": -426.67,
+          "y": 240.00
+        },
+        {
+          "x": -426.67,
+          "y": -240.00
+        },
+        {
+          "x": 640.00,
+          "y": -240.00
+        },
+        {
+          "x": 640.00,
+          "y": 360.00
+        },
+        {
+          "x": -640.00,
+          "y": 360.00
+        },
+        {
+          "x": -640.00,
+          "y": -360.00
+        },
+        {
+          "x": 853.33,
+          "y": -360.00
+        },
+        {
+          "x": 853.33,
+          "y": 480.00
+        },
+        {
+          "x": -853.33,
+          "y": 480.00
+        },
+        {
+          "x": -853.33,
+          "y": -480.00
+        },
+        {
+          "x": 960.00,
+          "y": -480.00
+        }
       ]
     }
   ],
@@ -182,116 +493,516 @@
     {
       "resourceInflux": 0,
       "enemies": [
-        { "tick":   0, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  20, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  40, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  60, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  80, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 100, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 120, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 140, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 160, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 180, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 200, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 220, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 240, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 260, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 280, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 300, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 320, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 340, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 360, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 380, "label": "InvaderAlphaBasic", "pathId": 0 }
+        {
+          "tick": 0,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 20,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 40,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 60,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 80,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 100,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 120,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 140,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 160,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 180,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 200,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 220,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 240,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 260,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 280,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 300,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 320,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 340,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 360,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 380,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        }
       ]
     },
     {
       "resourceInflux": 150,
       "enemies": [
-        { "tick":   0, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  15, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  30, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  45, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  60, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  75, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  90, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 105, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 120, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 135, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 150, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 165, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 180, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 195, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 210, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 225, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 240, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 255, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 270, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 285, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 300, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 315, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 330, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 345, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 360, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 375, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 390, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 405, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 420, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 435, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 450, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 465, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 480, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 495, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 510, "label": "InvaderAlphaBasic", "pathId": 0 }
+        {
+          "tick": 0,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 15,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 30,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 45,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 60,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 75,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 90,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 105,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 120,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 135,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 150,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 165,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 180,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 195,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 210,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 225,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 240,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 255,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 270,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 285,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 300,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 315,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 330,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 345,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 360,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 375,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 390,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 405,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 420,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 435,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 450,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 465,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 480,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 495,
+          "label": "InvaderBetaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 510,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        }
       ]
     },
     {
       "resourceInflux": 250,
       "enemies": [
-        { "tick":   0, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  10, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  20, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  30, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  40, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  50, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  60, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  70, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  80, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick":  90, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 100, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 110, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 120, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 130, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 140, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 150, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 160, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 170, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 180, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 190, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 200, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 210, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 220, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 230, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 240, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 250, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 260, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 270, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 280, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 290, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 300, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 310, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 320, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 330, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 340, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 350, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 360, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 370, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 380, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 390, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 400, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 410, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 420, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 430, "label": "InvaderAlphaBasic", "pathId": 0 },
-        { "tick": 440, "label": "InvaderAlphaBasic", "pathId": 0 }
+        {
+          "tick": 0,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 10,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 20,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 30,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 40,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 50,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 60,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 70,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 80,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 90,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 100,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 110,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 120,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 130,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 140,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 150,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 160,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 170,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 180,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 190,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 200,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 210,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 220,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 230,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 240,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 250,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 260,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 270,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 280,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 290,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 300,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 310,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 320,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 330,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 340,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 350,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 360,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 370,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 380,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 390,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 400,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 410,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 420,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 430,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        },
+        {
+          "tick": 440,
+          "label": "InvaderAlphaBasic",
+          "pathId": 0
+        }
       ]
     }
   ]

--- a/corvid/sim/maps/map1.json
+++ b/corvid/sim/maps/map1.json
@@ -1,0 +1,298 @@
+{
+  "categories": [
+    {
+      "name": "area",
+      "displayName": "Area",
+      "flavorText": "Damages all enemies within a radius.",
+      "appearance": {
+        "glyph": 65,
+        "radius": 28.0,
+        "fgColor": "0xFFFFFFFF",
+        "bgColor": "0x7F7FFFFF"
+      }
+    },
+    {
+      "name": "shooter",
+      "displayName": "Shooter",
+      "flavorText": "Fires projectiles at individual targets.",
+      "appearance": {
+        "glyph": 83,
+        "radius": 28.0,
+        "fgColor": "0xFFFFFFFF",
+        "bgColor": "0x107F50FF"
+      }
+    },
+    {
+      "name": "laser",
+      "displayName": "Laser",
+      "flavorText": "Instantly damages a single target with a beam.",
+      "appearance": {
+        "glyph": 76,
+        "radius": 28.0,
+        "fgColor": "0xFFFFFFFF",
+        "bgColor": "0x7F7F3FFF"
+      }
+    }
+  ],
+  "entities": [
+    {
+      "entityName": "InvaderAlphaBasic",
+      "position": {},
+      "appearance": {
+        "glyph": 945,
+        "radius": 30.0,
+        "fgColor": "0xFFFFFFFF",
+        "bgColor": "0x000000FF"
+      },
+      "visualEffects": {},
+      "pathing": { "speed": 50.0 },
+      "invader": { "hitCircleRadius": 30.0, "bounty": 10 },
+      "health": { "currentHealth": 50.0, "maxHealth": 50.0, "regen": 10.0 }
+    },
+    {
+      "entityName": "DefenderAoeBasic",
+      "displayName": "Area",
+      "category": "area",
+      "menuOrder": 1,
+      "flavorText": "Damages all enemies in range.",
+      "resourceCost": 50,
+      "position": {},
+      "appearance": {
+        "glyph": 65,
+        "radius": 30.0,
+        "fgColor": "0xFFFFFFFF",
+        "bgColor": "0x7F7FFFFF",
+        "attackRadius": 100.0
+      },
+      "visualEffects": { "flashColor": "0xFF7F7FFF", "flashExpiry": 5 },
+      "defender": {
+        "hitCircleRadius": 30.0,
+        "attackRadius": 100.0,
+        "rangeColor": "0xFFFF00FF",
+        "attackDamage": 5.0,
+        "cooldown": 20
+      },
+      "defenderStats": {},
+      "health": { "currentHealth": 100.0, "maxHealth": 100.0, "regen": 0.0 },
+      "defenderAoe": { "damageType": 1 }
+    },
+    {
+      "entityName": "DefenderShooterBasic",
+      "displayName": "Shooter",
+      "category": "shooter",
+      "menuOrder": 2,
+      "flavorText": "Fires projectiles at a single target.",
+      "resourceCost": 75,
+      "position": {},
+      "appearance": {
+        "glyph": 83,
+        "radius": 25.0,
+        "fgColor": "0xFFFFFFFF",
+        "bgColor": "0x107F50FF",
+        "attackRadius": 150.0
+      },
+      "visualEffects": { "flashColor": "0xFF7FFF7F", "flashExpiry": 5 },
+      "defender": {
+        "hitCircleRadius": 25.0,
+        "attackRadius": 150.0,
+        "rangeColor": "0xFF00FFFF",
+        "attackDamage": 15.0,
+        "cooldown": 30
+      },
+      "defenderStats": {},
+      "health": { "currentHealth": 80.0, "maxHealth": 80.0, "regen": 0.0 },
+      "defenderShooter": {
+        "fireRate": 0.033,
+        "bullet": {
+          "hitCircleRadius": 8.0,
+          "speed": 100.0,
+          "directDamage": 25.0,
+          "projectileType": 1,
+          "expiry": 5
+        },
+        "muzzleFlash": {
+          "startDistance": 25.0,
+          "expiry": 3,
+          "primaryColor": "0xFFFFC0FF",
+          "halfAngleDeg": 25.0,
+          "coneRadius": 50.0
+        }
+      }
+    },
+    {
+      "entityName": "DefenderHitscanBasic",
+      "displayName": "Laser",
+      "category": "laser",
+      "menuOrder": 3,
+      "flavorText": "Instantly damages a single target with an infrared laser beam.",
+      "resourceCost": 100,
+      "position": {},
+      "appearance": {
+        "glyph": 76,
+        "radius": 25.0,
+        "fgColor": "0xFFFFFFFF",
+        "bgColor": "0x7F7F3FFF",
+        "attackRadius": 200.0
+      },
+      "visualEffects": { "flashColor": "0xFFFF4040", "flashExpiry": 3 },
+      "defender": {
+        "hitCircleRadius": 25.0,
+        "attackRadius": 200.0,
+        "rangeColor": "0xFFFF00FF",
+        "attackDamage": 30.0,
+        "cooldown": 25
+      },
+      "defenderStats": {},
+      "health": { "currentHealth": 75.0, "maxHealth": 75.0, "regen": 0.0 },
+      "defenderHitscan": {
+        "startDistance": 25.0,
+        "expiry": 3,
+        "primaryColor": "0xFFFF4040",
+        "secondaryColor": "0xFFFFD080",
+        "lineWidth": 8.0
+      }
+    }
+  ],
+  "paths": [
+    {
+      "width": 40.0,
+      "joints": [
+        { "x":     0.00, "y":     0.00 },
+        { "x":   213.33, "y":     0.00 },
+        { "x":   213.33, "y":   120.00 },
+        { "x":  -213.33, "y":   120.00 },
+        { "x":  -213.33, "y":  -120.00 },
+        { "x":   426.67, "y":  -120.00 },
+        { "x":   426.67, "y":   240.00 },
+        { "x":  -426.67, "y":   240.00 },
+        { "x":  -426.67, "y":  -240.00 },
+        { "x":   640.00, "y":  -240.00 },
+        { "x":   640.00, "y":   360.00 },
+        { "x":  -640.00, "y":   360.00 },
+        { "x":  -640.00, "y":  -360.00 },
+        { "x":   853.33, "y":  -360.00 },
+        { "x":   853.33, "y":   480.00 },
+        { "x":  -853.33, "y":   480.00 },
+        { "x":  -853.33, "y":  -480.00 },
+        { "x":   960.00, "y":  -480.00 }
+      ]
+    }
+  ],
+  "waves": [
+    {
+      "resourceInflux": 0,
+      "enemies": [
+        { "tick":   0, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  20, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  40, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  60, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  80, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 100, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 120, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 140, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 160, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 180, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 200, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 220, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 240, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 260, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 280, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 300, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 320, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 340, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 360, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 380, "label": "InvaderAlphaBasic", "pathId": 0 }
+      ]
+    },
+    {
+      "resourceInflux": 150,
+      "enemies": [
+        { "tick":   0, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  15, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  30, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  45, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  60, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  75, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  90, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 105, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 120, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 135, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 150, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 165, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 180, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 195, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 210, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 225, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 240, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 255, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 270, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 285, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 300, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 315, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 330, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 345, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 360, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 375, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 390, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 405, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 420, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 435, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 450, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 465, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 480, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 495, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 510, "label": "InvaderAlphaBasic", "pathId": 0 }
+      ]
+    },
+    {
+      "resourceInflux": 250,
+      "enemies": [
+        { "tick":   0, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  10, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  20, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  30, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  40, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  50, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  60, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  70, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  80, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick":  90, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 100, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 110, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 120, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 130, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 140, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 150, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 160, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 170, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 180, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 190, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 200, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 210, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 220, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 230, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 240, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 250, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 260, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 270, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 280, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 290, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 300, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 310, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 320, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 330, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 340, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 350, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 360, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 370, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 380, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 390, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 400, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 410, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 420, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 430, "label": "InvaderAlphaBasic", "pathId": 0 },
+        { "tick": 440, "label": "InvaderAlphaBasic", "pathId": 0 }
+      ]
+    }
+  ]
+}

--- a/corvid/sim/maps/map1.json
+++ b/corvid/sim/maps/map1.json
@@ -231,7 +231,7 @@
           "expiry": 5
         },
         "muzzleFlash": {
-          "startDistance": 25.0,
+          "radius": 25.0,
           "expiry": 3,
           "primaryColor": "0xFFFFC0FF",
           "halfAngleDeg": 25.0,
@@ -281,7 +281,7 @@
           "expiry": 20
         },
         "muzzleFlash": {
-          "startDistance": 25.0,
+          "radius": 25.0,
           "expiry": 3,
           "primaryColor": "0xFFFFC0FF",
           "halfAngleDeg": 15.0,
@@ -322,7 +322,7 @@
         "regen": 0.0
       },
       "defenderHitscan": {
-        "startDistance": 25.0,
+        "radius": 25.0,
         "expiry": 3,
         "primaryColor": "0xFFFF4040",
         "secondaryColor": "0xFFFFD080",
@@ -362,7 +362,7 @@
         "regen": 0.0
       },
       "defenderHitscan": {
-        "startDistance": 40.0,
+        "radius": 40.0,
         "expiry": 3,
         "primaryColor": "0xFFFF4040",
         "secondaryColor": "0xFFFFD080",
@@ -402,7 +402,7 @@
         "regen": 0.0
       },
       "defenderHitscan": {
-        "startDistance": 25.0,
+        "radius": 25.0,
         "expiry": 3,
         "primaryColor": "0xFFFF4040",
         "secondaryColor": "0xFFFFD080",

--- a/corvid/sim/roadmap.md
+++ b/corvid/sim/roadmap.md
@@ -108,11 +108,7 @@ eponymous browser-based tower defense game.
 - Tower damage is disabled (`#if 0` in `towersAttack`); needs cooldown, health
   reduction, bounty award, and tombstoning.
 - Only one hardcoded map and one wave; need data-driven map/wave loading.
-- `placeTower()` in `SimGame` is a stub; spending resources and enforcing build
-  slots is not implemented.
 - No victory condition when all waves clear with lives remaining.
-- Enemy variety (`enemyType` field exists but all enemies share the same speed
-  and appearance).
 - `sidBullet` archetype exists but no projectile-firing tower type is wired up.
 - Web asset pipeline (Vite/TypeScript) must be built separately (`npm run
   build` in `web/`) before the C++ server can serve the dist files.

--- a/corvid/sim/roadmap.md
+++ b/corvid/sim/roadmap.md
@@ -105,10 +105,9 @@ eponymous browser-based tower defense game.
 ---
 
 ## Known gaps / next steps
-- Tower damage is disabled (`#if 0` in `towersAttack`); needs cooldown, health
-  reduction, bounty award, and tombstoning.
-- Only one hardcoded map and one wave; need data-driven map/wave loading.
-- No victory condition when all waves clear with lives remaining.
-- `sidBullet` archetype exists but no projectile-firing tower type is wired up.
 - Web asset pipeline (Vite/TypeScript) must be built separately (`npm run
   build` in `web/`) before the C++ server can serve the dist files.
+- No support for the idea of rotation speed limits.
+- Health regeneration not implemented.
+- No support for defenders taking damage.
+- No support for DoT and for various damage types, much less armor/resistance.

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -274,6 +274,7 @@ public:
 
   // Record most recent action intent from the UI canvas.
   [[nodiscard]] bool handleUiCanvas(const UiCanvasInput& input) {
+    // Drag a defender ghost.
     if (input.command == "placing") {
       if (input.parameters.empty() ||
           (input.event != UiCanvasEvent::dragstart &&
@@ -285,6 +286,7 @@ public:
       return true;
     }
 
+    // Click to spawn a defender.
     if (input.command == "spawn") {
       if (input.event != UiCanvasEvent::click || input.parameters.empty())
         return false;
@@ -293,6 +295,7 @@ public:
       return true;
     }
 
+    // Click to select a defender.
     if (input.button == UiMouseButton::left &&
         input.event == UiCanvasEvent::click)
     {
@@ -300,12 +303,7 @@ public:
       return true;
     }
 
-    if (input.button == UiMouseButton::right &&
-        input.event == UiCanvasEvent::click)
-      return world_.flashEntity(world_.findEntityAt({input.x, input.y}),
-          0xFF7F7FAF, WorldTick{5});
-
-    return false;
+    return true;
   }
 
   // Record most recent action intent from the UI action buttons.

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -349,8 +349,6 @@ public:
     return std::nullopt;
   }
 
-  void placeTower(/* later */);
-
   // Access the current map design (for streaming and inspection).
   [[nodiscard]] const MapDesign& mapDesign() const { return mapDesign_; }
 
@@ -410,7 +408,7 @@ private:
     if (!def) return false;
     const auto& app_opt = std::get<std::optional<Appearance>>(def->megatuple);
     if (!app_opt) return false;
-    return !world_.isTowerPlacementBlocked(pos, app_opt->radius);
+    return !world_.isDefenderPlacementBlocked(pos, app_opt->radius);
   }
 
   [[nodiscard]] UiResponse buildPlacementResponse(

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #pragma once
+#include <optional>
 #include <sys/types.h>
 
 #include <string>
@@ -163,6 +164,9 @@ struct MapDesign {
   std::vector<WaveDefinition> waves;
 };
 
+// Input from the UI canvas, such as mouse clicks and drags.
+// Includes `command` and `parameters` for when the mouse location is paired
+// with an action.
 struct UiCanvasInput {
   uint64_t seq{};
   UiCanvasEvent event{UiCanvasEvent::click};
@@ -180,14 +184,28 @@ struct UiCanvasInput {
   std::vector<std::string> parameters;
 };
 
+// Input from the UI for actions, such as form submissions.
 struct UiActionField {
   std::string key;
   std::string value;
 };
 
+// Represents an action input from the UI, such as a button click. Can include
+// related data, such as form fields.
 struct UiActionInput {
   uint64_t seq{};
   std::string action;
+  std::vector<UiActionField> fields;
+};
+
+// Represents a response to a UI action, including success status and related
+// data. Note all actions require a corresponding response, but those that do
+// will use the same sequence number.
+struct UiResponse {
+  uint64_t seq{};
+  bool ok{};
+  std::string response;
+  std::string reason;
   std::vector<UiActionField> fields;
 };
 
@@ -253,17 +271,28 @@ public:
     nextSpawnIndex_ = 0;
   }
 
-  void handleUiCanvas(const UiCanvasInput& input) {
-    // Explicit spawn command from the web build menu. The button is part of
-    // the UX contract, not the simulation command, so accept whichever button
-    // the client uses for confirmation.
+  [[nodiscard]] std::optional<UiResponse> handleUiCanvas(
+      const UiCanvasInput& input) {
+    // When dragging ghost, show indicator of validity.
+    if (input.command == "placing" && !input.parameters.empty() &&
+        (input.event == UiCanvasEvent::dragstart ||
+            input.event == UiCanvasEvent::dragmove ||
+            input.event == UiCanvasEvent::dragend))
+      return makePlacementValidationResponse(input.seq,
+          canPlaceEntity(input.parameters[0], {input.x, input.y}));
+
+    // Explicit spawn from right-clicking after placing a defender.
     if (input.event == UiCanvasEvent::click && input.command == "spawn" &&
         !input.parameters.empty() && phase_ == GamePhase::build)
     {
-      auto h = world_.spawnEntity(input.parameters[0]);
-      auto* pos = world_.try_get_component<Position>(h.id());
-      *pos = {input.x, input.y};
-      return;
+      const auto& entityName = input.parameters[0];
+      if (!canPlaceEntity(entityName, {input.x, input.y}))
+        return makePlacementValidationResponse(input.seq, false);
+
+      auto h = world_.spawnEntity(entityName);
+      if (!h) return makePlacementValidationResponse(input.seq, false);
+      *world_.try_get_component<Position>(h.id()) = {input.x, input.y};
+      return std::nullopt;
     }
 
     // Select tower on click.
@@ -299,13 +328,23 @@ public:
       (void)world_.flashEntity(world_.findEntityAt({input.x, input.y}),
           0xFF7F7FAF, WorldTick{5});
     }
+    return std::nullopt;
   }
 
-  void handleUiAction(const UiActionInput& input) {
+  [[nodiscard]] std::optional<UiResponse> handleUiAction(
+      const UiActionInput& input) {
     if (input.action == "start_wave") {
+      if (phase_ != GamePhase::build) {
+        return UiResponse{.seq = input.seq,
+            .ok = false,
+            .response = "action",
+            .reason = "phase_mismatch",
+            .fields = {}};
+      }
       start_wave();
-      return;
+      return std::nullopt;
     }
+    return std::nullopt;
   }
 
   void placeTower(/* later */);
@@ -322,7 +361,7 @@ public:
 
   // Extract a delta of the game state. The `cbUpserts(EntityId, Position,
   // Appearance, VisualEffects)` and `cbErased(EntityId)` callbacks will be
-  // interleaved. The `cbState(currentWave, waveTick, lives, resources)`
+  // interleaved. The `cbState(currentWave, waveTick, lives, resources, phase)`
   // callback is invoked last.
   [[nodiscard]] bool
   extractDelta(auto&& cbUpserts, auto&& cbErased, auto&& cbState) {
@@ -353,6 +392,33 @@ public:
   }
 
 private:
+  [[nodiscard]] static UiResponse
+  makePlacementValidationResponse(uint64_t seq, bool valid) {
+    return UiResponse{.seq = seq,
+        .ok = valid,
+        .response = "placement",
+        .reason = valid ? "" : "blocked",
+        .fields = {{"valid", valid ? "true" : "false"}}};
+  }
+
+  [[nodiscard]] bool
+  canPlaceEntity(std::string_view entity_name, const Position& pos) const {
+    if (phase_ != GamePhase::build) return false;
+    const auto def = find_opt(mapDesign_.entityDefs, entity_name);
+    if (!def) return false;
+    const auto& app_opt = std::get<std::optional<Appearance>>(def->megatuple);
+    if (!app_opt) return false;
+    return !world_.isTowerPlacementBlocked(pos, app_opt->radius);
+  }
+
+  [[nodiscard]] UiResponse buildPlacementResponse(
+      const UiCanvasInput& input) const {
+    const bool valid =
+        !input.parameters.empty() &&
+        canPlaceEntity(input.parameters[0], {input.x, input.y});
+    return makePlacementValidationResponse(input.seq, valid);
+  }
+
   // Register all entities and build the defender menu from
   // `mapDesign_.entityDefs`.
   [[nodiscard]] bool processEntityDefs() {

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -112,7 +112,8 @@ namespace corvid { inline namespace sim {
 // Enemy spawn definition for a wave.
 struct EnemySpawn {
   WaveTick startTicks;
-  int enemyType;
+  std::string
+      label; // matches a label registered with `SimWorld::registerEntity`
 };
 
 // All of the enemy spawns for a wave.
@@ -241,7 +242,9 @@ public:
     if (input.event == UiCanvasEvent::dblclick &&
         input.button == UiMouseButton::left)
     {
-      (void)world_.spawnDefenderAoe({input.x, input.y});
+      auto h = world_.spawnEntity("DefenderAoeBasic");
+      if (auto* pos = world_.try_get_component<Position>(h.id()))
+        *pos = {input.x, input.y};
     }
 
     if (input.event == UiCanvasEvent::click &&
@@ -308,12 +311,63 @@ private:
     for (; nextSpawnIndex_ < enemies.size(); ++nextSpawnIndex_) {
       const auto& enemy_def = enemies[nextSpawnIndex_];
       if (enemy_def.startTicks > waveTick_) break;
-      (void)world_.spawnInvaderAlpha(PathId{0});
+      auto h = world_.spawnEntity(enemy_def.label);
+      if (!h) continue;
+      // Set placement-specific fields not encoded in the template.
+      if (auto* pat = world_.try_get_component<Pathing>(h.id())) {
+        pat->path_id = PathId{0};
+        if (auto* pos = world_.try_get_component<Position>(h.id()))
+          if (const auto* path = world_.getPath(PathId{0}))
+            *pos = path->calculatePositionFromProgress(0.F, 0.F);
+      }
     }
   }
 
   void doLoadMap1() {
     resetMap();
+
+    // Register entity types available on this map. This is the single site
+    // that will later be replaced by CSV/JSON parsing.
+    {
+      WorldScene::megatuple_t tpl{};
+      std::get<std::optional<Position>>(tpl) = Position{};
+      std::get<std::optional<Appearance>>(
+          tpl) = Appearance{.glyph = U'\u03B1', // Greek alpha
+          .radius = 30.F,
+          .fgColor = 0xFFFFFFFF,
+          .bgColor = 0x000000FF};
+      std::get<std::optional<VisualEffects>>(tpl) = VisualEffects{};
+      std::get<std::optional<Pathing>>(tpl) =
+          Pathing{.path_id = PathId::invalid, .progress = 0.F, .speed = 50.F};
+      std::get<std::optional<Invader>>(tpl) =
+          Invader{.invaderType = 1, .hitCircleRadius = 30.F, .bounty = 10};
+      std::get<std::optional<Health>>(tpl) =
+          Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 10.F};
+      world_.registerEntity("InvaderAlphaBasic", tpl);
+    }
+    {
+      WorldScene::megatuple_t tpl{};
+      std::get<std::optional<Position>>(tpl) = Position{};
+      std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'A',
+          .radius = 30.F,
+          .fgColor = 0xFFFFFFFF,
+          .bgColor = 0x7F7FFFFF};
+      std::get<std::optional<VisualEffects>>(tpl) =
+          VisualEffects{.flashColor = 0xFF7F7FFF, .flashExpiry = WorldTick{5}};
+      std::get<std::optional<Defender>>(tpl) = Defender{.defenderType = 1,
+          .hitCircleRadius = 30.F,
+          .attackRadius = 100.F,
+          .rangeColor = 0xFFFF0000,
+          .attackDamage = 5.F,
+          .cooldown = WorldTick{20},
+          .nextAttack = WorldTick{0}};
+      std::get<std::optional<DefenderStats>>(tpl) = DefenderStats{};
+      std::get<std::optional<Health>>(tpl) =
+          Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 0.F};
+      std::get<std::optional<DefenderAoe>>(tpl) = DefenderAoe{.damageType = 1};
+      world_.registerEntity("DefenderAoeBasic", tpl);
+    }
+
     // For now, a hardcoded spiral.
     PathJoints p;
     p.joints.push_back({Position{0.0, 0.0}});
@@ -348,7 +402,7 @@ private:
 
     WaveDefinition wave;
     for (uint32_t i = 0; i < 20; ++i)
-      wave.enemies.push_back({WaveTick{i * 20}, 0});
+      wave.enemies.push_back({WaveTick{i * 20}, "InvaderAlphaBasic"});
 
     waves_.push_back(std::move(wave));
   }

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -217,11 +217,9 @@ public:
       // Deselect the previously selected tower, if it still exists.
       if (auto* fx = world_.changeVisualEffects(world_.getId(selected_tower_)))
       {
-        fx->selection_color = 0;
-        fx->range_radius = 0.F;
-        fx->range_color = 0;
-        fx->modified = world_.currentTick();
-        (void)world_.markDirty(world_.getId(selected_tower_));
+        fx->selectionColor = 0;
+        fx->rangeRadius = 0.F;
+        fx->rangeColor = 0;
         selected_tower_ = {};
       }
 
@@ -230,9 +228,9 @@ public:
       if (selected_tower_.id() != SimWorld::EntityId::invalid) {
         auto [pos, app, fx, tower] = world_.getTower(selected_tower_.id());
         if (pos) {
-          fx->selection_color = 0xFFF2B63FU;
-          fx->range_radius = tower->attack_radius;
-          fx->range_color = 0xFFFF007F;
+          fx->selectionColor = 0xFFF2B63FU;
+          fx->rangeRadius = tower->attackRadius;
+          fx->rangeColor = 0xFFFF007F;
           fx->modified = world_.currentTick();
           (void)world_.markDirty(selected_tower_.id());
         }
@@ -254,7 +252,7 @@ public:
     }
   }
 
-  void handle_UiAction(const UiActionInput& input) {
+  void handleUiAction(const UiActionInput& input) {
     if (input.action == "start_wave") {
       start_wave();
       return;

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -192,7 +192,7 @@ struct UiActionInput {
 struct UiState {
   std::optional<bool> placementAllowed;
   std::optional<bool> spawnAllowed;
-  bool defenderSelected{};
+  std::optional<Position> selectedDefender;
   std::optional<DefenderSummary> defenderSummary;
 };
 
@@ -462,7 +462,7 @@ private:
     (void)world_.markDirty(selectedId);
 
     selectedDefender_ = selected;
-    uiState_.defenderSelected = true;
+    uiState_.selectedDefender = *pos;
     uiState_.defenderSummary = buildSelectedDefenderSummary(*defender);
     return true;
   }
@@ -476,7 +476,7 @@ private:
     const auto& [pos, _, fx, defender] = world_.getDefender(selectedId);
     if (!pos || !defender || !fx) return clearSelectedDefender();
 
-    uiState_.defenderSelected = true;
+    uiState_.selectedDefender = *pos;
     return true;
   }
 
@@ -489,7 +489,7 @@ private:
       fx->rangeColor = 0;
     }
     selectedDefender_ = {};
-    uiState_.defenderSelected = false;
+    uiState_.selectedDefender.reset();
     uiState_.defenderSummary.reset();
     return true;
   }

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -373,9 +373,9 @@ private:
     const auto def = findEntityDef(entityName);
     if (!def) return false;
     // Look up initial defender radius.
-    const auto& app_opt = std::get<std::optional<Appearance>>(def->megatuple);
-    if (!app_opt) return false;
-    return !world_.isDefenderPlacementBlocked(pos, app_opt->radius);
+    const auto& def_opt = std::get<std::optional<Defender>>(def->megatuple);
+    if (!def_opt) return false;
+    return !world_.isDefenderPlacementBlocked(pos, def_opt->hitCircleRadius);
   }
 
   // Find `EntityDefinition` by name.

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -217,8 +217,11 @@ public:
       // Deselect the previously selected tower, if it still exists.
       if (auto* fx = world_.changeVisualEffects(world_.getId(selected_tower_)))
       {
+        fx->selection_color = 0;
         fx->range_radius = 0.F;
         fx->range_color = 0;
+        fx->modified = world_.currentTick();
+        (void)world_.markDirty(world_.getId(selected_tower_));
         selected_tower_ = {};
       }
 
@@ -227,6 +230,7 @@ public:
       if (selected_tower_.id() != SimWorld::EntityId::invalid) {
         auto [pos, app, fx, tower] = world_.getTower(selected_tower_.id());
         if (pos) {
+          fx->selection_color = 0xFFF2B63FU;
           fx->range_radius = tower->attack_radius;
           fx->range_color = 0xFFFF007F;
           fx->modified = world_.currentTick();

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -30,29 +30,13 @@
 
 namespace corvid { inline namespace sim {
 
-// Concepts:
-// - A map is a persistent layout defined by a collection of paths and build
-// slots, as well as resources, background graphics, and other metadata.
-// - The player selects a map and faces subsequent waves until the end of the
-// game run. The run ends with defeat or victory. Potentially, runs could be
-// grouped into campaigns or other higher-level structures.
-// - A player's defenders, score, lives, and resources persist throughout the
-// game run, albeit with modifications from wave to wave.
-// - A wave is a collection of enemy spawns. At the end of the wave, the player
-// gets a chance to build or upgrade before the next wave starts.
-// - Within a wave, spawns are enemies that appear on the track at fixed times
-// from the start of the wave.
-
-// Snapshot of the game state for sending to clients. Contains all information
-// needed to render the current state of the world, but no information about
-// the rules or game flow.
-
+// Different phases of the game.
 enum class GamePhase : uint8_t {
   invalid,
   build,     // Defender building
   wave,      // Active wave with enemies spawning and moving
   game_over, // Player has no lives left
-  victory,   // All waves completed with lives remaining
+  victory    // All waves completed with lives remaining
 };
 
 // Tick from start of wave.
@@ -60,22 +44,20 @@ enum class WaveTick : uint32_t {
   invalid = std::numeric_limits<uint32_t>::max()
 };
 
+// Mouse click events.
 enum class UiCanvasEvent : uint8_t {
   click,
   dblclick,
   contextmenu,
   dragstart,
   dragmove,
-  dragend,
+  dragend
 };
 
-enum class UiMouseButton : uint8_t {
-  left,
-  middle,
-  right,
-  other,
-};
+// Mouse buttons.
+enum class UiMouseButton : uint8_t { left, middle, right, other };
 
+// Targeting modes for defenders.
 enum class TargetMode : uint8_t { first, last, closest, strongest, weakest };
 
 }} // namespace corvid::sim
@@ -119,42 +101,44 @@ struct EnemySpawn {
 
 // All of the enemy spawns for a wave.
 struct WaveDefinition {
-  std::vector<EnemySpawn> enemies;
-  int resourceInflux{}; // Resources rewarded at start of wave
+  std::vector<EnemySpawn> enemies; // Sorted by `startTicks`
+  int resourceInflux{};            // Resources rewarded at start of wave
 };
 
 // Full definition of one entity type, combining display metadata with the
 // component template used to register and spawn it.
 struct EntityDefinition {
-  std::string entityName;
-  std::string displayName;
-  int menuOrder{}; // Display order.
-  std::string flavorText;
+  std::string entityName;  // Unique identifier.
+  std::string displayName; // Human-readable name.
+  int menuOrder{};         // Display order.
+  std::string flavorText;  // Description of its capabilities.
   // NaN means "not for sale" (all invaders default to this).
   float resourceCost{std::numeric_limits<float>::quiet_NaN()};
-  WorldScene::megatuple_t megatuple;
+  WorldScene::megatuple_t megatuple; // Component template.
 };
 
-// Keyed by `entityName` for O(1) lookup.
+// Collection of `EntityDefinition`s, keyed by `entityName`.
 using EntityDefinitions = string_unordered_map<EntityDefinition>;
 
-// One entry in the build menu streamed to the client. Already sorted by
-// `menuOrder` before streaming; `menuOrder` itself is not streamed.
-struct DefenderMenuEntry {
+// Human-focused summary of a defender, used for both the build menu and the
+// selected tab.
+struct DefenderSummary {
+  WorldTick modified{WorldTick::invalid}; // Not used for menu items
   std::string entityName;
   std::string displayName;
-  int menuOrder{};
+  int menuOrder{}; // Used for menu items.
   std::string flavorText;
   float resourceCost{};
   Appearance appearance; // extracted from megatuple at build time
 };
 
-// Sorted by `menuOrder`, filtered to purchasable defenders only.
-using DefenderMenu = std::vector<DefenderMenuEntry>;
+// Menu of available defenders. Sorted by `menuOrder`, filtered to purchasable
+// defenders only. Note that these are not indexed by `entityTemplateIndex`.
+using DefenderMenu = std::vector<DefenderSummary>;
 
 // Everything needed to play one map: paths, sprites, entity definitions,
 // derived defender menu, and wave schedule. Self-contained so that
-// `SimGame` can hold multiple `MapDesign`s in future.
+// `SimGame` can hold multiple `MapDesign`s, all read in from map files.
 struct MapDesign {
   std::vector<PathJoints> paths;
   std::string backgroundSpriteFile;
@@ -164,9 +148,8 @@ struct MapDesign {
   std::vector<WaveDefinition> waves;
 };
 
-// Input from the UI canvas, such as mouse clicks and drags.
-// Includes `command` and `parameters` for when the mouse location is paired
-// with an action.
+// Input from the UI canvas, such as mouse clicks and drags. Includes `command`
+// and `parameters` for when the mouse location is paired with an action.
 struct UiCanvasInput {
   uint64_t seq{};
   UiCanvasEvent event{UiCanvasEvent::click};
@@ -182,6 +165,13 @@ struct UiCanvasInput {
   bool meta{};
   std::string command;
   std::vector<std::string> parameters;
+
+  // Convenience accessor for the first parameter.
+  [[nodiscard]] std::string_view parameter() const {
+    std::string_view found;
+    if (!parameters.empty()) found = parameters[0];
+    return found;
+  }
 };
 
 // Input from the UI for actions, such as form submissions.
@@ -190,38 +180,37 @@ struct UiActionField {
   std::string value;
 };
 
-// Represents an action input from the UI, such as a button click. Can include
-// related data, such as form fields.
+// Represents an action input from the UI, such as pressing a button. Can
+// include related data, such as form fields.
 struct UiActionInput {
   uint64_t seq{};
   std::string action;
   std::vector<UiActionField> fields;
 };
 
-// Represents a response to a UI action, including success status and related
-// data. Note all actions require a corresponding response, but those that do
-// will use the same sequence number.
-struct UiResponse {
-  uint64_t seq{};
-  bool ok{};
-  std::string response;
-  std::string reason;
-  std::vector<UiActionField> fields;
+// Current state of the UI, for inclusion in a `WorldDelta` to the client.
+struct UiState {
+  std::optional<bool> placementAllowed;
+  std::optional<bool> spawnAllowed;
+  bool defenderSelected{};
+  std::optional<DefenderSummary> defenderSummary;
 };
 
 // Game simulation.
 class SimGame {
 public:
-  explicit SimGame() = default;
+  explicit SimGame() { (void)resetMap(); }
 
   // Load the chosen map, resetting all game state.
-  void loadMap() {
+  [[nodiscard]] bool loadMap() {
+    (void)resetMap();
     // TODO: Have multiple maps.
     (void)doLoadMap1();
+    return true;
   }
 
   // Resets all map information.
-  void resetMap() {
+  [[nodiscard]] bool resetMap() {
     world_.clear();
     phase_ = GamePhase::build;
     mapDesign_ = {};
@@ -230,12 +219,22 @@ public:
     nextSpawnIndex_ = 0;
     lives_ = 20;
     resources_ = 100;
+    uiState_ = {};
+    pendingPlacementIntent_.reset();
+    pendingSpawnIntent_.reset();
+    pendingSelectIntent_.reset();
+    pendingActionIntent_.reset();
+    selectedDefender_ = {};
+    return true;
   }
 
   // Run all physics and game logic for the current tick, without advancing the
-  // counter. Call `tick()` after streaming the state to clients.
+  // counter. To advance the counter, call `tick()` after streaming the state
+  // to clients.
   [[nodiscard]] bool next() {
+    (void)evaluatePendingUiIntents();
     (void)world_.next();
+
     if (phase_ == GamePhase::wave) {
       ++waveTick_;
       spawnPendingWaveEnemies();
@@ -244,7 +243,7 @@ public:
       (void)world_.resolveEscapees(
           [&lives](SimWorld::EntityId, const Position&, const Pathing&) {
             --lives;
-            // TODO: Treat front-escapees different from rear-escapees, and
+            // TODO: Treat front-escapees differently from rear-escapees, and
             // treat different enemies differently in terms of how many lives
             // they consume.
             return true;
@@ -253,6 +252,7 @@ public:
 
       if (lives_ <= 0) phase_ = GamePhase::game_over;
     }
+    (void)refreshSelectedDefenderState();
     return true;
   }
 
@@ -264,118 +264,93 @@ public:
   [[nodiscard]] WorldTick currentTick() const { return world_.currentTick(); }
 
   // Player action: start the next wave.
-  void start_wave() {
-    if (phase_ != GamePhase::build) return;
+  [[nodiscard]] bool start_wave() {
+    if (phase_ != GamePhase::build) return false;
     phase_ = GamePhase::wave;
     waveTick_ = {};
     nextSpawnIndex_ = 0;
+    return true;
   }
 
-  [[nodiscard]] std::optional<UiResponse> handleUiCanvas(
-      const UiCanvasInput& input) {
-    // When dragging ghost, show indicator of validity.
-    if (input.command == "placing" && !input.parameters.empty() &&
-        (input.event == UiCanvasEvent::dragstart ||
-            input.event == UiCanvasEvent::dragmove ||
-            input.event == UiCanvasEvent::dragend))
-      return makePlacementValidationResponse(input.seq,
-          canPlaceEntity(input.parameters[0], {input.x, input.y}));
+  // Record most recent action intent from the UI canvas.
+  [[nodiscard]] bool handleUiCanvas(const UiCanvasInput& input) {
+    if (input.command == "placing") {
+      if (input.parameters.empty() ||
+          (input.event != UiCanvasEvent::dragstart &&
+              input.event != UiCanvasEvent::dragmove &&
+              input.event != UiCanvasEvent::dragend))
+        return false;
 
-    // Explicit spawn from right-clicking after placing a defender.
-    if (input.event == UiCanvasEvent::click && input.command == "spawn" &&
-        !input.parameters.empty() && phase_ == GamePhase::build)
-    {
-      const auto& entityName = input.parameters[0];
-      if (!canPlaceEntity(entityName, {input.x, input.y}))
-        return makePlacementValidationResponse(input.seq, false);
-
-      auto h = world_.spawnEntity(entityName);
-      if (!h) return makePlacementValidationResponse(input.seq, false);
-      *world_.try_get_component<Position>(h.id()) = {input.x, input.y};
-      return std::nullopt;
+      pendingPlacementIntent_ = input;
+      return true;
     }
 
-    // Select defender on click.
-    if (input.event == UiCanvasEvent::click &&
-        input.button == UiMouseButton::left)
-    {
-      // Deselect the previously selected defender, if it still exists.
-      if (auto* fx =
-              world_.changeVisualEffects(world_.getId(selected_defender_)))
-      {
-        fx->selectionColor = 0;
-        fx->rangeRadius = 0.F;
-        fx->rangeColor = 0;
-        selected_defender_ = {};
-      }
+    if (input.command == "spawn") {
+      if (input.event != UiCanvasEvent::click || input.parameters.empty())
+        return false;
 
-      selected_defender_ =
-          world_.getHandle(world_.findDefenderAt({input.x, input.y}));
-      if (selected_defender_.id() != SimWorld::EntityId::invalid) {
-        auto [pos, app, fx, defender] =
-            world_.getDefender(selected_defender_.id());
-        if (pos) {
-          fx->selectionColor = 0xFFF2B63FU;
-          fx->rangeRadius = defender->attackRadius;
-          fx->rangeColor = 0xFFFF007F;
-          fx->modified = world_.currentTick();
-          (void)world_.markDirty(selected_defender_.id());
-        }
-      }
+      pendingSpawnIntent_ = input;
+      return true;
     }
 
-    if (input.event == UiCanvasEvent::click &&
-        input.button == UiMouseButton::right)
+    if (input.button == UiMouseButton::left &&
+        input.event == UiCanvasEvent::click)
     {
-      (void)world_.flashEntity(world_.findEntityAt({input.x, input.y}),
+      pendingSelectIntent_ = input;
+      return true;
+    }
+
+    if (input.button == UiMouseButton::right &&
+        input.event == UiCanvasEvent::click)
+      return world_.flashEntity(world_.findEntityAt({input.x, input.y}),
           0xFF7F7FAF, WorldTick{5});
-    }
-    return std::nullopt;
+
+    return false;
   }
 
-  [[nodiscard]] std::optional<UiResponse> handleUiAction(
-      const UiActionInput& input) {
-    if (input.action == "start_wave") {
-      if (phase_ != GamePhase::build) {
-        return UiResponse{.seq = input.seq,
-            .ok = false,
-            .response = "action",
-            .reason = "phase_mismatch",
-            .fields = {}};
-      }
-      start_wave();
-      return std::nullopt;
-    }
-    return std::nullopt;
+  // Record most recent action intent from the UI action buttons.
+  [[nodiscard]] bool handleUiAction(const UiActionInput& input) {
+    pendingActionIntent_ = input;
+    return true;
   }
 
   // Access the current map design (for streaming and inspection).
   [[nodiscard]] const MapDesign& mapDesign() const { return mapDesign_; }
+  [[nodiscard]] const UiState& uiState() const { return uiState_; }
 
-  // Extract a snapshot of the paths by calling `cbPath(pathId, Position)` for
-  // all joints of all paths.
+  // Extract a snapshot of the paths for `WorldSnapshot`, calling back
+  // `cbPath(PathId, Position)` for each joint.
   [[nodiscard]] bool extractPaths(auto&& cbPath) const {
     (void)world_.obtainPaths(cbPath);
     return true;
   }
 
-  // Extract a delta of the game state. The `cbUpserts(EntityId, Position,
-  // Appearance, VisualEffects)` and `cbErased(EntityId)` callbacks will be
-  // interleaved. The `cbState(currentWave, waveTick, lives, resources, phase)`
+  // Destructively extract a delta of the game state, for `WorldDelta`. The
+  // `cbUpserts(EntityId, Position, Appearance, VisualEffects)` and
+  // `cbErased(EntityId)` callbacks will be interleaved. The
+  // `cbState(currentWave, waveTick, lives, resources, phase, uiState)`
   // callback is invoked last.
   [[nodiscard]] bool
   extractDelta(auto&& cbUpserts, auto&& cbErased, auto&& cbState) {
+    // Clear the selected defender if it is no longer valid.
+    if (world_.getId(selectedDefender_) == SimWorld::EntityId::invalid)
+      (void)clearSelectedDefender();
+
     (void)world_.extractUpdatedEntities(cbUpserts, cbErased);
     (void)cbState(currentWave_, waveTick_, lives_, resources_,
-        sequence::enum_as_view(phase_));
+        sequence::enum_as_view(phase_), uiState_);
+
+    uiState_.placementAllowed.reset();
+    uiState_.spawnAllowed.reset();
 
     return true;
   }
 
-  // Extract a full snapshot of the game state. The `cbPath` callback will be
-  // invoked first, with `cbUpserts` and `cbErased` invoked afterwards and
-  // interleaved. `cbUpserts` receives an optional `VisualEffects` pointer. The
-  // `cbState` callback is invoked last.
+  // Destructively extract a full snapshot of the game state. The `cbPath`
+  // callback will be invoked first, with `cbUpserts(EntityId, Position,
+  // Appearance, VisualEffects)` and `cbErased(EntityId)` invoked afterwards,
+  // and interleaved. The `cbState(currentWave, waveTick, lives, resources,
+  // phase, uiState)` callback is invoked last.
   [[nodiscard]] bool extractFull(auto&& cbPath, auto&& cbUpserts,
       auto&& cbErased, auto&& cbState) {
     (void)extractPaths(cbPath);
@@ -392,61 +367,162 @@ public:
   }
 
 private:
-  [[nodiscard]] static UiResponse
-  makePlacementValidationResponse(uint64_t seq, bool valid) {
-    return UiResponse{.seq = seq,
-        .ok = valid,
-        .response = "placement",
-        .reason = valid ? "" : "blocked",
-        .fields = {{"valid", valid ? "true" : "false"}}};
-  }
-
+  // Determine whether an entity can be placed at a given position. We do not
+  // allow placement over a path or on top of another defender.
   [[nodiscard]] bool
-  canPlaceEntity(std::string_view entity_name, const Position& pos) const {
+  canPlaceDefender(std::string_view entityName, const Position& pos) const {
     if (phase_ != GamePhase::build) return false;
-    const auto def = find_opt(mapDesign_.entityDefs, entity_name);
+    const auto def = findEntityDef(entityName);
     if (!def) return false;
+    // Look up initial defender radius.
     const auto& app_opt = std::get<std::optional<Appearance>>(def->megatuple);
     if (!app_opt) return false;
     return !world_.isDefenderPlacementBlocked(pos, app_opt->radius);
   }
 
-  [[nodiscard]] UiResponse buildPlacementResponse(
-      const UiCanvasInput& input) const {
-    const bool valid =
-        !input.parameters.empty() &&
-        canPlaceEntity(input.parameters[0], {input.x, input.y});
-    return makePlacementValidationResponse(input.seq, valid);
+  // Find `EntityDefinition` by name.
+  [[nodiscard]] const EntityDefinition* findEntityDef(
+      std::string_view entityName) const {
+    return find_opt(mapDesign_.entityDefs, entityName);
+  }
+
+  // Build `DefenderSummary` for a selected defender by entity name.
+  [[nodiscard]] std::optional<DefenderSummary> buildSelectedDefenderSummary(
+      std::string_view entityName) const {
+    const auto* def = findEntityDef(entityName);
+    if (!def) return std::nullopt;
+    const auto& app_opt = std::get<std::optional<Appearance>>(def->megatuple);
+    if (!app_opt || std::isnan(def->resourceCost)) return std::nullopt;
+    return DefenderSummary{.modified = world_.currentTick(),
+        .entityName = def->entityName,
+        .displayName = def->displayName,
+        .flavorText = def->flavorText,
+        .resourceCost = def->resourceCost,
+        .appearance = *app_opt};
+  }
+
+  // Build `DefenderSummary` for a selected defender by `Defender` component.
+  [[nodiscard]] std::optional<DefenderSummary> buildSelectedDefenderSummary(
+      const Defender& defender) const {
+    return buildSelectedDefenderSummary(
+        world_.getEntityTemplateLabel(defender.entityTemplateIndex));
+  }
+
+  // Apply pending UI intents such as placement, spawn, selection, and actions.
+  [[nodiscard]] bool evaluatePendingUiIntents() {
+    if (pendingPlacementIntent_) {
+      const auto& input = *pendingPlacementIntent_;
+      uiState_.placementAllowed =
+          canPlaceDefender(input.parameter(), {input.x, input.y});
+      pendingPlacementIntent_.reset();
+    }
+
+    if (pendingSpawnIntent_) {
+      const auto& input = *pendingSpawnIntent_;
+      const auto parameter = input.parameter();
+      bool spawnAllowed = canPlaceDefender(parameter, {input.x, input.y});
+      if (spawnAllowed) {
+        auto h = world_.spawnEntity(parameter);
+        if (h)
+          *world_.try_get_component<Position>(h.id()) = {input.x, input.y};
+        else
+          spawnAllowed = false;
+      }
+      uiState_.spawnAllowed = spawnAllowed;
+      pendingSpawnIntent_.reset();
+    }
+
+    if (pendingSelectIntent_) {
+      const auto& input = *pendingSelectIntent_;
+      (void)selectDefenderAt({input.x, input.y});
+      pendingSelectIntent_.reset();
+    }
+
+    if (pendingActionIntent_) {
+      const auto& input = *pendingActionIntent_;
+      if (input.action == "start_wave" && phase_ == GamePhase::build)
+        (void)start_wave();
+      pendingActionIntent_.reset();
+    }
+    return true;
+  }
+
+  // Attempt to select a defender at the given position. Unselects the current
+  // selection, regardless.
+  [[nodiscard]] bool selectDefenderAt(const Position& targetPos) {
+    (void)clearSelectedDefender();
+    auto selected = world_.getHandle(world_.findDefenderAt(targetPos));
+    const auto selectedId = world_.getId(selected);
+    const auto& [pos, _, fx, defender] = world_.getDefender(selectedId);
+    if (!pos || !defender || !fx) return false;
+
+    // Add selection visual effects.
+    fx->selectionColor = 0xFFF2B63FU;
+    fx->rangeRadius = defender->attackRadius;
+    fx->rangeColor = 0xFFFF007F;
+    fx->modified = world_.currentTick();
+    (void)world_.markDirty(selectedId);
+
+    selectedDefender_ = selected;
+    uiState_.defenderSelected = true;
+    uiState_.defenderSummary = buildSelectedDefenderSummary(*defender);
+    return true;
+  }
+
+  // Ensure that the selected defender is valid.
+  [[nodiscard]] bool refreshSelectedDefenderState() {
+    const auto selectedId = world_.getId(selectedDefender_);
+    if (selectedId == SimWorld::EntityId::invalid)
+      return clearSelectedDefender();
+
+    const auto& [pos, _, fx, defender] = world_.getDefender(selectedId);
+    if (!pos || !defender || !fx) return clearSelectedDefender();
+
+    uiState_.defenderSelected = true;
+    return true;
+  }
+
+  // Clear the currently selected defender.
+  [[nodiscard]] bool clearSelectedDefender() {
+    if (auto* fx = world_.changeVisualEffects(world_.getId(selectedDefender_)))
+    {
+      fx->selectionColor = 0;
+      fx->rangeRadius = 0.F;
+      fx->rangeColor = 0;
+    }
+    selectedDefender_ = {};
+    uiState_.defenderSelected = false;
+    uiState_.defenderSummary.reset();
+    return true;
   }
 
   // Register all entities and build the defender menu from
   // `mapDesign_.entityDefs`.
-  [[nodiscard]] bool processEntityDefs() {
+  [[nodiscard]] bool registerEntityDefs() {
     auto& defs = mapDesign_.entityDefs;
     auto& menu = mapDesign_.defenderMenu;
     menu.clear();
+
     for (const auto& [name, def] : defs) {
-      world_.registerEntity(def.entityName, def.megatuple);
-      if (!std::isnan(def.resourceCost)) {
-        const auto& app_opt =
-            std::get<std::optional<Appearance>>(def.megatuple);
-        menu.push_back({.entityName = def.entityName,
-            .displayName = def.displayName,
-            .menuOrder = def.menuOrder,
-            .flavorText = def.flavorText,
-            .resourceCost = def.resourceCost,
-            .appearance = *app_opt});
-      }
+      if (!world_.registerEntity(def.entityName, def.megatuple)) continue;
+      if (std::isnan(def.resourceCost)) continue;
+      const auto& app_opt = std::get<std::optional<Appearance>>(def.megatuple);
+      menu.push_back({.entityName = def.entityName,
+          .displayName = def.displayName,
+          .menuOrder = def.menuOrder,
+          .flavorText = def.flavorText,
+          .resourceCost = def.resourceCost,
+          .appearance = *app_opt});
     }
     std::ranges::sort(menu,
-        [](const DefenderMenuEntry& a, const DefenderMenuEntry& b) {
+        [](const DefenderSummary& a, const DefenderSummary& b) {
           return a.menuOrder < b.menuOrder;
         });
     return true;
   }
 
   // Add each `PathJoints` from `mapDesign_.paths` to the world.
-  [[nodiscard]] bool processPaths() {
+  [[nodiscard]] bool registerPaths() {
     for (const auto& pj : mapDesign_.paths) (void)world_.addPath(pj);
     return true;
   }
@@ -463,20 +539,20 @@ private:
 
       // Set placement-specific fields not encoded in the template.
       auto [pos, pat] = world_.try_get_components<Position, Pathing>(h.id());
-      if (pos) {
-        pat->pathId = enemyDef.pathId;
-        const auto* path = world_.getPath(pat->pathId);
-        assert(path);
-        *pos = path->calculatePositionFromProgress(0.F, 0.F);
-      }
+      assert(pos);
+      pat->pathId = enemyDef.pathId;
+      const auto* path = world_.getPath(pat->pathId);
+      assert(path);
+      *pos = path->calculatePositionFromProgress(0.F, 0.F);
     }
   }
 
+  // Ugly placeholder for map loading.
   [[nodiscard]] bool doLoadMap1() {
-    resetMap();
+    (void)resetMap();
 
-    // Entity definitions. This is the single site that will later be replaced
-    // by CSV/JSON parsing.
+    // Entity definitions. This is the single site that will later be
+    // replaced by CSV/JSON parsing.
     {
       EntityDefinition def;
       def.entityName = "InvaderAlphaBasic";
@@ -492,7 +568,7 @@ private:
       std::get<std::optional<Pathing>>(tpl) =
           Pathing{.pathId = PathId::invalid, .progress = 0.F, .speed = 50.F};
       std::get<std::optional<Invader>>(tpl) =
-          Invader{.invaderType = 1, .hitCircleRadius = 30.F, .bounty = 10};
+          Invader{.hitCircleRadius = 30.F, .bounty = 10};
       std::get<std::optional<Health>>(tpl) =
           Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 10.F};
       mapDesign_.entityDefs.try_emplace(def.entityName, std::move(def));
@@ -513,8 +589,8 @@ private:
           .attackRadius = 100.F};
       std::get<std::optional<VisualEffects>>(tpl) =
           VisualEffects{.flashColor = 0xFF7F7FFF, .flashExpiry = WorldTick{5}};
-      std::get<std::optional<Defender>>(tpl) = Defender{.defenderType = 1,
-          .hitCircleRadius = 30.F,
+      std::get<std::optional<Defender>>(
+          tpl) = Defender{.hitCircleRadius = 30.F,
           .attackRadius = 100.F,
           .rangeColor = 0xFFFF0000,
           .attackDamage = 5.F,
@@ -542,8 +618,8 @@ private:
           .attackRadius = 150.F};
       std::get<std::optional<VisualEffects>>(tpl) =
           VisualEffects{.flashColor = 0xFF7FFF7F, .flashExpiry = WorldTick{5}};
-      std::get<std::optional<Defender>>(tpl) = Defender{.defenderType = 2,
-          .hitCircleRadius = 25.F,
+      std::get<std::optional<Defender>>(
+          tpl) = Defender{.hitCircleRadius = 25.F,
           .attackRadius = 150.F,
           .rangeColor = 0xFF00FF00,
           .attackDamage = 15.F,
@@ -553,7 +629,7 @@ private:
       std::get<std::optional<Health>>(tpl) =
           Health{.currentHealth = 80.F, .maxHealth = 80.F, .regen = 0.F};
       std::get<std::optional<DefenderShooter>>(tpl) = DefenderShooter{
-          .bullet_template = DefenderBullet{.speed = 200.F,
+          .bulletTemplate = DefenderBullet{.speed = 200.F,
               .directDamage = 15.F,
               .projectileType = 1,
               .expiry = WorldTick{60}},
@@ -603,7 +679,7 @@ private:
       mapDesign_.waves.push_back(std::move(wave));
     }
 
-    return processEntityDefs() && processPaths();
+    return registerEntityDefs() && registerPaths();
   }
 
 private:
@@ -628,10 +704,15 @@ private:
 
   int lives_{20};
   int resources_{100};
+  UiState uiState_;
 
-  // Handle to the currently selected defender, used to clear its range circle
-  // when deselected. A default-constructed handle is invalid and indicates
-  // no selection.
-  SimWorld::Handle selected_defender_;
+  std::optional<UiCanvasInput> pendingPlacementIntent_;
+  std::optional<UiCanvasInput> pendingSpawnIntent_;
+  std::optional<UiCanvasInput> pendingSelectIntent_;
+  std::optional<UiActionInput> pendingActionIntent_;
+
+  // Handle to the currently selected defender, used to clear its range
+  // circle when deselected.
+  SimWorld::Handle selectedDefender_;
 };
 }} // namespace corvid::sim

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -459,6 +459,40 @@ private:
       std::get<std::optional<DefenderAoe>>(tpl) = DefenderAoe{.damageType = 1};
       mapDesign_.entityDefs.try_emplace(def.entityName, std::move(def));
     }
+    {
+      EntityDefinition def;
+      def.entityName = "DefenderShooterBasic";
+      def.displayName = "Shooter";
+      def.menuOrder = 2;
+      def.flavorText = "Fires projectiles at a single target.";
+      def.resourceCost = 75.F;
+      auto& tpl = def.megatuple;
+      std::get<std::optional<Position>>(tpl) = Position{};
+      std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'S',
+          .radius = 25.F,
+          .fgColor = 0xFFFFFFFF,
+          .bgColor = 0x7FFF7F3F,
+          .attackRadius = 150.F};
+      std::get<std::optional<VisualEffects>>(tpl) =
+          VisualEffects{.flashColor = 0xFF7FFF7F, .flashExpiry = WorldTick{5}};
+      std::get<std::optional<Defender>>(tpl) = Defender{.defenderType = 2,
+          .hitCircleRadius = 25.F,
+          .attackRadius = 150.F,
+          .rangeColor = 0xFF00FF00,
+          .attackDamage = 15.F,
+          .cooldown = WorldTick{30},
+          .nextAttack = WorldTick{0}};
+      std::get<std::optional<DefenderStats>>(tpl) = DefenderStats{};
+      std::get<std::optional<Health>>(tpl) =
+          Health{.currentHealth = 80.F, .maxHealth = 80.F, .regen = 0.F};
+      std::get<std::optional<DefenderShooter>>(tpl) = DefenderShooter{
+          .bullet_template = DefenderBullet{.speed = 200.F,
+              .directDamage = 15.F,
+              .projectileType = 1,
+              .expiry = WorldTick{60}},
+          .fireRate = 0.033F};
+      mapDesign_.entityDefs.try_emplace(def.entityName, std::move(def));
+    }
 
     // Path geometry (sprite files empty until sprites are added).
     {

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -112,14 +112,14 @@ namespace corvid { inline namespace sim {
 // Enemy spawn definition for a wave.
 struct EnemySpawn {
   WaveTick startTicks;
-  std::string
-      label; // matches a label registered with `SimWorld::registerEntity`
+  std::string label; // matches a label in `SimWorld::registerEntity`
+  PathId pathId{};
 };
 
 // All of the enemy spawns for a wave.
 struct WaveDefinition {
   std::vector<EnemySpawn> enemies;
-  int resourceInflux = 0; // Resources rewarded at start of wave
+  int resourceInflux{}; // Resources rewarded at start of wave
 };
 
 struct UiCanvasInput {
@@ -313,12 +313,13 @@ private:
       if (enemy_def.startTicks > waveTick_) break;
       auto h = world_.spawnEntity(enemy_def.label);
       if (!h) continue;
+
       // Set placement-specific fields not encoded in the template.
-      if (auto* pat = world_.try_get_component<Pathing>(h.id())) {
-        pat->path_id = PathId{0};
-        if (auto* pos = world_.try_get_component<Position>(h.id()))
-          if (const auto* path = world_.getPath(PathId{0}))
-            *pos = path->calculatePositionFromProgress(0.F, 0.F);
+      auto [pos, pat] = world_.try_get_components<Position, Pathing>(h.id());
+      if (pos) {
+        pat->pathId = enemy_def.pathId;
+        const auto* path = world_.getPath(pat->pathId);
+        *pos = path->calculatePositionFromProgress(0.F, 0.F);
       }
     }
   }
@@ -338,7 +339,7 @@ private:
           .bgColor = 0x000000FF};
       std::get<std::optional<VisualEffects>>(tpl) = VisualEffects{};
       std::get<std::optional<Pathing>>(tpl) =
-          Pathing{.path_id = PathId::invalid, .progress = 0.F, .speed = 50.F};
+          Pathing{.pathId = PathId::invalid, .progress = 0.F, .speed = 50.F};
       std::get<std::optional<Invader>>(tpl) =
           Invader{.invaderType = 1, .hitCircleRadius = 30.F, .bounty = 10};
       std::get<std::optional<Health>>(tpl) =
@@ -413,8 +414,8 @@ private:
   GamePhase phase_ = GamePhase::build;
 
   // Tick counter for the current wave, used to trigger spawns at the right
-  // times. This is reset with each wave, so it is not the same tick counter as
-  // the world's, and may not even run at the same speed.
+  // times. This is reset with each wave, so it is not the same tick counter
+  // as the world's, and may not even run at the same speed.
   WaveTick waveTick_{};
 
   // Wave definitions for the current map.
@@ -423,16 +424,16 @@ private:
   // Current wave.
   size_t currentWave_{};
 
-  // Index of the next spawn in the current `WaveDefinition`, which is checked
-  // against `wave_tick_`.
+  // Index of the next spawn in the current `WaveDefinition`, which is
+  // checked against `wave_tick_`.
   size_t nextSpawnIndex_{};
 
   int lives_{20};
   int resources_{100};
 
   // Handle to the currently selected tower, used to clear its range circle
-  // when deselected. A default-constructed handle is invalid and indicates no
-  // selection.
+  // when deselected. A default-constructed handle is invalid and indicates
+  // no selection.
   SimWorld::Handle selected_tower_;
 };
 }} // namespace corvid::sim

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -254,9 +254,10 @@ public:
   }
 
   void handleUiCanvas(const UiCanvasInput& input) {
-    // Spawn command from build menu confirmation double-click.
-    if (input.event == UiCanvasEvent::click &&
-        input.button == UiMouseButton::left && input.command == "spawn" &&
+    // Explicit spawn command from the web build menu. The button is part of
+    // the UX contract, not the simulation command, so accept whichever button
+    // the client uses for confirmation.
+    if (input.event == UiCanvasEvent::click && input.command == "spawn" &&
         !input.parameters.empty() && phase_ == GamePhase::build)
     {
       auto h = world_.spawnEntity(input.parameters[0]);

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -180,7 +180,7 @@ public:
 
       auto lives = lives_;
       (void)world_.resolveEscapees(
-          [&lives](SimWorld::EntityId, const Position&, const PathFollower&) {
+          [&lives](SimWorld::EntityId, const Position&, const Pathing&) {
             --lives;
             // TODO: Treat front-escapees different from rear-escapees, and
             // treat different enemies differently in terms of how many lives
@@ -226,10 +226,12 @@ public:
           world_.getHandle(world_.findTowerAt({input.x, input.y}));
       if (selected_tower_.id() != SimWorld::EntityId::invalid) {
         auto [pos, app, fx, tower] = world_.getTower(selected_tower_.id());
-        fx.range_radius = tower.attack_radius;
-        fx.range_color = 0xFFFF007F;
-        fx.modified = world_.currentTick();
-        (void)world_.markDirty(selected_tower_.id());
+        if (pos) {
+          fx->range_radius = tower->attack_radius;
+          fx->range_color = 0xFFFF007F;
+          fx->modified = world_.currentTick();
+          (void)world_.markDirty(selected_tower_.id());
+        }
       }
     }
 
@@ -237,7 +239,7 @@ public:
     if (input.event == UiCanvasEvent::dblclick &&
         input.button == UiMouseButton::left)
     {
-      (void)world_.spawnTower({input.x, input.y});
+      (void)world_.spawnDefenderAoe({input.x, input.y});
     }
 
     if (input.event == UiCanvasEvent::click &&
@@ -304,7 +306,7 @@ private:
     for (; nextSpawnIndex_ < enemies.size(); ++nextSpawnIndex_) {
       const auto& enemy_def = enemies[nextSpawnIndex_];
       if (enemy_def.startTicks > waveTick_) break;
-      (void)world_.spawnEnemy(PathId{0}, 20.F, 0.F);
+      (void)world_.spawnInvaderAlpha(PathId{0});
     }
   }
 

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -569,7 +569,7 @@ private:
       p.joints.push_back({Position{0.0, 0.0}});
       constexpr float kHalfWidth = SimWorld::widthOfWorld / 2.F;
       constexpr float kHalfHeight = SimWorld::heightOfWorld / 2.F;
-      constexpr float kStepSize = 80.0;
+      constexpr float kStepSize = 120.0;
       constexpr float kAspect =
           SimWorld::widthOfWorld / SimWorld::heightOfWorld;
       constexpr float kXStepSize = kStepSize * kAspect;

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -309,16 +309,17 @@ private:
     const auto& wave = waves_[currentWave_];
     const auto& enemies = wave.enemies;
     for (; nextSpawnIndex_ < enemies.size(); ++nextSpawnIndex_) {
-      const auto& enemy_def = enemies[nextSpawnIndex_];
-      if (enemy_def.startTicks > waveTick_) break;
-      auto h = world_.spawnEntity(enemy_def.label);
+      const auto& enemyDef = enemies[nextSpawnIndex_];
+      if (enemyDef.startTicks > waveTick_) break;
+      auto h = world_.spawnEntity(enemyDef.label);
       if (!h) continue;
 
       // Set placement-specific fields not encoded in the template.
       auto [pos, pat] = world_.try_get_components<Position, Pathing>(h.id());
       if (pos) {
-        pat->pathId = enemy_def.pathId;
+        pat->pathId = enemyDef.pathId;
         const auto* path = world_.getPath(pat->pathId);
+        assert(path);
         *pos = path->calculatePositionFromProgress(0.F, 0.F);
       }
     }

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -122,6 +122,47 @@ struct WaveDefinition {
   int resourceInflux{}; // Resources rewarded at start of wave
 };
 
+// Full definition of one entity type, combining display metadata with the
+// component template used to register and spawn it.
+struct EntityDefinition {
+  std::string entityName;
+  std::string displayName;
+  int menuOrder{}; // Display order.
+  std::string flavorText;
+  // NaN means "not for sale" (all invaders default to this).
+  float resourceCost{std::numeric_limits<float>::quiet_NaN()};
+  WorldScene::megatuple_t megatuple;
+};
+
+// Keyed by `entityName` for O(1) lookup.
+using EntityDefinitions = string_unordered_map<EntityDefinition>;
+
+// One entry in the build menu streamed to the client. Already sorted by
+// `menuOrder` before streaming; `menuOrder` itself is not streamed.
+struct DefenderMenuEntry {
+  std::string entityName;
+  std::string displayName;
+  int menuOrder{};
+  std::string flavorText;
+  float resourceCost{};
+  Appearance appearance; // extracted from megatuple at build time
+};
+
+// Sorted by `menuOrder`, filtered to purchasable defenders only.
+using DefenderMenu = std::vector<DefenderMenuEntry>;
+
+// Everything needed to play one map: paths, sprites, entity definitions,
+// derived defender menu, and wave schedule. Self-contained so that
+// `SimGame` can hold multiple `MapDesign`s in future.
+struct MapDesign {
+  std::vector<PathJoints> paths;
+  std::string backgroundSpriteFile;
+  std::string foregroundSpriteFile;
+  EntityDefinitions entityDefs;
+  DefenderMenu defenderMenu;
+  std::vector<WaveDefinition> waves;
+};
+
 struct UiCanvasInput {
   uint64_t seq{};
   UiCanvasEvent event{UiCanvasEvent::click};
@@ -156,14 +197,14 @@ public:
   // Load the chosen map, resetting all game state.
   void loadMap() {
     // TODO: Have multiple maps.
-    doLoadMap1();
+    (void)doLoadMap1();
   }
 
   // Resets all map information.
   void resetMap() {
     world_.clear();
     phase_ = GamePhase::build;
-    waves_.clear();
+    mapDesign_ = {};
     currentWave_ = 0;
     waveTick_ = {};
     nextSpawnIndex_ = 0;
@@ -264,6 +305,9 @@ public:
 
   void placeTower(/* later */);
 
+  // Access the current map design (for streaming and inspection).
+  [[nodiscard]] const MapDesign& mapDesign() const { return mapDesign_; }
+
   // Extract a snapshot of the paths by calling `cbPath(pathId, Position)` for
   // all joints of all paths.
   [[nodiscard]] bool extractPaths(auto&& cbPath) const {
@@ -304,9 +348,41 @@ public:
   }
 
 private:
+  // Register all entities and build the defender menu from
+  // `mapDesign_.entityDefs`.
+  [[nodiscard]] bool processEntityDefs() {
+    auto& defs = mapDesign_.entityDefs;
+    auto& menu = mapDesign_.defenderMenu;
+    menu.clear();
+    for (const auto& [name, def] : defs) {
+      world_.registerEntity(def.entityName, def.megatuple);
+      if (!std::isnan(def.resourceCost)) {
+        const auto& app_opt =
+            std::get<std::optional<Appearance>>(def.megatuple);
+        menu.push_back({.entityName = def.entityName,
+            .displayName = def.displayName,
+            .menuOrder = def.menuOrder,
+            .flavorText = def.flavorText,
+            .resourceCost = def.resourceCost,
+            .appearance = *app_opt});
+      }
+    }
+    std::ranges::sort(menu,
+        [](const DefenderMenuEntry& a, const DefenderMenuEntry& b) {
+          return a.menuOrder < b.menuOrder;
+        });
+    return true;
+  }
+
+  // Add each `PathJoints` from `mapDesign_.paths` to the world.
+  [[nodiscard]] bool processPaths() {
+    for (const auto& pj : mapDesign_.paths) (void)world_.addPath(pj);
+    return true;
+  }
+
   // Spawn all the enemies slated for this wave tick.
   void spawnPendingWaveEnemies() {
-    const auto& wave = waves_[currentWave_];
+    const auto& wave = mapDesign_.waves[currentWave_];
     const auto& enemies = wave.enemies;
     for (; nextSpawnIndex_ < enemies.size(); ++nextSpawnIndex_) {
       const auto& enemyDef = enemies[nextSpawnIndex_];
@@ -325,13 +401,16 @@ private:
     }
   }
 
-  void doLoadMap1() {
+  [[nodiscard]] bool doLoadMap1() {
     resetMap();
 
-    // Register entity types available on this map. This is the single site
-    // that will later be replaced by CSV/JSON parsing.
+    // Entity definitions. This is the single site that will later be replaced
+    // by CSV/JSON parsing.
     {
-      WorldScene::megatuple_t tpl{};
+      EntityDefinition def;
+      def.entityName = "InvaderAlphaBasic";
+      // `resourceCost` stays NaN (not for sale).
+      auto& tpl = def.megatuple;
       std::get<std::optional<Position>>(tpl) = Position{};
       std::get<std::optional<Appearance>>(
           tpl) = Appearance{.glyph = U'\u03B1', // Greek alpha
@@ -345,10 +424,16 @@ private:
           Invader{.invaderType = 1, .hitCircleRadius = 30.F, .bounty = 10};
       std::get<std::optional<Health>>(tpl) =
           Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 10.F};
-      world_.registerEntity("InvaderAlphaBasic", tpl);
+      mapDesign_.entityDefs.try_emplace(def.entityName, std::move(def));
     }
     {
-      WorldScene::megatuple_t tpl{};
+      EntityDefinition def;
+      def.entityName = "DefenderAoeBasic";
+      def.displayName = "AoE Defender";
+      def.menuOrder = 1;
+      def.flavorText = "Damages all enemies in range.";
+      def.resourceCost = 50.F;
+      auto& tpl = def.megatuple;
       std::get<std::optional<Position>>(tpl) = Position{};
       std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'A',
           .radius = 30.F,
@@ -367,46 +452,52 @@ private:
       std::get<std::optional<Health>>(tpl) =
           Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 0.F};
       std::get<std::optional<DefenderAoe>>(tpl) = DefenderAoe{.damageType = 1};
-      world_.registerEntity("DefenderAoeBasic", tpl);
+      mapDesign_.entityDefs.try_emplace(def.entityName, std::move(def));
     }
 
-    // For now, a hardcoded spiral.
-    PathJoints p;
-    p.joints.push_back({Position{0.0, 0.0}});
-    constexpr float kHalfWidth = SimWorld::widthOfWorld / 2.F;
-    constexpr float kHalfHeight = SimWorld::heightOfWorld / 2.F;
-    constexpr float kStepSize = 80.0;
-    constexpr float kAspect = SimWorld::widthOfWorld / SimWorld::heightOfWorld;
-    constexpr float kXStepSize = kStepSize * kAspect;
-    float x = 0.0;
-    float y = 0.0;
-    float x_run = kXStepSize;
-    float y_run = kStepSize;
-    auto append_segment = [&](float dx, float dy) {
-      x = std::clamp(x + dx, -kHalfWidth, kHalfWidth);
-      y = std::clamp(y + dy, -kHalfHeight, kHalfHeight);
-      p.joints.push_back({Position{x, y}});
-      return x > -kHalfWidth && x < kHalfWidth && y > -kHalfHeight &&
-             y < kHalfHeight;
-    };
-
-    while (true) {
-      if (!append_segment(x_run, 0.F)) break;
-      if (!append_segment(0.F, y_run)) break;
-      x_run += kXStepSize;
-      if (!append_segment(-x_run, 0.F)) break;
-      y_run += kStepSize;
-      if (!append_segment(0.F, -y_run)) break;
-      x_run += kXStepSize;
-      y_run += kStepSize;
+    // Path geometry (sprite files empty until sprites are added).
+    {
+      PathJoints p;
+      p.joints.push_back({Position{0.0, 0.0}});
+      constexpr float kHalfWidth = SimWorld::widthOfWorld / 2.F;
+      constexpr float kHalfHeight = SimWorld::heightOfWorld / 2.F;
+      constexpr float kStepSize = 80.0;
+      constexpr float kAspect =
+          SimWorld::widthOfWorld / SimWorld::heightOfWorld;
+      constexpr float kXStepSize = kStepSize * kAspect;
+      float x = 0.0;
+      float y = 0.0;
+      float x_run = kXStepSize;
+      float y_run = kStepSize;
+      auto append_segment = [&](float dx, float dy) {
+        x = std::clamp(x + dx, -kHalfWidth, kHalfWidth);
+        y = std::clamp(y + dy, -kHalfHeight, kHalfHeight);
+        p.joints.push_back({Position{x, y}});
+        return x > -kHalfWidth && x < kHalfWidth && y > -kHalfHeight &&
+               y < kHalfHeight;
+      };
+      while (true) {
+        if (!append_segment(x_run, 0.F)) break;
+        if (!append_segment(0.F, y_run)) break;
+        x_run += kXStepSize;
+        if (!append_segment(-x_run, 0.F)) break;
+        y_run += kStepSize;
+        if (!append_segment(0.F, -y_run)) break;
+        x_run += kXStepSize;
+        y_run += kStepSize;
+      }
+      mapDesign_.paths.push_back(std::move(p));
     }
-    (void)world_.addPath(p);
 
-    WaveDefinition wave;
-    for (uint32_t i = 0; i < 20; ++i)
-      wave.enemies.push_back({WaveTick{i * 20}, "InvaderAlphaBasic"});
+    // Wave definitions.
+    {
+      WaveDefinition wave;
+      for (uint32_t i = 0; i < 20; ++i)
+        wave.enemies.push_back({WaveTick{i * 20}, "InvaderAlphaBasic"});
+      mapDesign_.waves.push_back(std::move(wave));
+    }
 
-    waves_.push_back(std::move(wave));
+    return processEntityDefs() && processPaths();
   }
 
 private:
@@ -419,8 +510,8 @@ private:
   // as the world's, and may not even run at the same speed.
   WaveTick waveTick_{};
 
-  // Wave definitions for the current map.
-  std::vector<WaveDefinition> waves_;
+  // All design-time data for the currently loaded map.
+  MapDesign mapDesign_;
 
   // Current wave.
   size_t currentWave_{};

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -176,6 +176,8 @@ struct UiCanvasInput {
   bool ctrl{};
   bool alt{};
   bool meta{};
+  std::string command;
+  std::vector<std::string> parameters;
 };
 
 struct UiActionField {
@@ -252,6 +254,17 @@ public:
   }
 
   void handleUiCanvas(const UiCanvasInput& input) {
+    // Spawn command from build menu confirmation double-click.
+    if (input.event == UiCanvasEvent::click &&
+        input.button == UiMouseButton::left && input.command == "spawn" &&
+        !input.parameters.empty() && phase_ == GamePhase::build)
+    {
+      auto h = world_.spawnEntity(input.parameters[0]);
+      auto* pos = world_.try_get_component<Position>(h.id());
+      *pos = {input.x, input.y};
+      return;
+    }
+
     // Select tower on click.
     if (input.event == UiCanvasEvent::click &&
         input.button == UiMouseButton::left)
@@ -277,15 +290,6 @@ public:
           (void)world_.markDirty(selected_tower_.id());
         }
       }
-    }
-
-    // Place tower on double-click.
-    if (input.event == UiCanvasEvent::dblclick &&
-        input.button == UiMouseButton::left)
-    {
-      auto h = world_.spawnEntity("DefenderAoeBasic");
-      if (auto* pos = world_.try_get_component<Position>(h.id()))
-        *pos = {input.x, input.y};
     }
 
     if (input.event == UiCanvasEvent::click &&
@@ -438,7 +442,8 @@ private:
       std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'A',
           .radius = 30.F,
           .fgColor = 0xFFFFFFFF,
-          .bgColor = 0x7F7FFFFF};
+          .bgColor = 0x7F7FFFFF,
+          .attackRadius = 100.F};
       std::get<std::optional<VisualEffects>>(tpl) =
           VisualEffects{.flashColor = 0xFF7F7FFF, .flashExpiry = WorldTick{5}};
       std::get<std::optional<Defender>>(tpl) = Defender{.defenderType = 1,

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -36,8 +36,8 @@ namespace corvid { inline namespace sim {
 // - The player selects a map and faces subsequent waves until the end of the
 // game run. The run ends with defeat or victory. Potentially, runs could be
 // grouped into campaigns or other higher-level structures.
-// - A player's towers, score, lives, and resources persist throughout the game
-// run, albeit with modifications from wave to wave.
+// - A player's defenders, score, lives, and resources persist throughout the
+// game run, albeit with modifications from wave to wave.
 // - A wave is a collection of enemy spawns. At the end of the wave, the player
 // gets a chance to build or upgrade before the next wave starts.
 // - Within a wave, spawns are enemies that appear on the track at fixed times
@@ -49,7 +49,7 @@ namespace corvid { inline namespace sim {
 
 enum class GamePhase : uint8_t {
   invalid,
-  build,     // Tower building
+  build,     // Defender building
   wave,      // Active wave with enemies spawning and moving
   game_over, // Player has no lives left
   victory,   // All waves completed with lives remaining
@@ -295,29 +295,31 @@ public:
       return std::nullopt;
     }
 
-    // Select tower on click.
+    // Select defender on click.
     if (input.event == UiCanvasEvent::click &&
         input.button == UiMouseButton::left)
     {
-      // Deselect the previously selected tower, if it still exists.
-      if (auto* fx = world_.changeVisualEffects(world_.getId(selected_tower_)))
+      // Deselect the previously selected defender, if it still exists.
+      if (auto* fx =
+              world_.changeVisualEffects(world_.getId(selected_defender_)))
       {
         fx->selectionColor = 0;
         fx->rangeRadius = 0.F;
         fx->rangeColor = 0;
-        selected_tower_ = {};
+        selected_defender_ = {};
       }
 
-      selected_tower_ =
-          world_.getHandle(world_.findTowerAt({input.x, input.y}));
-      if (selected_tower_.id() != SimWorld::EntityId::invalid) {
-        auto [pos, app, fx, tower] = world_.getTower(selected_tower_.id());
+      selected_defender_ =
+          world_.getHandle(world_.findDefenderAt({input.x, input.y}));
+      if (selected_defender_.id() != SimWorld::EntityId::invalid) {
+        auto [pos, app, fx, defender] =
+            world_.getDefender(selected_defender_.id());
         if (pos) {
           fx->selectionColor = 0xFFF2B63FU;
-          fx->rangeRadius = tower->attackRadius;
+          fx->rangeRadius = defender->attackRadius;
           fx->rangeColor = 0xFFFF007F;
           fx->modified = world_.currentTick();
-          (void)world_.markDirty(selected_tower_.id());
+          (void)world_.markDirty(selected_defender_.id());
         }
       }
     }
@@ -629,9 +631,9 @@ private:
   int lives_{20};
   int resources_{100};
 
-  // Handle to the currently selected tower, used to clear its range circle
+  // Handle to the currently selected defender, used to clear its range circle
   // when deselected. A default-constructed handle is invalid and indicates
   // no selection.
-  SimWorld::Handle selected_tower_;
+  SimWorld::Handle selected_defender_;
 };
 }} // namespace corvid::sim

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -57,9 +57,6 @@ enum class UiCanvasEvent : uint8_t {
 // Mouse buttons.
 enum class UiMouseButton : uint8_t { left, middle, right, other };
 
-// Targeting modes for defenders.
-enum class TargetMode : uint8_t { first, last, closest, strongest, weakest };
-
 }} // namespace corvid::sim
 
 template<>
@@ -84,11 +81,6 @@ constexpr auto
     corvid::enums::registry::enum_spec_v<corvid::sim::UiMouseButton> =
         corvid::enums::sequence::make_sequence_enum_spec<
             corvid::sim::UiMouseButton, "left, middle, right, other">();
-
-template<>
-constexpr auto corvid::enums::registry::enum_spec_v<corvid::sim::TargetMode> =
-    corvid::enums::sequence::make_sequence_enum_spec<corvid::sim::TargetMode,
-        "first, last, closest, strongest, weakest">();
 
 namespace corvid { inline namespace sim {
 
@@ -249,6 +241,16 @@ public:
             return true;
           });
       lives_ = lives;
+
+      auto resources = resources_;
+      (void)world_.resolveKills(
+          [&resources](SimWorld::EntityId, const Position&,
+              const Invader& inv) {
+            resources += inv.bounty;
+            // TODO: Spawn a transient death animation at `pos`.
+            return true;
+          });
+      resources_ = resources;
 
       if (lives_ <= 0) phase_ = GamePhase::game_over;
     }
@@ -632,6 +634,38 @@ private:
               .projectileType = 1,
               .expiry = WorldTick{60}},
           .fireRate = 0.033F};
+      mapDesign_.entityDefs.try_emplace(def.entityName, std::move(def));
+    }
+    {
+      EntityDefinition def;
+      def.entityName = "DefenderHitscanBasic";
+      def.displayName = "Laser";
+      def.menuOrder = 3;
+      def.flavorText =
+          "Instantly damages a single target with an infrared laser beam.";
+      def.resourceCost = 100.F;
+      auto& tpl = def.megatuple;
+      std::get<std::optional<Position>>(tpl) = Position{};
+      std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'L',
+          .radius = 25.F,
+          .fgColor = 0xFFFFFFFF,
+          .bgColor = 0x7FFF3F3F,
+          .attackRadius = 200.F};
+      std::get<std::optional<VisualEffects>>(tpl) =
+          VisualEffects{.flashColor = 0xFFFF4040, .flashExpiry = WorldTick{3}};
+      std::get<std::optional<Defender>>(
+          tpl) = Defender{.hitCircleRadius = 25.F,
+          .attackRadius = 200.F,
+          .rangeColor = 0xFFFF0000,
+          .attackDamage = 30.F,
+          .cooldown = WorldTick{45},
+          .nextAttack = WorldTick{0}};
+      std::get<std::optional<DefenderStats>>(tpl) = DefenderStats{};
+      std::get<std::optional<Health>>(tpl) =
+          Health{.currentHealth = 75.F, .maxHealth = 75.F, .regen = 0.F};
+      std::get<std::optional<DefenderHitscan>>(
+          tpl) = DefenderHitscan{.beamColor = 0xFFFF4040,
+          .beamDuration = WorldTick{3}};
       mapDesign_.entityDefs.try_emplace(def.entityName, std::move(def));
     }
 

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -121,7 +121,9 @@ struct DefenderSummary {
   int menuOrder{}; // Used for menu items.
   std::string flavorText;
   float resourceCost{};
-  Appearance appearance; // extracted from megatuple at build time
+  Appearance appearance;    // Extracted from megatuple at build time.
+  float totalDamageDealt{}; // Live stats; only valid for selected defenders.
+  float totalKills{};
 };
 
 // Menu of available defenders. Sorted by `menuOrder`, filtered to purchasable
@@ -469,7 +471,7 @@ private:
     return true;
   }
 
-  // Ensure that the selected defender is valid.
+  // Ensure that the selected defender has the correct values.
   [[nodiscard]] bool refreshSelectedDefenderState() {
     const auto selectedId = world_.getId(selectedDefender_);
     if (selectedId == SimWorld::EntityId::invalid)
@@ -479,6 +481,21 @@ private:
     if (!pos || !defender || !fx) return clearSelectedDefender();
 
     uiState_.selectedDefender = *pos;
+
+    // Refresh live stats into the summary, stamping `modified` only when
+    // the values actually change so the wire layer sends it selectively.
+    if (uiState_.defenderSummary) {
+      auto& summary = *uiState_.defenderSummary;
+      const auto* stats = world_.try_get_component<DefenderStats>(selectedId);
+      assert(stats);
+      if (stats->totalDamageDealt != summary.totalDamageDealt ||
+          stats->totalKills != summary.totalKills)
+      {
+        summary.totalDamageDealt = stats->totalDamageDealt;
+        summary.totalKills = stats->totalKills;
+        summary.modified = world_.currentTick();
+      }
+    }
     return true;
   }
 
@@ -570,7 +587,7 @@ private:
       std::get<std::optional<Invader>>(tpl) =
           Invader{.hitCircleRadius = 30.F, .bounty = 10};
       std::get<std::optional<Health>>(tpl) =
-          Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 10.F};
+          Health{.currentHealth = 10.F, .maxHealth = 100.F, .regen = 10.F};
       mapDesign_.entityDefs.try_emplace(def.entityName, std::move(def));
     }
     {

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -675,7 +675,7 @@ private:
       std::get<std::optional<Invader>>(tpl) =
           Invader{.hitCircleRadius = 30.F, .bounty = 10};
       std::get<std::optional<Health>>(tpl) =
-          Health{.currentHealth = 10.F, .maxHealth = 100.F, .regen = 10.F};
+          Health{.currentHealth = 50.F, .maxHealth = 50.F, .regen = 10.F};
       mapDesign_.entityDefs.try_emplace(def.entityName, std::move(def));
     }
     {
@@ -697,7 +697,7 @@ private:
       std::get<std::optional<Defender>>(
           tpl) = Defender{.hitCircleRadius = 30.F,
           .attackRadius = 100.F,
-          .rangeColor = 0xFFFF0000,
+          .rangeColor = 0xFFFF00FF,
           .attackDamage = 5.F,
           .cooldown = WorldTick{20},
           .nextAttack = WorldTick{0}};
@@ -719,14 +719,14 @@ private:
       std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'S',
           .radius = 25.F,
           .fgColor = 0xFFFFFFFF,
-          .bgColor = 0x7FFF7F3F,
+          .bgColor = 0x107F50FF,
           .attackRadius = 150.F};
       std::get<std::optional<VisualEffects>>(tpl) =
           VisualEffects{.flashColor = 0xFF7FFF7F, .flashExpiry = WorldTick{5}};
       std::get<std::optional<Defender>>(
           tpl) = Defender{.hitCircleRadius = 25.F,
           .attackRadius = 150.F,
-          .rangeColor = 0xFF00FF00,
+          .rangeColor = 0xFF00FFFF,
           .attackDamage = 15.F,
           .cooldown = WorldTick{30},
           .nextAttack = WorldTick{0}};
@@ -735,10 +735,10 @@ private:
           Health{.currentHealth = 80.F, .maxHealth = 80.F, .regen = 0.F};
       std::get<std::optional<DefenderShooter>>(tpl) = DefenderShooter{
           .bulletTemplate = DefenderBullet{.hitCircleRadius = 8.F,
-              .speed = 200.F,
-              .directDamage = 15.F,
+              .speed = 100.F,
+              .directDamage = 25.F,
               .projectileType = 1,
-              .expiry = WorldTick{60}},
+              .expiry = WorldTick{5}},
           .fireRate = 0.033F};
       mapDesign_.entityDefs.try_emplace(def.entityName, std::move(def));
     }
@@ -755,14 +755,14 @@ private:
       std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'L',
           .radius = 25.F,
           .fgColor = 0xFFFFFFFF,
-          .bgColor = 0x7FFF3F3F,
+          .bgColor = 0x7F7F3FFF,
           .attackRadius = 200.F};
       std::get<std::optional<VisualEffects>>(tpl) =
           VisualEffects{.flashColor = 0xFFFF4040, .flashExpiry = WorldTick{3}};
       std::get<std::optional<Defender>>(
           tpl) = Defender{.hitCircleRadius = 25.F,
           .attackRadius = 200.F,
-          .rangeColor = 0xFFFF0000,
+          .rangeColor = 0xFFFF00FF,
           .attackDamage = 30.F,
           .cooldown = WorldTick{25},
           .nextAttack = WorldTick{0}};

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -218,6 +218,7 @@ public:
     pendingSpawnIntent_.reset();
     pendingSelectIntent_.reset();
     pendingActionIntent_.reset();
+    pendingMoveIntent_.reset();
     selectedDefender_ = {};
     return true;
   }
@@ -302,6 +303,17 @@ public:
         return false;
 
       pendingPlacementIntent_ = input;
+      return true;
+    }
+
+    // Drag the selected defender to a new position.
+    if (input.command == "moving") {
+      if (input.event != UiCanvasEvent::dragstart &&
+          input.event != UiCanvasEvent::dragmove &&
+          input.event != UiCanvasEvent::dragend)
+        return false;
+
+      pendingMoveIntent_ = input;
       return true;
     }
 
@@ -410,6 +422,36 @@ private:
     return canPlaceDefender(findEntityDef(entityName), pos);
   }
 
+  // Apply a move-drag intent: validate placement and, on dragend, relocate
+  // the selected defender.
+  [[nodiscard]] bool applyMoveIntent(const UiCanvasInput& input) {
+    const auto newPos = Position{input.x, input.y};
+    const bool valid = canMoveDefender(newPos);
+    uiState_.placementAllowed = valid;
+    if (!valid || input.event != UiCanvasEvent::dragend) return true;
+    const auto selectedId = world_.getId(selectedDefender_);
+    if (selectedId == SimWorld::EntityId::invalid) return true;
+    if (auto* pos = world_.try_get_component<Position>(selectedId)) {
+      *pos = newPos;
+      (void)world_.markDirty(selectedId);
+      uiState_.selectedDefender = newPos;
+    }
+    return true;
+  }
+
+  // Determine whether the currently selected defender can be moved to `pos`.
+  // No resource check: relocation is free. The defender's own footprint is
+  // excluded from the overlap test so it can be "placed" at its origin.
+  [[nodiscard]] bool canMoveDefender(const Position& pos) {
+    if (phase_ != GamePhase::build) return false;
+    const auto selectedId = world_.getId(selectedDefender_);
+    if (selectedId == SimWorld::EntityId::invalid) return false;
+    const auto& [_pos, _app, _fx, defender] = world_.getDefender(selectedId);
+    if (!defender) return false;
+    return !world_.isDefenderPlacementBlocked(pos, defender->hitCircleRadius,
+        selectedId);
+  }
+
   // Build `DefenderSummary` for a selected defender by entity definition.
   [[nodiscard]] std::optional<DefenderSummary> buildSelectedDefenderSummary(
       const EntityDefinition* def) const {
@@ -470,6 +512,11 @@ private:
       const auto& input = *pendingSelectIntent_;
       (void)selectDefenderAt({input.x, input.y});
       pendingSelectIntent_.reset();
+    }
+
+    if (pendingMoveIntent_) {
+      (void)applyMoveIntent(*pendingMoveIntent_);
+      pendingMoveIntent_.reset();
     }
 
     if (pendingActionIntent_) {
@@ -808,6 +855,7 @@ private:
   std::optional<UiCanvasInput> pendingSpawnIntent_;
   std::optional<UiCanvasInput> pendingSelectIntent_;
   std::optional<UiActionInput> pendingActionIntent_;
+  std::optional<UiCanvasInput> pendingMoveIntent_;
 
   // Handle to the currently selected defender, used to clear its range
   // circle when deselected.

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -102,7 +102,7 @@ struct EnemySpawn {
 // All of the enemy spawns for a wave.
 struct WaveDefinition {
   std::vector<EnemySpawn> enemies; // Sorted by `startTicks`
-  int resourceInflux{};            // Resources rewarded at start of wave
+  uint32_t resourceInflux{};       // Resources rewarded at start of wave
 };
 
 // Top-level category in the build menu. Each category has its own `Appearance`
@@ -159,6 +159,7 @@ struct MapDesign {
   std::string backgroundSpriteFile;
   std::string foregroundSpriteFile;
   EntityDefinitions entityDefs;
+  EntityTemplateStore entityTemplateStore;
   DefenderMenu defenderMenu;
   std::vector<WaveDefinition> waves;
 };
@@ -219,21 +220,21 @@ public:
   // Load all maps from the maps directory and activate the first one.
   [[nodiscard]] bool loadMap() {
     (void)resetMap();
-    if (!doLoadMaps()) return false;
-    return selectMap(loadedMaps_.begin()->first);
+    if (loadedMaps().empty()) return false;
+    return selectMap(loadedMaps().begin()->first);
   }
 
   // Human-readable CSV dump of the currently selected map's invader and
   // defender definitions.
   [[nodiscard]] std::string buildCurrentMapEntityCsvReport() const {
-    return buildMapEntityCsvReport(mapDesign_);
+    return buildMapEntityCsvReport(*mapDesign_);
   }
 
   // Resets all map information.
   [[nodiscard]] bool resetMap() {
     world_.clear();
     phase_ = GamePhase::build;
-    mapDesign_ = {};
+    mapDesign_ = nullptr;
     currentWave_ = 0;
     waveTick_ = {};
     nextSpawnIndex_ = 0;
@@ -274,6 +275,7 @@ public:
 
       if (lives_ <= 0) {
         phase_ = GamePhase::game_over;
+        lives_ = 0;
         (void)refreshSelectedDefenderState();
         return true;
       }
@@ -288,13 +290,13 @@ public:
       resources_ = resources;
 
       // Wave is over when all enemies have been spawned and none remain.
-      const auto& wave = mapDesign_.waves[currentWave_];
+      const auto& wave = mapDesign_->waves[currentWave_];
       if (nextSpawnIndex_ >= wave.enemies.size() &&
           !world_.hasActiveInvaders())
       {
         ++currentWave_;
         phase_ =
-            (currentWave_ >= mapDesign_.waves.size())
+            (currentWave_ >= mapDesign_->waves.size())
                 ? GamePhase::victory
                 : GamePhase::build;
       }
@@ -313,7 +315,7 @@ public:
   // Player action: start the next wave.
   [[nodiscard]] bool start_wave() {
     if (phase_ != GamePhase::build) return false;
-    resources_ += mapDesign_.waves[currentWave_].resourceInflux;
+    resources_ += mapDesign_->waves[currentWave_].resourceInflux;
     phase_ = GamePhase::wave;
     waveTick_ = {};
     nextSpawnIndex_ = 0;
@@ -372,7 +374,7 @@ public:
   }
 
   // Access the current map design (for streaming and inspection).
-  [[nodiscard]] const MapDesign& mapDesign() const { return mapDesign_; }
+  [[nodiscard]] const MapDesign& mapDesign() const { return *mapDesign_; }
   [[nodiscard]] const UiState& uiState() const { return uiState_; }
 
   // Extract a snapshot of the paths for `WorldSnapshot`, calling back
@@ -433,7 +435,7 @@ private:
   // Find `EntityDefinition` by name.
   [[nodiscard]] const EntityDefinition* findEntityDef(
       std::string_view entityName) const {
-    return find_opt(mapDesign_.entityDefs, entityName);
+    return find_opt(mapDesign_->entityDefs, entityName);
   }
 
   // Determine whether an entity can be placed at a given position. We do not
@@ -629,21 +631,18 @@ private:
     return true;
   }
 
-  // Register all entities and build the defender menu from
-  // `mapDesign_.entityDefs`.
-  [[nodiscard]] bool registerEntityDefs() {
-    auto& defs = mapDesign_.entityDefs;
-    auto& menu = mapDesign_.defenderMenu;
-    menu.clear();
-
-    for (const auto& [name, def] : defs) {
-      if (!world_.registerEntity(def.entityName, def.megatuple))
+  // Populate `entityTemplateStore` and `defenderMenu` from `entityDefs`.
+  // Called once per map at load time, before the map enters the singleton.
+  static void finalizeMapDesign(MapDesign& design) {
+    for (const auto& [name, def] : design.entityDefs) {
+      if (!design.entityTemplateStore.registerEntity(def.entityName,
+              def.megatuple))
         throw std::runtime_error(
             "Failed to register entity: " + def.entityName);
       if (def.resourceCost == std::numeric_limits<uint32_t>::max()) continue;
       const auto& app_opt = std::get<std::optional<Appearance>>(def.megatuple);
       assert(app_opt);
-      menu.push_back({.entityName = def.entityName,
+      design.defenderMenu.push_back({.entityName = def.entityName,
           .displayName = def.displayName,
           .menuOrder = def.menuOrder,
           .category = def.category,
@@ -651,22 +650,22 @@ private:
           .resourceCost = def.resourceCost,
           .appearance = *app_opt});
     }
-    std::ranges::sort(menu,
+    std::ranges::sort(design.defenderMenu,
         [](const DefenderSummary& a, const DefenderSummary& b) {
           return a.menuOrder < b.menuOrder;
         });
-    return true;
   }
 
-  // Add each `PathJoints` from `mapDesign_.paths` to the world.
+  // Add each `PathJoints` from `mapDesign_->paths` to the world. Previous
+  // paths must first be cleared by `resetMap`.
   [[nodiscard]] bool registerPaths() {
-    for (const auto& pj : mapDesign_.paths) (void)world_.addPath(pj);
+    for (const auto& pj : mapDesign_->paths) (void)world_.addPath(pj);
     return true;
   }
 
   // Spawn all the enemies slated for this wave tick.
   void spawnPendingWaveEnemies() {
-    const auto& wave = mapDesign_.waves[currentWave_];
+    const auto& wave = mapDesign_->waves[currentWave_];
     const auto& enemies = wave.enemies;
     for (; nextSpawnIndex_ < enemies.size(); ++nextSpawnIndex_) {
       const auto& enemyDef = enemies[nextSpawnIndex_];
@@ -695,11 +694,7 @@ private:
   WaveTick waveTick_{};
 
   // All design-time data for the currently loaded map.
-  MapDesign mapDesign_;
-
-  // All maps loaded from disk, keyed by stem filename (e.g., "map1").
-  // Sorted alphabetically so the first entry is deterministic.
-  std::map<std::string, MapDesign> loadedMaps_;
+  const MapDesign* mapDesign_{};
 
   // Current wave.
   size_t currentWave_{};
@@ -747,13 +742,14 @@ private:
     return std::getenv("CORVID_SUPPRESS_MAP_ENTITY_CSV") == nullptr;
   }
 
-  // Load all `.json` files from the maps directory into `loadedMaps_`.
-  [[nodiscard]] bool doLoadMaps() {
-    loadedMaps_.clear();
+  // Load all `.json` files from the maps directory and return them keyed by
+  // stem filename (e.g., "map1"), sorted alphabetically.
+  [[nodiscard]] static string_map<MapDesign> doLoadMaps() {
+    string_map<MapDesign> maps;
     const auto dir = findSimMapsDir();
     if (dir.empty()) {
       std::cerr << "Maps directory not found\n";
-      return false;
+      return maps;
     }
     std::error_code ec;
     for (const auto& entry : std::filesystem::directory_iterator(dir, ec)) {
@@ -763,19 +759,28 @@ private:
         std::cerr << "Failed to load map: " << entry.path() << "\n";
         continue;
       }
+      finalizeMapDesign(design);
       if (shouldEmitMapEntityCsvReport())
         std::cout << buildMapEntityCsvReport(design);
-      loadedMaps_.emplace(entry.path().stem().string(), std::move(design));
+      maps.emplace(entry.path().stem().string(), std::move(design));
     }
-    return !loadedMaps_.empty();
+    return maps;
+  }
+
+  // All maps loaded from disk, keyed by stem filename (e.g., "map1").
+  // Sorted alphabetically so the first entry is deterministic.
+  [[nodiscard]] static const string_map<MapDesign>& loadedMaps() {
+    static const auto maps = doLoadMaps();
+    return maps;
   }
 
   // Copy the named map into `mapDesign_` and register its entities and paths.
   [[nodiscard]] bool selectMap(std::string_view name) {
-    auto it = loadedMaps_.find(std::string{name});
-    if (it == loadedMaps_.end()) return false;
-    mapDesign_ = it->second;
-    return registerEntityDefs() && registerPaths();
+    auto found = find_opt(loadedMaps(), name);
+    if (!found) return false;
+    mapDesign_ = found;
+    world_.setEntityTemplateStore(&mapDesign_->entityTemplateStore);
+    return registerPaths();
   }
 };
 

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -642,6 +642,7 @@ private:
             "Failed to register entity: " + def.entityName);
       if (def.resourceCost == std::numeric_limits<uint32_t>::max()) continue;
       const auto& app_opt = std::get<std::optional<Appearance>>(def.megatuple);
+      assert(app_opt);
       menu.push_back({.entityName = def.entityName,
           .displayName = def.displayName,
           .menuOrder = def.menuOrder,
@@ -742,6 +743,10 @@ private:
   [[nodiscard]] static std::string buildMapEntityCsvReport(
       const MapDesign& design);
 
+  [[nodiscard]] static bool shouldEmitMapEntityCsvReport() {
+    return std::getenv("CORVID_SUPPRESS_MAP_ENTITY_CSV") == nullptr;
+  }
+
   // Load all `.json` files from the maps directory into `loadedMaps_`.
   [[nodiscard]] bool doLoadMaps() {
     loadedMaps_.clear();
@@ -758,7 +763,8 @@ private:
         std::cerr << "Failed to load map: " << entry.path() << "\n";
         continue;
       }
-      std::cout << buildMapEntityCsvReport(design);
+      if (shouldEmitMapEntityCsvReport())
+        std::cout << buildMapEntityCsvReport(design);
       loadedMaps_.emplace(entry.path().stem().string(), std::move(design));
     }
     return !loadedMaps_.empty();
@@ -775,6 +781,7 @@ private:
 
 // Parse a single map JSON file into `out`. The caller is responsible for
 // calling `registerEntityDefs()` and `registerPaths()` afterward.
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 [[nodiscard]] inline bool
 SimGame::loadMapFromJson(const std::filesystem::path& file, MapDesign& out) {
   // Slurp the file.
@@ -1054,6 +1061,7 @@ SimGame::loadMapFromJson(const std::filesystem::path& file, MapDesign& out) {
 
   return true;
 }
+// NOLINTEND(readability-function-cognitive-complexity)
 
 [[nodiscard]] inline std::string SimGame::buildMapEntityCsvReport(
     const MapDesign& design) {
@@ -1093,6 +1101,7 @@ SimGame::loadMapFromJson(const std::filesystem::path& file, MapDesign& out) {
     const auto& invader = std::get<std::optional<Invader>>(def->megatuple);
     const auto& app = std::get<std::optional<Appearance>>(def->megatuple);
     const auto& health = std::get<std::optional<Health>>(def->megatuple);
+    assert(pathing && invader && app && health);
     oss << csv_escape(def->entityName) << ',' << invader->hitCircleRadius
         << ',' << pathing->speed << ',' << app->radius << ','
         << health->currentHealth << ',' << health->regen << ','
@@ -1104,6 +1113,7 @@ SimGame::loadMapFromJson(const std::filesystem::path& file, MapDesign& out) {
   for (const auto* def : defenders) {
     const auto& defender = std::get<std::optional<Defender>>(def->megatuple);
     const auto& app = std::get<std::optional<Appearance>>(def->megatuple);
+    assert(defender && app);
     oss << csv_escape(def->entityName) << ',' << def->resourceCost << ','
         << app->radius << ',' << defender->attackRadius << ','
         << defender->attackDamage << ',' << *defender->cooldown << '\n';

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -20,6 +20,7 @@
 #include <fstream>
 #include <map>
 #include <optional>
+#include <sstream>
 #include <sys/types.h>
 
 #include <algorithm>
@@ -220,6 +221,12 @@ public:
     (void)resetMap();
     if (!doLoadMaps()) return false;
     return selectMap(loadedMaps_.begin()->first);
+  }
+
+  // Human-readable CSV dump of the currently selected map's invader and
+  // defender definitions.
+  [[nodiscard]] std::string buildCurrentMapEntityCsvReport() const {
+    return buildMapEntityCsvReport(mapDesign_);
   }
 
   // Resets all map information.
@@ -732,6 +739,9 @@ private:
   [[nodiscard]] static bool
   loadMapFromJson(const std::filesystem::path& file, MapDesign& out);
 
+  [[nodiscard]] static std::string buildMapEntityCsvReport(
+      const MapDesign& design);
+
   // Load all `.json` files from the maps directory into `loadedMaps_`.
   [[nodiscard]] bool doLoadMaps() {
     loadedMaps_.clear();
@@ -748,6 +758,7 @@ private:
         std::cerr << "Failed to load map: " << entry.path() << "\n";
         continue;
       }
+      std::cout << buildMapEntityCsvReport(design);
       loadedMaps_.emplace(entry.path().stem().string(), std::move(design));
     }
     return !loadedMaps_.empty();
@@ -1042,6 +1053,62 @@ SimGame::loadMapFromJson(const std::filesystem::path& file, MapDesign& out) {
   }
 
   return true;
+}
+
+[[nodiscard]] inline std::string SimGame::buildMapEntityCsvReport(
+    const MapDesign& design) {
+  auto csv_escape = [](std::string_view value) {
+    std::string out;
+    out.reserve(value.size() + 2);
+    const bool needs_quotes =
+        value.contains(',') || value.contains('"') || value.contains('\n');
+    if (!needs_quotes) return std::string{value};
+    out.push_back('"');
+    for (const char ch : value) {
+      if (ch == '"') out.push_back('"');
+      out.push_back(ch);
+    }
+    out.push_back('"');
+    return out;
+  };
+
+  std::vector<const EntityDefinition*> invaders;
+  std::vector<const EntityDefinition*> defenders;
+  for (const auto& [_, def] : design.entityDefs)
+    if (std::get<std::optional<Defender>>(def.megatuple))
+      defenders.push_back(&def);
+    else if (std::get<std::optional<Invader>>(def.megatuple))
+      invaders.push_back(&def);
+
+  auto by_name = [](const EntityDefinition* lhs, const EntityDefinition* rhs) {
+    return lhs->entityName < rhs->entityName;
+  };
+  std::ranges::sort(invaders, by_name);
+  std::ranges::sort(defenders, by_name);
+
+  std::ostringstream oss;
+  oss << "entityName,Radius,Speed,Radius,Health,Regen,Bounty\n";
+  for (const auto* def : invaders) {
+    const auto& pathing = std::get<std::optional<Pathing>>(def->megatuple);
+    const auto& invader = std::get<std::optional<Invader>>(def->megatuple);
+    const auto& app = std::get<std::optional<Appearance>>(def->megatuple);
+    const auto& health = std::get<std::optional<Health>>(def->megatuple);
+    oss << csv_escape(def->entityName) << ',' << invader->hitCircleRadius
+        << ',' << pathing->speed << ',' << app->radius << ','
+        << health->currentHealth << ',' << health->regen << ','
+        << invader->bounty << '\n';
+  }
+
+  oss << "\nentityName,resourceCost,radius,attackRadius,attackDamage,"
+         "cooldown\n";
+  for (const auto* def : defenders) {
+    const auto& defender = std::get<std::optional<Defender>>(def->megatuple);
+    const auto& app = std::get<std::optional<Appearance>>(def->megatuple);
+    oss << csv_escape(def->entityName) << ',' << def->resourceCost << ','
+        << app->radius << ',' << defender->attackRadius << ','
+        << defender->attackDamage << ',' << *defender->cooldown << '\n';
+  }
+  return oss.str();
 }
 
 }} // namespace corvid::sim

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -247,7 +247,8 @@ public:
   // to clients.
   [[nodiscard]] bool next() {
     (void)evaluatePendingUiIntents();
-    (void)world_.next();
+    if (phase_ == GamePhase::build || phase_ == GamePhase::wave)
+      (void)world_.next();
 
     if (phase_ == GamePhase::wave) {
       ++waveTick_;
@@ -264,6 +265,12 @@ public:
           });
       lives_ = lives;
 
+      if (lives_ <= 0) {
+        phase_ = GamePhase::game_over;
+        (void)refreshSelectedDefenderState();
+        return true;
+      }
+
       auto resources = resources_;
       (void)world_.resolveKills(
           [&resources](SimWorld::EntityId, const Position&,
@@ -273,20 +280,16 @@ public:
           });
       resources_ = resources;
 
-      if (lives_ <= 0) {
-        phase_ = GamePhase::game_over;
-      } else {
-        // Wave is over when all enemies have been spawned and none remain.
-        const auto& wave = mapDesign_.waves[currentWave_];
-        if (nextSpawnIndex_ >= wave.enemies.size() &&
-            !world_.hasActiveInvaders())
-        {
-          ++currentWave_;
-          phase_ =
-              (currentWave_ >= mapDesign_.waves.size())
-                  ? GamePhase::victory
-                  : GamePhase::build;
-        }
+      // Wave is over when all enemies have been spawned and none remain.
+      const auto& wave = mapDesign_.waves[currentWave_];
+      if (nextSpawnIndex_ >= wave.enemies.size() &&
+          !world_.hasActiveInvaders())
+      {
+        ++currentWave_;
+        phase_ =
+            (currentWave_ >= mapDesign_.waves.size())
+                ? GamePhase::victory
+                : GamePhase::build;
       }
     }
     (void)refreshSelectedDefenderState();

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -734,7 +734,8 @@ private:
       std::get<std::optional<Health>>(tpl) =
           Health{.currentHealth = 80.F, .maxHealth = 80.F, .regen = 0.F};
       std::get<std::optional<DefenderShooter>>(tpl) = DefenderShooter{
-          .bulletTemplate = DefenderBullet{.speed = 200.F,
+          .bulletTemplate = DefenderBullet{.hitCircleRadius = 8.F,
+              .speed = 200.F,
               .directDamage = 15.F,
               .projectileType = 1,
               .expiry = WorldTick{60}},

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -976,8 +976,8 @@ SimGame::loadMapFromJson(const std::filesystem::path& file, MapDesign& out) {
             s.bulletTemplate.expiry = WorldTick{*v};
         }
         if (const auto mo = so.get_object("muzzleFlash")) {
-          if (const auto v = mo.get_number<float>("startDistance"))
-            s.muzzleFlashTemplate.startDistance = *v;
+          if (const auto v = mo.get_number<float>("radius"))
+            s.muzzleFlashTemplate.circle.radius = *v;
           if (const auto v = mo.get_number<uint32_t>("expiry"))
             s.muzzleFlashTemplate.expiry = WorldTick{*v};
           (void)parse_color(mo, "primaryColor",
@@ -993,8 +993,8 @@ SimGame::loadMapFromJson(const std::filesystem::path& file, MapDesign& out) {
       // Hitscan (instant-beam) attack.
       if (const auto hso = eo.get_object("defenderHitscan")) {
         TransientBeam beam;
-        if (const auto v = hso.get_number<float>("startDistance"))
-          beam.startDistance = *v;
+        if (const auto v = hso.get_number<float>("radius"))
+          beam.circle.radius = *v;
         if (const auto v = hso.get_number<uint32_t>("expiry"))
           beam.expiry = WorldTick{*v};
         (void)parse_color(hso, "primaryColor", beam.primaryColor);

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -15,13 +15,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #pragma once
+#include <charconv>
+#include <filesystem>
+#include <fstream>
+#include <map>
 #include <optional>
 #include <sys/types.h>
 
+#include <algorithm>
+#include <iostream>
 #include <string>
 #include <string_view>
 #include <utility>
 
+#include "../proto/json_parser.h"
 #include "sim_world.h"
 
 // SimGame: encapsulates the game rules and flow, using SimWorld for state and
@@ -97,12 +104,23 @@ struct WaveDefinition {
   int resourceInflux{};            // Resources rewarded at start of wave
 };
 
+// Top-level category in the build menu. Each category has its own `Appearance`
+// (including the glyph that doubles as a hotkey) and a `flavorText` shown when
+// hovering over the category cell.
+struct CategoryDefinition {
+  std::string name; // Matches the `category` field on `EntityDefinition`.
+  std::string displayName; // Human-readable label.
+  std::string flavorText;  // Shown in the info box on hover.
+  Appearance appearance;   // Glyph, radius, and colors for the category cell.
+};
+
 // Full definition of one entity type, combining display metadata with the
 // component template used to register and spawn it.
 struct EntityDefinition {
   std::string entityName;  // Unique identifier.
   std::string displayName; // Human-readable name.
-  int menuOrder{};         // Display order.
+  int menuOrder{};         // Display order within the category.
+  std::string category;    // Top-level menu category (e.g., "area", "laser").
   std::string flavorText;  // Description of its capabilities.
   // `max()` means "not for sale" (all invaders default to this).
   uint32_t resourceCost{std::numeric_limits<uint32_t>::max()};
@@ -119,6 +137,7 @@ struct DefenderSummary {
   std::string entityName;
   std::string displayName;
   int menuOrder{}; // Used for menu items.
+  std::string category;
   std::string flavorText;
   uint32_t resourceCost{};
   Appearance appearance;    // Extracted from megatuple at build time.
@@ -134,6 +153,7 @@ using DefenderMenu = std::vector<DefenderSummary>;
 // derived defender menu, and wave schedule. Self-contained so that
 // `SimGame` can hold multiple `MapDesign`s, all read in from map files.
 struct MapDesign {
+  std::vector<CategoryDefinition> categories; // Top-level menu categories.
   std::vector<PathJoints> paths;
   std::string backgroundSpriteFile;
   std::string foregroundSpriteFile;
@@ -195,12 +215,11 @@ class SimGame {
 public:
   explicit SimGame() { (void)resetMap(); }
 
-  // Load the chosen map, resetting all game state.
+  // Load all maps from the maps directory and activate the first one.
   [[nodiscard]] bool loadMap() {
     (void)resetMap();
-    // TODO: Have multiple maps.
-    (void)doLoadMap1();
-    return true;
+    if (!doLoadMaps()) return false;
+    return selectMap(loadedMaps_.begin()->first);
   }
 
   // Resets all map information.
@@ -468,6 +487,7 @@ private:
     return DefenderSummary{.modified = world_.currentTick(),
         .entityName = def->entityName,
         .displayName = def->displayName,
+        .category = def->category,
         .flavorText = def->flavorText,
         .resourceCost = def->resourceCost,
         .appearance = *app_opt};
@@ -615,6 +635,7 @@ private:
       menu.push_back({.entityName = def.entityName,
           .displayName = def.displayName,
           .menuOrder = def.menuOrder,
+          .category = def.category,
           .flavorText = def.flavorText,
           .resourceCost = def.resourceCost,
           .appearance = *app_opt});
@@ -652,192 +673,6 @@ private:
     }
   }
 
-  // Ugly placeholder for map loading.
-  [[nodiscard]] bool doLoadMap1() {
-    (void)resetMap();
-
-    // Entity definitions. This is the single site that will later be
-    // replaced by CSV/JSON parsing.
-    {
-      EntityDefinition def;
-      def.entityName = "InvaderAlphaBasic";
-      // `resourceCost` stays `max()` (not for sale).
-      auto& tpl = def.megatuple;
-      std::get<std::optional<Position>>(tpl) = Position{};
-      std::get<std::optional<Appearance>>(
-          tpl) = Appearance{.glyph = U'\u03B1', // Greek alpha
-          .radius = 30.F,
-          .fgColor = 0xFFFFFFFF,
-          .bgColor = 0x000000FF};
-      std::get<std::optional<VisualEffects>>(tpl) = VisualEffects{};
-      std::get<std::optional<Pathing>>(tpl) =
-          Pathing{.pathId = PathId::invalid, .progress = 0.F, .speed = 50.F};
-      std::get<std::optional<Invader>>(tpl) =
-          Invader{.hitCircleRadius = 30.F, .bounty = 10};
-      std::get<std::optional<Health>>(tpl) =
-          Health{.currentHealth = 50.F, .maxHealth = 50.F, .regen = 10.F};
-      mapDesign_.entityDefs.try_emplace(def.entityName, std::move(def));
-    }
-    {
-      EntityDefinition def;
-      def.entityName = "DefenderAoeBasic";
-      def.displayName = "AoE Defender";
-      def.menuOrder = 1;
-      def.flavorText = "Damages all enemies in range.";
-      def.resourceCost = 50U;
-      auto& tpl = def.megatuple;
-      std::get<std::optional<Position>>(tpl) = Position{};
-      std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'A',
-          .radius = 30.F,
-          .fgColor = 0xFFFFFFFF,
-          .bgColor = 0x7F7FFFFF,
-          .attackRadius = 100.F};
-      std::get<std::optional<VisualEffects>>(tpl) =
-          VisualEffects{.flashColor = 0xFF7F7FFF, .flashExpiry = WorldTick{5}};
-      std::get<std::optional<Defender>>(
-          tpl) = Defender{.hitCircleRadius = 30.F,
-          .attackRadius = 100.F,
-          .rangeColor = 0xFFFF00FF,
-          .attackDamage = 5.F,
-          .cooldown = WorldTick{20},
-          .nextAttack = WorldTick{0}};
-      std::get<std::optional<DefenderStats>>(tpl) = DefenderStats{};
-      std::get<std::optional<Health>>(tpl) =
-          Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 0.F};
-      std::get<std::optional<DefenderAoe>>(tpl) = DefenderAoe{.damageType = 1};
-      mapDesign_.entityDefs.try_emplace(def.entityName, std::move(def));
-    }
-    {
-      EntityDefinition def;
-      def.entityName = "DefenderShooterBasic";
-      def.displayName = "Shooter";
-      def.menuOrder = 2;
-      def.flavorText = "Fires projectiles at a single target.";
-      def.resourceCost = 75U;
-      auto& tpl = def.megatuple;
-      std::get<std::optional<Position>>(tpl) = Position{};
-      std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'S',
-          .radius = 25.F,
-          .fgColor = 0xFFFFFFFF,
-          .bgColor = 0x107F50FF,
-          .attackRadius = 150.F};
-      std::get<std::optional<VisualEffects>>(tpl) =
-          VisualEffects{.flashColor = 0xFF7FFF7F, .flashExpiry = WorldTick{5}};
-      std::get<std::optional<Defender>>(
-          tpl) = Defender{.hitCircleRadius = 25.F,
-          .attackRadius = 150.F,
-          .rangeColor = 0xFF00FFFF,
-          .attackDamage = 15.F,
-          .cooldown = WorldTick{30},
-          .nextAttack = WorldTick{0}};
-      std::get<std::optional<DefenderStats>>(tpl) = DefenderStats{};
-      std::get<std::optional<Health>>(tpl) =
-          Health{.currentHealth = 80.F, .maxHealth = 80.F, .regen = 0.F};
-      std::get<std::optional<DefenderShooter>>(tpl) = DefenderShooter{
-          .bulletTemplate = DefenderBullet{.hitCircleRadius = 8.F,
-              .speed = 100.F,
-              .directDamage = 25.F,
-              .projectileType = 1,
-              .expiry = WorldTick{5}},
-          .fireRate = 0.033F};
-      mapDesign_.entityDefs.try_emplace(def.entityName, std::move(def));
-    }
-    {
-      EntityDefinition def;
-      def.entityName = "DefenderHitscanBasic";
-      def.displayName = "Laser";
-      def.menuOrder = 3;
-      def.flavorText =
-          "Instantly damages a single target with an infrared laser beam.";
-      def.resourceCost = 100U;
-      auto& tpl = def.megatuple;
-      std::get<std::optional<Position>>(tpl) = Position{};
-      std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'L',
-          .radius = 25.F,
-          .fgColor = 0xFFFFFFFF,
-          .bgColor = 0x7F7F3FFF,
-          .attackRadius = 200.F};
-      std::get<std::optional<VisualEffects>>(tpl) =
-          VisualEffects{.flashColor = 0xFFFF4040, .flashExpiry = WorldTick{3}};
-      std::get<std::optional<Defender>>(
-          tpl) = Defender{.hitCircleRadius = 25.F,
-          .attackRadius = 200.F,
-          .rangeColor = 0xFFFF00FF,
-          .attackDamage = 30.F,
-          .cooldown = WorldTick{25},
-          .nextAttack = WorldTick{0}};
-      std::get<std::optional<DefenderStats>>(tpl).emplace();
-      std::get<std::optional<Health>>(tpl) =
-          Health{.currentHealth = 75.F, .maxHealth = 75.F, .regen = 0.F};
-      std::get<std::optional<DefenderHitscan>>(tpl).emplace(TransientBeam{
-          .startDistance = 25.F,
-          .expiry = WorldTick{3},
-          .primaryColor = 0xFFFF4040,
-          .secondaryColor = 0xFFFFD080,
-          .lineWidth = 8.F});
-      mapDesign_.entityDefs.try_emplace(def.entityName, std::move(def));
-    }
-
-    // Path geometry (sprite files empty until sprites are added).
-    {
-      PathJoints p;
-      p.joints.push_back({Position{0.0, 0.0}});
-      constexpr float kHalfWidth = SimWorld::widthOfWorld / 2.F;
-      constexpr float kHalfHeight = SimWorld::heightOfWorld / 2.F;
-      constexpr float kStepSize = 120.0;
-      constexpr float kAspect =
-          SimWorld::widthOfWorld / SimWorld::heightOfWorld;
-      constexpr float kXStepSize = kStepSize * kAspect;
-      float x = 0.0;
-      float y = 0.0;
-      float x_run = kXStepSize;
-      float y_run = kStepSize;
-      auto append_segment = [&](float dx, float dy) {
-        x = std::clamp(x + dx, -kHalfWidth, kHalfWidth);
-        y = std::clamp(y + dy, -kHalfHeight, kHalfHeight);
-        p.joints.push_back({Position{x, y}});
-        return x > -kHalfWidth && x < kHalfWidth && y > -kHalfHeight &&
-               y < kHalfHeight;
-      };
-      while (true) {
-        if (!append_segment(x_run, 0.F)) break;
-        if (!append_segment(0.F, y_run)) break;
-        x_run += kXStepSize;
-        if (!append_segment(-x_run, 0.F)) break;
-        y_run += kStepSize;
-        if (!append_segment(0.F, -y_run)) break;
-        x_run += kXStepSize;
-        y_run += kStepSize;
-      }
-      mapDesign_.paths.push_back(std::move(p));
-    }
-
-    // Wave definitions.
-    {
-      WaveDefinition wave;
-      wave.resourceInflux = 0; // Starting resources come from resetMap.
-      for (uint32_t i = 0; i < 20; ++i)
-        wave.enemies.push_back({WaveTick{i * 20}, "InvaderAlphaBasic"});
-      mapDesign_.waves.push_back(std::move(wave));
-    }
-    {
-      WaveDefinition wave;
-      wave.resourceInflux = 150; // Bonus resources at the start of wave 2.
-      for (uint32_t i = 0; i < 35; ++i)
-        wave.enemies.push_back({WaveTick{i * 15}, "InvaderAlphaBasic"});
-      mapDesign_.waves.push_back(std::move(wave));
-    }
-    {
-      WaveDefinition wave;
-      wave.resourceInflux = 250; // Bonus resources at the start of wave 3.
-      for (uint32_t i = 0; i < 45; ++i)
-        wave.enemies.push_back({WaveTick{i * 10}, "InvaderAlphaBasic"});
-      mapDesign_.waves.push_back(std::move(wave));
-    }
-
-    return registerEntityDefs() && registerPaths();
-  }
-
 private:
   SimWorld world_;
 
@@ -850,6 +685,10 @@ private:
 
   // All design-time data for the currently loaded map.
   MapDesign mapDesign_;
+
+  // All maps loaded from disk, keyed by stem filename (e.g., "map1").
+  // Sorted alphabetically so the first entry is deterministic.
+  std::map<std::string, MapDesign> loadedMaps_;
 
   // Current wave.
   size_t currentWave_{};
@@ -871,5 +710,335 @@ private:
   // Handle to the currently selected defender, used to clear its range
   // circle when deselected.
   SimWorld::Handle selectedDefender_;
+
+  // Walk up from the executable to find the `corvid/sim/maps` directory.
+  [[nodiscard]] static std::filesystem::path findSimMapsDir() {
+    std::error_code ec;
+    auto exe = std::filesystem::read_symlink("/proc/self/exe", ec);
+    if (ec) return {};
+    for (auto dir = exe.parent_path(); dir != dir.parent_path();
+        dir = dir.parent_path())
+    {
+      auto candidate = dir / "corvid/sim/maps";
+      if (std::filesystem::is_directory(candidate, ec)) return candidate;
+    }
+    return {};
+  }
+
+  // Parse a single map JSON file into `out`. Returns false on any error.
+  [[nodiscard]] static bool
+  loadMapFromJson(const std::filesystem::path& file, MapDesign& out);
+
+  // Load all `.json` files from the maps directory into `loadedMaps_`.
+  [[nodiscard]] bool doLoadMaps() {
+    loadedMaps_.clear();
+    const auto dir = findSimMapsDir();
+    if (dir.empty()) {
+      std::cerr << "Maps directory not found\n";
+      return false;
+    }
+    std::error_code ec;
+    for (const auto& entry : std::filesystem::directory_iterator(dir, ec)) {
+      if (entry.path().extension() != ".json") continue;
+      MapDesign design;
+      if (!loadMapFromJson(entry.path(), design)) {
+        std::cerr << "Failed to load map: " << entry.path() << "\n";
+        continue;
+      }
+      loadedMaps_.emplace(entry.path().stem().string(), std::move(design));
+    }
+    return !loadedMaps_.empty();
+  }
+
+  // Copy the named map into `mapDesign_` and register its entities and paths.
+  [[nodiscard]] bool selectMap(std::string_view name) {
+    auto it = loadedMaps_.find(std::string{name});
+    if (it == loadedMaps_.end()) return false;
+    mapDesign_ = it->second;
+    return registerEntityDefs() && registerPaths();
+  }
 };
+
+// Parse a single map JSON file into `out`. The caller is responsible for
+// calling `registerEntityDefs()` and `registerPaths()` afterward.
+[[nodiscard]] inline bool
+SimGame::loadMapFromJson(const std::filesystem::path& file, MapDesign& out) {
+  // Slurp the file.
+  std::ifstream ifs{file};
+  if (!ifs.is_open()) {
+    std::cerr << "Cannot open map file: " << file << "\n";
+    return false;
+  }
+  const std::string content{std::istreambuf_iterator<char>(ifs),
+      std::istreambuf_iterator<char>()};
+
+  // Parse top-level object.
+  json_value_view root;
+  if (!parse_json(content, root) || !root.is_object()) {
+    std::cerr << "JSON parse error in: " << file << "\n";
+    return false;
+  }
+  const auto obj = root.as_object();
+
+  // Decode an optional string key into `result` (unchanged if absent).
+  auto opt_str =
+      [](json_object_view o, std::string_view key, std::string& result) {
+        if (const auto v = o.find(key)) (void)v.decode_string(result);
+      };
+
+  // Parse a color value from `key` into `result`. Accepts a "0xRRGGBBAA"
+  // hex string or a plain decimal integer. Returns false if key is absent or
+  // the value cannot be parsed; `result` is unchanged on failure.
+  auto parse_color =
+      [](json_object_view o, std::string_view key, uint32_t& result) -> bool {
+    const auto v = o.find(key);
+    if (!v) return false;
+    if (const auto sv = v.string_view_if_plain()) {
+      auto s = *sv;
+      if (s.size() > 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X')) {
+        s.remove_prefix(2);
+        uint32_t parsed{};
+        auto [ptr, ec] =
+            std::from_chars(s.data(), s.data() + s.size(), parsed, 16);
+        if (ec == std::errc{} && ptr == s.data() + s.size()) {
+          result = parsed;
+          return true;
+        }
+        return false;
+      }
+    }
+    if (const auto n = v.as_number<uint32_t>()) {
+      result = *n;
+      return true;
+    }
+    return false;
+  };
+
+  // Parse "categories" array.
+  if (const auto cats = obj.get_array("categories")) {
+    for (const auto elem : cats) {
+      if (!elem.is_object()) continue;
+      const auto co = elem.as_object();
+      CategoryDefinition cat;
+      opt_str(co, "name", cat.name);
+      if (cat.name.empty()) continue;
+      opt_str(co, "displayName", cat.displayName);
+      opt_str(co, "flavorText", cat.flavorText);
+      if (const auto app = co.get_object("appearance")) {
+        uint32_t glyph{};
+        (void)app.parse_number("glyph", glyph);
+        cat.appearance.glyph = static_cast<char32_t>(glyph);
+        (void)app.parse_number("radius", cat.appearance.radius);
+        (void)parse_color(app, "fgColor", cat.appearance.fgColor);
+        (void)parse_color(app, "bgColor", cat.appearance.bgColor);
+        if (const auto v = app.get_number<float>("attackRadius"))
+          cat.appearance.attackRadius = *v;
+      }
+      out.categories.push_back(std::move(cat));
+    }
+  }
+
+  // Parse "entities" array.
+  if (const auto ents = obj.get_array("entities")) {
+    for (const auto elem : ents) {
+      if (!elem.is_object()) continue;
+      const auto eo = elem.as_object();
+
+      EntityDefinition def;
+      opt_str(eo, "entityName", def.entityName);
+      if (def.entityName.empty()) continue;
+      opt_str(eo, "displayName", def.displayName);
+      opt_str(eo, "category", def.category);
+      opt_str(eo, "flavorText", def.flavorText);
+      if (const auto v = eo.get_number<int>("menuOrder")) def.menuOrder = *v;
+      // Absent `resourceCost` leaves the default `max()` = not for sale.
+      if (const auto v = eo.get_number<uint32_t>("resourceCost"))
+        def.resourceCost = *v;
+
+      auto& tpl = def.megatuple;
+
+      // Position (always present when the entity has world placement).
+      if (eo.find("position"))
+        std::get<std::optional<Position>>(tpl) = Position{};
+
+      // Appearance.
+      if (const auto app = eo.get_object("appearance")) {
+        Appearance a;
+        uint32_t glyph{};
+        (void)app.parse_number("glyph", glyph);
+        a.glyph = static_cast<char32_t>(glyph);
+        (void)app.parse_number("radius", a.radius);
+        (void)parse_color(app, "fgColor", a.fgColor);
+        (void)parse_color(app, "bgColor", a.bgColor);
+        if (const auto v = app.get_number<float>("attackRadius"))
+          a.attackRadius = *v;
+        std::get<std::optional<Appearance>>(tpl) = a;
+      }
+
+      // VisualEffects (key presence required; value may be empty `{}`).
+      if (eo.find("visualEffects")) {
+        VisualEffects vfx;
+        if (const auto vo = eo.get_object("visualEffects")) {
+          (void)parse_color(vo, "flashColor", vfx.flashColor);
+          if (const auto v = vo.get_number<uint32_t>("flashExpiry"))
+            vfx.flashExpiry = WorldTick{*v};
+        }
+        std::get<std::optional<VisualEffects>>(tpl) = vfx;
+      }
+
+      // Pathing (invaders only).
+      if (const auto po = eo.get_object("pathing")) {
+        Pathing p{.pathId = PathId::invalid};
+        if (const auto v = po.get_number<float>("speed")) p.speed = *v;
+        std::get<std::optional<Pathing>>(tpl) = p;
+      }
+
+      // Invader component.
+      if (const auto io = eo.get_object("invader")) {
+        Invader inv;
+        if (const auto v = io.get_number<float>("hitCircleRadius"))
+          inv.hitCircleRadius = *v;
+        if (const auto v = io.get_number<uint32_t>("bounty")) inv.bounty = *v;
+        std::get<std::optional<Invader>>(tpl) = inv;
+      }
+
+      // Health.
+      if (const auto ho = eo.get_object("health")) {
+        Health h;
+        if (const auto v = ho.get_number<float>("currentHealth"))
+          h.currentHealth = *v;
+        if (const auto v = ho.get_number<float>("maxHealth")) h.maxHealth = *v;
+        if (const auto v = ho.get_number<float>("regen")) h.regen = *v;
+        std::get<std::optional<Health>>(tpl) = h;
+      }
+
+      // Defender base component.
+      if (const auto dfo = eo.get_object("defender")) {
+        Defender d;
+        if (const auto v = dfo.get_number<float>("hitCircleRadius"))
+          d.hitCircleRadius = *v;
+        if (const auto v = dfo.get_number<float>("attackRadius"))
+          d.attackRadius = *v;
+        (void)parse_color(dfo, "rangeColor", d.rangeColor);
+        if (const auto v = dfo.get_number<float>("attackDamage"))
+          d.attackDamage = *v;
+        if (const auto v = dfo.get_number<uint32_t>("cooldown"))
+          d.cooldown = WorldTick{*v};
+        std::get<std::optional<Defender>>(tpl) = d;
+      }
+
+      // DefenderStats (key presence is sufficient; value is empty `{}`).
+      if (eo.find("defenderStats"))
+        std::get<std::optional<DefenderStats>>(tpl) = DefenderStats{};
+
+      // Area-of-effect attack.
+      if (const auto ao = eo.get_object("defenderAoe")) {
+        DefenderAoe a;
+        if (const auto v = ao.get_number<int>("damageType")) a.damageType = *v;
+        std::get<std::optional<DefenderAoe>>(tpl) = a;
+      }
+
+      // Projectile attack.
+      if (const auto so = eo.get_object("defenderShooter")) {
+        DefenderShooter s;
+        if (const auto v = so.get_number<float>("fireRate")) s.fireRate = *v;
+        if (const auto bo = so.get_object("bullet")) {
+          if (const auto v = bo.get_number<float>("hitCircleRadius"))
+            s.bulletTemplate.hitCircleRadius = *v;
+          if (const auto v = bo.get_number<float>("speed"))
+            s.bulletTemplate.speed = *v;
+          if (const auto v = bo.get_number<float>("directDamage"))
+            s.bulletTemplate.directDamage = *v;
+          if (const auto v = bo.get_number<int>("projectileType"))
+            s.bulletTemplate.projectileType = *v;
+          if (const auto v = bo.get_number<uint32_t>("expiry"))
+            s.bulletTemplate.expiry = WorldTick{*v};
+        }
+        if (const auto mo = so.get_object("muzzleFlash")) {
+          if (const auto v = mo.get_number<float>("startDistance"))
+            s.muzzleFlashTemplate.startDistance = *v;
+          if (const auto v = mo.get_number<uint32_t>("expiry"))
+            s.muzzleFlashTemplate.expiry = WorldTick{*v};
+          (void)parse_color(mo, "primaryColor",
+              s.muzzleFlashTemplate.primaryColor);
+          if (const auto v = mo.get_number<float>("halfAngleDeg"))
+            s.muzzleFlashTemplate.halfAngleDeg = *v;
+          if (const auto v = mo.get_number<float>("coneRadius"))
+            s.muzzleFlashTemplate.coneRadius = *v;
+        }
+        std::get<std::optional<DefenderShooter>>(tpl) = s;
+      }
+
+      // Hitscan (instant-beam) attack.
+      if (const auto hso = eo.get_object("defenderHitscan")) {
+        TransientBeam beam;
+        if (const auto v = hso.get_number<float>("startDistance"))
+          beam.startDistance = *v;
+        if (const auto v = hso.get_number<uint32_t>("expiry"))
+          beam.expiry = WorldTick{*v};
+        (void)parse_color(hso, "primaryColor", beam.primaryColor);
+        (void)parse_color(hso, "secondaryColor", beam.secondaryColor);
+        if (const auto v = hso.get_number<float>("lineWidth"))
+          beam.lineWidth = *v;
+        std::get<std::optional<DefenderHitscan>>(tpl).emplace(beam);
+      }
+
+      const auto def_name = def.entityName;
+      out.entityDefs.try_emplace(def_name, std::move(def));
+    }
+  }
+
+  // Parse "paths" array.
+  if (const auto paths = obj.get_array("paths")) {
+    for (const auto elem : paths) {
+      if (!elem.is_object()) continue;
+      const auto po = elem.as_object();
+      PathJoints pj;
+      if (const auto v = po.get_number<float>("width")) pj.width = *v;
+      if (const auto joints = po.get_array("joints")) {
+        for (const auto jelem : joints) {
+          if (!jelem.is_object()) continue;
+          const auto jo = jelem.as_object();
+          Position pos;
+          if (const auto v = jo.get_number<float>("x")) pos.x = *v;
+          if (const auto v = jo.get_number<float>("y")) pos.y = *v;
+          pj.joints.push_back({pos});
+        }
+      }
+      out.paths.push_back(std::move(pj));
+    }
+  }
+
+  // Parse "waves" array.
+  if (const auto waves = obj.get_array("waves")) {
+    for (const auto elem : waves) {
+      if (!elem.is_object()) continue;
+      const auto wo = elem.as_object();
+      WaveDefinition wave;
+      if (const auto v = wo.get_number<int>("resourceInflux"))
+        wave.resourceInflux = *v;
+      if (const auto enemies = wo.get_array("enemies")) {
+        for (const auto eelem : enemies) {
+          if (!eelem.is_object()) continue;
+          const auto eo2 = eelem.as_object();
+          EnemySpawn spawn;
+          if (const auto v = eo2.get_number<uint32_t>("tick"))
+            spawn.startTicks = WaveTick{*v};
+          opt_str(eo2, "label", spawn.label);
+          if (const auto v = eo2.get_number<uint32_t>("pathId"))
+            spawn.pathId = static_cast<PathId>(*v);
+          wave.enemies.push_back(std::move(spawn));
+        }
+      }
+      std::ranges::sort(wave.enemies,
+          [](const EnemySpawn& a, const EnemySpawn& b) {
+            return a.startTicks < b.startTicks;
+          });
+      out.waves.push_back(std::move(wave));
+    }
+  }
+
+  return true;
+}
+
 }} // namespace corvid::sim

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -354,7 +354,7 @@ public:
   }
 
   // Destructively extract a delta of the game state, for `WorldDelta`. The
-  // `cbUpserts(EntityId, Position, Appearance, VisualEffects)` and
+  // `cbUpserts(EntityId, Position, Appearance, VisualEffects, Health)` and
   // `cbErased(EntityId)` callbacks will be interleaved.
   // `cbExplosion(TransientExplosion)` and `cbBeam(TransientBeam)` are invoked
   // for each fire-and-forget transient emitted this frame. The
@@ -380,8 +380,8 @@ public:
 
   // Destructively extract a full snapshot of the game state. The `cbPath`
   // callback will be invoked first, with `cbUpserts(EntityId, Position,
-  // Appearance, VisualEffects)` and `cbErased(EntityId)` invoked afterwards,
-  // and interleaved. `cbExplosion(TransientExplosion)` and
+  // Appearance, VisualEffects, Health)` and `cbErased(EntityId)` invoked
+  // afterwards, and interleaved. `cbExplosion(TransientExplosion)` and
   // `cbBeam(TransientBeam)` are invoked for each fire-and-forget transient
   // emitted this frame. The `cbState(currentWave, waveTick, lives, resources,
   // phase, uiState)` callback is invoked last.

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -104,8 +104,8 @@ struct EntityDefinition {
   std::string displayName; // Human-readable name.
   int menuOrder{};         // Display order.
   std::string flavorText;  // Description of its capabilities.
-  // NaN means "not for sale" (all invaders default to this).
-  float resourceCost{std::numeric_limits<float>::quiet_NaN()};
+  // `max()` means "not for sale" (all invaders default to this).
+  uint32_t resourceCost{std::numeric_limits<uint32_t>::max()};
   WorldScene::megatuple_t megatuple; // Component template.
 };
 
@@ -120,7 +120,7 @@ struct DefenderSummary {
   std::string displayName;
   int menuOrder{}; // Used for menu items.
   std::string flavorText;
-  float resourceCost{};
+  uint32_t resourceCost{};
   Appearance appearance;    // Extracted from megatuple at build time.
   float totalDamageDealt{}; // Live stats; only valid for selected defenders.
   float totalKills{};
@@ -212,7 +212,7 @@ public:
     waveTick_ = {};
     nextSpawnIndex_ = 0;
     lives_ = 20;
-    resources_ = 100;
+    resources_ = 1000;
     uiState_ = {};
     pendingPlacementIntent_.reset();
     pendingSpawnIntent_.reset();
@@ -254,7 +254,21 @@ public:
           });
       resources_ = resources;
 
-      if (lives_ <= 0) phase_ = GamePhase::game_over;
+      if (lives_ <= 0) {
+        phase_ = GamePhase::game_over;
+      } else {
+        // Wave is over when all enemies have been spawned and none remain.
+        const auto& wave = mapDesign_.waves[currentWave_];
+        if (nextSpawnIndex_ >= wave.enemies.size() &&
+            !world_.hasActiveInvaders())
+        {
+          ++currentWave_;
+          phase_ =
+              (currentWave_ >= mapDesign_.waves.size())
+                  ? GamePhase::victory
+                  : GamePhase::build;
+        }
+      }
     }
     (void)refreshSelectedDefenderState();
     return true;
@@ -270,6 +284,7 @@ public:
   // Player action: start the next wave.
   [[nodiscard]] bool start_wave() {
     if (phase_ != GamePhase::build) return false;
+    resources_ += mapDesign_.waves[currentWave_].resourceInflux;
     phase_ = GamePhase::wave;
     waveTick_ = {};
     nextSpawnIndex_ = 0;
@@ -369,38 +384,52 @@ public:
   }
 
 private:
-  // Determine whether an entity can be placed at a given position. We do not
-  // allow placement over a path or on top of another defender.
-  [[nodiscard]] bool
-  canPlaceDefender(std::string_view entityName, const Position& pos) const {
-    if (phase_ != GamePhase::build) return false;
-    const auto def = findEntityDef(entityName);
-    if (!def) return false;
-    // Look up initial defender radius.
-    const auto& def_opt = std::get<std::optional<Defender>>(def->megatuple);
-    if (!def_opt) return false;
-    return !world_.isDefenderPlacementBlocked(pos, def_opt->hitCircleRadius);
-  }
-
   // Find `EntityDefinition` by name.
   [[nodiscard]] const EntityDefinition* findEntityDef(
       std::string_view entityName) const {
     return find_opt(mapDesign_.entityDefs, entityName);
   }
 
-  // Build `DefenderSummary` for a selected defender by entity name.
+  // Determine whether an entity can be placed at a given position. We do not
+  // allow placement over a path or on top of another defender.
+  [[nodiscard]] bool
+  canPlaceDefender(const EntityDefinition* def, const Position& pos) const {
+    if (!def) return false;
+    if (phase_ != GamePhase::build) return false;
+    // Reject if the player cannot afford this defender.
+    if (resources_ < def->resourceCost) return false;
+    // Look up initial defender radius.
+    const auto& def_opt = std::get<std::optional<Defender>>(def->megatuple);
+    assert(def_opt);
+    return !world_.isDefenderPlacementBlocked(pos, def_opt->hitCircleRadius);
+  }
+
+  // Determine whether a named entity can be placed at a given position.
+  [[nodiscard]] bool
+  canPlaceDefender(std::string_view entityName, const Position& pos) const {
+    return canPlaceDefender(findEntityDef(entityName), pos);
+  }
+
+  // Build `DefenderSummary` for a selected defender by entity definition.
   [[nodiscard]] std::optional<DefenderSummary> buildSelectedDefenderSummary(
-      std::string_view entityName) const {
-    const auto* def = findEntityDef(entityName);
+      const EntityDefinition* def) const {
     if (!def) return std::nullopt;
     const auto& app_opt = std::get<std::optional<Appearance>>(def->megatuple);
-    if (!app_opt || std::isnan(def->resourceCost)) return std::nullopt;
+    assert(app_opt);
+    if (def->resourceCost == std::numeric_limits<uint32_t>::max())
+      return std::nullopt;
     return DefenderSummary{.modified = world_.currentTick(),
         .entityName = def->entityName,
         .displayName = def->displayName,
         .flavorText = def->flavorText,
         .resourceCost = def->resourceCost,
         .appearance = *app_opt};
+  }
+
+  // Build `DefenderSummary` for a selected defender by entity name.
+  [[nodiscard]] std::optional<DefenderSummary> buildSelectedDefenderSummary(
+      std::string_view entityName) const {
+    return buildSelectedDefenderSummary(findEntityDef(entityName));
   }
 
   // Build `DefenderSummary` for a selected defender by `Defender` component.
@@ -422,12 +451,15 @@ private:
     if (pendingSpawnIntent_) {
       const auto& input = *pendingSpawnIntent_;
       const auto parameter = input.parameter();
-      bool spawnAllowed = canPlaceDefender(parameter, {input.x, input.y});
+      auto def = findEntityDef(parameter);
+      auto pos = Position{input.x, input.y};
+      bool spawnAllowed = canPlaceDefender(def, pos);
       if (spawnAllowed) {
-        auto h = world_.spawnEntity(parameter);
-        if (h)
-          *world_.try_get_component<Position>(h.id()) = {input.x, input.y};
-        else
+        auto h = world_.spawnEntity(&def->megatuple);
+        if (h) {
+          *world_.try_get_component<Position>(h.id()) = pos;
+          if (def) resources_ -= def->resourceCost;
+        } else
           spawnAllowed = false;
       }
       uiState_.spawnAllowed = spawnAllowed;
@@ -521,8 +553,10 @@ private:
     menu.clear();
 
     for (const auto& [name, def] : defs) {
-      if (!world_.registerEntity(def.entityName, def.megatuple)) continue;
-      if (std::isnan(def.resourceCost)) continue;
+      if (!world_.registerEntity(def.entityName, def.megatuple))
+        throw std::runtime_error(
+            "Failed to register entity: " + def.entityName);
+      if (def.resourceCost == std::numeric_limits<uint32_t>::max()) continue;
       const auto& app_opt = std::get<std::optional<Appearance>>(def.megatuple);
       menu.push_back({.entityName = def.entityName,
           .displayName = def.displayName,
@@ -573,7 +607,7 @@ private:
     {
       EntityDefinition def;
       def.entityName = "InvaderAlphaBasic";
-      // `resourceCost` stays NaN (not for sale).
+      // `resourceCost` stays `max()` (not for sale).
       auto& tpl = def.megatuple;
       std::get<std::optional<Position>>(tpl) = Position{};
       std::get<std::optional<Appearance>>(
@@ -596,7 +630,7 @@ private:
       def.displayName = "AoE Defender";
       def.menuOrder = 1;
       def.flavorText = "Damages all enemies in range.";
-      def.resourceCost = 50.F;
+      def.resourceCost = 50U;
       auto& tpl = def.megatuple;
       std::get<std::optional<Position>>(tpl) = Position{};
       std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'A',
@@ -625,7 +659,7 @@ private:
       def.displayName = "Shooter";
       def.menuOrder = 2;
       def.flavorText = "Fires projectiles at a single target.";
-      def.resourceCost = 75.F;
+      def.resourceCost = 75U;
       auto& tpl = def.megatuple;
       std::get<std::optional<Position>>(tpl) = Position{};
       std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'S',
@@ -660,7 +694,7 @@ private:
       def.menuOrder = 3;
       def.flavorText =
           "Instantly damages a single target with an infrared laser beam.";
-      def.resourceCost = 100.F;
+      def.resourceCost = 100U;
       auto& tpl = def.megatuple;
       std::get<std::optional<Position>>(tpl) = Position{};
       std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'L',
@@ -675,7 +709,7 @@ private:
           .attackRadius = 200.F,
           .rangeColor = 0xFFFF0000,
           .attackDamage = 30.F,
-          .cooldown = WorldTick{45},
+          .cooldown = WorldTick{25},
           .nextAttack = WorldTick{0}};
       std::get<std::optional<DefenderStats>>(tpl) = DefenderStats{};
       std::get<std::optional<Health>>(tpl) =
@@ -723,8 +757,23 @@ private:
     // Wave definitions.
     {
       WaveDefinition wave;
+      wave.resourceInflux = 0; // Starting resources come from resetMap.
       for (uint32_t i = 0; i < 20; ++i)
         wave.enemies.push_back({WaveTick{i * 20}, "InvaderAlphaBasic"});
+      mapDesign_.waves.push_back(std::move(wave));
+    }
+    {
+      WaveDefinition wave;
+      wave.resourceInflux = 150; // Bonus resources at the start of wave 2.
+      for (uint32_t i = 0; i < 35; ++i)
+        wave.enemies.push_back({WaveTick{i * 15}, "InvaderAlphaBasic"});
+      mapDesign_.waves.push_back(std::move(wave));
+    }
+    {
+      WaveDefinition wave;
+      wave.resourceInflux = 250; // Bonus resources at the start of wave 3.
+      for (uint32_t i = 0; i < 45; ++i)
+        wave.enemies.push_back({WaveTick{i * 10}, "InvaderAlphaBasic"});
       mapDesign_.waves.push_back(std::move(wave));
     }
 
@@ -751,8 +800,8 @@ private:
   // checked against `wave_tick_`.
   size_t nextSpawnIndex_{};
 
-  int lives_{20};
-  int resources_{100};
+  int16_t lives_{20};
+  uint32_t resources_{100};
   UiState uiState_;
 
   std::optional<UiCanvasInput> pendingPlacementIntent_;

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -497,7 +497,9 @@ private:
       auto pos = Position{input.x, input.y};
       bool spawnAllowed = canPlaceDefender(def, pos);
       if (spawnAllowed) {
-        auto h = world_.spawnEntity(&def->megatuple);
+        // We need to spawn the entity using the registered template label, not
+        // the map definition.
+        auto h = world_.spawnEntity(parameter);
         if (h) {
           *world_.try_get_component<Position>(h.id()) = pos;
           if (def) resources_ -= def->resourceCost;

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -446,7 +446,7 @@ private:
     if (resources_ < def->resourceCost) return false;
     // Look up initial defender radius.
     const auto& def_opt = std::get<std::optional<Defender>>(def->megatuple);
-    assert(def_opt);
+    if (!def_opt) return false;
     return !world_.isDefenderPlacementBlocked(pos, def_opt->hitCircleRadius);
   }
 

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -250,7 +250,6 @@ public:
           [&resources](SimWorld::EntityId, const Position&,
               const Invader& inv) {
             resources += inv.bounty;
-            // TODO: Spawn a transient death animation at `pos`.
             return true;
           });
       resources_ = resources;
@@ -356,16 +355,20 @@ public:
 
   // Destructively extract a delta of the game state, for `WorldDelta`. The
   // `cbUpserts(EntityId, Position, Appearance, VisualEffects)` and
-  // `cbErased(EntityId)` callbacks will be interleaved. The
+  // `cbErased(EntityId)` callbacks will be interleaved.
+  // `cbExplosion(TransientExplosion)` and `cbBeam(TransientBeam)` are invoked
+  // for each fire-and-forget transient emitted this frame. The
   // `cbState(currentWave, waveTick, lives, resources, phase, uiState)`
   // callback is invoked last.
-  [[nodiscard]] bool
-  extractDelta(auto&& cbUpserts, auto&& cbErased, auto&& cbState) {
+  [[nodiscard]] bool extractDelta(auto&& cbUpserts, auto&& cbErased,
+      auto&& cbExplosion, auto&& cbBeam, auto&& cbState) {
     // Clear the selected defender if it is no longer valid.
     if (world_.getId(selectedDefender_) == SimWorld::EntityId::invalid)
       (void)clearSelectedDefender();
 
     (void)world_.extractUpdatedEntities(cbUpserts, cbErased);
+    (void)world_.extractTransientExplosions(cbExplosion);
+    (void)world_.extractTransientBeams(cbBeam);
     (void)cbState(currentWave_, waveTick_, lives_, resources_,
         sequence::enum_as_view(phase_), uiState_);
 
@@ -378,13 +381,15 @@ public:
   // Destructively extract a full snapshot of the game state. The `cbPath`
   // callback will be invoked first, with `cbUpserts(EntityId, Position,
   // Appearance, VisualEffects)` and `cbErased(EntityId)` invoked afterwards,
-  // and interleaved. The `cbState(currentWave, waveTick, lives, resources,
+  // and interleaved. `cbExplosion(TransientExplosion)` and
+  // `cbBeam(TransientBeam)` are invoked for each fire-and-forget transient
+  // emitted this frame. The `cbState(currentWave, waveTick, lives, resources,
   // phase, uiState)` callback is invoked last.
   [[nodiscard]] bool extractFull(auto&& cbPath, auto&& cbUpserts,
-      auto&& cbErased, auto&& cbState) {
+      auto&& cbErased, auto&& cbExplosion, auto&& cbBeam, auto&& cbState) {
     (void)extractPaths(cbPath);
     (void)markAllDirty();
-    (void)extractDelta(cbUpserts, cbErased, cbState);
+    (void)extractDelta(cbUpserts, cbErased, cbExplosion, cbBeam, cbState);
     return true;
   }
 
@@ -760,12 +765,15 @@ private:
           .attackDamage = 30.F,
           .cooldown = WorldTick{25},
           .nextAttack = WorldTick{0}};
-      std::get<std::optional<DefenderStats>>(tpl) = DefenderStats{};
+      std::get<std::optional<DefenderStats>>(tpl).emplace();
       std::get<std::optional<Health>>(tpl) =
           Health{.currentHealth = 75.F, .maxHealth = 75.F, .regen = 0.F};
-      std::get<std::optional<DefenderHitscan>>(
-          tpl) = DefenderHitscan{.beamColor = 0xFFFF4040,
-          .beamDuration = WorldTick{3}};
+      std::get<std::optional<DefenderHitscan>>(tpl).emplace(TransientBeam{
+          .startDistance = 25.F,
+          .expiry = WorldTick{3},
+          .primaryColor = 0xFFFF4040,
+          .secondaryColor = 0xFFFFD080,
+          .lineWidth = 8.F});
       mapDesign_.entityDefs.try_emplace(def.entityName, std::move(def));
     }
 

--- a/corvid/sim/sim_json_parse.h
+++ b/corvid/sim/sim_json_parse.h
@@ -125,6 +125,18 @@ parseSimClientMessageRoot(std::string_view msg) {
           detail::decodeString(msg, "button")))
     return std::nullopt;
 
+  // Optional; missing or non-string is silently treated as empty.
+  (void)detail::decodeString(msg, "command", input.command);
+
+  // Optional array of string parameters; missing or malformed entries silently
+  // omitted.
+  if (const auto params = msg.get_array("parameters")) {
+    std::string param;
+    for (const auto elem : params) {
+      if (elem.decode_string(param)) input.parameters.push_back(param);
+    }
+  }
+
   return input;
 }
 

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -64,6 +64,25 @@ struct SimGameStateJson {
   return body;
 }
 
+[[nodiscard]] inline std::string buildSimUiResponseJson(
+    const UiResponse& response) {
+  std::string body;
+  json_writer writer{body};
+  auto root = writer.object();
+  root->member(json_trusted{"type"}, json_trusted{"ui_response"})
+      .member(json_trusted{"seq"}, response.seq)
+      .member(json_trusted{"ok"}, response.ok)
+      .member(json_trusted{"response"}, response.response);
+  if (!response.reason.empty())
+    root->member(json_trusted{"reason"}, response.reason);
+  if (!response.fields.empty()) {
+    auto fields = root->member_object(json_trusted{"fields"});
+    for (const auto& field : response.fields)
+      fields->member(field.key, field.value);
+  }
+  return body;
+}
+
 [[nodiscard]] inline bool buildSimGameStateJson(SimGameStateJson& result,
     SimGame& game,
     update_strategy send_strategy = update_strategy::incremental) {

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -28,48 +28,33 @@
 namespace corvid { inline namespace sim {
 
 [[nodiscard]] inline uint32_t
-flash_expiry_delay_ms(const VisualEffects& effects, WorldTick current_tick) {
-  if (effects.flash_color == 0 || effects.flash_expiry == WorldTick::invalid ||
-      effects.flash_expiry < current_tick)
+flashExpiryDelayMs(const VisualEffects& effects, WorldTick current_tick) {
+  // If not flashing, nothing to do.
+  if (effects.flashColor == 0 || effects.flashExpiry == WorldTick::invalid ||
+      effects.flashExpiry < current_tick)
     return 0;
 
-  constexpr uint64_t ms_per_tick = 50;
-  const auto ticks_until_expiry =
-      static_cast<uint64_t>(*effects.flash_expiry) -
-      static_cast<uint64_t>(*current_tick);
+  // Calculate milliseconds until expiry, capping at max uint32_t.
+  constexpr uint32_t ms_per_tick = 50;
+  const auto ticks_until_expiry = *effects.flashExpiry - *current_tick;
   const auto expiry_delay_ms = ticks_until_expiry * ms_per_tick;
-  return static_cast<uint32_t>(std::min(expiry_delay_ms,
-      static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())));
+  return std::min(expiry_delay_ms, std::numeric_limits<uint32_t>::max());
 }
 
 // Reusable state, to avoid repeated allocations.
-struct sim_game_state_json {
+struct SimGameStateJson {
   std::string body;
   std::vector<SimWorld::EntityId> erased_ids;
 
-  // Clear the body and erased IDs, updating highwater marks for future
-  // reserve.
+  // Clear the body and erased IDs. These fields retain their allocations.
   [[nodiscard]] bool clear() {
-    body_highwater = std::max(body.size(), body_highwater);
-    erased_ids_highwater = std::max(erased_ids.size(), erased_ids_highwater);
     body.clear();
     erased_ids.clear();
     return true;
   }
-
-  [[nodiscard]] bool reset() {
-    (void)clear();
-    body.reserve(body_highwater);
-    erased_ids.reserve(erased_ids_highwater);
-    return true;
-  }
-
-private:
-  size_t body_highwater{16ULL * 1024};
-  size_t erased_ids_highwater{64};
 };
 
-[[nodiscard]] inline std::string build_sim_hello_ack_json(
+[[nodiscard]] inline std::string buildSimHelloAckJson(
     std::string_view message = "connected") {
   std::string body;
   json_writer{body}
@@ -79,10 +64,10 @@ private:
   return body;
 }
 
-[[nodiscard]] inline bool
-build_sim_game_state_json(sim_game_state_json& result, SimGame& game,
+[[nodiscard]] inline bool buildSimGameStateJson(SimGameStateJson& result,
+    SimGame& game,
     update_strategy send_strategy = update_strategy::incremental) {
-  (void)result.reset();
+  (void)result.clear();
   const auto current_tick = game.currentTick();
   json_writer writer{result.body};
   if (send_strategy == update_strategy::full)
@@ -121,19 +106,19 @@ build_sim_game_state_json(sim_game_state_json& result, SimGame& game,
                       static_cast<uint32_t>(app.glyph))
                   .member(json_trusted{"radius"}, app.radius,
                       std::chars_format::fixed, 3)
-                  .member(json_trusted{"fg"}, app.fg_color)
-                  .member(json_trusted{"bg"}, app.bg_color);
+                  .member(json_trusted{"fg"}, app.fgColor)
+                  .member(json_trusted{"bg"}, app.bgColor);
             }
 
             if (effects.modified == current_tick) {
               entity->member_object(json_trusted{"vfx"})
-                  ->member(json_trusted{"selection"}, effects.selection_color)
-                  .member(json_trusted{"rangeRadius"}, effects.range_radius,
+                  ->member(json_trusted{"selection"}, effects.selectionColor)
+                  .member(json_trusted{"rangeRadius"}, effects.rangeRadius,
                       std::chars_format::fixed, 3)
-                  .member(json_trusted{"range"}, effects.range_color)
-                  .member(json_trusted{"flash"}, effects.flash_color)
+                  .member(json_trusted{"range"}, effects.rangeColor)
+                  .member(json_trusted{"flash"}, effects.flashColor)
                   .member(json_trusted{"flashExpiryMs"},
-                      flash_expiry_delay_ms(effects, current_tick));
+                      flashExpiryDelayMs(effects, current_tick));
             }
 
             return true;

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -107,7 +107,9 @@ struct SimGameStateJson {
                   .member(json_trusted{"radius"}, app.radius,
                       std::chars_format::fixed, 3)
                   .member(json_trusted{"fg"}, app.fgColor)
-                  .member(json_trusted{"bg"}, app.bgColor);
+                  .member(json_trusted{"bg"}, app.bgColor)
+                  .member(json_trusted{"attackRadius"}, app.attackRadius,
+                      std::chars_format::fixed, 1);
             }
 
             if (effects.modified == current_tick) {
@@ -185,7 +187,9 @@ struct SimGameStateJson {
               .member(json_trusted{"radius"}, entry.appearance.radius,
                   std::chars_format::fixed, 3)
               .member(json_trusted{"fg"}, entry.appearance.fgColor)
-              .member(json_trusted{"bg"}, entry.appearance.bgColor);
+              .member(json_trusted{"bg"}, entry.appearance.bgColor)
+              .member(json_trusted{"attackRadius"},
+                  entry.appearance.attackRadius, std::chars_format::fixed, 1);
         }
       }
     }

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -64,25 +64,6 @@ struct SimGameStateJson {
   return body;
 }
 
-[[nodiscard]] inline std::string buildSimUiResponseJson(
-    const UiResponse& response) {
-  std::string body;
-  json_writer writer{body};
-  auto root = writer.object();
-  root->member(json_trusted{"type"}, json_trusted{"ui_response"})
-      .member(json_trusted{"seq"}, response.seq)
-      .member(json_trusted{"ok"}, response.ok)
-      .member(json_trusted{"response"}, response.response);
-  if (!response.reason.empty())
-    root->member(json_trusted{"reason"}, response.reason);
-  if (!response.fields.empty()) {
-    auto fields = root->member_object(json_trusted{"fields"});
-    for (const auto& field : response.fields)
-      fields->member(field.key, field.value);
-  }
-  return body;
-}
-
 [[nodiscard]] inline bool buildSimGameStateJson(SimGameStateJson& result,
     SimGame& game,
     update_strategy send_strategy = update_strategy::incremental) {
@@ -97,10 +78,12 @@ struct SimGameStateJson {
   int lives_count{};
   int resources_count{};
   std::string_view phase{};
+  UiState ui_state;
 
   auto write_delta = [&writer, &game, &result, current_tick, &current_wave,
-                         &wave_tick, &lives_count, &resources_count,
-                         &phase](json_writer<std::string>& target) {
+                         &wave_tick, &lives_count, &resources_count, &phase,
+                         &ui_state, send_strategy](
+                        json_writer<std::string>& target) {
     target.member(json_trusted{"type"}, json_trusted{"world_delta"})
         .member(json_trusted{"tick"}, *current_tick);
 
@@ -149,13 +132,15 @@ struct SimGameStateJson {
             return true;
           },
           [&current_wave, &wave_tick, &lives_count, &resources_count,
-              &phase](auto new_current_wave, auto new_wave_tick,
-              auto new_lives, auto new_resources, auto new_phase) {
+              &phase, &ui_state](auto new_current_wave, auto new_wave_tick,
+              auto new_lives, auto new_resources, auto new_phase,
+              const UiState& new_ui_state) {
             current_wave = new_current_wave;
             wave_tick = new_wave_tick;
             lives_count = new_lives;
             resources_count = new_resources;
             phase = new_phase;
+            ui_state = new_ui_state;
             return true;
           });
     }
@@ -169,6 +154,37 @@ struct SimGameStateJson {
         .member(json_trusted{"lives"}, lives_count)
         .member(json_trusted{"resources"}, resources_count)
         .member(json_trusted{"phase"}, json_trusted{phase});
+    if (auto ui = target.member_object(json_trusted{"uiState"})) {
+      ui->member(json_trusted{"defenderSelected"}, ui_state.defenderSelected);
+      if (ui_state.placementAllowed.has_value())
+        ui->member(json_trusted{"placementAllowed"},
+            *ui_state.placementAllowed);
+      if (ui_state.spawnAllowed.has_value())
+        ui->member(json_trusted{"spawnAllowed"}, *ui_state.spawnAllowed);
+      const bool include_summary = ui_state.defenderSelected &&
+          ui_state.defenderSummary.has_value() &&
+          (send_strategy == update_strategy::full ||
+              ui_state.defenderSummary->modified == current_tick);
+      if (include_summary) {
+        const auto& summary = *ui_state.defenderSummary;
+        auto defender = ui->member_object(json_trusted{"defenderSummary"});
+        defender->member(json_trusted{"entityName"}, summary.entityName)
+            .member(json_trusted{"displayName"}, summary.displayName)
+            .member(json_trusted{"flavorText"}, summary.flavorText)
+            .member(json_trusted{"resourceCost"}, summary.resourceCost,
+                std::chars_format::fixed, 1);
+        if (auto app = defender->member_object(json_trusted{"appearance"})) {
+          app->member(json_trusted{"glyph"},
+                 static_cast<uint32_t>(summary.appearance.glyph))
+              .member(json_trusted{"radius"}, summary.appearance.radius,
+                  std::chars_format::fixed, 3)
+              .member(json_trusted{"fg"}, summary.appearance.fgColor)
+              .member(json_trusted{"bg"}, summary.appearance.bgColor)
+              .member(json_trusted{"attackRadius"},
+                  summary.appearance.attackRadius, std::chars_format::fixed, 1);
+        }
+      }
+    }
   };
 
   if (send_strategy == update_strategy::full) {

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -153,14 +153,43 @@ struct SimGameStateJson {
   if (send_strategy == update_strategy::full) {
     auto snapshot = writer.object();
     snapshot->member(json_trusted{"type"}, json_trusted{"world_snapshot"});
-    if (auto paths = snapshot->member_array(json_trusted{"paths"})) {
-      (void)game.extractPaths([&writer](auto, const Position& pos) {
-        auto path = writer.object();
-        path->member(json_trusted{"x"}, pos.x, std::chars_format::fixed, 1)
-            .member(json_trusted{"y"}, pos.y, std::chars_format::fixed, 1);
-        return true;
-      });
+
+    // Map design: sprite filenames + path joints.
+    if (auto map_design = snapshot->member_object(json_trusted{"mapDesign"})) {
+      const auto& md = game.mapDesign();
+      map_design
+          ->member(json_trusted{"backgroundSprite"}, md.backgroundSpriteFile)
+          .member(json_trusted{"foregroundSprite"}, md.foregroundSpriteFile);
+      if (auto paths = map_design->member_array(json_trusted{"paths"})) {
+        (void)game.extractPaths([&writer](auto, const Position& pos) {
+          auto path = writer.object();
+          path->member(json_trusted{"x"}, pos.x, std::chars_format::fixed, 1)
+              .member(json_trusted{"y"}, pos.y, std::chars_format::fixed, 1);
+          return true;
+        });
+      }
     }
+
+    // Defender build menu (purchasable defenders, in menu order).
+    if (auto menu = snapshot->member_array(json_trusted{"defenderMenu"})) {
+      for (const auto& entry : game.mapDesign().defenderMenu) {
+        auto item = writer.object();
+        item->member(json_trusted{"entityName"}, entry.entityName)
+            .member(json_trusted{"displayName"}, entry.displayName)
+            .member(json_trusted{"flavorText"}, entry.flavorText)
+            .member(json_trusted{"resourceCost"}, entry.resourceCost,
+                std::chars_format::fixed, 1);
+        if (auto app = item->member_object(json_trusted{"appearance"})) {
+          app->member(json_trusted{"glyph"},
+                 static_cast<uint32_t>(entry.appearance.glyph))
+              .member(json_trusted{"radius"}, entry.appearance.radius,
+                  std::chars_format::fixed, 3)
+              .member(json_trusted{"fg"}, entry.appearance.fgColor)
+              .member(json_trusted{"bg"}, entry.appearance.bgColor);
+        }
+      }
+    }
+
     write_delta(*snapshot->member_object(json_trusted{"delta"}));
   } else
     write_delta(*writer.object());

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -82,8 +82,8 @@ struct SimGameStateJson {
 
   auto write_delta = [&writer, &game, &result, current_tick, &current_wave,
                          &wave_tick, &lives_count, &resources_count, &phase,
-                         &ui_state, send_strategy](
-                        json_writer<std::string>& target) {
+                         &ui_state,
+                         send_strategy](json_writer<std::string>& target) {
     target.member(json_trusted{"type"}, json_trusted{"world_delta"})
         .member(json_trusted{"tick"}, *current_tick);
 
@@ -131,8 +131,8 @@ struct SimGameStateJson {
             result.erased_ids.push_back(entity_id);
             return true;
           },
-          [&current_wave, &wave_tick, &lives_count, &resources_count,
-              &phase, &ui_state](auto new_current_wave, auto new_wave_tick,
+          [&current_wave, &wave_tick, &lives_count, &resources_count, &phase,
+              &ui_state](auto new_current_wave, auto new_wave_tick,
               auto new_lives, auto new_resources, auto new_phase,
               const UiState& new_ui_state) {
             current_wave = new_current_wave;
@@ -161,8 +161,8 @@ struct SimGameStateJson {
             *ui_state.placementAllowed);
       if (ui_state.spawnAllowed.has_value())
         ui->member(json_trusted{"spawnAllowed"}, *ui_state.spawnAllowed);
-      const bool include_summary = ui_state.defenderSelected &&
-          ui_state.defenderSummary.has_value() &&
+      const bool include_summary =
+          ui_state.defenderSelected && ui_state.defenderSummary.has_value() &&
           (send_strategy == update_strategy::full ||
               ui_state.defenderSummary->modified == current_tick);
       if (include_summary) {
@@ -181,7 +181,8 @@ struct SimGameStateJson {
               .member(json_trusted{"fg"}, summary.appearance.fgColor)
               .member(json_trusted{"bg"}, summary.appearance.bgColor)
               .member(json_trusted{"attackRadius"},
-                  summary.appearance.attackRadius, std::chars_format::fixed, 1);
+                  summary.appearance.attackRadius, std::chars_format::fixed,
+                  1);
         }
       }
     }

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -155,14 +155,23 @@ struct SimGameStateJson {
         .member(json_trusted{"resources"}, resources_count)
         .member(json_trusted{"phase"}, json_trusted{phase});
     if (auto ui = target.member_object(json_trusted{"uiState"})) {
-      ui->member(json_trusted{"defenderSelected"}, ui_state.defenderSelected);
+      if (ui_state.selectedDefender.has_value()) {
+        const auto& selected = *ui_state.selectedDefender;
+        if (auto pos = ui->member_object(json_trusted{"selectedDefender"})) {
+          pos->member(json_trusted{"x"}, selected.x, std::chars_format::fixed,
+                 1)
+              .member(json_trusted{"y"}, selected.y, std::chars_format::fixed,
+                  1);
+        }
+      }
       if (ui_state.placementAllowed.has_value())
         ui->member(json_trusted{"placementAllowed"},
             *ui_state.placementAllowed);
       if (ui_state.spawnAllowed.has_value())
         ui->member(json_trusted{"spawnAllowed"}, *ui_state.spawnAllowed);
       const bool include_summary =
-          ui_state.defenderSelected && ui_state.defenderSummary.has_value() &&
+          ui_state.selectedDefender.has_value() &&
+          ui_state.defenderSummary.has_value() &&
           (send_strategy == update_strategy::full ||
               ui_state.defenderSummary->modified == current_tick);
       if (include_summary) {

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -180,7 +180,10 @@ struct SimGameStateJson {
       const auto& md = game.mapDesign();
       map_design
           ->member(json_trusted{"backgroundSprite"}, md.backgroundSpriteFile)
-          .member(json_trusted{"foregroundSprite"}, md.foregroundSpriteFile);
+          .member(json_trusted{"foregroundSprite"}, md.foregroundSpriteFile)
+          .member(json_trusted{"pathWidth"},
+              md.paths.empty() ? 40.F : md.paths.front().width,
+              std::chars_format::fixed, 1);
       if (auto paths = map_design->member_array(json_trusted{"paths"})) {
         (void)game.extractPaths([&writer](auto, const Position& pos) {
           auto path = writer.object();

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -148,6 +148,8 @@ struct SimGameStateJson {
                       flashExpiryDelayMs(effects, current_tick))
                   .member(json_trusted{"cooldown"}, effects.cooldownColor)
                   .member(json_trusted{"cooldownExpiryMs"},
+                      cooldownExpiryDelayMs(effects, current_tick))
+                  .member(json_trusted{"cooldownDurationMs"},
                       cooldownExpiryDelayMs(effects, current_tick));
             }
 

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -86,6 +86,7 @@ struct SimGameStateJson {
   return body;
 }
 
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 [[nodiscard]] inline bool buildSimGameStateJson(SimGameStateJson& result,
     SimGame& game,
     update_strategy send_strategy = update_strategy::incremental) {
@@ -357,5 +358,6 @@ struct SimGameStateJson {
 
   return true;
 }
+// NOLINTEND(readability-function-cognitive-complexity)
 
 }} // namespace corvid::sim

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -133,7 +133,8 @@ struct SimGameStateJson {
                   .member(json_trusted{"fg"}, app.fgColor)
                   .member(json_trusted{"bg"}, app.bgColor)
                   .member(json_trusted{"attackRadius"}, app.attackRadius,
-                      std::chars_format::fixed, 1);
+                      std::chars_format::fixed, 1)
+                  .member(json_trusted{"trailColor"}, app.trailColor);
             }
 
             if (effects.modified == current_tick) {

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -42,14 +42,14 @@ tickExpiryDelayMs(uint32_t color, WorldTick expiry, WorldTick current_tick) {
 
 [[nodiscard]] inline uint32_t
 flashExpiryDelayMs(const VisualEffects& effects, WorldTick current_tick) {
-  return tickExpiryDelayMs(
-      effects.flashColor, effects.flashExpiry, current_tick);
+  return tickExpiryDelayMs(effects.flashColor, effects.flashExpiry,
+      current_tick);
 }
 
 [[nodiscard]] inline uint32_t
 cooldownExpiryDelayMs(const VisualEffects& effects, WorldTick current_tick) {
-  return tickExpiryDelayMs(
-      effects.cooldownColor, effects.cooldownExpiry, current_tick);
+  return tickExpiryDelayMs(effects.cooldownColor, effects.cooldownExpiry,
+      current_tick);
 }
 
 // Reusable state, to avoid repeated allocations.
@@ -207,8 +207,9 @@ struct SimGameStateJson {
                   summary.appearance.attackRadius, std::chars_format::fixed,
                   1);
         }
-        defender->member(json_trusted{"totalDamageDealt"},
-                    summary.totalDamageDealt, std::chars_format::fixed, 1)
+        defender
+            ->member(json_trusted{"totalDamageDealt"},
+                summary.totalDamageDealt, std::chars_format::fixed, 1)
             .member(json_trusted{"totalKills"}, summary.totalKills,
                 std::chars_format::fixed, 0);
       }

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -113,7 +113,7 @@ struct SimGameStateJson {
       (void)game.extractDelta(
           [&writer, current_tick](SimWorld::EntityId entity_id,
               const Position& pos, const Appearance& app,
-              const VisualEffects& effects) {
+              const VisualEffects& effects, const Health& hp) {
             auto entity = writer.object();
 
             if (auto position = entity->member_object(json_trusted{"pos"})) {
@@ -149,6 +149,14 @@ struct SimGameStateJson {
                   .member(json_trusted{"cooldown"}, effects.cooldownColor)
                   .member(json_trusted{"cooldownExpiryMs"},
                       cooldownExpiryDelayMs(effects, current_tick));
+            }
+
+            if (hp.modified == current_tick) {
+              entity->member_object(json_trusted{"health"})
+                  ->member(json_trusted{"current"}, hp.currentHealth,
+                      std::chars_format::fixed, 1)
+                  .member(json_trusted{"max"}, hp.maxHealth,
+                      std::chars_format::fixed, 1);
             }
 
             return true;

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -189,38 +189,45 @@ struct SimGameStateJson {
     {
       for (const auto& explosion : result.transient_explosions) {
         explosions->object()
-            ->member(json_trusted{"x"}, explosion.x, std::chars_format::fixed,
-                1)
-            .member(json_trusted{"y"}, explosion.y, std::chars_format::fixed,
-                1)
+            ->member(json_trusted{"x"}, explosion.circle.x,
+                std::chars_format::fixed, 1)
+            .member(json_trusted{"y"}, explosion.circle.y,
+                std::chars_format::fixed, 1)
             .member(json_trusted{"expiryTick"},
                 tickExpiryTick(explosion.expiry))
             .member(json_trusted{"primaryColor"}, explosion.primaryColor)
             .member(json_trusted{"secondaryColor"}, explosion.secondaryColor)
-            .member(json_trusted{"radius"}, explosion.radius,
+            .member(json_trusted{"radius"}, explosion.circle.radius,
                 std::chars_format::fixed, 1);
       }
     }
     if (auto beams = target.member_array(json_trusted{"transientBeams"})) {
       for (const auto& beam : result.transient_beams) {
-        beams->object()
-            ->member(json_trusted{"x"}, beam.x, std::chars_format::fixed, 1)
-            .member(json_trusted{"y"}, beam.y, std::chars_format::fixed, 1)
+        auto beam_json = beams->object();
+        beam_json
+            ->member(json_trusted{"x"}, beam.circle.x,
+                std::chars_format::fixed, 1)
+            .member(json_trusted{"y"}, beam.circle.y,
+                std::chars_format::fixed, 1)
+            .member(json_trusted{"radius"}, beam.circle.radius,
+                std::chars_format::fixed, 1)
             .member(json_trusted{"expiryTick"}, tickExpiryTick(beam.expiry))
             .member(json_trusted{"primaryColor"}, beam.primaryColor)
             .member(json_trusted{"secondaryColor"}, beam.secondaryColor)
-            .member(json_trusted{"targetX"}, beam.targetX,
-                std::chars_format::fixed, 1)
-            .member(json_trusted{"targetY"}, beam.targetY,
-                std::chars_format::fixed, 1)
-            .member(json_trusted{"startDistance"}, beam.startDistance,
-                std::chars_format::fixed, 1)
             .member(json_trusted{"lineWidth"}, beam.lineWidth,
                 std::chars_format::fixed, 1)
             .member(json_trusted{"halfAngleDeg"}, beam.halfAngleDeg,
                 std::chars_format::fixed, 1)
             .member(json_trusted{"coneRadius"}, beam.coneRadius,
                 std::chars_format::fixed, 1);
+        if (auto target_pos = beam_json->member_object(json_trusted{"targetPos"}))
+        {
+          target_pos
+              ->member(json_trusted{"x"}, beam.targetPos.x,
+                  std::chars_format::fixed, 1)
+              .member(json_trusted{"y"}, beam.targetPos.y,
+                  std::chars_format::fixed, 1);
+        }
       }
     }
 

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -225,6 +225,10 @@ struct SimGameStateJson {
             .member(json_trusted{"startDistance"}, beam.startDistance,
                 std::chars_format::fixed, 1)
             .member(json_trusted{"lineWidth"}, beam.lineWidth,
+                std::chars_format::fixed, 1)
+            .member(json_trusted{"halfAngleDeg"}, beam.halfAngleDeg,
+                std::chars_format::fixed, 1)
+            .member(json_trusted{"coneRadius"}, beam.coneRadius,
                 std::chars_format::fixed, 1);
       }
     }
@@ -259,6 +263,7 @@ struct SimGameStateJson {
         auto defender = ui->member_object(json_trusted{"defenderSummary"});
         defender->member(json_trusted{"entityName"}, summary.entityName)
             .member(json_trusted{"displayName"}, summary.displayName)
+            .member(json_trusted{"category"}, summary.category)
             .member(json_trusted{"flavorText"}, summary.flavorText)
             .member(json_trusted{"resourceCost"}, summary.resourceCost);
         if (auto app = defender->member_object(json_trusted{"appearance"})) {
@@ -310,6 +315,7 @@ struct SimGameStateJson {
         auto item = writer.object();
         item->member(json_trusted{"entityName"}, entry.entityName)
             .member(json_trusted{"displayName"}, entry.displayName)
+            .member(json_trusted{"category"}, entry.category)
             .member(json_trusted{"flavorText"}, entry.flavorText)
             .member(json_trusted{"resourceCost"}, entry.resourceCost);
         if (auto app = item->member_object(json_trusted{"appearance"})) {
@@ -321,6 +327,26 @@ struct SimGameStateJson {
               .member(json_trusted{"bg"}, entry.appearance.bgColor)
               .member(json_trusted{"attackRadius"},
                   entry.appearance.attackRadius, std::chars_format::fixed, 1);
+        }
+      }
+    }
+
+    // Category definitions for the top-level build menu.
+    if (auto cats = snapshot->member_array(json_trusted{"categories"})) {
+      for (const auto& cat : game.mapDesign().categories) {
+        auto item = writer.object();
+        item->member(json_trusted{"name"}, cat.name)
+            .member(json_trusted{"displayName"}, cat.displayName)
+            .member(json_trusted{"flavorText"}, cat.flavorText);
+        if (auto app = item->member_object(json_trusted{"appearance"})) {
+          app->member(json_trusted{"glyph"},
+                 static_cast<uint32_t>(cat.appearance.glyph))
+              .member(json_trusted{"radius"}, cat.appearance.radius,
+                  std::chars_format::fixed, 3)
+              .member(json_trusted{"fg"}, cat.appearance.fgColor)
+              .member(json_trusted{"bg"}, cat.appearance.bgColor)
+              .member(json_trusted{"attackRadius"},
+                  cat.appearance.attackRadius, std::chars_format::fixed, 1);
         }
       }
     }

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -193,6 +193,10 @@ struct SimGameStateJson {
                   summary.appearance.attackRadius, std::chars_format::fixed,
                   1);
         }
+        defender->member(json_trusted{"totalDamageDealt"},
+                    summary.totalDamageDealt, std::chars_format::fixed, 1)
+            .member(json_trusted{"totalKills"}, summary.totalKills,
+                std::chars_format::fixed, 0);
       }
     }
   };

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -27,36 +27,27 @@
 
 namespace corvid { inline namespace sim {
 
-// Calculate milliseconds until a tick-based expiry, capping at max uint32_t.
-// Returns 0 if the expiry has already passed.
-[[nodiscard]] inline uint32_t
-tickExpiryDelayMs(WorldTick expiry, WorldTick current_tick) {
-  if (expiry == WorldTick::invalid || expiry < current_tick) return 0;
-
-  constexpr uint32_t ms_per_tick = 50;
-  const auto ticks_until_expiry = *expiry - *current_tick;
-  const auto expiry_delay_ms = ticks_until_expiry * ms_per_tick;
-  return std::min(expiry_delay_ms, std::numeric_limits<uint32_t>::max());
+// Return the absolute world tick of an expiry as a uint32_t.
+// Returns 0 if `expiry` is invalid (i.e. no expiry is set).
+[[nodiscard]] inline uint32_t tickExpiryTick(WorldTick expiry) {
+  if (expiry == WorldTick::invalid) return 0;
+  return *expiry;
 }
 
-// Calculate milliseconds until a tick-based expiry, capping at max uint32_t.
-// Returns 0 if the color is unset or the expiry has already passed.
+// Returns 0 if the color is unset; otherwise returns the absolute expiry tick.
 [[nodiscard]] inline uint32_t
-tickExpiryDelayMs(uint32_t color, WorldTick expiry, WorldTick current_tick) {
+tickExpiryTick(uint32_t color, WorldTick expiry) {
   if (color == 0) return 0;
-  return tickExpiryDelayMs(expiry, current_tick);
+  return tickExpiryTick(expiry);
 }
 
-[[nodiscard]] inline uint32_t
-flashExpiryDelayMs(const VisualEffects& effects, WorldTick current_tick) {
-  return tickExpiryDelayMs(effects.flashColor, effects.flashExpiry,
-      current_tick);
+[[nodiscard]] inline uint32_t flashExpiryTick(const VisualEffects& effects) {
+  return tickExpiryTick(effects.flashColor, effects.flashExpiry);
 }
 
-[[nodiscard]] inline uint32_t
-cooldownExpiryDelayMs(const VisualEffects& effects, WorldTick current_tick) {
-  return tickExpiryDelayMs(effects.cooldownColor, effects.cooldownExpiry,
-      current_tick);
+[[nodiscard]] inline uint32_t cooldownExpiryTick(
+    const VisualEffects& effects) {
+  return tickExpiryTick(effects.cooldownColor, effects.cooldownExpiry);
 }
 
 // Reusable state, to avoid repeated allocations.
@@ -145,13 +136,13 @@ struct SimGameStateJson {
                       std::chars_format::fixed, 3)
                   .member(json_trusted{"range"}, effects.rangeColor)
                   .member(json_trusted{"flash"}, effects.flashColor)
-                  .member(json_trusted{"flashExpiryMs"},
-                      flashExpiryDelayMs(effects, current_tick))
+                  .member(json_trusted{"flashExpiryTick"},
+                      flashExpiryTick(effects))
                   .member(json_trusted{"cooldown"}, effects.cooldownColor)
-                  .member(json_trusted{"cooldownExpiryMs"},
-                      cooldownExpiryDelayMs(effects, current_tick))
-                  .member(json_trusted{"cooldownDurationMs"},
-                      cooldownExpiryDelayMs(effects, current_tick));
+                  .member(json_trusted{"cooldownExpiryTick"},
+                      cooldownExpiryTick(effects))
+                  .member(json_trusted{"cooldownDurationTick"},
+                      cooldownExpiryTick(effects));
             }
 
             if (hp.modified == current_tick) {
@@ -202,8 +193,8 @@ struct SimGameStateJson {
                 1)
             .member(json_trusted{"y"}, explosion.y, std::chars_format::fixed,
                 1)
-            .member(json_trusted{"expiryMs"},
-                tickExpiryDelayMs(explosion.expiry, current_tick))
+            .member(json_trusted{"expiryTick"},
+                tickExpiryTick(explosion.expiry))
             .member(json_trusted{"primaryColor"}, explosion.primaryColor)
             .member(json_trusted{"secondaryColor"}, explosion.secondaryColor)
             .member(json_trusted{"radius"}, explosion.radius,
@@ -215,8 +206,7 @@ struct SimGameStateJson {
         beams->object()
             ->member(json_trusted{"x"}, beam.x, std::chars_format::fixed, 1)
             .member(json_trusted{"y"}, beam.y, std::chars_format::fixed, 1)
-            .member(json_trusted{"expiryMs"},
-                tickExpiryDelayMs(beam.expiry, current_tick))
+            .member(json_trusted{"expiryTick"}, tickExpiryTick(beam.expiry))
             .member(json_trusted{"primaryColor"}, beam.primaryColor)
             .member(json_trusted{"secondaryColor"}, beam.secondaryColor)
             .member(json_trusted{"targetX"}, beam.targetX,

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -88,14 +88,13 @@ struct SimGameStateJson {
     (void)game.markAllDirty(update_strategy::full);
 
   size_t current_wave{};
-  WaveTick wave_tick{};
   int lives_count{};
   int resources_count{};
   std::string_view phase{};
   UiState ui_state;
 
   auto write_delta = [&writer, &game, &result, current_tick, &current_wave,
-                         &wave_tick, &lives_count, &resources_count, &phase,
+                         &lives_count, &resources_count, &phase,
                          &ui_state,
                          send_strategy](json_writer<std::string>& target) {
     target.member(json_trusted{"type"}, json_trusted{"world_delta"})
@@ -167,12 +166,11 @@ struct SimGameStateJson {
             result.transient_beams.push_back(beam);
             return true;
           },
-          [&current_wave, &wave_tick, &lives_count, &resources_count, &phase,
-              &ui_state](auto new_current_wave, auto new_wave_tick,
+          [&current_wave, &lives_count, &resources_count, &phase,
+              &ui_state](auto new_current_wave, auto /*new_wave_tick*/,
               auto new_lives, auto new_resources, auto new_phase,
               const UiState& new_ui_state) {
             current_wave = new_current_wave;
-            wave_tick = new_wave_tick;
             lives_count = new_lives;
             resources_count = new_resources;
             phase = new_phase;
@@ -240,7 +238,6 @@ struct SimGameStateJson {
     }
 
     target.member(json_trusted{"currentWave"}, current_wave)
-        .member(json_trusted{"waveTick"}, *wave_tick)
         .member(json_trusted{"lives"}, lives_count)
         .member(json_trusted{"resources"}, resources_count)
         .member(json_trusted{"phase"}, json_trusted{phase});

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -188,30 +188,37 @@ struct SimGameStateJson {
             target.member_array(json_trusted{"transientExplosions"}))
     {
       for (const auto& explosion : result.transient_explosions) {
-        explosions->object()
-            ->member(json_trusted{"x"}, explosion.circle.x,
-                std::chars_format::fixed, 1)
-            .member(json_trusted{"y"}, explosion.circle.y,
-                std::chars_format::fixed, 1)
-            .member(json_trusted{"expiryTick"},
+        auto exp_json = explosions->object();
+        if (auto circle = exp_json->member_object(json_trusted{"circle"})) {
+          circle
+              ->member(json_trusted{"x"}, explosion.circle.x,
+                  std::chars_format::fixed, 1)
+              .member(json_trusted{"y"}, explosion.circle.y,
+                  std::chars_format::fixed, 1)
+              .member(json_trusted{"radius"}, explosion.circle.radius,
+                  std::chars_format::fixed, 1);
+        }
+        exp_json
+            ->member(json_trusted{"expiryTick"},
                 tickExpiryTick(explosion.expiry))
             .member(json_trusted{"primaryColor"}, explosion.primaryColor)
-            .member(json_trusted{"secondaryColor"}, explosion.secondaryColor)
-            .member(json_trusted{"radius"}, explosion.circle.radius,
-                std::chars_format::fixed, 1);
+            .member(json_trusted{"secondaryColor"}, explosion.secondaryColor);
       }
     }
     if (auto beams = target.member_array(json_trusted{"transientBeams"})) {
       for (const auto& beam : result.transient_beams) {
         auto beam_json = beams->object();
+        if (auto circle = beam_json->member_object(json_trusted{"circle"})) {
+          circle
+              ->member(json_trusted{"x"}, beam.circle.x,
+                  std::chars_format::fixed, 1)
+              .member(json_trusted{"y"}, beam.circle.y,
+                  std::chars_format::fixed, 1)
+              .member(json_trusted{"radius"}, beam.circle.radius,
+                  std::chars_format::fixed, 1);
+        }
         beam_json
-            ->member(json_trusted{"x"}, beam.circle.x,
-                std::chars_format::fixed, 1)
-            .member(json_trusted{"y"}, beam.circle.y,
-                std::chars_format::fixed, 1)
-            .member(json_trusted{"radius"}, beam.circle.radius,
-                std::chars_format::fixed, 1)
-            .member(json_trusted{"expiryTick"}, tickExpiryTick(beam.expiry))
+            ->member(json_trusted{"expiryTick"}, tickExpiryTick(beam.expiry))
             .member(json_trusted{"primaryColor"}, beam.primaryColor)
             .member(json_trusted{"secondaryColor"}, beam.secondaryColor)
             .member(json_trusted{"lineWidth"}, beam.lineWidth,
@@ -220,7 +227,8 @@ struct SimGameStateJson {
                 std::chars_format::fixed, 1)
             .member(json_trusted{"coneRadius"}, beam.coneRadius,
                 std::chars_format::fixed, 1);
-        if (auto target_pos = beam_json->member_object(json_trusted{"targetPos"}))
+        if (auto target_pos =
+                beam_json->member_object(json_trusted{"targetPos"}))
         {
           target_pos
               ->member(json_trusted{"x"}, beam.targetPos.x,

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -93,8 +93,8 @@ struct SimGameStateJson {
 
   auto write_delta = [&writer, &game, &result, current_tick, &current_wave,
                          &wave_tick, &lives_count, &resources_count, &phase,
-                         &ui_state,
-                         send_strategy](json_writer<std::string>& target) {
+                         &ui_state, send_strategy](
+                         json_writer<std::string>& target) {
     target.member(json_trusted{"type"}, json_trusted{"world_delta"})
         .member(json_trusted{"tick"}, *current_tick);
 

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -28,16 +28,23 @@
 namespace corvid { inline namespace sim {
 
 // Calculate milliseconds until a tick-based expiry, capping at max uint32_t.
-// Returns 0 if the color is unset or the expiry has already passed.
+// Returns 0 if the expiry has already passed.
 [[nodiscard]] inline uint32_t
-tickExpiryDelayMs(uint32_t color, WorldTick expiry, WorldTick current_tick) {
-  if (color == 0 || expiry == WorldTick::invalid || expiry < current_tick)
-    return 0;
+tickExpiryDelayMs(WorldTick expiry, WorldTick current_tick) {
+  if (expiry == WorldTick::invalid || expiry < current_tick) return 0;
 
   constexpr uint32_t ms_per_tick = 50;
   const auto ticks_until_expiry = *expiry - *current_tick;
   const auto expiry_delay_ms = ticks_until_expiry * ms_per_tick;
   return std::min(expiry_delay_ms, std::numeric_limits<uint32_t>::max());
+}
+
+// Calculate milliseconds until a tick-based expiry, capping at max uint32_t.
+// Returns 0 if the color is unset or the expiry has already passed.
+[[nodiscard]] inline uint32_t
+tickExpiryDelayMs(uint32_t color, WorldTick expiry, WorldTick current_tick) {
+  if (color == 0) return 0;
+  return tickExpiryDelayMs(expiry, current_tick);
 }
 
 [[nodiscard]] inline uint32_t
@@ -56,11 +63,15 @@ cooldownExpiryDelayMs(const VisualEffects& effects, WorldTick current_tick) {
 struct SimGameStateJson {
   std::string body;
   std::vector<SimWorld::EntityId> erased_ids;
+  std::vector<TransientExplosion> transient_explosions;
+  std::vector<TransientBeam> transient_beams;
 
   // Clear the body and erased IDs. These fields retain their allocations.
   [[nodiscard]] bool clear() {
     body.clear();
     erased_ids.clear();
+    transient_explosions.clear();
+    transient_beams.clear();
     return true;
   }
 };
@@ -93,8 +104,8 @@ struct SimGameStateJson {
 
   auto write_delta = [&writer, &game, &result, current_tick, &current_wave,
                          &wave_tick, &lives_count, &resources_count, &phase,
-                         &ui_state, send_strategy](
-                         json_writer<std::string>& target) {
+                         &ui_state,
+                         send_strategy](json_writer<std::string>& target) {
     target.member(json_trusted{"type"}, json_trusted{"world_delta"})
         .member(json_trusted{"tick"}, *current_tick);
 
@@ -145,6 +156,14 @@ struct SimGameStateJson {
             result.erased_ids.push_back(entity_id);
             return true;
           },
+          [&result](const TransientExplosion& explosion) {
+            result.transient_explosions.push_back(explosion);
+            return true;
+          },
+          [&result](const TransientBeam& beam) {
+            result.transient_beams.push_back(beam);
+            return true;
+          },
           [&current_wave, &wave_tick, &lives_count, &resources_count, &phase,
               &ui_state](auto new_current_wave, auto new_wave_tick,
               auto new_lives, auto new_resources, auto new_phase,
@@ -161,6 +180,42 @@ struct SimGameStateJson {
 
     if (auto erased = target.member_array(json_trusted{"erased"})) {
       for (const auto entity_id : result.erased_ids) erased->value(*entity_id);
+    }
+    if (auto explosions =
+            target.member_array(json_trusted{"transientExplosions"}))
+    {
+      for (const auto& explosion : result.transient_explosions) {
+        explosions->object()
+            ->member(json_trusted{"x"}, explosion.x, std::chars_format::fixed,
+                1)
+            .member(json_trusted{"y"}, explosion.y, std::chars_format::fixed,
+                1)
+            .member(json_trusted{"expiryMs"},
+                tickExpiryDelayMs(explosion.expiry, current_tick))
+            .member(json_trusted{"primaryColor"}, explosion.primaryColor)
+            .member(json_trusted{"secondaryColor"}, explosion.secondaryColor)
+            .member(json_trusted{"radius"}, explosion.radius,
+                std::chars_format::fixed, 1);
+      }
+    }
+    if (auto beams = target.member_array(json_trusted{"transientBeams"})) {
+      for (const auto& beam : result.transient_beams) {
+        beams->object()
+            ->member(json_trusted{"x"}, beam.x, std::chars_format::fixed, 1)
+            .member(json_trusted{"y"}, beam.y, std::chars_format::fixed, 1)
+            .member(json_trusted{"expiryMs"},
+                tickExpiryDelayMs(beam.expiry, current_tick))
+            .member(json_trusted{"primaryColor"}, beam.primaryColor)
+            .member(json_trusted{"secondaryColor"}, beam.secondaryColor)
+            .member(json_trusted{"targetX"}, beam.targetX,
+                std::chars_format::fixed, 1)
+            .member(json_trusted{"targetY"}, beam.targetY,
+                std::chars_format::fixed, 1)
+            .member(json_trusted{"startDistance"}, beam.startDistance,
+                std::chars_format::fixed, 1)
+            .member(json_trusted{"lineWidth"}, beam.lineWidth,
+                std::chars_format::fixed, 1);
+      }
     }
 
     target.member(json_trusted{"currentWave"}, current_wave)

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -194,8 +194,7 @@ struct SimGameStateJson {
         defender->member(json_trusted{"entityName"}, summary.entityName)
             .member(json_trusted{"displayName"}, summary.displayName)
             .member(json_trusted{"flavorText"}, summary.flavorText)
-            .member(json_trusted{"resourceCost"}, summary.resourceCost,
-                std::chars_format::fixed, 1);
+            .member(json_trusted{"resourceCost"}, summary.resourceCost);
         if (auto app = defender->member_object(json_trusted{"appearance"})) {
           app->member(json_trusted{"glyph"},
                  static_cast<uint32_t>(summary.appearance.glyph))
@@ -246,8 +245,7 @@ struct SimGameStateJson {
         item->member(json_trusted{"entityName"}, entry.entityName)
             .member(json_trusted{"displayName"}, entry.displayName)
             .member(json_trusted{"flavorText"}, entry.flavorText)
-            .member(json_trusted{"resourceCost"}, entry.resourceCost,
-                std::chars_format::fixed, 1);
+            .member(json_trusted{"resourceCost"}, entry.resourceCost);
         if (auto app = item->member_object(json_trusted{"appearance"})) {
           app->member(json_trusted{"glyph"},
                  static_cast<uint32_t>(entry.appearance.glyph))

--- a/corvid/sim/sim_json_wire.h
+++ b/corvid/sim/sim_json_wire.h
@@ -27,18 +27,29 @@
 
 namespace corvid { inline namespace sim {
 
+// Calculate milliseconds until a tick-based expiry, capping at max uint32_t.
+// Returns 0 if the color is unset or the expiry has already passed.
 [[nodiscard]] inline uint32_t
-flashExpiryDelayMs(const VisualEffects& effects, WorldTick current_tick) {
-  // If not flashing, nothing to do.
-  if (effects.flashColor == 0 || effects.flashExpiry == WorldTick::invalid ||
-      effects.flashExpiry < current_tick)
+tickExpiryDelayMs(uint32_t color, WorldTick expiry, WorldTick current_tick) {
+  if (color == 0 || expiry == WorldTick::invalid || expiry < current_tick)
     return 0;
 
-  // Calculate milliseconds until expiry, capping at max uint32_t.
   constexpr uint32_t ms_per_tick = 50;
-  const auto ticks_until_expiry = *effects.flashExpiry - *current_tick;
+  const auto ticks_until_expiry = *expiry - *current_tick;
   const auto expiry_delay_ms = ticks_until_expiry * ms_per_tick;
   return std::min(expiry_delay_ms, std::numeric_limits<uint32_t>::max());
+}
+
+[[nodiscard]] inline uint32_t
+flashExpiryDelayMs(const VisualEffects& effects, WorldTick current_tick) {
+  return tickExpiryDelayMs(
+      effects.flashColor, effects.flashExpiry, current_tick);
+}
+
+[[nodiscard]] inline uint32_t
+cooldownExpiryDelayMs(const VisualEffects& effects, WorldTick current_tick) {
+  return tickExpiryDelayMs(
+      effects.cooldownColor, effects.cooldownExpiry, current_tick);
 }
 
 // Reusable state, to avoid repeated allocations.
@@ -122,7 +133,10 @@ struct SimGameStateJson {
                   .member(json_trusted{"range"}, effects.rangeColor)
                   .member(json_trusted{"flash"}, effects.flashColor)
                   .member(json_trusted{"flashExpiryMs"},
-                      flashExpiryDelayMs(effects, current_tick));
+                      flashExpiryDelayMs(effects, current_tick))
+                  .member(json_trusted{"cooldown"}, effects.cooldownColor)
+                  .member(json_trusted{"cooldownExpiryMs"},
+                      cooldownExpiryDelayMs(effects, current_tick));
             }
 
             return true;

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -241,10 +241,10 @@ struct Pathing {
 // TODO: Add field for sprite selection.
 struct Appearance {
   WorldTick modified{WorldTick::invalid}; // Tick when last modified.
-  char32_t glyph{};    // a Unicode character to display, if any.
-  float radius{5.F};   // world-space radius of the rendered shape.
-  uint32_t fg_color{}; // RGBA.
-  uint32_t bg_color{}; // RGBA.
+  char32_t glyph{};   // a Unicode character to display, if any.
+  float radius{5.F};  // world-space radius of the rendered shape.
+  uint32_t fgColor{}; // RGBA.
+  uint32_t bgColor{}; // RGBA.
 };
 
 // Health component. Applies to both defenders and invaders. The two health
@@ -252,8 +252,8 @@ struct Appearance {
 // `regen` is server-side only.
 struct Health {
   WorldTick modified{WorldTick::invalid}; // Tick when last modified.
-  float current_health{};
-  float max_health{};
+  float currentHealth{};
+  float maxHealth{};
   float regen{}; // Regeneration or bleed per tick.
 };
 
@@ -261,44 +261,44 @@ struct Health {
 // but has no effect on physics or game logic.
 struct VisualEffects {
   WorldTick modified{WorldTick::invalid}; // Tick when last modified.
-  uint32_t selection_color{};             // RGBA.
-  float range_radius{};
-  uint32_t range_color{}; // RGBA.
-  uint32_t flash_color{}; // RGBA.
-  WorldTick flash_expiry{WorldTick::invalid};
+  uint32_t selectionColor{};              // RGBA.
+  float rangeRadius{};
+  uint32_t rangeColor{}; // RGBA.
+  uint32_t flashColor{}; // RGBA.
+  WorldTick flashExpiry{WorldTick::invalid};
 };
 
 // Defensive tower component, common across all defenders.
 struct Defender {
-  int defender_type{};       // Eventually an enum.
-  float hit_circle_radius{}; // Hit detection, as opposed to appearance.
-  float attack_radius{};
-  uint32_t range_color{}; // RGBA.
-  float attack_damage{};  // Interpretation depends on the tower type.
+  int defenderType{};      // Eventually an enum.
+  float hitCircleRadius{}; // Hit detection, as opposed to appearance.
+  float attackRadius{};
+  uint32_t rangeColor{}; // RGBA.
+  float attackDamage{};  // Interpretation depends on the tower type.
   WorldTick cooldown{};
-  WorldTick next_attack{}; // Updated when the tower attacks.
+  WorldTick nextAttack{}; // Updated when the tower attacks.
 };
 
 // Stats for defenders, shown when selecting a defender.
 struct DefenderStats {
-  float total_damage_dealt{};
-  float total_damage_taken{};
-  float total_kills{};
+  float totalDamageDealt{};
+  float totalDamageTaken{};
+  float totalKills{};
 };
 
 // Area-of-effect component for defenders that have an attack that hits an area
 // rather than a single target.
 struct DefenderAoe {
-  int damage_type{}; // Eventually an enum.
+  int damageType{}; // Eventually an enum.
 };
 
 // Hitscan component for defenders that have an attack that hits a single
 // target instantly, rather than spawning a projectile that travels to the
 // target.
 struct DefenderHitscan {
-  uint32_t beam_color{}; // RGBA.
-  WorldTick beam_duration{};
-  int beam_type{}; // Eventually an enum.
+  uint32_t beamColor{}; // RGBA.
+  WorldTick beamDuration{};
+  int beamType{}; // Eventually an enum.
 };
 
 // Projectile component for `DefenderShooter`. Used as part of its own
@@ -307,12 +307,12 @@ struct DefenderHitscan {
 // its final moment.
 struct DefenderBullet {
   float speed{};
-  float direct_damage{};
-  float damage_over_time{};
-  float splash_radius{};
-  float direct_damage_type{}; // Eventually an enum.
-  float dot_damage_type{};    // Eventually an enum.
-  int projectile_type{};      // Eventually an enum.
+  float directDamage{};
+  float damageOverTime{};
+  float splashRadius{};
+  float directDamageType{}; // Eventually an enum.
+  float dotDamageType{};    // Eventually an enum.
+  int projectileType{};     // Eventually an enum.
   WorldTick expiry{};
 };
 
@@ -321,14 +321,14 @@ struct DefenderBullet {
 // tower's attack, but with their own position and velocity.
 struct DefenderShooter {
   DefenderBullet bullet_template{};
-  float fire_rate{}; // Shots per tick.
-  int spread{};      // Eventually an enum.
+  float fireRate{}; // Shots per tick.
+  int spread{};     // Eventually an enum.
 };
 
 // Invader component, shared across all invaders.
 struct Invader {
-  int invader_type{};        // Eventually an enum.
-  float hit_circle_radius{}; // Hit detection, as opposed to appearance.
+  int invaderType{};       // Eventually an enum.
+  float hitCircleRadius{}; // Hit detection, as opposed to appearance.
   int bounty{10}; // Resources awarded to the player for killing this enemy.
 };
 
@@ -378,7 +378,7 @@ using WorldScene = archetype_scene<WorldReg, ArchInvaderAlpha, ArchDefenderAoe,
 // Simulation world: encapsulates all ECS entity state for the game and
 // provides physics.
 //
-// Each `tick()` advances `Position` components based by velocity and bounces
+// Each `tick()` advances `Position` components based on velocity and bounces
 // off the world boundary. The registry metadata records the tick count at each
 // entity's last state change so callers can request delta snapshots starting
 // from any past tick.
@@ -408,18 +408,16 @@ public:
     Appearance app{.modified = tick_,
         .glyph = U'\u03B1', // Greek alpha
         .radius = 30.F,
-        .fg_color = 0xFFFFFFFF,
-        .bg_color = 0x000000FF};
+        .fgColor = 0xFFFFFFFF,
+        .bgColor = 0x000000FF};
     VisualEffects fx{.modified = tick_,
-        .flash_color = 0xFF7F7FFF,
-        .flash_expiry = WorldTick{5}};
+        .flashColor = 0xFF7F7FFF,
+        .flashExpiry = WorldTick{5}};
     Pathing pathing{.path_id = pathId, .progress = progress, .speed = 50.F};
-    Invader invader{.invader_type = 1,
-        .hit_circle_radius = 30.F,
-        .bounty = 10};
+    Invader invader{.invaderType = 1, .hitCircleRadius = 30.F, .bounty = 10};
     Health health{.modified = tick_,
-        .current_health = 100.F,
-        .max_health = 100.F,
+        .currentHealth = 100.F,
+        .maxHealth = 100.F,
         .regen = 10.F};
     const auto pos =
         paths_[pathId].calculatePositionFromProgress(progress, progress);
@@ -431,26 +429,26 @@ public:
 
   // Spawn an AOE defender.
   [[nodiscard]] Handle spawnDefenderAoe(Position pos) {
-    Defender defender{.defender_type = 1,
-        .hit_circle_radius = 30.F,
-        .attack_radius = 100.F,
-        .range_color = 0xFFFF0000,
-        .attack_damage = 5.F,
+    Defender defender{.defenderType = 1,
+        .hitCircleRadius = 30.F,
+        .attackRadius = 100.F,
+        .rangeColor = 0xFFFF0000,
+        .attackDamage = 5.F,
         .cooldown = WorldTick{20},
-        .next_attack = WorldTick{0}};
+        .nextAttack = WorldTick{0}};
     Appearance app{.modified = tick_,
         .glyph = U'A',
         .radius = 30.F,
-        .fg_color = 0xFFFFFFFF,
-        .bg_color = 0x7F7FFFFF};
+        .fgColor = 0xFFFFFFFF,
+        .bgColor = 0x7F7FFFFF};
     VisualEffects fx{.modified = tick_,
-        .flash_color = 0xFF7F7FFF,
-        .flash_expiry = WorldTick{5}};
+        .flashColor = 0xFF7F7FFF,
+        .flashExpiry = WorldTick{5}};
     Health health{.modified = tick_,
-        .current_health = 100.F,
-        .max_health = 100.F,
+        .currentHealth = 100.F,
+        .maxHealth = 100.F,
         .regen = 0.F};
-    DefenderAoe defenderAoe{.damage_type = 1};
+    DefenderAoe defenderAoe{.damageType = 1};
     DefenderStats defenderStats{};
     auto h = scene_.store_new_entity<sidDefenderAoe>({WorldTick::invalid}, pos,
         app, fx, defender, defenderStats, health, defenderAoe);
@@ -461,35 +459,35 @@ public:
   // Spawn a shooter defender.
   [[nodiscard]] Handle spawnDefenderShooter(Position pos) {
     DefenderBullet bullet_template{.speed = 200.F,
-        .direct_damage = 20.F,
-        .damage_over_time = 0.F,
-        .splash_radius = 0.F,
-        .direct_damage_type = 1,
-        .dot_damage_type = 0,
-        .projectile_type = 1,
+        .directDamage = 20.F,
+        .damageOverTime = 0.F,
+        .splashRadius = 0.F,
+        .directDamageType = 1,
+        .dotDamageType = 0,
+        .projectileType = 1,
         .expiry = WorldTick{20}};
-    Defender defender{.defender_type = 1,
-        .hit_circle_radius = 20.F,
-        .attack_radius = 100.F,
-        .range_color = 0xFFFF0000,
-        .attack_damage = 5.F,
+    Defender defender{.defenderType = 1,
+        .hitCircleRadius = 20.F,
+        .attackRadius = 100.F,
+        .rangeColor = 0xFFFF0000,
+        .attackDamage = 5.F,
         .cooldown = WorldTick{20},
-        .next_attack = WorldTick{0}};
+        .nextAttack = WorldTick{0}};
     Appearance app{.modified = tick_,
         .glyph = U'S',
         .radius = 20.F,
-        .fg_color = 0xFFFFFFFF,
-        .bg_color = 0x7FFF7FFF};
+        .fgColor = 0xFFFFFFFF,
+        .bgColor = 0x7FFF7FFF};
     VisualEffects fx{.modified = tick_,
-        .flash_color = 0xFF7F7FFF,
-        .flash_expiry = WorldTick{5}};
+        .flashColor = 0xFF7F7FFF,
+        .flashExpiry = WorldTick{5}};
     Health health{.modified = tick_,
-        .current_health = 100.F,
-        .max_health = 100.F,
+        .currentHealth = 100.F,
+        .maxHealth = 100.F,
         .regen = 0.F};
     DefenderStats defenderStats{};
     DefenderShooter defenderShooter{.bullet_template = bullet_template,
-        .fire_rate = 1.F,
+        .fireRate = 1.F,
         .spread = 0};
     auto h = scene_.store_new_entity<sidDefenderShooter>({WorldTick::invalid},
         pos, app, fx, defender, defenderStats, health, defenderShooter);
@@ -539,8 +537,8 @@ public:
       WorldTick duration = WorldTick{20}) {
     auto* effects = changeVisualEffects(id);
     if (!effects) return false;
-    effects->flash_color = color;
-    effects->flash_expiry = WorldTick{*tick_ + *duration};
+    effects->flashColor = color;
+    effects->flashExpiry = WorldTick{*tick_ + *duration};
     return true;
   }
 
@@ -817,12 +815,12 @@ private:
     // damage and trigger a flash on both.
     scene_.for_each<Position, Defender>([&](auto towerId, auto towerComps) {
       auto& [towerPos, tower] = towerComps;
-      if (tick_ < tower.next_attack) return true;
+      if (tick_ < tower.nextAttack) return true;
 
       scene_.for_each<Position, Invader>([&](auto enemyId, auto enemyComps) {
         auto& [enemyPos, invader] = enemyComps;
-        if (!circlesOverlap(towerPos, tower.attack_radius, enemyPos,
-                invader.hit_circle_radius))
+        if (!circlesOverlap(towerPos, tower.attackRadius, enemyPos,
+                invader.hitCircleRadius))
           return true;
 
         (void)flashEntity(towerId, 0xFFFFFFFF, WorldTick{5});

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -227,23 +227,34 @@ constexpr Tick invalidTick = std::numeric_limits<Tick>::max();
 // For circle hitboxes, collision is trivial: when the distance between centers
 // is less than the sum of the radii, they collide.
 
-// Path-following component. Stored alongside `Position` in the enemy
-// archetype. Each tick, `progress` advances by `speed`; the entity's
-// `Position` is re-derived from the segmented path geometry.
-struct PathFollower {
-  PathId pathId{};  // Index into `sim_world::paths_`.
+// Path-following component. Typically part of an invader archetype, but may
+// also apply to defenders. On each tick, `progress` advances by `speed`; the
+// entity's `Position` is re-derived from the segmented path geometry.
+struct Pathing {
+  PathId path_id{}; // Index into `sim_world::paths_`.
   float progress{}; // Distance traveled along the path so far.
   float speed{};    // Distance per tick.
 };
 
 // Appearance component. Controls rendering on client side, but has no effect
 // on physics or game logic.
+// TODO: Add field for sprite selection.
 struct Appearance {
   WorldTick modified{WorldTick::invalid}; // Tick when last modified.
   char32_t glyph{};    // a Unicode character to display, if any.
   float radius{5.F};   // world-space radius of the rendered shape.
   uint32_t fg_color{}; // RGBA.
   uint32_t bg_color{}; // RGBA.
+};
+
+// Health component. Applies to both defenders and invaders. The two health
+// fields are streamed to the client in order to render health bars. The
+// `regen` is server-side only.
+struct Health {
+  WorldTick modified{WorldTick::invalid}; // Tick when last modified.
+  float current_health{};
+  float max_health{};
+  float regen{}; // Regeneration or bleed per tick.
 };
 
 // Visual effects component. Controls transient overlays on the client side,
@@ -257,46 +268,68 @@ struct VisualEffects {
   WorldTick flash_expiry{WorldTick::invalid};
 };
 
-// Defensive tower component. Stored alongside `Position` in the tower
-// archetype.
-//
-// Note that towers sitting in the catalog or being dragged and dropped into
-// place are not entities, just client-side UI ephemera. Only once a tower is
-// placed does it become part of the world.
-struct Tower {
-  int tower_type{};
+// Defensive tower component, common across all defenders.
+struct Defender {
+  int defender_type{};       // Eventually an enum.
+  float hit_circle_radius{}; // Hit detection, as opposed to appearance.
   float attack_radius{};
-  uint32_t range_color{};  // RGBA.
-  float attack_damage{};   // Per-attack damage.
-  WorldTick cooldown{};    // Cooldown for this sort of tower, in ticks.
-  WorldTick next_attack{}; // Tick when the next attack can occur.
+  uint32_t range_color{}; // RGBA.
+  float attack_damage{};  // Interpretation depends on the tower type.
+  WorldTick cooldown{};
+  WorldTick next_attack{}; // Updated when the tower attacks.
 };
 
-// TODO: Standardize on Defender and Invader as the two sides, rather than
-// Tower and Enemy. Defender is more general and can apply to both towers and
-// bullets, while Enemy is more specific and only applies to the path-following
-// invaders. We may want to add a separate archetype for non-path-following
-// enemies, such as flying ones.
+// Stats for defenders, shown when selecting a defender.
+struct DefenderStats {
+  float total_damage_dealt{};
+  float total_damage_taken{};
+  float total_kills{};
+};
 
-// TODO: Rename Tower to DefenderAoe.  Add DefenderHitscan, which is similar
-// except that it has a beam_color and beam_duration. Add DefenderProjective,
-// which has a projectile_speed and projectile_damage, which is used to spawn a
-// bullet.
+// Area-of-effect component for defenders that have an attack that hits an area
+// rather than a single target.
+struct DefenderAoe {
+  int damage_type{}; // Eventually an enum.
+};
 
-// Enemy invader component. Stored alongside `Position` and `PathFollower` in
-// the enemy archetype.
+// Hitscan component for defenders that have an attack that hits a single
+// target instantly, rather than spawning a projectile that travels to the
+// target.
+struct DefenderHitscan {
+  uint32_t beam_color{}; // RGBA.
+  WorldTick beam_duration{};
+  int beam_type{}; // Eventually an enum.
+};
+
+// Projectile component for `DefenderShooter`. Used as part of its own
+// archetype, and also as the `bullet_template`. As a template, the `expiry`
+// field stores the TTL. Once instantiated, added to the current tick to gets
+// its final moment.
+struct DefenderBullet {
+  float speed{};
+  float direct_damage{};
+  float damage_over_time{};
+  float splash_radius{};
+  float direct_damage_type{}; // Eventually an enum.
+  float dot_damage_type{};    // Eventually an enum.
+  int projectile_type{};      // Eventually an enum.
+  WorldTick expiry{};
+};
+
+// Shooter component for defenders that spawn projectiles. The
+// `bullet_template` is used to spawn bullets with the same properties as the
+// tower's attack, but with their own position and velocity.
+struct DefenderShooter {
+  DefenderBullet bullet_template{};
+  float fire_rate{}; // Shots per tick.
+  int spread{};      // Eventually an enum.
+};
+
+// Invader component, shared across all invaders.
 struct Invader {
-  float health{};
-  float radius{}; // Distinct from appearance: this is used for hit detection.
-  int bounty{1};  // Resources awarded to the player for killing this enemy.
-};
-
-// Bullet component. Stored alongside `Position` and `Velocity` in the bullet
-// archetype.
-struct Bullet {
-  int bullet_type{};
-  float damage{};
-  WorldTick expiration{};
+  int invader_type{};        // Eventually an enum.
+  float hit_circle_radius{}; // Hit detection, as opposed to appearance.
+  int bounty{10}; // Resources awarded to the player for killing this enemy.
 };
 
 // ECS types for the simulation world.
@@ -305,60 +338,60 @@ struct Bullet {
 // enabling delta snapshots without a separate dirty set.
 //
 // Storage layout (store_id assignment is positional, 1-based):
-//   `sidStaging` = 0                      : staging storage, used as tombstone
+//   `sidStaging`         = 0 -> staging storage, used as tombstone
 //
-//   `sidPos`     = 1  -> `ArchP`          : background / destructible entities
-//                                           (Position + Appearance)
+//   `sidInvaderAlpha`    = 1 -> `ArchInvaderAlpha`
+//                               alpha invaders
+//                               (Position + Appearance + VisualEffects +
+//                               Pathing + Invader + Health)
 //
-//   `sidPosVel`  = 2  -> `ArchPV`         : moving entities
-//                                           (Position + Velocity +
-//                                           Appearance)
+//   `sidDefenderAoe`     = 2 -> `ArchDefenderAoe`
+//                               area-of-effect defenders
+//                               (Position + Appearance + VisualEffects +
+//                               Defender + DefenderStats + Health +
+//                               DefenderAoe)
 //
-//   `sidEnemy`   = 3  -> `ArchEnemy`      : path-following enemies
-//                                           (Position + Appearance +
-//                                           VisualEffects + PathFollower +
-//                                           Invader)
+//   `sidBullet`          = 3 -> `ArchBullet`
+//                               spawned projectiles
+//                               (Position + Velocity + DefenderBullet)
 //
-//   `sidTower`   = 4  -> `ArchTower`      : placed towers
-//                                          (Position + Appearance +
-//                                          VisualEffects + Tower)
-//
-//   `sidBullet`  = 5  -> `ArchBullet`     : bullets
-//                                           (Position + Velocity + Bullet)
-//
-// Background storage comes first so that retiring a mobile entity is a
-// natural `archetype_scene::migrate_entity` call rather than erase + re-add.
+//   `sidDefenderShooter` = 4 -> `ArchDefenderShooter`
+//                               projectile-firing defenders
+//                               (Position + Appearance + VisualEffects +
+//                               Defender + DefenderStats + Health +
+//                               DefenderShooter)
 using WorldReg = entity_registry<WorldTick>;
 using WorldSid = WorldReg::store_id_t;
-using ArchP = archetype_storage<WorldReg, std::tuple<Position, Appearance>>;
-using ArchPV =
-    archetype_storage<WorldReg, std::tuple<Position, Velocity, Appearance>>;
-using ArchEnemy = archetype_storage<WorldReg,
-    std::tuple<Position, Appearance, VisualEffects, PathFollower, Invader>>;
-using ArchTower = archetype_storage<WorldReg,
-    std::tuple<Position, Appearance, VisualEffects, Tower>>;
-using ArchBullet =
-    archetype_storage<WorldReg, std::tuple<Position, Velocity, Bullet>>;
-using WorldScene =
-    archetype_scene<WorldReg, ArchP, ArchPV, ArchEnemy, ArchTower, ArchBullet>;
+using ArchInvaderAlpha = archetype_storage<WorldReg,
+    std::tuple<Position, Appearance, VisualEffects, Pathing, Invader, Health>>;
+using ArchDefenderAoe = archetype_storage<WorldReg,
+    std::tuple<Position, Appearance, VisualEffects, Defender, DefenderStats,
+        Health, DefenderAoe>>;
+using ArchBullet = archetype_storage<WorldReg,
+    std::tuple<Position, Velocity, DefenderBullet>>;
+using ArchDefenderShooter = archetype_storage<WorldReg,
+    std::tuple<Position, Appearance, VisualEffects, Defender, DefenderStats,
+        Health, DefenderShooter>>;
+using WorldScene = archetype_scene<WorldReg, ArchInvaderAlpha, ArchDefenderAoe,
+    ArchBullet, ArchDefenderShooter>;
 
 // Simulation world: encapsulates all ECS entity state for the game and
 // provides physics.
 //
-// Each `tick()` advances `Position` components based on
-// by velocity and bounces off the world boundary. The registry metadata
-// records the tick count at each entity's last state change so callers can
-// request delta snapshots starting from any past tick.
+// Each `tick()` advances `Position` components based by velocity and bounces
+// off the world boundary. The registry metadata records the tick count at each
+// entity's last state change so callers can request delta snapshots starting
+// from any past tick.
 class SimWorld {
 public:
   using EntityId = WorldReg::id_t;
   using Handle = WorldReg::handle_t;
 
   static constexpr WorldSid sidStaging{0};
-  static constexpr WorldSid sidPos{1};
-  static constexpr WorldSid sidPosVel{2};
-  static constexpr WorldSid sidEnemy{3};
-  static constexpr WorldSid sidTower{4};
+  static constexpr WorldSid sidInvaderAlpha{1};
+  static constexpr WorldSid sidDefenderAoe{2};
+  static constexpr WorldSid sidBullet{3};
+  static constexpr WorldSid sidDefenderShooter{4};
   static constexpr float widthOfWorld = 1920.F;
   static constexpr float heightOfWorld = 1080.F;
 
@@ -370,49 +403,96 @@ public:
     tick_ = {};
   }
 
-  // Spawn a moving entity with the given initial position and velocity.
-  // Returns a handle for later `despawn()`. The entity's last-change tick
-  // is set to the current tick count.
-  [[nodiscard]] Handle spawnMover(Position pos, Velocity vel) {
+  [[nodiscard]] Handle spawnInvaderAlpha(PathId pathId, float progress = 0.F) {
+    if (pathId >= paths_.size_as_enum()) return {};
     Appearance app{.modified = tick_,
-        .glyph = U'M',
-        .radius = 5.F,
+        .glyph = U'\u03B1', // Greek alpha
+        .radius = 10.F,
         .fg_color = 0xFFFFFFFF,
-        .bg_color = 0xFF};
-    auto h = scene_.store_new_entity<sidPosVel>({WorldTick::invalid}, pos, vel,
-        app);
+        .bg_color = 0x000000FF};
+    VisualEffects fx{.modified = tick_,
+        .flash_color = 0xFF7F7FFF,
+        .flash_expiry = WorldTick{5}};
+    Pathing pathing{.path_id = pathId, .progress = progress, .speed = 100.F};
+    Invader invader{.invader_type = 1,
+        .hit_circle_radius = 10.F,
+        .bounty = 10};
+    Health health{.modified = tick_,
+        .current_health = 100.F,
+        .max_health = 100.F,
+        .regen = 10.F};
+    const auto pos =
+        paths_[pathId].calculatePositionFromProgress(progress, progress);
+    auto h = scene_.store_new_entity<sidInvaderAlpha>({WorldTick::invalid},
+        pos, app, fx, pathing, invader, health);
     if (h) (void)markDirty(h.id());
     return h;
   }
 
-  // Spawn an immobile entity. Returns a handle for later `despawn()`.
-  [[nodiscard]] Handle spawnBackground(Position pos) {
-    Appearance app{.modified = tick_,
-        .glyph = U'B',
-        .radius = 5.F,
-        .fg_color = 0xFFFFFFFF,
-        .bg_color = 0xFF};
-    auto h = scene_.store_new_entity<sidPos>({WorldTick::invalid}, pos, app);
-    if (h) (void)markDirty(h.id());
-    return h;
-  }
-
-  // Spawn an immobile entity. Returns a handle for later `despawn()`.
-  [[nodiscard]] Handle spawnTower(Position pos) {
-    Tower tower{.tower_type = 1,
+  // Spawn an AOE defender.
+  [[nodiscard]] Handle spawnDefenderAoe(Position pos) {
+    Defender defender{.defender_type = 1,
+        .hit_circle_radius = 30.F,
         .attack_radius = 100.F,
-        .range_color = 0xFFFF007F,
-        .attack_damage = 10.F,
-        .cooldown = {},
-        .next_attack = tick_};
+        .range_color = 0xFFFF0000,
+        .attack_damage = 5.F,
+        .cooldown = WorldTick{20},
+        .next_attack = WorldTick{0}};
     Appearance app{.modified = tick_,
-        .glyph = U'T',
+        .glyph = U'A',
+        .radius = 30.F,
+        .fg_color = 0xFFFFFFFF,
+        .bg_color = 0x7F7FFFFF};
+    VisualEffects fx{.modified = tick_,
+        .flash_color = 0xFF7F7FFF,
+        .flash_expiry = WorldTick{5}};
+    Health health{.modified = tick_,
+        .current_health = 100.F,
+        .max_health = 100.F,
+        .regen = 0.F};
+    DefenderAoe defenderAoe{.damage_type = 1};
+    DefenderStats defenderStats{};
+    auto h = scene_.store_new_entity<sidDefenderAoe>({WorldTick::invalid}, pos,
+        app, fx, defender, defenderStats, health, defenderAoe);
+    if (h) (void)markDirty(h.id());
+    return h;
+  }
+
+  // Spawn a shooter defender.
+  [[nodiscard]] Handle spawnDefenderShooter(Position pos) {
+    DefenderBullet bullet_template{.speed = 200.F,
+        .direct_damage = 20.F,
+        .damage_over_time = 0.F,
+        .splash_radius = 0.F,
+        .direct_damage_type = 1,
+        .dot_damage_type = 0,
+        .projectile_type = 1,
+        .expiry = WorldTick{20}};
+    Defender defender{.defender_type = 1,
+        .hit_circle_radius = 20.F,
+        .attack_radius = 100.F,
+        .range_color = 0xFFFF0000,
+        .attack_damage = 5.F,
+        .cooldown = WorldTick{20},
+        .next_attack = WorldTick{0}};
+    Appearance app{.modified = tick_,
+        .glyph = U'S',
         .radius = 20.F,
         .fg_color = 0xFFFFFFFF,
-        .bg_color = 0xFF};
-    VisualEffects fx;
-    auto h = scene_.store_new_entity<sidTower>({WorldTick::invalid}, pos, app,
-        fx, tower);
+        .bg_color = 0x7FFF7FFF};
+    VisualEffects fx{.modified = tick_,
+        .flash_color = 0xFF7F7FFF,
+        .flash_expiry = WorldTick{5}};
+    Health health{.modified = tick_,
+        .current_health = 100.F,
+        .max_health = 100.F,
+        .regen = 0.F};
+    DefenderStats defenderStats{};
+    DefenderShooter defenderShooter{.bullet_template = bullet_template,
+        .fire_rate = 1.F,
+        .spread = 0};
+    auto h = scene_.store_new_entity<sidDefenderShooter>({WorldTick::invalid},
+        pos, app, fx, defender, defenderStats, health, defenderShooter);
     if (h) (void)markDirty(h.id());
     return h;
   }
@@ -429,27 +509,6 @@ public:
   [[nodiscard]] const SegmentedPath* getPath(PathId pathId) const {
     if (pathId >= paths_.size_as_enum()) return nullptr;
     return &paths_[pathId];
-  }
-
-  // Spawn a path-following enemy. Initial position is derived from `progress`
-  // on the named path. Returns a handle for later `despawn()`.
-  [[nodiscard]] Handle
-  spawnEnemy(PathId pathId, float speed, float progress = 0.F) {
-    if (pathId >= paths_.size_as_enum()) return {};
-    // Enemies are only spawned during the active world step, so their
-    // appearance must replicate on the current tick rather than the next one.
-    Appearance app{.modified = tick_,
-        .glyph = U'U',
-        .radius = 10.F,
-        .fg_color = 0xFFFFFFFF,
-        .bg_color = 0xFF};
-    VisualEffects fx{};
-    const auto pos =
-        paths_[pathId].calculatePositionFromProgress(progress, progress);
-    auto h = scene_.store_new_entity<sidEnemy>({WorldTick::invalid}, pos, app,
-        fx, PathFollower{pathId, progress, speed}, Invader{});
-    if (h) (void)markDirty(h.id());
-    return h;
   }
 
   // Obtain a pointer to the `Appearance` for the entity. It is already marked
@@ -516,12 +575,13 @@ public:
   }
 
   [[nodiscard]] auto getTower(EntityId id) {
-    return scene_.storage<sidTower>()[id].components();
+    return scene_
+        .try_get_components<Position, Appearance, VisualEffects, Defender>(id);
   }
 
   [[nodiscard]] EntityId findTowerAt(const Position& pos) const {
     EntityId found_id = EntityId::invalid;
-    scene_.for_each<Position, Appearance, Tower>([&](auto id, auto comps) {
+    scene_.for_each<Position, Appearance, Defender>([&](auto id, auto comps) {
       const auto& [epos, app, _] = comps;
       const auto radius = app.radius;
       // If point outside of bounding box, keep searching.
@@ -607,7 +667,7 @@ public:
   }
 
   // Resolve path escapees by calling `cbEscapee(EntityId, const Position&,
-  // const PathFollower&)` for each.
+  // const Pathing&)` for each.
   //
   // Destructively iterates through the list of path escapees. If `cbEscapee`
   // returns true, the escapee is erased; if false, it's left alive, so the
@@ -616,7 +676,7 @@ public:
   [[nodiscard]] bool resolveEscapees(auto&& cbEscapee) {
     for (auto id : pathEscapees_) {
       if (!scene_.registry().is_valid(id)) continue;
-      auto [pos, pf] = scene_.try_get_components<Position, PathFollower>(id);
+      auto [pos, pf] = scene_.try_get_components<Position, Pathing>(id);
       if (!pos || !pf) continue;
       if (!cbEscapee(id, *pos, *pf)) continue;
       (void)tombstoneEntity(id);
@@ -727,16 +787,16 @@ private:
   // Advance path-following enemies. Collect entities that changed, as well as
   // those that escaped the path.
   [[nodiscard]] bool updatePathFollowers() {
-    scene_.for_each<Position, PathFollower>([&](auto id, auto comps) {
+    scene_.for_each<Position, Pathing>([&](auto id, auto comps) {
       auto& [pos, pf] = comps;
-      assert(pf.pathId < paths_.size_as_enum());
+      assert(pf.path_id < paths_.size_as_enum());
       if (pf.speed == 0.F) return true;
 
       (void)markDirty(id);
 
       const float previousProgress = pf.progress;
       pf.progress += pf.speed;
-      const auto& sp = paths_[pf.pathId];
+      const auto& sp = paths_[pf.path_id];
 
       // Collect escapees.
       if (pf.progress >= sp.totalLength || pf.progress < 0.F) {
@@ -755,14 +815,14 @@ private:
     // Range over all towers. For each tower, range over all enemies and check
     // for hits. If an enemy is in range and the tower is off cooldown, apply
     // damage and trigger a flash on both.
-    scene_.for_each<Position, Tower>([&](auto towerId, auto towerComps) {
+    scene_.for_each<Position, Defender>([&](auto towerId, auto towerComps) {
       auto& [towerPos, tower] = towerComps;
       if (tick_ < tower.next_attack) return true;
 
       scene_.for_each<Position, Invader>([&](auto enemyId, auto enemyComps) {
         auto& [enemyPos, invader] = enemyComps;
         if (!circlesOverlap(towerPos, tower.attack_radius, enemyPos,
-                invader.radius))
+                invader.hit_circle_radius))
           return true;
 
         (void)flashEntity(towerId, 0xFFFFFFFF, WorldTick{5});

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -407,15 +407,15 @@ public:
     if (pathId >= paths_.size_as_enum()) return {};
     Appearance app{.modified = tick_,
         .glyph = U'\u03B1', // Greek alpha
-        .radius = 10.F,
+        .radius = 30.F,
         .fg_color = 0xFFFFFFFF,
         .bg_color = 0x000000FF};
     VisualEffects fx{.modified = tick_,
         .flash_color = 0xFF7F7FFF,
         .flash_expiry = WorldTick{5}};
-    Pathing pathing{.path_id = pathId, .progress = progress, .speed = 100.F};
+    Pathing pathing{.path_id = pathId, .progress = progress, .speed = 50.F};
     Invader invader{.invader_type = 1,
-        .hit_circle_radius = 10.F,
+        .hit_circle_radius = 30.F,
         .bounty = 10};
     Health health{.modified = tick_,
         .current_health = 100.F,

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -246,10 +246,11 @@ struct Pathing {
 // TODO: Add field for sprite selection.
 struct Appearance {
   WorldTick modified{WorldTick::invalid}; // Tick when last modified.
-  char32_t glyph{};   // a Unicode character to display, if any.
-  float radius{5.F};  // world-space radius of the rendered shape.
-  uint32_t fgColor{}; // RGBA.
-  uint32_t bgColor{}; // RGBA.
+  char32_t glyph{};     // A Unicode character to display, if any.
+  float radius{5.F};    // World-space radius of the rendered shape.
+  uint32_t fgColor{};   // RGBA.
+  uint32_t bgColor{};   // RGBA.
+  float attackRadius{}; // Display-only (world units).
 };
 
 // Health component. Applies to both defenders and invaders. The two health

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -21,7 +21,11 @@
 #include <cstdint>
 #include <numbers>
 #include <stdexcept>
+#include <string>
+#include <string_view>
 #include <vector>
+
+#include "../containers/transparent.h"
 
 #include "../ecs.h"
 
@@ -403,96 +407,44 @@ public:
     tick_ = {};
   }
 
-  [[nodiscard]] Handle spawnInvaderAlpha(PathId pathId, float progress = 0.F) {
-    if (pathId >= paths_.size_as_enum()) return {};
-    Appearance app{.modified = tick_,
-        .glyph = U'\u03B1', // Greek alpha
-        .radius = 30.F,
-        .fgColor = 0xFFFFFFFF,
-        .bgColor = 0x000000FF};
-    VisualEffects fx{.modified = tick_,
-        .flashColor = 0xFF7F7FFF,
-        .flashExpiry = WorldTick{5}};
-    Pathing pathing{.path_id = pathId, .progress = progress, .speed = 50.F};
-    Invader invader{.invaderType = 1, .hitCircleRadius = 30.F, .bounty = 10};
-    Health health{.modified = tick_,
-        .currentHealth = 100.F,
-        .maxHealth = 100.F,
-        .regen = 10.F};
-    const auto pos =
-        paths_[pathId].calculatePositionFromProgress(progress, progress);
-    auto h = scene_.store_new_entity<sidInvaderAlpha>({WorldTick::invalid},
-        pos, app, fx, pathing, invader, health);
-    if (h) (void)markDirty(h.id());
+  // Register a named entity type from a `megatuple_t` template. The set of
+  // optionals that have values must exactly match one archetype's components.
+  // Templates survive `clear()` and are only replaced by calling this method
+  // again with the same label.
+  void registerEntity(std::string label, WorldScene::megatuple_t tpl) {
+    entity_templates_.insert_or_assign(std::move(label), std::move(tpl));
+  }
+
+  // Spawn an entity by label. Looks up the pre-registered template, stamps
+  // `tick_` into any `modified` fields, marks the entity dirty, and returns
+  // its handle. Returns an invalid handle if the label is unknown or the
+  // template bitmap does not match any archetype.
+  [[nodiscard]] Handle spawnEntity(std::string_view label) {
+    auto it = entity_templates_.find(label);
+    if (it == entity_templates_.end()) return {};
+    auto h =
+        scene_.store_new_entity_from_mega({WorldTick::invalid}, it->second);
+    if (!h) return {};
+    // Stamp the current tick into modification-tracking fields.
+    if (auto* app = scene_.try_get_component<Appearance>(h.id()))
+      app->modified = tick_;
+    if (auto* fx = scene_.try_get_component<VisualEffects>(h.id())) {
+      fx->modified = tick_;
+      // In templates, `flashExpiry` encodes TTL (ticks). Convert to absolute.
+      if (fx->flashColor != 0 && fx->flashExpiry != WorldTick{})
+        fx->flashExpiry = WorldTick{*tick_ + *fx->flashExpiry};
+    }
+    if (auto* hp = scene_.try_get_component<Health>(h.id()))
+      hp->modified = tick_;
+    (void)markDirty(h.id());
     return h;
   }
 
-  // Spawn an AOE defender.
-  [[nodiscard]] Handle spawnDefenderAoe(Position pos) {
-    Defender defender{.defenderType = 1,
-        .hitCircleRadius = 30.F,
-        .attackRadius = 100.F,
-        .rangeColor = 0xFFFF0000,
-        .attackDamage = 5.F,
-        .cooldown = WorldTick{20},
-        .nextAttack = WorldTick{0}};
-    Appearance app{.modified = tick_,
-        .glyph = U'A',
-        .radius = 30.F,
-        .fgColor = 0xFFFFFFFF,
-        .bgColor = 0x7F7FFFFF};
-    VisualEffects fx{.modified = tick_,
-        .flashColor = 0xFF7F7FFF,
-        .flashExpiry = WorldTick{5}};
-    Health health{.modified = tick_,
-        .currentHealth = 100.F,
-        .maxHealth = 100.F,
-        .regen = 0.F};
-    DefenderAoe defenderAoe{.damageType = 1};
-    DefenderStats defenderStats{};
-    auto h = scene_.store_new_entity<sidDefenderAoe>({WorldTick::invalid}, pos,
-        app, fx, defender, defenderStats, health, defenderAoe);
-    if (h) (void)markDirty(h.id());
-    return h;
-  }
-
-  // Spawn a shooter defender.
-  [[nodiscard]] Handle spawnDefenderShooter(Position pos) {
-    DefenderBullet bullet_template{.speed = 200.F,
-        .directDamage = 20.F,
-        .damageOverTime = 0.F,
-        .splashRadius = 0.F,
-        .directDamageType = 1,
-        .dotDamageType = 0,
-        .projectileType = 1,
-        .expiry = WorldTick{20}};
-    Defender defender{.defenderType = 1,
-        .hitCircleRadius = 20.F,
-        .attackRadius = 100.F,
-        .rangeColor = 0xFFFF0000,
-        .attackDamage = 5.F,
-        .cooldown = WorldTick{20},
-        .nextAttack = WorldTick{0}};
-    Appearance app{.modified = tick_,
-        .glyph = U'S',
-        .radius = 20.F,
-        .fgColor = 0xFFFFFFFF,
-        .bgColor = 0x7FFF7FFF};
-    VisualEffects fx{.modified = tick_,
-        .flashColor = 0xFF7F7FFF,
-        .flashExpiry = WorldTick{5}};
-    Health health{.modified = tick_,
-        .currentHealth = 100.F,
-        .maxHealth = 100.F,
-        .regen = 0.F};
-    DefenderStats defenderStats{};
-    DefenderShooter defenderShooter{.bullet_template = bullet_template,
-        .fireRate = 1.F,
-        .spread = 0};
-    auto h = scene_.store_new_entity<sidDefenderShooter>({WorldTick::invalid},
-        pos, app, fx, defender, defenderStats, health, defenderShooter);
-    if (h) (void)markDirty(h.id());
-    return h;
+  // Return a pointer to component `C` for entity `id`, or `nullptr` if the
+  // entity does not carry that component.
+  template<typename C>
+  [[nodiscard]] C* try_get_component(EntityId id) noexcept {
+    return scene_.try_get_component<C>(id);
   }
 
   // Bake and store a path. Returns the index used as `path_follower::path_id`.
@@ -740,6 +692,9 @@ private:
 
   std::vector<EntityId> updatedEntities_;
   std::vector<EntityId> pathEscapees_;
+
+  // Entity type definitions: label -> component template. Survives `clear()`.
+  string_unordered_map<WorldScene::megatuple_t> entity_templates_;
 
   // Logically erases an entity, adding it to the dirty list.
   [[nodiscard]] bool tombstoneEntity(EntityId id) {

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -551,6 +551,44 @@ public:
     return found_id;
   }
 
+  [[nodiscard]] bool
+  doesTowerOverlapExisting(const Position& pos, float radius) const {
+    bool overlaps = false;
+    scene_.for_each<Position, Appearance, Defender>([&](auto, auto comps) {
+      const auto& [tower_pos, tower_app, _] = comps;
+      if (!circlesOverlap(pos, radius, tower_pos, tower_app.radius))
+        return true;
+      overlaps = true;
+      return false;
+    });
+    return overlaps;
+  }
+
+  [[nodiscard]] bool
+  doesTowerTouchPath(const Position& pos, float radius) const {
+    for (const auto& path : paths_) {
+      const float expanded_radius = radius + (path.width * 0.5F);
+      const float expanded_radius_sq = expanded_radius * expanded_radius;
+      for (const auto& seg : path.segments) {
+        if (distanceSquaredToSegment(pos, seg.front, seg.back) <=
+            expanded_radius_sq)
+          return true;
+      }
+    }
+    return false;
+  }
+
+  [[nodiscard]] bool
+  isTowerPlacementBlocked(const Position& pos, float radius) const {
+    constexpr float half_w = widthOfWorld * 0.5F;
+    constexpr float half_h = heightOfWorld * 0.5F;
+    if (pos.x - radius < -half_w || pos.x + radius > half_w ||
+        pos.y - radius < -half_h || pos.y + radius > half_h)
+      return true;
+    return doesTowerOverlapExisting(pos, radius) ||
+           doesTowerTouchPath(pos, radius);
+  }
+
   // Run all physics for the current tick without advancing the counter. Call
   // `tick()` once all game logic for this frame is complete, including
   // streaming the state to clients.
@@ -688,6 +726,23 @@ public:
       const Position& posB, float radiusB) {
     const float r = radiusA + radiusB;
     return distanceSquared(posA, posB) <= r * r;
+  }
+
+  static constexpr float distanceSquaredToSegment(const Position& point,
+      const Position& segA, const Position& segB) {
+    const float dx = segB.x - segA.x;
+    const float dy = segB.y - segA.y;
+    const float len_sq = (dx * dx) + (dy * dy);
+    if (len_sq <= 0.F) return distanceSquared(point, segA);
+
+    const float t = std::clamp(
+        (((point.x - segA.x) * dx) + ((point.y - segA.y) * dy)) / len_sq, 0.F,
+        1.F);
+    const Position projection{
+        segA.x + (dx * t),
+        segA.y + (dy * t),
+    };
+    return distanceSquared(point, projection);
   }
 
 private:

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -605,7 +605,7 @@ public:
 
   [[nodiscard]] bool
   isDefenderPlacementBlocked(const Position& pos, float radius) const {
-    return isInBounds(pos, radius) || doesOveralapDefenders(pos, radius) ||
+    return !isInBounds(pos, radius) || doesOveralapDefenders(pos, radius) ||
            doesTouchPath(pos, radius);
   }
 

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -40,10 +40,10 @@
 //   served up as one or more PNG files. Again, only the client has to care
 //   about how to render, while the server focuses on physics, geometry, and
 //   logic.
-// - The definitions of enemies, towers, maps, and waves are kept in plain CSV
-//   files, which we can parse with nothing more than a comma splitter. These
-//   are deserialized into C++ structs at startup. We do not serve the CSV
-//   files.
+// - The definitions of invaders, defenders, maps, and waves are kept in plain
+//   CSV files, which we can parse with nothing more than a comma splitter.
+//   These are deserialized into C++ structs at startup. We do not serve the
+//   CSV files.
 // - To aid this, we might change the default web server to skip over anything
 //   with a leading dot, allowing us to store ".game-definitions.csv" even if
 //   CSV files were enabled.
@@ -223,14 +223,14 @@ constexpr Tick invalidTick = std::numeric_limits<Tick>::max();
 // geometric type (square, circle, etc), its size, radius, length, width,
 // etc., and local basis (orientation). This can be used to compute the
 // bounding box (which could be AABB (axis-aligned bounding box) or OBB
-// (oriented bounding box) or even a circle collider (super-fast for towers))
-// for collision detection and hit box purposes. We may also need an Aura for
-// field effects. Rendering cares about the origin/anchor point of the shape,
-// which may not be the center. Towers may have an Aura (radius, damage,
-// dmgtype) or ProjectileRange (), or both. We could use Components for Hitbox,
-// Hurtbox, Attack (dmg, knockback, statusEffect), Expiry (ttl in ticks).
-// For circle hitboxes, collision is trivial: when the distance between centers
-// is less than the sum of the radii, they collide.
+// (oriented bounding box) or even a circle collider (super-fast for
+// defenders)) for collision detection and hit box purposes. We may also need
+// an Aura for field effects. Rendering cares about the origin/anchor point of
+// the shape, which may not be the center. Defenders may have an Aura (radius,
+// damage, dmgtype) or ProjectileRange (), or both. We could use Components for
+// Hitbox, Hurtbox, Attack (dmg, knockback, statusEffect), Expiry (ttl in
+// ticks). For circle hitboxes, collision is trivial: when the distance between
+// centers is less than the sum of the radii, they collide.
 
 // Path-following component. Typically part of an invader archetype, but may
 // also apply to defenders. On each tick, `progress` advances by `speed`; the
@@ -274,15 +274,15 @@ struct VisualEffects {
   WorldTick flashExpiry{WorldTick::invalid};
 };
 
-// Defensive tower component, common across all defenders.
+// Defensive component, common across all defenders.
 struct Defender {
   int defenderType{};      // Eventually an enum.
   float hitCircleRadius{}; // Hit detection, as opposed to appearance.
   float attackRadius{};
   uint32_t rangeColor{}; // RGBA.
-  float attackDamage{};  // Interpretation depends on the tower type.
+  float attackDamage{};  // Interpretation depends on the defender type.
   WorldTick cooldown{};
-  WorldTick nextAttack{}; // Updated when the tower attacks.
+  WorldTick nextAttack{}; // Updated when the defender attacks.
 };
 
 // Stats for defenders, shown when selecting a defender.
@@ -324,7 +324,7 @@ struct DefenderBullet {
 
 // Shooter component for defenders that spawn projectiles. The
 // `bullet_template` is used to spawn bullets with the same properties as the
-// tower's attack, but with their own position and velocity.
+// defender's attack, but with their own position and velocity.
 struct DefenderShooter {
   DefenderBullet bullet_template{};
   float fireRate{}; // Shots per tick.
@@ -335,7 +335,7 @@ struct DefenderShooter {
 struct Invader {
   int invaderType{};       // Eventually an enum.
   float hitCircleRadius{}; // Hit detection, as opposed to appearance.
-  int bounty{10}; // Resources awarded to the player for killing this enemy.
+  int bounty{10}; // Resources awarded to the player for killing this invader.
 };
 
 // ECS types for the simulation world.
@@ -529,12 +529,12 @@ public:
     return found_id;
   }
 
-  [[nodiscard]] auto getTower(EntityId id) {
+  [[nodiscard]] auto getDefender(EntityId id) {
     return scene_
         .try_get_components<Position, Appearance, VisualEffects, Defender>(id);
   }
 
-  [[nodiscard]] EntityId findTowerAt(const Position& pos) const {
+  [[nodiscard]] EntityId findDefenderAt(const Position& pos) const {
     EntityId found_id = EntityId::invalid;
     scene_.for_each<Position, Appearance, Defender>([&](auto id, auto comps) {
       const auto& [epos, app, _] = comps;
@@ -555,8 +555,8 @@ public:
   doesTowerOverlapExisting(const Position& pos, float radius) const {
     bool overlaps = false;
     scene_.for_each<Position, Appearance, Defender>([&](auto, auto comps) {
-      const auto& [tower_pos, tower_app, _] = comps;
-      if (!circlesOverlap(pos, radius, tower_pos, tower_app.radius))
+      const auto& [defender_pos, defender_app, _] = comps;
+      if (!circlesOverlap(pos, radius, defender_pos, defender_app.radius))
         return true;
       overlaps = true;
       return false;
@@ -595,7 +595,7 @@ public:
   [[nodiscard]] bool next() {
     (void)updateMovers();
     (void)updatePathFollowers();
-    (void)towersAttack();
+    (void)defendersAttack();
     return true;
   }
 
@@ -824,38 +824,40 @@ private:
     return true;
   }
 
-  [[nodiscard]] bool towersAttack() {
-    // Range over all towers. For each tower, range over all enemies and check
-    // for hits. If an enemy is in range and the tower is off cooldown, apply
-    // damage and trigger a flash on both.
-    scene_.for_each<Position, Defender>([&](auto towerId, auto towerComps) {
-      auto& [towerPos, tower] = towerComps;
-      if (tick_ < tower.nextAttack) return true;
+  [[nodiscard]] bool defendersAttack() {
+    // Range over all defenders. For each defender, range over all enemies and
+    // check for hits. If an enemy is in range and the defender is off
+    // cooldown, apply damage and trigger a flash on both.
+    scene_.for_each<Position, Defender>(
+        [&](auto defenderId, auto defenderComps) {
+          auto& [defenderPos, defender] = defenderComps;
+          if (tick_ < defender.nextAttack) return true;
 
-      scene_.for_each<Position, Invader>([&](auto enemyId, auto enemyComps) {
-        auto& [enemyPos, invader] = enemyComps;
-        if (!circlesOverlap(towerPos, tower.attackRadius, enemyPos,
-                invader.hitCircleRadius))
-          return true;
+          scene_.for_each<Position, Invader>(
+              [&](auto enemyId, auto enemyComps) {
+                auto& [enemyPos, invader] = enemyComps;
+                if (!circlesOverlap(defenderPos, defender.attackRadius,
+                        enemyPos, invader.hitCircleRadius))
+                  return true;
 
-        (void)flashEntity(towerId, 0xFFFFFFFF, WorldTick{5});
-        (void)flashEntity(enemyId, 0xFF7F7FFF, WorldTick{5});
-        return true;
+                (void)flashEntity(defenderId, 0xFFFFFFFF, WorldTick{5});
+                (void)flashEntity(enemyId, 0xFF7F7FFF, WorldTick{5});
+                return true;
 #if 0
-        invader.health -= tower.attack_damage;
-        tower.next_attack = WorldTick{*tick_ + *tower.cooldown};
-        (void)flashEntity(towerId, 0xFFFFFFFF);
+        invader.health -= defender.attackDamage;
+        defender.nextAttack = WorldTick{*tick_ + *defender.cooldown};
+        (void)flashEntity(defenderId, 0xFFFFFFFF);
         if (invader.health <= 0.F) {
           (void)tombstoneEntity(enemyId);
         } else {
           (void)flashEntity(enemyId, 0xFF0000FF);
         }
-        return false; // Stop after first hit per tower per tick.
+        return false; // Stop after first hit per defender per tick.
 #endif
-      });
+              });
 
-      return true;
-    });
+          return true;
+        });
 
     return true;
   }

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "../containers/transparent.h"
+#include "../containers/opt_find.h"
 
 #include "../ecs.h"
 
@@ -235,7 +236,7 @@ constexpr Tick invalidTick = std::numeric_limits<Tick>::max();
 // also apply to defenders. On each tick, `progress` advances by `speed`; the
 // entity's `Position` is re-derived from the segmented path geometry.
 struct Pathing {
-  PathId path_id{}; // Index into `sim_world::paths_`.
+  PathId pathId{};  // Index into `sim_world::paths_`.
   float progress{}; // Distance traveled along the path so far.
   float speed{};    // Distance per tick.
 };
@@ -420,22 +421,18 @@ public:
   // its handle. Returns an invalid handle if the label is unknown or the
   // template bitmap does not match any archetype.
   [[nodiscard]] Handle spawnEntity(std::string_view label) {
-    auto it = entity_templates_.find(label);
-    if (it == entity_templates_.end()) return {};
+    auto megatuple = find_opt(entity_templates_, label);
+    if (!megatuple) return {};
     auto h =
-        scene_.store_new_entity_from_mega({WorldTick::invalid}, it->second);
+        scene_.store_new_entity_from_mega({WorldTick::invalid}, *megatuple);
     if (!h) return {};
     // Stamp the current tick into modification-tracking fields.
-    if (auto* app = scene_.try_get_component<Appearance>(h.id()))
-      app->modified = tick_;
-    if (auto* fx = scene_.try_get_component<VisualEffects>(h.id())) {
-      fx->modified = tick_;
-      // In templates, `flashExpiry` encodes TTL (ticks). Convert to absolute.
-      if (fx->flashColor != 0 && fx->flashExpiry != WorldTick{})
-        fx->flashExpiry = WorldTick{*tick_ + *fx->flashExpiry};
-    }
-    if (auto* hp = scene_.try_get_component<Health>(h.id()))
-      hp->modified = tick_;
+    auto [app, fx, hp] =
+        scene_.try_get_some_components<Appearance, VisualEffects, Health>(
+            h.id());
+    if (app) app->modified = tick_;
+    if (fx) fx->modified = tick_;
+    if (hp) hp->modified = tick_;
     (void)markDirty(h.id());
     return h;
   }
@@ -447,7 +444,14 @@ public:
     return scene_.try_get_component<C>(id);
   }
 
-  // Bake and store a path. Returns the index used as `path_follower::path_id`.
+  // Return a tuple of pointers to components `Cs...` for entity `id`, or a
+  // tuple of `nullptr`s if the entity does not carry all of those components.
+  template<typename... Cs>
+  [[nodiscard]] auto try_get_components(EntityId id) noexcept {
+    return scene_.try_get_components<Cs...>(id);
+  }
+
+  // Bake and store a path. Returns the index used as `path_follower::pathId`.
   // The index is stable for the lifetime of the world.
   [[nodiscard]] PathId addPath(const PathJoints& p) {
     if (!paths_.push_back(SegmentedPath::fromJoints(p)))
@@ -742,14 +746,14 @@ private:
   [[nodiscard]] bool updatePathFollowers() {
     scene_.for_each<Position, Pathing>([&](auto id, auto comps) {
       auto& [pos, pf] = comps;
-      assert(pf.path_id < paths_.size_as_enum());
+      assert(pf.pathId < paths_.size_as_enum());
       if (pf.speed == 0.F) return true;
 
       (void)markDirty(id);
 
       const float previousProgress = pf.progress;
       pf.progress += pf.speed;
-      const auto& sp = paths_[pf.path_id];
+      const auto& sp = paths_[pf.pathId];
 
       // Collect escapees.
       if (pf.progress >= sp.totalLength || pf.progress < 0.F) {

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -534,12 +534,13 @@ public:
         .try_get_components<Position, Appearance, VisualEffects, Defender>(id);
   }
 
+  // Find entity of defender at the given position, if any. Uses simple
+  // bounding box.
   [[nodiscard]] EntityId findDefenderAt(const Position& pos) const {
-    EntityId found_id = EntityId::invalid;
+    auto found_id = EntityId::invalid;
     scene_.for_each<Position, Appearance, Defender>([&](auto id, auto comps) {
       const auto& [epos, app, _] = comps;
       const auto radius = app.radius;
-      // If point outside of bounding box, keep searching.
       if (std::abs(epos.x - pos.x) >= radius ||
           std::abs(epos.y - pos.y) >= radius)
         return true;
@@ -552,7 +553,7 @@ public:
   }
 
   [[nodiscard]] bool
-  doesTowerOverlapExisting(const Position& pos, float radius) const {
+  doesOveralapDefenders(const Position& pos, float radius) const {
     bool overlaps = false;
     scene_.for_each<Position, Appearance, Defender>([&](auto, auto comps) {
       const auto& [defender_pos, defender_app, _] = comps;
@@ -565,7 +566,7 @@ public:
   }
 
   [[nodiscard]] bool
-  doesTowerTouchPath(const Position& pos, float radius) const {
+  doDefendersTouch(const Position& pos, float radius) const {
     for (const auto& path : paths_) {
       const float expanded_radius = radius + (path.width * 0.5F);
       const float expanded_radius_sq = expanded_radius * expanded_radius;
@@ -579,14 +580,13 @@ public:
   }
 
   [[nodiscard]] bool
-  isTowerPlacementBlocked(const Position& pos, float radius) const {
+  isDefenderPlacementBlocked(const Position& pos, float radius) const {
     constexpr float half_w = widthOfWorld * 0.5F;
     constexpr float half_h = heightOfWorld * 0.5F;
     if (pos.x - radius < -half_w || pos.x + radius > half_w ||
         pos.y - radius < -half_h || pos.y + radius > half_h)
       return true;
-    return doesTowerOverlapExisting(pos, radius) ||
-           doesTowerTouchPath(pos, radius);
+    return doesOveralapDefenders(pos, radius) || doDefendersTouch(pos, radius);
   }
 
   // Run all physics for the current tick without advancing the counter. Call

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <numbers>
 #include <stdexcept>
 #include <string>
@@ -77,7 +78,7 @@ namespace corvid { inline namespace sim {
 // polar form (length, direction). Direction is in radians, with 0 along the
 // positive x-axis and increasing counter-clockwise.
 namespace convert {
-// Convert Cartesian coordinates Euclidean vector,
+// Convert Cartesian coordinates to a Euclidean vector.
 [[nodiscard]] constexpr std::pair<float, float>
 CartesianToPolar(float x, float y) noexcept {
   float length = std::sqrt((x * x) + (y * y));
@@ -96,7 +97,7 @@ PolarToCartesian(float length, float direction) noexcept {
 
 // Linear interpolation, where t is the interpolation factor in [0,1]. Returns
 // a when t=0 and b when t=1. Can also be used for extrapolation when t is
-// outside [0,1].
+// outside this range.
 [[nodiscard]] constexpr float lerp(float a, float b, float t) noexcept {
   return a + ((b - a) * t);
 }
@@ -106,7 +107,7 @@ struct Position {
   float x{};
   float y{};
 
-  static Position fromPolar(float radius, float angle) {
+  [[nodiscard]] static Position fromPolar(float radius, float angle) {
     auto [x, y] = convert::PolarToCartesian(radius, angle);
     return {x, y};
   }
@@ -123,6 +124,27 @@ struct Velocity {
   }
 };
 
+struct SimWorldBounds {
+  static constexpr float widthOfWorld = 1920.F;
+  static constexpr float heightOfWorld = 1080.F;
+  static constexpr float half_w = widthOfWorld * 0.5F;
+  static constexpr float half_h = heightOfWorld * 0.5F;
+
+  // Is the position within the bounds of the world.
+  [[nodiscard]] static constexpr bool isInBounds(const Position& pos) {
+    return pos.x >= -half_w && pos.x <= half_w && pos.y >= -half_h &&
+           pos.y <= half_h;
+  }
+
+  // Is the position within the bounds of the world, taking a radius into
+  // account.
+  [[nodiscard]] static constexpr bool
+  isInBounds(const Position& pos, float radius) {
+    return pos.x - radius >= -half_w && pos.x + radius <= half_w &&
+           pos.y - radius >= -half_h && pos.y + radius <= half_h;
+  }
+};
+
 // --- Path geometry ---
 
 // `PathJoints` defines a path in terms of the coordinates of its joints. This
@@ -130,7 +152,7 @@ struct Velocity {
 // not ideal for runtime use, which is why it's converted to `SegmentedPath`.
 struct PathJoints {
   struct Joint {
-    Position p;
+    Position pos;
   };
 
   std::vector<Joint> joints;
@@ -154,9 +176,7 @@ struct SegmentedPath {
   float width{};
 
   // Map a distance traveled (`progress`) to a world-space `Position`.
-  // If `previousProgress` was on an earlier segment, emit the joint position
-  // first so fast-moving entities visibly take corners instead of cutting
-  // across them between updates. `progress` is clamped to `[0, totalLength]`.
+  // `progress` is clamped to `[0, totalLength]`.
   // Returns the origin if `segments` is empty.
   [[nodiscard]] Position
   calculatePositionFromProgress(float progress, float previousProgress) const {
@@ -169,6 +189,9 @@ struct SegmentedPath {
     if (it != segments.begin()) --it;
     const auto& seg = *it;
 
+    // If `previousProgress` was on an earlier segment, emit the joint position
+    // first, so that fast-moving entities visibly take corners instead of
+    // cutting across them between updates.
     if (previousProgress < seg.cumulativeStart) return seg.front;
 
     // Calculate the interpolation factor `t` along this segment, then lerp the
@@ -180,29 +203,21 @@ struct SegmentedPath {
         lerp(seg.front.y, seg.back.y, t)};
   }
 
-  // Convert authored `PathJoints` into a `SegmentedPath`. Requires at
-  // least two joints; returns an empty `SegmentedPath` if the input is
-  // degenerate.
-  static SegmentedPath fromJoints(const PathJoints& p) {
+  // Convert authored `PathJoints` into a `SegmentedPath`.
+  [[nodiscard]] static SegmentedPath fromJoints(const PathJoints& p) {
     if (p.joints.size() < 2) return {};
     SegmentedPath sp;
     sp.width = p.width;
     sp.segments.reserve(p.joints.size() - 1);
     float cumulative{};
-    constexpr float half_w = 1920.F / 2.F;
-    constexpr float half_h = 1080.F / 2.F;
 
-    for (const auto& joint : p.joints) {
-      const auto& pos = joint.p;
-      // Check for configuration errors.
-      if (pos.x < -half_w || pos.x > half_w || pos.y < -half_h ||
-          pos.y > half_h)
+    for (const auto& joint : p.joints)
+      if (!SimWorldBounds::isInBounds(joint.pos))
         throw std::runtime_error("Path joint lies outside the world bounds");
-    }
 
     for (std::size_t i = 0; i + 1 < p.joints.size(); ++i) {
-      const Position& front = p.joints[i].p;
-      const Position& back = p.joints[i + 1].p;
+      const Position& front = p.joints[i].pos;
+      const Position& back = p.joints[i + 1].pos;
       const float dx = back.x - front.x;
       const float dy = back.y - front.y;
       const float len = std::hypot(dx, dy);
@@ -214,24 +229,6 @@ struct SegmentedPath {
   }
 };
 
-using Tick = uint64_t;
-constexpr Tick invalidTick = std::numeric_limits<Tick>::max();
-
-// TODO: We likely want to break out the physics-relevant properties into
-// components. We already have Position and Velocity (as well as PathFollower,
-// which is a type of velocity). We may need a Shape component which has the
-// geometric type (square, circle, etc), its size, radius, length, width,
-// etc., and local basis (orientation). This can be used to compute the
-// bounding box (which could be AABB (axis-aligned bounding box) or OBB
-// (oriented bounding box) or even a circle collider (super-fast for
-// defenders)) for collision detection and hit box purposes. We may also need
-// an Aura for field effects. Rendering cares about the origin/anchor point of
-// the shape, which may not be the center. Defenders may have an Aura (radius,
-// damage, dmgtype) or ProjectileRange (), or both. We could use Components for
-// Hitbox, Hurtbox, Attack (dmg, knockback, statusEffect), Expiry (ttl in
-// ticks). For circle hitboxes, collision is trivial: when the distance between
-// centers is less than the sum of the radii, they collide.
-
 // Path-following component. Typically part of an invader archetype, but may
 // also apply to defenders. On each tick, `progress` advances by `speed`; the
 // entity's `Position` is re-derived from the segmented path geometry.
@@ -241,8 +238,9 @@ struct Pathing {
   float speed{};    // Distance per tick.
 };
 
-// Appearance component. Controls rendering on client side, but has no effect
-// on physics or game logic.
+// Appearance component. Controls rendering on client side. The `radius` does
+// affect placement, but otherwise these fields have no effect on physics or
+// game logic.
 // TODO: Add field for sprite selection.
 struct Appearance {
   WorldTick modified{WorldTick::invalid}; // Tick when last modified.
@@ -260,7 +258,7 @@ struct Health {
   WorldTick modified{WorldTick::invalid}; // Tick when last modified.
   float currentHealth{};
   float maxHealth{};
-  float regen{}; // Regeneration or bleed per tick.
+  float regen{}; // Regeneration or bleed per tick. Not streamed to clients.
 };
 
 // Visual effects component. Controls transient overlays on the client side,
@@ -276,7 +274,7 @@ struct VisualEffects {
 
 // Defensive component, common across all defenders.
 struct Defender {
-  int defenderType{};      // Eventually an enum.
+  uint16_t entityTemplateIndex{std::numeric_limits<uint16_t>::max()};
   float hitCircleRadius{}; // Hit detection, as opposed to appearance.
   float attackRadius{};
   uint32_t rangeColor{}; // RGBA.
@@ -292,8 +290,8 @@ struct DefenderStats {
   float totalKills{};
 };
 
-// Area-of-effect component for defenders that have an attack that hits an area
-// rather than a single target.
+// Area-of-effect component for defenders which have an attack that hits an
+// area rather than a single target.
 struct DefenderAoe {
   int damageType{}; // Eventually an enum.
 };
@@ -308,7 +306,7 @@ struct DefenderHitscan {
 };
 
 // Projectile component for `DefenderShooter`. Used as part of its own
-// archetype, and also as the `bullet_template`. As a template, the `expiry`
+// archetype, and also as the `bulletTemplate`. As a template, the `expiry`
 // field stores the TTL. Once instantiated, added to the current tick to gets
 // its final moment.
 struct DefenderBullet {
@@ -323,25 +321,25 @@ struct DefenderBullet {
 };
 
 // Shooter component for defenders that spawn projectiles. The
-// `bullet_template` is used to spawn bullets with the same properties as the
+// `bulletTemplate` is used to spawn bullets with the same properties as the
 // defender's attack, but with their own position and velocity.
 struct DefenderShooter {
-  DefenderBullet bullet_template{};
+  DefenderBullet bulletTemplate{};
   float fireRate{}; // Shots per tick.
   int spread{};     // Eventually an enum.
 };
 
 // Invader component, shared across all invaders.
 struct Invader {
-  int invaderType{};       // Eventually an enum.
+  uint16_t entityTemplateIndex{std::numeric_limits<uint16_t>::max()};
   float hitCircleRadius{}; // Hit detection, as opposed to appearance.
   int bounty{10}; // Resources awarded to the player for killing this invader.
 };
 
 // ECS types for the simulation world.
 //
-// Registry metadata (`uint64_t`) stores each entity's last-change tick count,
-// enabling delta snapshots without a separate dirty set.
+// Registry metadata (`uint64_t`) stores each entity's last-change tick
+// count, enabling delta snapshots without a separate dirty set.
 //
 // Storage layout (store_id assignment is positional, 1-based):
 //   `sidStaging`         = 0 -> staging storage, used as tombstone
@@ -385,10 +383,10 @@ using WorldScene = archetype_scene<WorldReg, ArchInvaderAlpha, ArchDefenderAoe,
 // provides physics.
 //
 // Each `tick()` advances `Position` components based on velocity and bounces
-// off the world boundary. The registry metadata records the tick count at each
-// entity's last state change so callers can request delta snapshots starting
-// from any past tick.
-class SimWorld {
+// off the world boundary. The registry metadata records the tick count at
+// each entity's last state change so callers can request delta snapshots
+// starting from any past tick.
+class SimWorld: public SimWorldBounds {
 public:
   using EntityId = WorldReg::id_t;
   using Handle = WorldReg::handle_t;
@@ -398,23 +396,38 @@ public:
   static constexpr WorldSid sidDefenderAoe{2};
   static constexpr WorldSid sidBullet{3};
   static constexpr WorldSid sidDefenderShooter{4};
-  static constexpr float widthOfWorld = 1920.F;
-  static constexpr float heightOfWorld = 1080.F;
 
   void clear() {
     scene_.clear();
     paths_.clear();
     updatedEntities_.clear();
     pathEscapees_.clear();
+    entityTemplates_.clear();
+    entityTemplateLabels_.clear();
     tick_ = {};
   }
 
   // Register a named entity type from a `megatuple_t` template. The set of
-  // optionals that have values must exactly match one archetype's components.
-  // Templates survive `clear()` and are only replaced by calling this method
-  // again with the same label.
-  void registerEntity(std::string label, WorldScene::megatuple_t tpl) {
-    entity_templates_.insert_or_assign(std::move(label), std::move(tpl));
+  // optionals that have values must exactly match one archetype's
+  // components.
+  [[nodiscard]] bool
+  registerEntity(std::string label, WorldScene::megatuple_t tpl) {
+    auto [it, inserted] =
+        entityTemplates_.insert_or_assign(std::move(label), std::move(tpl));
+    if (!inserted) return false;
+
+    // Track index for cheap lookup.
+    auto& [key, value] = *it;
+    entityTemplateLabels_.push_back(key);
+    auto entityTemplateIndex =
+        static_cast<uint16_t>(entityTemplateLabels_.size() - 1);
+
+    // Store index in component.
+    auto& defender = std::get<std::optional<Defender>>(value);
+    if (defender) defender->entityTemplateIndex = entityTemplateIndex;
+    auto& invader = std::get<std::optional<Invader>>(value);
+    if (invader) invader->entityTemplateIndex = entityTemplateIndex;
+    return true;
   }
 
   // Spawn an entity by label. Looks up the pre-registered template, stamps
@@ -422,7 +435,7 @@ public:
   // its handle. Returns an invalid handle if the label is unknown or the
   // template bitmap does not match any archetype.
   [[nodiscard]] Handle spawnEntity(std::string_view label) {
-    auto megatuple = find_opt(entity_templates_, label);
+    auto megatuple = find_opt(entityTemplates_, label);
     if (!megatuple) return {};
     auto h =
         scene_.store_new_entity_from_mega({WorldTick::invalid}, *megatuple);
@@ -446,28 +459,38 @@ public:
   }
 
   // Return a tuple of pointers to components `Cs...` for entity `id`, or a
-  // tuple of `nullptr`s if the entity does not carry all of those components.
+  // tuple of `nullptr`s if the entity does not carry all of those
+  // components.
   template<typename... Cs>
   [[nodiscard]] auto try_get_components(EntityId id) noexcept {
     return scene_.try_get_components<Cs...>(id);
   }
 
-  // Bake and store a path. Returns the index used as `path_follower::pathId`.
+  // Bake and store a path. Returns the index used, as `Pathing::pathId`.
   // The index is stable for the lifetime of the world.
-  [[nodiscard]] PathId addPath(const PathJoints& p) {
-    if (!paths_.push_back(SegmentedPath::fromJoints(p)))
+  [[nodiscard]] PathId addPath(const PathJoints& pj) {
+    if (!paths_.push_back(SegmentedPath::fromJoints(pj)))
       return PathId::invalid;
     return paths_.size_as_enum() - 1;
   }
 
-  // Return a pointer to the baked path at `id`, or `nullptr` if out of range.
+  // Return a pointer to the baked path at `pathId`, or `nullptr` if out of
+  // range.
   [[nodiscard]] const SegmentedPath* getPath(PathId pathId) const {
     if (pathId >= paths_.size_as_enum()) return nullptr;
     return &paths_[pathId];
   }
 
-  // Obtain a pointer to the `Appearance` for the entity. It is already marked
-  // dirty and `modified`, so the caller only needs to change the other fields.
+  // Get the label for an entity template by its index.
+  [[nodiscard]] std::string_view getEntityTemplateLabel(
+      uint16_t entityTemplateIndex) const {
+    if (entityTemplateIndex >= entityTemplateLabels_.size()) return {};
+    return entityTemplateLabels_[entityTemplateIndex];
+  }
+
+  // Obtain a pointer to the `Appearance` for the entity. It is already
+  // marked dirty and `modified`, so the caller only needs to change the
+  // other fields.
   [[nodiscard]] Appearance* changeAppearance(EntityId id) {
     auto* app = scene_.try_get_component<Appearance>(id);
     if (!app) return nullptr;
@@ -477,8 +500,8 @@ public:
   }
 
   // Obtain a pointer to the `VisualEffects` for the entity. It is already
-  // marked dirty and `modified`, so the caller only needs to change the other
-  // fields.
+  // marked dirty and `modified`, so the caller only needs to change the
+  // other fields.
   [[nodiscard]] VisualEffects* changeVisualEffects(EntityId id) {
     auto* effects = scene_.try_get_component<VisualEffects>(id);
     if (!effects) return nullptr;
@@ -499,27 +522,26 @@ public:
     return true;
   }
 
-  // Return a generation-versioned handle for `id`, suitable for storage across
-  // ticks, or whenever there is a risk of the underlying entity going away.
-  // Use `getId` to get the ID back, just in time.
+  // Return a generation-versioned handle for `id`, suitable for storage
+  // across ticks, or whenever there is a risk of the underlying entity going
+  // away. Use `getId` to get the ID back, just in time, with validation.
   [[nodiscard]] Handle getHandle(EntityId id) const {
     return scene_.registry().get_handle(id);
   }
 
-  // Return the entity ID for `handle`, or `EntityId::invalid` if the handle is
+  // Return the entity ID for the `Handle`, or `EntityId::invalid` if it's
   // invalid.
   [[nodiscard]] EntityId getId(Handle h) const {
     return scene_.registry().id_from_handle(h);
   }
 
+  // Find an entity at a given position, if any. Uses simple bounding box.
   [[nodiscard]] EntityId findEntityAt(const Position& pos) const {
     EntityId found_id = EntityId::invalid;
     scene_.for_each<Position, Appearance>([&](auto id, auto comps) {
       const auto& [epos, app] = comps;
-      const auto radius = app.radius;
-      // If point outside of bounding box, keep searching.
-      if (std::abs(epos.x - pos.x) >= radius ||
-          std::abs(epos.y - pos.y) >= radius)
+      if (std::abs(epos.x - pos.x) >= app.radius ||
+          std::abs(epos.y - pos.y) >= app.radius)
         return true;
 
       found_id = id;
@@ -529,20 +551,20 @@ public:
     return found_id;
   }
 
+  // Obtain standard components for a defender entity.
   [[nodiscard]] auto getDefender(EntityId id) {
     return scene_
         .try_get_components<Position, Appearance, VisualEffects, Defender>(id);
   }
 
-  // Find entity of defender at the given position, if any. Uses simple
+  // Find ID of the defender at the given position, if any. Uses simple
   // bounding box.
   [[nodiscard]] EntityId findDefenderAt(const Position& pos) const {
     auto found_id = EntityId::invalid;
     scene_.for_each<Position, Appearance, Defender>([&](auto id, auto comps) {
       const auto& [epos, app, _] = comps;
-      const auto radius = app.radius;
-      if (std::abs(epos.x - pos.x) >= radius ||
-          std::abs(epos.y - pos.y) >= radius)
+      if (std::abs(epos.x - pos.x) >= app.radius ||
+          std::abs(epos.y - pos.y) >= app.radius)
         return true;
 
       found_id = id;
@@ -552,6 +574,8 @@ public:
     return found_id;
   }
 
+  // Check if an object at `pos` with a given `radius` overlaps any
+  // defenders. Uses for placement.
   [[nodiscard]] bool
   doesOveralapDefenders(const Position& pos, float radius) const {
     bool overlaps = false;
@@ -565,8 +589,8 @@ public:
     return overlaps;
   }
 
-  [[nodiscard]] bool
-  doDefendersTouch(const Position& pos, float radius) const {
+  // Check if an object at `pos` with a given `radius` touches any paths.
+  [[nodiscard]] bool doesTouchPath(const Position& pos, float radius) const {
     for (const auto& path : paths_) {
       const float expanded_radius = radius + (path.width * 0.5F);
       const float expanded_radius_sq = expanded_radius * expanded_radius;
@@ -581,12 +605,8 @@ public:
 
   [[nodiscard]] bool
   isDefenderPlacementBlocked(const Position& pos, float radius) const {
-    constexpr float half_w = widthOfWorld * 0.5F;
-    constexpr float half_h = heightOfWorld * 0.5F;
-    if (pos.x - radius < -half_w || pos.x + radius > half_w ||
-        pos.y - radius < -half_h || pos.y + radius > half_h)
-      return true;
-    return doesOveralapDefenders(pos, radius) || doDefendersTouch(pos, radius);
+    return isInBounds(pos, radius) || doesOveralapDefenders(pos, radius) ||
+           doesTouchPath(pos, radius);
   }
 
   // Run all physics for the current tick without advancing the counter. Call
@@ -607,17 +627,18 @@ public:
   // Return the current tick counter without advancing it.
   [[nodiscard]] WorldTick currentTick() const { return tick_; }
 
-  // Total number of entities in all storages (does not count staged entities).
+  // Total number of entities in all storages (does not count staged
+  // entities).
   [[nodiscard]] std::size_t size() const { return scene_.size(); }
 
   // Destructively extract upserts and erasures.
   //
   // Call back `cbUpserts(EntityId, Position, Appearance, VisualEffects)` for
-  // each changed entity that has a `Position` and `Appearance` and has changed
-  // since the last tick, and `cbErased(EntityId)` for each entity that has
-  // been erased since the last tick. The visual effects pointer is null for
-  // archetypes that do not carry that component. These calls will be
-  // interleaved.
+  // each changed entity that has a `Position` and `Appearance` and has
+  // changed since the last tick, and `cbErased(EntityId)` for each entity
+  // that has been erased since the last tick. The visual effects pointer is
+  // null for archetypes that do not carry that component. These calls will
+  // be interleaved.
   [[nodiscard]] bool
   extractUpdatedEntities(auto&& cbUpserts, auto&& cbErased) {
     static constexpr VisualEffects nfx;
@@ -641,7 +662,7 @@ public:
     return true;
   }
 
-  // Call back `extractPath(pathId, Position)` for all joints of the path
+  // Call back `cbPath(PathId, Position)` for all joints of the path
   // identified by `pathId`.
   [[nodiscard]] bool obtainPath(auto&& cbPath, PathId pathId) const {
     if (pathId >= paths_.size_as_enum()) return false;
@@ -652,7 +673,7 @@ public:
     return true;
   }
 
-  // Call back `cbPath(pathId, Position)` for all joints of all paths.
+  // Call back `cbPath(PathId, Position)` for all joints of all paths.
   [[nodiscard]] bool obtainPaths(auto&& cbPath) const {
     for (PathId pathId{0}; pathId < paths_.size_as_enum(); ++pathId)
       if (!obtainPath(cbPath, pathId)) return false;
@@ -753,8 +774,12 @@ private:
   std::vector<EntityId> updatedEntities_;
   std::vector<EntityId> pathEscapees_;
 
-  // Entity type definitions: label -> component template. Survives `clear()`.
-  string_unordered_map<WorldScene::megatuple_t> entity_templates_;
+  // Entity type definitions: label -> component template.
+  string_unordered_map<WorldScene::megatuple_t> entityTemplates_;
+
+  // List of entity labels. The index is used in the `Defender` or `Invader`
+  // components as `entityTemplateIndex_`.
+  std::vector<std::string> entityTemplateLabels_;
 
   // Logically erases an entity, adding it to the dirty list.
   [[nodiscard]] bool tombstoneEntity(EntityId id) {
@@ -775,15 +800,15 @@ private:
       // method that does both. For that matter, the current algorithm is
       // wrong: an entity hitting a boundary shouldn't be clipped to the
       // boundary and its velocity reversed. Rather, part of its movement
-      // should be reflected back. So, for example, if dx is 20 and the entity
-      // is 5 pixels from the right edge, it should spend 5 of those 20 moving
-      // to the right, and then 15 moving back. Its velocity should be reversed
-      // starting at the edge. The only reason the current algorithm works at
-      // all is that velocities are small. The algorithm is also bad in a
-      // different way, which is that it measures position from the center, not
-      // a bounding box, so the balls enter the boundary before reversing. Even
-      // then, a square bounding box would be hit-detected prematurely if the
-      // entity is moving at a diagonal.
+      // should be reflected back. So, for example, if dx is 20 and the
+      // entity is 5 pixels from the right edge, it should spend 5 of those
+      // 20 moving to the right, and then 15 moving back. Its velocity should
+      // be reversed starting at the edge. The only reason the current
+      // algorithm works at all is that velocities are small. The algorithm
+      // is also bad in a different way, which is that it measures position
+      // from the center, not a bounding box, so the balls enter the boundary
+      // before reversing. Even then, a square bounding box would be
+      // hit-detected prematurely if the entity is moving at a diagonal.
       (void)markDirty(id);
 
       pos.x += vel.vx;
@@ -797,8 +822,8 @@ private:
     return true;
   }
 
-  // Advance path-following enemies. Collect entities that changed, as well as
-  // those that escaped the path.
+  // Advance path-following enemies. Collect entities that changed, as well
+  // as those that escaped the path.
   [[nodiscard]] bool updatePathFollowers() {
     scene_.for_each<Position, Pathing>([&](auto id, auto comps) {
       auto& [pos, pf] = comps;
@@ -825,8 +850,8 @@ private:
   }
 
   [[nodiscard]] bool defendersAttack() {
-    // Range over all defenders. For each defender, range over all enemies and
-    // check for hits. If an enemy is in range and the defender is off
+    // Range over all defenders. For each defender, range over all enemies
+    // and check for hits. If an enemy is in range and the defender is off
     // cooldown, apply damage and trigger a flash on both.
     scene_.for_each<Position, Defender>(
         [&](auto defenderId, auto defenderComps) {
@@ -866,8 +891,8 @@ private:
     return (color & 0xFFU) != 0U;
   }
 
-  // Clamp `pos` to `[-limit/2, +limit/2]` and, if it was out of range, negate
-  // `vel` so the entity bounces off that boundary wall.
+  // Clamp `pos` to `[-limit/2, +limit/2]` and, if it was out of range,
+  // negate `vel` so the entity bounces off that boundary wall.
   // TODO: Is there an off-by-one error here? If the world is 1920 wide, the
   // actual range isn't [-960, +960], it's [-960, +960). Do we need to deal
   // with this? It depends on how the client scales it, right?
@@ -882,5 +907,4 @@ private:
     }
   }
 };
-
 }} // namespace corvid::sim

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -1284,8 +1284,8 @@ private:
     assert(defenderPos);
     pendingTransientExplosions_.emplace_back(TransientExplosion{
         .expiry = WorldTick{*tick_ + 1},
-        .circle = Circle{
-            Position{defenderPos->x, defenderPos->y}, defender.attackRadius},
+        .circle = Circle{Position{defenderPos->x, defenderPos->y},
+            defender.attackRadius},
         .primaryColor = withAlpha(defender.rangeColor, 0x30U),
         .secondaryColor = withAlpha(defender.rangeColor, 0x10U)});
     for (const auto& cand : candidates) {

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -963,17 +963,22 @@ private:
   // `pendingKills_` for `SimGame` to resolve (bounty, death animation, etc.).
   // Then put the defender on cooldown.
   [[nodiscard]] bool attackWithAoe(EntityId defenderId, Defender& defender,
-      const std::vector<InvaderCandidate>& candidates, const DefenderAoe&) {
+      DefenderStats& stats, const std::vector<InvaderCandidate>& candidates,
+      const DefenderAoe&) {
     for (const auto& cand : candidates) {
       auto* hp = scene_.try_get_component<Health>(cand.id);
       if (!hp) continue;
+      const float actualDamage = std::min(defender.attackDamage, cand.currentHealth);
       hp->modified = tick_;
       hp->currentHealth -= defender.attackDamage;
       (void)markDirty(cand.id);
-      if (hp->currentHealth <= 0.F)
+      if (hp->currentHealth <= 0.F) {
         pendingKills_.push_back(cand.id);
-      else
+        stats.totalKills += 1.F;
+      } else {
         (void)flashEntity(cand.id, 0xFF7F7FFF, WorldTick{5});
+      }
+      stats.totalDamageDealt += actualDamage;
     }
     defender.nextAttack = WorldTick{*tick_ + *defender.cooldown};
     (void)flashEntity(defenderId, 0xFFFFFFFF, WorldTick{5});
@@ -1088,7 +1093,7 @@ private:
   // defender and target. Puts the defender on cooldown.
   // TODO: Spawn a transient beam line from the defender to the target.
   [[nodiscard]] bool attackWithHitscan(EntityId defenderId, Defender& defender,
-      const std::vector<InvaderCandidate>& candidates,
+      DefenderStats& stats, const std::vector<InvaderCandidate>& candidates,
       const DefenderHitscan& hitscan) {
     const auto targetId = selectTarget(candidates, defender.targetMode);
     if (targetId == EntityId::invalid) return false;
@@ -1096,13 +1101,17 @@ private:
     auto* hp = scene_.try_get_component<Health>(targetId);
     if (!hp) return false;
 
+    const float actualDamage = std::min(defender.attackDamage, hp->currentHealth);
     hp->modified = tick_;
     hp->currentHealth -= defender.attackDamage;
     (void)markDirty(targetId);
-    if (hp->currentHealth <= 0.F)
+    if (hp->currentHealth <= 0.F) {
       pendingKills_.push_back(targetId);
-    else
+      stats.totalKills += 1.F;
+    } else {
       (void)flashEntity(targetId, hitscan.beamColor, hitscan.beamDuration);
+    }
+    stats.totalDamageDealt += actualDamage;
 
     defender.nextAttack = WorldTick{*tick_ + *defender.cooldown};
     (void)flashEntity(defenderId, hitscan.beamColor, hitscan.beamDuration);
@@ -1114,27 +1123,28 @@ private:
   // Cooldown is only reset when the defender actually fires.
   [[nodiscard]] bool defendersAttack() {
     std::vector<InvaderCandidate> candidates;
-    scene_.for_each<Position,
-        Defender>([&](auto defenderId, auto defenderComps) {
-      auto& [defenderPos, defender] = defenderComps;
-      if (tick_ < defender.nextAttack) return true;
+    scene_.for_each<Position, Defender, DefenderStats>(
+        [&](auto defenderId, auto defenderComps) {
+          auto& [defenderPos, defender, stats] = defenderComps;
+          if (tick_ < defender.nextAttack) return true;
 
-      if (!collectCandidates(defenderPos, defender.attackRadius, candidates))
-        return true;
+          if (!collectCandidates(defenderPos, defender.attackRadius, candidates))
+            return true;
 
-      auto comp = scene_.try_get_some_components<DefenderAoe, DefenderShooter,
-          DefenderHitscan>(defenderId);
-      auto [aoe, shooter, hitscan] = comp;
-      if (aoe)
-        (void)attackWithAoe(defenderId, defender, candidates, *aoe);
-      else if (shooter)
-        (void)attackWithShooter(defenderId, defender, defenderPos, candidates,
-            *shooter);
-      else if (hitscan)
-        (void)attackWithHitscan(defenderId, defender, candidates, *hitscan);
+          auto [aoe, shooter, hitscan] =
+              scene_.try_get_some_components<DefenderAoe, DefenderShooter,
+                  DefenderHitscan>(defenderId);
+          if (aoe)
+            (void)attackWithAoe(defenderId, defender, stats, candidates, *aoe);
+          else if (shooter)
+            (void)attackWithShooter(defenderId, defender, defenderPos,
+                candidates, *shooter);
+          else if (hitscan)
+            (void)attackWithHitscan(
+                defenderId, defender, stats, candidates, *hitscan);
 
-      return true;
-    });
+          return true;
+        });
 
     return true;
   }

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -132,6 +132,11 @@ struct Velocity {
   }
 };
 
+// Circular hitbox, defined by a center position and a radius.
+struct Circle: public Position {
+  float radius{};
+};
+
 // Boundaries of the simulation world, where `(0,0)` is the center.
 struct SimWorldBounds {
   using WorldReg = entity_registry<WorldTick>;
@@ -327,26 +332,21 @@ struct VisualEffects {
 // `expiry` is absolute for emitted instances; when embedded as a template it
 // stores the desired duration to add to the current tick.
 struct TransientExplosion {
-  float x{};
-  float y{};
   WorldTick expiry{WorldTick::invalid};
+  Circle circle{};
   uint32_t primaryColor{};
   uint32_t secondaryColor{};
-  float radius{};
 };
 
 // Fire-and-forget, display-only beam streamed once to the client.
 // `expiry` is absolute for emitted instances; when embedded as a template it
 // stores the desired duration to add to the current tick.
 struct TransientBeam {
-  float x{};
-  float y{};
-  float startDistance{};
+  Circle circle{};
   WorldTick expiry{WorldTick::invalid};
   uint32_t primaryColor{};
   uint32_t secondaryColor{}; // Not used in wedge mode
-  float targetX{};
-  float targetY{};
+  Position targetPos{};
   float lineWidth{};
   float halfAngleDeg{}; // When > 0, render as wedge
   float coneRadius{};
@@ -389,6 +389,7 @@ struct DefenderHitscan {
 // field stores the TTL. Once instantiated, added to the current tick to gets
 // its final moment.
 struct DefenderBullet {
+  WorldTick expiry{}; // Expiration tick of the projectile.
   SimWorldBounds::EntityId shooterId{SimWorldBounds::EntityId::invalid};
   float hitCircleRadius{}; // Hit detection, used for physics and game logic.
   float speed{};
@@ -398,7 +399,6 @@ struct DefenderBullet {
   float directDamageType{}; // Eventually an enum.
   float dotDamageType{};    // Eventually an enum.
   int projectileType{};     // Eventually an enum.
-  WorldTick expiry{};       // Expiration tick of the projectile.
 };
 
 // Shooter component for defenders that spawn projectiles. The
@@ -867,12 +867,10 @@ public:
       auto [pos, inv] = scene_.try_get_components<Position, Invader>(id);
       if (pos && cbKill(id, *pos, *inv)) {
         pendingTransientExplosions_.emplace_back(TransientExplosion{
-            .x = pos->x,
-            .y = pos->y,
             .expiry = WorldTick{*tick_ + 6},
+            .circle = Circle{Position{pos->x, pos->y}, inv->hitCircleRadius},
             .primaryColor = 0xFFB040E6U,
-            .secondaryColor = 0xFFFFD080U,
-            .radius = inv->hitCircleRadius});
+            .secondaryColor = 0xFFFFD080U});
         (void)tombstoneEntity(id);
       }
     }
@@ -1125,13 +1123,12 @@ private:
   // Emit the explosion visual for a detonating projectile.
   [[nodiscard]] bool
   emitProjectileExplosion(const Position& pos, const DefenderBullet& bullet) {
-    pendingTransientExplosions_.emplace_back(TransientExplosion{.x = pos.x,
-        .y = pos.y,
+    pendingTransientExplosions_.emplace_back(TransientExplosion{
         .expiry = WorldTick{*tick_ + 3},
+        .circle = Circle{Position{pos.x, pos.y},
+            std::max(bullet.splashRadius, bullet.hitCircleRadius * 3.F)},
         .primaryColor = 0xFFFF80FFU,
-        .secondaryColor = 0xFF8020C0U,
-        .radius =
-            std::max(bullet.splashRadius, bullet.hitCircleRadius * 3.F)});
+        .secondaryColor = 0xFF8020C0U});
     return true;
   }
 
@@ -1286,12 +1283,11 @@ private:
     const auto* defenderPos = scene_.try_get_component<Position>(defenderId);
     assert(defenderPos);
     pendingTransientExplosions_.emplace_back(TransientExplosion{
-        .x = defenderPos->x,
-        .y = defenderPos->y,
         .expiry = WorldTick{*tick_ + 1},
+        .circle = Circle{
+            Position{defenderPos->x, defenderPos->y}, defender.attackRadius},
         .primaryColor = withAlpha(defender.rangeColor, 0x30U),
-        .secondaryColor = withAlpha(defender.rangeColor, 0x10U),
-        .radius = defender.attackRadius});
+        .secondaryColor = withAlpha(defender.rangeColor, 0x10U)});
     for (const auto& cand : candidates) {
       auto* hp = scene_.try_get_component<Health>(cand.id);
       if (!hp) continue;
@@ -1399,14 +1395,13 @@ private:
 
     (void)spawnBullet(defenderPos, vel, bullet);
     if (shooter.muzzleFlashTemplate.primaryColor != 0) {
-      pendingTransientBeams_.emplace_back(TransientBeam{.x = defenderPos.x,
-          .y = defenderPos.y,
-          .startDistance = shooter.muzzleFlashTemplate.startDistance,
+      pendingTransientBeams_.emplace_back(TransientBeam{
+          .circle = Circle{Position{defenderPos.x, defenderPos.y},
+              shooter.muzzleFlashTemplate.circle.radius},
           .expiry = WorldTick{*tick_ + *shooter.muzzleFlashTemplate.expiry},
           .primaryColor = shooter.muzzleFlashTemplate.primaryColor,
           .secondaryColor = shooter.muzzleFlashTemplate.secondaryColor,
-          .targetX = aimPos.x,
-          .targetY = aimPos.y,
+          .targetPos = aimPos,
           .lineWidth = shooter.muzzleFlashTemplate.lineWidth,
           .halfAngleDeg = shooter.muzzleFlashTemplate.halfAngleDeg,
           .coneRadius = shooter.muzzleFlashTemplate.coneRadius});
@@ -1458,14 +1453,13 @@ private:
     const auto* targetPos = scene_.try_get_component<Position>(targetId);
     if (!defenderPos || !targetPos) return false;
 
-    pendingTransientBeams_.emplace_back(TransientBeam{.x = defenderPos->x,
-        .y = defenderPos->y,
-        .startDistance = hitscan.transientTemplate.startDistance,
+    pendingTransientBeams_.emplace_back(TransientBeam{
+        .circle = Circle{Position{defenderPos->x, defenderPos->y},
+            hitscan.transientTemplate.circle.radius},
         .expiry = WorldTick{*tick_ + *hitscan.transientTemplate.expiry},
         .primaryColor = hitscan.transientTemplate.primaryColor,
         .secondaryColor = hitscan.transientTemplate.secondaryColor,
-        .targetX = targetPos->x,
-        .targetY = targetPos->y,
+        .targetPos = *targetPos,
         .lineWidth = hitscan.transientTemplate.lineWidth});
 
     defender.nextAttack = WorldTick{*tick_ + *defender.cooldown};

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -649,11 +649,14 @@ public:
   }
 
   // Check if an object at `pos` with a given `radius` overlaps any
-  // defenders. Used for placement.
-  [[nodiscard]] bool
-  doesOveralapDefenders(const Position& pos, float radius) const {
+  // defenders. Used for placement. Skips the entity with `excludeId` (pass
+  // `EntityId::invalid` to skip no entity; used when moving a placed
+  // defender so it can partially overlap its own footprint).
+  [[nodiscard]] bool doesOveralapDefenders(const Position& pos, float radius,
+      EntityId excludeId = EntityId::invalid) const {
     bool overlaps = false;
-    scene_.for_each<Position, Appearance, Defender>([&](auto, auto comps) {
+    scene_.for_each<Position, Appearance, Defender>([&](auto id, auto comps) {
+      if (id == excludeId) return true;
       const auto& [defender_pos, defender_app, _] = comps;
       if (!circlesOverlap(pos, radius, defender_pos, defender_app.radius))
         return true;
@@ -678,9 +681,12 @@ public:
   }
 
   // Whether defender placement at `pos` with a given `radius` is blocked.
-  [[nodiscard]] bool
-  isDefenderPlacementBlocked(const Position& pos, float radius) const {
-    return !isInBounds(pos, radius) || doesOveralapDefenders(pos, radius) ||
+  // Pass `excludeId` when relocating an already-placed defender so its own
+  // footprint does not veto the destination.
+  [[nodiscard]] bool isDefenderPlacementBlocked(const Position& pos,
+      float radius, EntityId excludeId = EntityId::invalid) const {
+    return !isInBounds(pos, radius) ||
+           doesOveralapDefenders(pos, radius, excludeId) ||
            doesTouchPath(pos, radius);
   }
 

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -289,9 +289,11 @@ struct VisualEffects {
   WorldTick modified{WorldTick::invalid}; // Tick when last modified.
   uint32_t selectionColor{};              // RGBA.
   float rangeRadius{};
-  uint32_t rangeColor{}; // RGBA.
-  uint32_t flashColor{}; // RGBA.
+  uint32_t rangeColor{};    // RGBA.
+  uint32_t flashColor{};    // RGBA.
   WorldTick flashExpiry{WorldTick::invalid};
+  uint32_t cooldownColor{}; // RGBA. Active from fire time until `nextAttack`.
+  WorldTick cooldownExpiry{WorldTick::invalid};
 };
 
 // Defensive component, common across all defenders.
@@ -553,6 +555,17 @@ public:
     if (!effects) return false;
     effects->flashColor = color;
     effects->flashExpiry = WorldTick{*tick_ + *duration};
+    return true;
+  }
+
+  // Set a cooldown overlay on a defender. `absoluteExpiry` is an absolute tick
+  // (typically `defender.nextAttack`) at which the overlay clears.
+  [[nodiscard]] bool setCooldown(EntityId id, uint32_t color,
+      WorldTick absoluteExpiry) {
+    auto* effects = changeVisualEffects(id);
+    if (!effects) return false;
+    effects->cooldownColor = color;
+    effects->cooldownExpiry = absoluteExpiry;
     return true;
   }
 
@@ -982,6 +995,7 @@ private:
     }
     defender.nextAttack = WorldTick{*tick_ + *defender.cooldown};
     (void)flashEntity(defenderId, 0xFFFFFFFF, WorldTick{5});
+    (void)setCooldown(defenderId, 0x7F000000U, defender.nextAttack);
     return true;
   }
 
@@ -1070,6 +1084,7 @@ private:
     (void)spawnBullet(defenderPos, vel, bullet);
     defender.nextAttack = WorldTick{*tick_ + *defender.cooldown};
     (void)flashEntity(defenderId, 0xFFFFFFFF, WorldTick{5});
+    (void)setCooldown(defenderId, 0x7F000000U, defender.nextAttack);
     return true;
   }
 
@@ -1115,6 +1130,7 @@ private:
 
     defender.nextAttack = WorldTick{*tick_ + *defender.cooldown};
     (void)flashEntity(defenderId, hitscan.beamColor, hitscan.beamDuration);
+    (void)setCooldown(defenderId, 0x7F000000U, defender.nextAttack);
     return true;
   }
 

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -387,6 +387,7 @@ struct DefenderHitscan {
 // its final moment.
 struct DefenderBullet {
   SimWorldBounds::EntityId shooterId{SimWorldBounds::EntityId::invalid};
+  float hitCircleRadius{}; // Hit detection, used for physics and game logic.
   float speed{};
   float directDamage{};     // Damage upon impact.
   float damageOverTime{};   // Damage applied over time.
@@ -454,7 +455,7 @@ using ArchDefenderAoe = archetype_storage<WorldReg,
     std::tuple<Position, Appearance, VisualEffects, Defender, DefenderStats,
         Health, DefenderAoe>>;
 using ArchBullet = archetype_storage<WorldReg,
-    std::tuple<Position, Velocity, DefenderBullet>>;
+    std::tuple<Position, Velocity, Appearance, DefenderBullet>>;
 using ArchDefenderShooter = archetype_storage<WorldReg,
     std::tuple<Position, Appearance, VisualEffects, Defender, DefenderStats,
         Health, DefenderShooter>>;
@@ -739,6 +740,7 @@ public:
   [[nodiscard]] bool next() {
     (void)updateMovers();
     (void)updatePathFollowers();
+    (void)updateProjectiles();
     // TODO: Add regen.
     (void)defendersAttack();
 
@@ -959,6 +961,24 @@ private:
   // components as `entityTemplateIndex_`.
   std::vector<std::string> entityTemplateLabels_;
 
+  [[nodiscard]] static Appearance appearanceForProjectile(
+      const DefenderBullet& bullet) {
+    switch (bullet.projectileType) {
+    case 1:
+      return Appearance{.glyph = U'*',
+          .radius = 8.F,
+          .fgColor = 0xFFFFFFFFU,
+          .bgColor = 0xFFFFA020U,
+          .attackRadius = 0.F};
+    default:
+      return Appearance{.glyph = U'.',
+          .radius = 6.F,
+          .fgColor = 0xFFFFFFFFU,
+          .bgColor = 0xFFC0C0C0U,
+          .attackRadius = 0.F};
+    }
+  }
+
   // Move an entity to staging to tombstone it, adding it to the dirty list so
   // that it will show up as a deletion.
   [[nodiscard]] bool tombstoneEntity(EntityId id) {
@@ -997,6 +1017,168 @@ private:
       return true;
     });
 
+    return true;
+  }
+
+  // Apply projectile damage to one invader and credit the originating
+  // defender's live stats. Shared by both direct-hit and splash-hit
+  // resolution.
+  // TODO: This will need to be expanded to handle different damage types, as
+  // well as applying a lingering damage-over-time effect.
+  [[nodiscard]] bool applyProjectileDamage(EntityId targetId, float damage,
+      DefenderStats& shooterStats, uint32_t flashColor) {
+    auto* hp = scene_.try_get_component<Health>(targetId);
+    if (!hp || hp->currentHealth <= 0.F || damage <= 0.F) return false;
+
+    // Apply damage.
+    const float actualDamage = std::min(damage, hp->currentHealth);
+    hp->modified = tick_;
+    hp->currentHealth -= actualDamage;
+    shooterStats.totalDamageDealt += actualDamage;
+    (void)markDirty(targetId);
+
+    // Check for death.
+    if (hp->currentHealth <= 0.F) {
+      pendingKills_.push_back(targetId);
+      shooterStats.totalKills += 1.F;
+    } else
+      (void)flashEntity(targetId, flashColor, WorldTick{5});
+
+    return true;
+  }
+
+  // Project `point` onto the swept segment from `start` to `end` and return
+  // its squared travel distance from `start`. Used to choose the first
+  // invader a projectile encounters during this frame.
+  [[nodiscard]] static float calculateSweepDistance(const Position& start,
+      const Position& end, const Position& point) {
+    const float dx = end.x - start.x;
+    const float dy = end.y - start.y;
+    const float lenSq = (dx * dx) + (dy * dy);
+    if (lenSq <= 0.F) return 0.F;
+
+    // Clamp the projected point to the segment so the returned value stays
+    // within this frame's swept path.
+    const float t = std::clamp(
+        (((point.x - start.x) * dx) + ((point.y - start.y) * dy)) / lenSq, 0.F,
+        1.F);
+    return t * lenSq;
+  }
+
+  // Find the first invader, if any, struck by this projectile along its swept
+  // path. Returns {targetId, impactPos}; an invalid `targetId` means no hit.
+  [[nodiscard]] std::pair<EntityId, Position>
+  findFirstProjectileHit(const Position& bulletPos, const Velocity& vel,
+      const DefenderBullet& bullet) {
+    const Position previousPos{bulletPos.x - vel.vx, bulletPos.y - vel.vy};
+
+    EntityId targetId = EntityId::invalid;
+    Position impactPos = bulletPos;
+    float bestTravel = std::numeric_limits<float>::max();
+    scene_.for_each<Position, Invader>([&](auto enemyId, auto comps) {
+      const auto& [enemyPos, invader] = comps;
+      const float r = bullet.hitCircleRadius + invader.hitCircleRadius;
+      // Skip if it misses.
+      if (distanceSquaredToSegment(enemyPos, previousPos, bulletPos) > r * r)
+        return true;
+
+      // Keep closest hit.
+      const float travel =
+          calculateSweepDistance(previousPos, bulletPos, enemyPos);
+      if (travel < bestTravel) {
+        bestTravel = travel;
+        targetId = enemyId;
+        impactPos = enemyPos;
+      }
+      return true;
+    });
+
+    return {targetId, impactPos};
+  }
+
+  // Apply splash damage around a detonation point.
+  [[nodiscard]] bool applySplashProjectileDamage(const Position& center,
+      const DefenderBullet& bullet, DefenderStats& shooterStats) {
+    scene_.for_each<Position, Invader>([&](auto enemyId, auto enemyComps) {
+      const auto& [enemyPos, invader] = enemyComps;
+      if (!circlesOverlap(center, bullet.splashRadius, enemyPos,
+              invader.hitCircleRadius))
+        return true;
+      (void)applyProjectileDamage(enemyId, bullet.directDamage, shooterStats,
+          0xFFFFA040U);
+      return true;
+    });
+    return true;
+  }
+
+  // Emit the explosion visual for a detonating projectile.
+  [[nodiscard]] bool
+  emitProjectileExplosion(const Position& pos, const DefenderBullet& bullet) {
+    pendingTransientExplosions_.emplace_back(TransientExplosion{.x = pos.x,
+        .y = pos.y,
+        .expiry = WorldTick{*tick_ + 3},
+        .primaryColor = 0xFFFFA040U,
+        .secondaryColor = 0x80FF6020U,
+        .radius =
+            std::max(bullet.splashRadius, bullet.hitCircleRadius * 2.F)});
+    return true;
+  }
+
+  // Resolve a confirmed projectile hit by applying its damage policy and
+  // emitting the impact visual. Structural erasure is handled by the caller
+  // after projectile iteration completes.
+  [[nodiscard]] bool resolveProjectileHit(EntityId targetId,
+      const Position& impactPos, const DefenderBullet& bullet) {
+    auto shooterStats =
+        scene_.try_get_component<DefenderStats>(bullet.shooterId);
+    assert(shooterStats);
+    if (bullet.directDamage > 0.F)
+      (void)applyProjectileDamage(targetId, bullet.directDamage, *shooterStats,
+          0xFFFFA040U);
+    if (bullet.splashRadius > 0.F)
+      (void)applySplashProjectileDamage(impactPos, bullet, *shooterStats);
+    (void)emitProjectileExplosion(impactPos, bullet);
+    return true;
+  }
+
+  // Resolve an explosive projectile that expired in flight: apply splash
+  // damage and emit the detonation visual. No-op if the bullet has no splash
+  // radius.
+  [[nodiscard]] bool
+  resolveExpiredProjectile(const Position& pos, const DefenderBullet& bullet) {
+    if (bullet.splashRadius <= 0.F) return true;
+    auto shooterStats =
+        scene_.try_get_component<DefenderStats>(bullet.shooterId);
+    assert(shooterStats);
+    (void)applySplashProjectileDamage(pos, bullet, *shooterStats);
+    (void)emitProjectileExplosion(pos, bullet);
+    return true;
+  }
+
+  // Resolve projectile lifecycle after movement: expire old bullets, detect
+  // hits along their swept paths, and queue bullets for erasure when done.
+  [[nodiscard]] bool updateProjectiles() {
+    std::vector<EntityId> expiredBullets;
+    scene_.for_each<Position, Velocity, DefenderBullet>(
+        [&](auto bulletId, auto comps) {
+          auto& [bulletPos, vel, bullet] = comps;
+          if (bullet.expiry <= tick_) {
+            (void)resolveExpiredProjectile(bulletPos, bullet);
+            expiredBullets.push_back(bulletId);
+            return true;
+          }
+          // Check whether the projectile hits an invader along its path.
+          if (auto [targetId, impactPos] =
+                  findFirstProjectileHit(bulletPos, vel, bullet);
+              targetId != EntityId::invalid)
+          {
+            (void)resolveProjectileHit(targetId, impactPos, bullet);
+            expiredBullets.push_back(bulletId);
+          }
+          return true;
+        });
+
+    for (auto bulletId : expiredBullets) (void)tombstoneEntity(bulletId);
     return true;
   }
 
@@ -1201,6 +1383,7 @@ private:
 
     // `bulletTemplate.expiry` stores TTL; convert to an absolute tick.
     auto bullet = shooter.bulletTemplate;
+    bullet.shooterId = defenderId;
     bullet.expiry = WorldTick{*tick_ + *shooter.bulletTemplate.expiry};
 
     (void)spawnBullet(defenderPos, vel, bullet);
@@ -1219,8 +1402,9 @@ private:
     WorldScene::megatuple_t tpl{};
     std::get<std::optional<Position>>(tpl) = pos;
     std::get<std::optional<Velocity>>(tpl) = vel;
+    std::get<std::optional<Appearance>>(tpl) = appearanceForProjectile(bullet);
     std::get<std::optional<DefenderBullet>>(tpl) = bullet;
-    auto h = scene_.store_new_entity_from_mega({tick_}, tpl);
+    auto h = scene_.store_new_entity_from_mega({WorldTick::invalid}, tpl);
     if (h) (void)markDirty(h.id());
     return h;
   }

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -344,10 +344,12 @@ struct TransientBeam {
   float startDistance{};
   WorldTick expiry{WorldTick::invalid};
   uint32_t primaryColor{};
-  uint32_t secondaryColor{};
+  uint32_t secondaryColor{}; // Not used in wedge mode
   float targetX{};
   float targetY{};
   float lineWidth{};
+  float halfAngleDeg{}; // When > 0, render as wedge
+  float coneRadius{};
 };
 
 // Defensive component, common across all defenders.
@@ -401,11 +403,15 @@ struct DefenderBullet {
 
 // Shooter component for defenders that spawn projectiles. The
 // `bulletTemplate` is used to spawn bullets with the same properties as the
-// defender's attack, but with their own position and velocity.
+// defender's attack, but with their own position and velocity. When
+// `muzzleFlashTemplate.primaryColor` is set, a transient beam is emitted
+// toward `aimPos` on each shot, guaranteeing a visible effect even if the
+// bullet hits within a single tick.
 struct DefenderShooter {
   DefenderBullet bulletTemplate{};
-  float fireRate{}; // Shots per tick.
-  int spread{};     // Eventually an enum.
+  TransientBeam muzzleFlashTemplate{}; // Template; `expiry` stores TTL.
+  float fireRate{};                    // Shots per tick.
+  int spread{};                        // Eventually an enum.
 };
 
 // Invader component, shared across all invaders.
@@ -1122,10 +1128,10 @@ private:
     pendingTransientExplosions_.emplace_back(TransientExplosion{.x = pos.x,
         .y = pos.y,
         .expiry = WorldTick{*tick_ + 3},
-        .primaryColor = 0xFFFFA040U,
-        .secondaryColor = 0x80FF6020U,
+        .primaryColor = 0xFFFF80FFU,
+        .secondaryColor = 0xFF8020C0U,
         .radius =
-            std::max(bullet.splashRadius, bullet.hitCircleRadius * 2.F)});
+            std::max(bullet.splashRadius, bullet.hitCircleRadius * 3.F)});
     return true;
   }
 
@@ -1392,6 +1398,19 @@ private:
     bullet.expiry = WorldTick{*tick_ + *shooter.bulletTemplate.expiry};
 
     (void)spawnBullet(defenderPos, vel, bullet);
+    if (shooter.muzzleFlashTemplate.primaryColor != 0) {
+      pendingTransientBeams_.emplace_back(TransientBeam{.x = defenderPos.x,
+          .y = defenderPos.y,
+          .startDistance = shooter.muzzleFlashTemplate.startDistance,
+          .expiry = WorldTick{*tick_ + *shooter.muzzleFlashTemplate.expiry},
+          .primaryColor = shooter.muzzleFlashTemplate.primaryColor,
+          .secondaryColor = shooter.muzzleFlashTemplate.secondaryColor,
+          .targetX = aimPos.x,
+          .targetY = aimPos.y,
+          .lineWidth = shooter.muzzleFlashTemplate.lineWidth,
+          .halfAngleDeg = shooter.muzzleFlashTemplate.halfAngleDeg,
+          .coneRadius = shooter.muzzleFlashTemplate.coneRadius});
+    }
     defender.nextAttack = WorldTick{*tick_ + *defender.cooldown};
     (void)flashEntity(defenderId, 0xFFFFFFFF, WorldTick{5});
     (void)setCooldown(defenderId, 0x0000007FU, defender.nextAttack);

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -82,9 +82,9 @@ constexpr auto corvid::enums::registry::enum_spec_v<corvid::sim::TargetMode> =
 
 namespace corvid { inline namespace sim {
 
-// Conversions between Cartesian coordinates (x, y) and Euclidean vectors in
-// polar form (length, direction). Direction is in radians, with 0 along the
-// positive x-axis and increasing counter-clockwise.
+// Conversions between Cartesian coordinates (x, y), and Euclidean vectors
+// represented in polar form (length, direction). Direction is in radians, with
+// 0 along the positive x-axis and increasing counter-clockwise.
 namespace convert {
 // Convert Cartesian coordinates to a Euclidean vector.
 [[nodiscard]] constexpr std::pair<float, float>
@@ -103,9 +103,9 @@ PolarToCartesian(float length, float direction) noexcept {
 }
 } // namespace convert
 
-// Linear interpolation, where t is the interpolation factor in [0,1]. Returns
-// a when t=0 and b when t=1. Can also be used for extrapolation when t is
-// outside this range.
+// Linear interpolation, where `t` is the interpolation factor in `[0,1]`.
+// Returns a when `t==0` and b when `t==1`. Can also be used for extrapolation
+// when `t` is outside this range.
 [[nodiscard]] constexpr float lerp(float a, float b, float t) noexcept {
   return a + ((b - a) * t);
 }
@@ -132,24 +132,49 @@ struct Velocity {
   }
 };
 
+// Boundaries of the simulation world, where `(0,0)` is the center.
 struct SimWorldBounds {
+  using WorldReg = entity_registry<WorldTick>;
+  using WorldSid = WorldReg::store_id_t;
+  using EntityId = WorldReg::id_t;
+  using Handle = WorldReg::handle_t;
   static constexpr float widthOfWorld = 1920.F;
   static constexpr float heightOfWorld = 1080.F;
   static constexpr float half_w = widthOfWorld * 0.5F;
   static constexpr float half_h = heightOfWorld * 0.5F;
 
-  // Is the position within the bounds of the world.
+  // Whether the position is within the bounds of the world.
   [[nodiscard]] static constexpr bool isInBounds(const Position& pos) {
     return pos.x >= -half_w && pos.x <= half_w && pos.y >= -half_h &&
            pos.y <= half_h;
   }
 
-  // Is the position within the bounds of the world, taking a radius into
-  // account.
+  // Whether a radius around the position is within the bounds of the world.
   [[nodiscard]] static constexpr bool
   isInBounds(const Position& pos, float radius) {
     return pos.x - radius >= -half_w && pos.x + radius <= half_w &&
            pos.y - radius >= -half_h && pos.y + radius <= half_h;
+  }
+
+  // Clamp `pos` to `[-limit/2, +limit/2]` and, if it was out of range,
+  // negate `vel` so the entity bounces off that boundary wall. Return whether
+  // it was in bounds.
+  // TODO: Is there an off-by-one error here? If the world is 1920 wide, the
+  // actual range isn't [-960, +960], it's [-960, +960). Do we need to deal
+  // with this? It depends on how the client scales it, right?
+  [[nodiscard]] constexpr static bool
+  bounceFromBoundary(float& pos, float& vel, float limit) {
+    const float half = limit / 2.F;
+    if (pos < -half) {
+      pos = -half;
+      vel = -vel;
+      return false;
+    } else if (pos > half) {
+      pos = half;
+      vel = -vel;
+      return false;
+    }
+    return true;
   }
 };
 
@@ -168,10 +193,10 @@ struct PathJoints {
 };
 
 // `SegmentedPath` is built from a `PathJoints` and consists of pre-computed
-// segments with cumulative distances, enabling efficient runtime mapping from
-// distance traveled to world position. Essentially, it's an indexed vertex
-// buffer for the path geometry.
-struct SegmentedPath {
+// segments with cumulative distances and angles, enabling efficient runtime
+// mapping from distance traveled to world position. Essentially, it's an
+// indexed vertex buffer for the path geometry.
+struct SegmentedPath: private SimWorldBounds {
   struct Segment {
     Position front;
     Position back;
@@ -185,8 +210,9 @@ struct SegmentedPath {
   float width{};
 
   // Return the segment that contains `progress`, clamping `progress` to
-  // `[0, totalLength]` in place. Assumes `segments` is non-empty.
+  // `[0, totalLength]` in place.
   [[nodiscard]] const Segment& segmentAtProgress(float& progress) const {
+    assert(segments.size());
     progress = std::clamp(progress, 0.F, totalLength);
     auto it = std::ranges::upper_bound(segments, progress, {},
         &Segment::cumulativeStart);
@@ -194,12 +220,10 @@ struct SegmentedPath {
     return *it;
   }
 
-  // Map a distance traveled (`progress`) to a world-space `Position`.
+  // Map `progress`, a distance traveled, to a world-space `Position`.
   // `progress` is clamped to `[0, totalLength]`.
-  // Returns the origin if `segments` is empty.
   [[nodiscard]] Position
   calculatePositionFromProgress(float progress, float previousProgress) const {
-    if (segments.empty()) return {};
     const auto& seg = segmentAtProgress(progress);
 
     // If `previousProgress` was on an earlier segment, emit the joint position
@@ -217,32 +241,33 @@ struct SegmentedPath {
   }
 
   // Return the direction angle (radians) of the segment containing
-  // `progress`. Returns `NaN` if `segments` is empty.
+  // `progress`.
   [[nodiscard]] float angleAtProgress(float progress) const {
-    if (segments.empty()) return std::numeric_limits<float>::quiet_NaN();
+    assert(segments.size());
     return segmentAtProgress(progress).angle;
   }
 
   // Convert authored `PathJoints` into a `SegmentedPath`.
   [[nodiscard]] static SegmentedPath fromJoints(const PathJoints& p) {
-    if (p.joints.size() < 2) return {};
+    assert(p.joints.size() >= 2);
+
     SegmentedPath sp;
     sp.width = p.width;
     sp.segments.reserve(p.joints.size() - 1);
     float cumulative{};
 
-    for (const auto& joint : p.joints)
-      if (!SimWorldBounds::isInBounds(joint.pos))
-        throw std::runtime_error("Path joint lies outside the world bounds");
-
     for (std::size_t i = 0; i + 1 < p.joints.size(); ++i) {
       const Position& front = p.joints[i].pos;
       const Position& back = p.joints[i + 1].pos;
+      assert(isInBounds(front));
+      assert(isInBounds(back));
+
       const float dx = back.x - front.x;
       const float dy = back.y - front.y;
       const float len = std::hypot(dx, dy);
       assert(len != 0.F);
       const float angle = std::atan2(dy, dx);
+
       sp.segments.push_back({front, back, len, cumulative, angle});
       cumulative += len;
     }
@@ -252,8 +277,9 @@ struct SegmentedPath {
 };
 
 // Path-following component. Typically part of an invader archetype, but may
-// also apply to defenders. On each tick, `progress` advances by `speed`; the
-// entity's `Position` is re-derived from the segmented path geometry.
+// in principle apply to defenders. On each tick, `progress` advances by
+// `speed`; the entity's `Position` is re-derived from the segmented path
+// geometry.
 struct Pathing {
   PathId pathId{};  // Index into `sim_world::paths_`.
   float progress{}; // Distance traveled along the path so far.
@@ -288,7 +314,7 @@ struct Health {
 struct VisualEffects {
   WorldTick modified{WorldTick::invalid}; // Tick when last modified.
   uint32_t selectionColor{};              // RGBA.
-  float rangeRadius{};
+  float rangeRadius{}; // Does not affect physics or game logic; display-only.
   uint32_t rangeColor{}; // RGBA.
   uint32_t flashColor{}; // RGBA.
   WorldTick flashExpiry{WorldTick::invalid};
@@ -300,11 +326,11 @@ struct VisualEffects {
 struct Defender {
   uint16_t entityTemplateIndex{std::numeric_limits<uint16_t>::max()};
   float hitCircleRadius{}; // Hit detection, as opposed to appearance.
-  float attackRadius{};
-  uint32_t rangeColor{}; // RGBA.
-  float attackDamage{};  // Interpretation depends on the defender type.
-  WorldTick cooldown{};
-  WorldTick nextAttack{}; // Updated when the defender attacks.
+  float attackRadius{};    // Used for physics and game logic.
+  uint32_t rangeColor{};   // RGBA.
+  float attackDamage{};    // Interpretation depends on the defender type.
+  WorldTick cooldown{};    // Time between attacks.
+  WorldTick nextAttack{};  // Updated when the defender attacks.
   TargetMode targetMode{TargetMode::first};
 };
 
@@ -335,14 +361,15 @@ struct DefenderHitscan {
 // field stores the TTL. Once instantiated, added to the current tick to gets
 // its final moment.
 struct DefenderBullet {
+  SimWorldBounds::EntityId shooterId{SimWorldBounds::EntityId::invalid};
   float speed{};
-  float directDamage{};
-  float damageOverTime{};
-  float splashRadius{};
+  float directDamage{};     // Damage upon impact.
+  float damageOverTime{};   // Damage applied over time.
+  float splashRadius{};     // Radius for area-of-effect damage.
   float directDamageType{}; // Eventually an enum.
   float dotDamageType{};    // Eventually an enum.
   int projectileType{};     // Eventually an enum.
-  WorldTick expiry{};
+  WorldTick expiry{};       // Expiration tick of the projectile.
 };
 
 // Shooter component for defenders that spawn projectiles. The
@@ -357,8 +384,8 @@ struct DefenderShooter {
 // Invader component, shared across all invaders.
 struct Invader {
   uint16_t entityTemplateIndex{std::numeric_limits<uint16_t>::max()};
-  float hitCircleRadius{}; // Hit detection, as opposed to appearance.
-  int bounty{10}; // Resources awarded to the player for killing this invader.
+  float hitCircleRadius{}; // Hit detection, used for physics and game logic.
+  uint32_t bounty{10};     // Resources awarded for killing this invader.
 };
 
 // ECS types for the simulation world.
@@ -395,8 +422,7 @@ struct Invader {
 //                                (Position + Appearance + VisualEffects +
 //                                Defender + DefenderStats + Health +
 //                                DefenderHitscan)
-using WorldReg = entity_registry<WorldTick>;
-using WorldSid = WorldReg::store_id_t;
+using WorldReg = SimWorldBounds::WorldReg;
 using ArchInvaderAlpha = archetype_storage<WorldReg,
     std::tuple<Position, Appearance, VisualEffects, Pathing, Invader, Health>>;
 using ArchDefenderAoe = archetype_storage<WorldReg,
@@ -422,9 +448,6 @@ using WorldScene = archetype_scene<WorldReg, ArchInvaderAlpha, ArchDefenderAoe,
 // starting from any past tick.
 class SimWorld: public SimWorldBounds {
 public:
-  using EntityId = WorldReg::id_t;
-  using Handle = WorldReg::handle_t;
-
   static constexpr WorldSid sidStaging{0};
   static constexpr WorldSid sidInvaderAlpha{1};
   static constexpr WorldSid sidDefenderAoe{2};
@@ -432,6 +455,7 @@ public:
   static constexpr WorldSid sidDefenderShooter{4};
   static constexpr WorldSid sidDefenderHitscan{5};
 
+  // Clear state.
   void clear() {
     scene_.clear();
     paths_.clear();
@@ -459,19 +483,21 @@ public:
         static_cast<uint16_t>(entityTemplateLabels_.size() - 1);
 
     // Store index in component.
-    auto& defender = std::get<std::optional<Defender>>(value);
-    if (defender) defender->entityTemplateIndex = entityTemplateIndex;
-    auto& invader = std::get<std::optional<Invader>>(value);
-    if (invader) invader->entityTemplateIndex = entityTemplateIndex;
+    if (auto& defender = std::get<std::optional<Defender>>(value); defender)
+      defender->entityTemplateIndex = entityTemplateIndex;
+    else if (auto& invader = std::get<std::optional<Invader>>(value); invader)
+      invader->entityTemplateIndex = entityTemplateIndex;
     return true;
   }
 
-  // Spawn an entity by label. Looks up the pre-registered template, stamps
-  // `tick_` into any `modified` fields, marks the entity dirty, and returns
-  // its handle. Returns an invalid handle if the label is unknown or the
-  // template bitmap does not match any archetype.
+  // Spawn an entity by label. Looks up the pre-registered template.
   [[nodiscard]] Handle spawnEntity(std::string_view label) {
-    auto megatuple = find_opt(entityTemplates_, label);
+    return spawnEntity(find_opt(entityTemplates_, label));
+  }
+
+  // Spawn an entity by definition. Stamps `tick_` into any `modified` fields,
+  // marks the entity dirty, and returns its handle.
+  [[nodiscard]] Handle spawnEntity(const WorldScene::megatuple_t* megatuple) {
     if (!megatuple) return {};
     auto h =
         scene_.store_new_entity_from_mega({WorldTick::invalid}, *megatuple);
@@ -582,11 +608,29 @@ public:
     return scene_.registry().id_from_handle(h);
   }
 
-  // Find an entity at a given position, if any. Uses simple bounding box.
+  // Find an entity at a given position, if any. Uses simple bounding box,
+  // suitable for UI, not hit detection.
   [[nodiscard]] EntityId findEntityAt(const Position& pos) const {
     EntityId found_id = EntityId::invalid;
     scene_.for_each<Position, Appearance>([&](auto id, auto comps) {
       const auto& [epos, app] = comps;
+      if (std::abs(epos.x - pos.x) >= app.radius ||
+          std::abs(epos.y - pos.y) >= app.radius)
+        return true;
+
+      found_id = id;
+      return false;
+    });
+
+    return found_id;
+  }
+
+  // Find ID of the defender at the given position, if any. Uses simple
+  // bounding box, suitable for UI, not hit detection.
+  [[nodiscard]] EntityId findDefenderAt(const Position& pos) const {
+    auto found_id = EntityId::invalid;
+    scene_.for_each<Position, Appearance, Defender>([&](auto id, auto comps) {
+      const auto& [epos, app, _] = comps;
       if (std::abs(epos.x - pos.x) >= app.radius ||
           std::abs(epos.y - pos.y) >= app.radius)
         return true;
@@ -604,25 +648,8 @@ public:
         .try_get_components<Position, Appearance, VisualEffects, Defender>(id);
   }
 
-  // Find ID of the defender at the given position, if any. Uses simple
-  // bounding box.
-  [[nodiscard]] EntityId findDefenderAt(const Position& pos) const {
-    auto found_id = EntityId::invalid;
-    scene_.for_each<Position, Appearance, Defender>([&](auto id, auto comps) {
-      const auto& [epos, app, _] = comps;
-      if (std::abs(epos.x - pos.x) >= app.radius ||
-          std::abs(epos.y - pos.y) >= app.radius)
-        return true;
-
-      found_id = id;
-      return false;
-    });
-
-    return found_id;
-  }
-
   // Check if an object at `pos` with a given `radius` overlaps any
-  // defenders. Uses for placement.
+  // defenders. Used for placement.
   [[nodiscard]] bool
   doesOveralapDefenders(const Position& pos, float radius) const {
     bool overlaps = false;
@@ -630,6 +657,7 @@ public:
       const auto& [defender_pos, defender_app, _] = comps;
       if (!circlesOverlap(pos, radius, defender_pos, defender_app.radius))
         return true;
+
       overlaps = true;
       return false;
     });
@@ -641,15 +669,15 @@ public:
     for (const auto& path : paths_) {
       const float expanded_radius = radius + (path.width * 0.5F);
       const float expanded_radius_sq = expanded_radius * expanded_radius;
-      for (const auto& seg : path.segments) {
+      for (const auto& seg : path.segments)
         if (distanceSquaredToSegment(pos, seg.front, seg.back) <=
             expanded_radius_sq)
           return true;
-      }
     }
     return false;
   }
 
+  // Whether defender placement at `pos` with a given `radius` is blocked.
   [[nodiscard]] bool
   isDefenderPlacementBlocked(const Position& pos, float radius) const {
     return !isInBounds(pos, radius) || doesOveralapDefenders(pos, radius) ||
@@ -662,7 +690,9 @@ public:
   [[nodiscard]] bool next() {
     (void)updateMovers();
     (void)updatePathFollowers();
+    // TODO: Add regen.
     (void)defendersAttack();
+
     return true;
   }
 
@@ -678,29 +708,37 @@ public:
   // entities).
   [[nodiscard]] std::size_t size() const { return scene_.size(); }
 
+  // Whether any invader entities are currently active (i.e. not yet
+  // tombstoned). Call after `resolveEscapees` and `resolveKills` so that
+  // entities removed this tick are not counted.
+  [[nodiscard]] bool hasActiveInvaders() const {
+    bool found = false;
+    scene_.for_each<Invader>([&found](auto, auto) {
+      found = true;
+      return false; // Stop on first match.
+    });
+    return found;
+  }
+
   // Destructively extract upserts and erasures.
   //
   // Call back `cbUpserts(EntityId, Position, Appearance, VisualEffects)` for
   // each changed entity that has a `Position` and `Appearance` and has
   // changed since the last tick, and `cbErased(EntityId)` for each entity
   // that has been erased since the last tick. The visual effects pointer is
-  // null for archetypes that do not carry that component. These calls will
+  // null for archetypes that do not carry that component. These callbacks will
   // be interleaved.
   [[nodiscard]] bool
   extractUpdatedEntities(auto&& cbUpserts, auto&& cbErased) {
     static constexpr VisualEffects nfx;
     auto& reg = scene_.registry();
     for (auto id : updatedEntities_) {
-      if (!reg.is_valid(id)) continue;
-      const auto [pos, app] =
-          scene_.try_get_components<Position, Appearance>(id);
+      const auto [pos, app, fx] =
+          scene_.try_get_some_components<Position, Appearance, VisualEffects>(
+              id);
       if (pos && app) {
-        const auto* fx = &nfx;
-        auto maybeFx = scene_.try_get_component<VisualEffects>(id);
-        if (maybeFx) fx = maybeFx;
-        (void)cbUpserts(id, *pos, *app, *fx);
-      } else {
-        if (reg.get_location(id).store_id != sidStaging) continue;
+        (void)cbUpserts(id, *pos, *app, fx ? *fx : nfx);
+      } else if (reg.get_location(id).store_id == sidStaging) {
         (void)cbErased(id);
         (void)scene_.erase_entity(id);
       }
@@ -712,18 +750,17 @@ public:
   // Call back `cbPath(PathId, Position)` for all joints of the path
   // identified by `pathId`.
   [[nodiscard]] bool obtainPath(auto&& cbPath, PathId pathId) const {
-    if (pathId >= paths_.size_as_enum()) return false;
+    assert(pathId < paths_.size_as_enum());
     const auto& sp = paths_[pathId];
-    for (const auto& seg : sp.segments) cbPath(pathId, Position{seg.front});
-    if (!sp.segments.empty())
-      cbPath(pathId, Position{sp.segments.back().back});
+    for (const auto& seg : sp.segments) cbPath(pathId, seg.front);
+    if (!sp.segments.empty()) cbPath(pathId, sp.segments.back().back);
     return true;
   }
 
   // Call back `cbPath(PathId, Position)` for all joints of all paths.
   [[nodiscard]] bool obtainPaths(auto&& cbPath) const {
     for (PathId pathId{0}; pathId < paths_.size_as_enum(); ++pathId)
-      if (!obtainPath(cbPath, pathId)) return false;
+      (void)obtainPath(cbPath, pathId);
     return true;
   }
 
@@ -738,36 +775,30 @@ public:
     for (auto id : pathEscapees_) {
       if (!scene_.registry().is_valid(id)) continue;
       auto [pos, pf] = scene_.try_get_components<Position, Pathing>(id);
-      if (!pos || !pf) continue;
-      if (!cbEscapee(id, *pos, *pf)) continue;
-      (void)tombstoneEntity(id);
+      if (pos && cbEscapee(id, *pos, *pf)) (void)tombstoneEntity(id);
     }
     pathEscapees_.clear();
     return true;
   }
 
   // Resolve pending kills by calling `cbKill(EntityId, const Position&, const
-  // Invader&)` for each. If `cbKill` returns true the entity is tombstoned;
-  // if false it is left alive so the caller can migrate it (e.g. to a
+  // Invader&)` for each. If `cbKill` returns true, the entity is tombstoned;
+  // if false, it is left alive so the caller can migrate it (e.g. to a
   // transient death animation).
   //
   // Destructively iterates the pending-kills list.
   [[nodiscard]] bool resolveKills(auto&& cbKill) {
     for (auto id : pendingKills_) {
-      if (!scene_.registry().is_valid(id)) continue;
       auto [pos, inv] = scene_.try_get_components<Position, Invader>(id);
-      if (!pos || !inv) continue;
-      if (!cbKill(id, *pos, *inv)) continue;
-      (void)tombstoneEntity(id);
+      if (pos && cbKill(id, *pos, *inv)) (void)tombstoneEntity(id);
     }
     pendingKills_.clear();
     return true;
   }
 
-  // Marks an entity as dirty so that it will be included in the next delta
+  // Mark an entity as dirty so that it will be included in the next delta
   // snapshot.
   [[nodiscard]] bool markDirty(EntityId id) {
-    // If it's been deleted, it's already dirty.
     if (!scene_.registry().is_valid(id)) return false;
     auto& last_updated = scene_.registry()[id];
     if (last_updated != tick_) {
@@ -779,10 +810,10 @@ public:
   }
 
   // Mark all entities dirty. When `update_strategy::incremental`, marks
-  // entities for extraction only. When `update_strategy::full`, also stamps
-  // `Appearance` and `VisualEffects` `modified` fields with `tick_` so the
-  // next extraction includes them. Must be called before `tick()` so
-  // `markDirty`'s deduplication check (`last_updated == tick_`) is valid.
+  // entities only. When `update_strategy::full`, also stamps `Appearance` and
+  // `VisualEffects` `modified` fields with `tick_` so the next extraction
+  // includes them. Must be called before `tick()` so `markDirty`'s
+  // deduplication check (`last_updated == tick_`) is valid.
   [[nodiscard]] bool markAllDirty(
       update_strategy strategy = update_strategy::incremental) {
     scene_.registry().for_each([&](auto id, auto&) {
@@ -792,15 +823,16 @@ public:
       (void)markDirty(id);
       if (strategy == update_strategy::incremental) return true;
 
-      if (auto app = scene_.try_get_component<Appearance>(id))
-        app->modified = tick_;
-      if (auto effects = scene_.try_get_component<VisualEffects>(id))
-        effects->modified = tick_;
+      auto [app, fx] =
+          scene_.try_get_some_components<Appearance, VisualEffects>(id);
+      if (app) app->modified = tick_;
+      if (fx) fx->modified = tick_;
       return true;
     });
     return true;
   }
 
+  // Calculate squared distance between two positions.
   static constexpr float
   distanceSquared(const Position& a, const Position& b) {
     const float dx = a.x - b.x;
@@ -808,12 +840,15 @@ public:
     return (dx * dx) + (dy * dy);
   }
 
+  // Determine if two circles overlap.
   static constexpr bool circlesOverlap(const Position& posA, float radiusA,
       const Position& posB, float radiusB) {
     const float r = radiusA + radiusB;
     return distanceSquared(posA, posB) <= r * r;
   }
 
+  // Calculate the squared distance from a point to the closest point on a line
+  // segment.
   static constexpr float distanceSquaredToSegment(const Position& point,
       const Position& segA, const Position& segB) {
     const float dx = segB.x - segA.x;
@@ -847,9 +882,9 @@ private:
   // components as `entityTemplateIndex_`.
   std::vector<std::string> entityTemplateLabels_;
 
-  // Logically erases an entity, adding it to the dirty list.
+  // Move an entity to staging to tombstone it, adding it to the dirty list so
+  // that it will show up as a deletion.
   [[nodiscard]] bool tombstoneEntity(EntityId id) {
-    // Can't kill the dead.
     if (!scene_.registry().is_valid(id)) return false;
     (void)markDirty(id);
     return scene_.remove_entity(id);
@@ -880,8 +915,8 @@ private:
       pos.x += vel.vx;
       pos.y += vel.vy;
 
-      bounceFromBoundary(pos.x, vel.vx, widthOfWorld);
-      bounceFromBoundary(pos.y, vel.vy, heightOfWorld);
+      (void)bounceFromBoundary(pos.x, vel.vx, widthOfWorld);
+      (void)bounceFromBoundary(pos.y, vel.vy, heightOfWorld);
       return true;
     });
 
@@ -1170,22 +1205,6 @@ private:
 
   [[nodiscard]] static constexpr bool isVisibleColor(uint32_t color) noexcept {
     return (color & 0xFFU) != 0U;
-  }
-
-  // Clamp `pos` to `[-limit/2, +limit/2]` and, if it was out of range,
-  // negate `vel` so the entity bounces off that boundary wall.
-  // TODO: Is there an off-by-one error here? If the world is 1920 wide, the
-  // actual range isn't [-960, +960], it's [-960, +960). Do we need to deal
-  // with this? It depends on how the client scales it, right?
-  static void bounceFromBoundary(float& pos, float& vel, float limit) {
-    const float half = limit / 2.F;
-    if (pos < -half) {
-      pos = -half;
-      vel = -vel;
-    } else if (pos > half) {
-      pos = half;
-      vel = -vel;
-    }
   }
 };
 }} // namespace corvid::sim

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -964,23 +964,23 @@ private:
   // components as `entityTemplateIndex_`.
   std::vector<std::string> entityTemplateLabels_;
 
-  [[nodiscard]] static Appearance appearanceForProjectile(
-      const DefenderBullet& bullet) {
+  [[nodiscard]] static const Appearance&
+  appearanceForProjectile(const DefenderBullet& bullet) {
+    static constexpr Appearance kType1{.glyph = U'*',
+        .radius = 8.F,
+        .fgColor = 0xFFFFFFFFU,
+        .bgColor = 0xFFA020FFU,
+        .attackRadius = 0.F,
+        .trailColor = 0xFFA020FFU};
+    static constexpr Appearance kDefault{.glyph = U'.',
+        .radius = 6.F,
+        .fgColor = 0xFFFFFFFFU,
+        .bgColor = 0xC0C0C0FFU,
+        .attackRadius = 0.F,
+        .trailColor = 0xC0C0C0FFU};
     switch (bullet.projectileType) {
-    case 1:
-      return Appearance{.glyph = U'*',
-          .radius = 8.F,
-          .fgColor = 0xFFFFFFFFU,
-          .bgColor = 0xFFA020FFU,
-          .attackRadius = 0.F,
-          .trailColor = 0xFFA020FFU};
-    default:
-      return Appearance{.glyph = U'.',
-          .radius = 6.F,
-          .fgColor = 0xFFFFFFFFU,
-          .bgColor = 0xC0C0C0FFU,
-          .attackRadius = 0.F,
-          .trailColor = 0xC0C0C0FFU};
+    case 1: return kType1;
+    default: return kDefault;
     }
   }
 
@@ -1402,14 +1402,8 @@ private:
   // system by using the template in the defender itself
   [[nodiscard]] Handle spawnBullet(const Position& pos, const Velocity& vel,
       const DefenderBullet& bullet) {
-    // TODO: This is dumb. We shouldn't create a fake megatuple just to spawn
-    // the bullet.
-    WorldScene::megatuple_t tpl{};
-    std::get<std::optional<Position>>(tpl) = pos;
-    std::get<std::optional<Velocity>>(tpl) = vel;
-    std::get<std::optional<Appearance>>(tpl) = appearanceForProjectile(bullet);
-    std::get<std::optional<DefenderBullet>>(tpl) = bullet;
-    auto h = scene_.store_new_entity_from_mega({WorldTick::invalid}, tpl);
+    auto h = scene_.store_new_entity({WorldTick::invalid},
+        std::tuple{pos, vel, appearanceForProjectile(bullet), bullet});
     if (h) {
       if (auto* app = scene_.try_get_component<Appearance>(h.id()))
         app->modified = tick_;

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -968,13 +968,13 @@ private:
       return Appearance{.glyph = U'*',
           .radius = 8.F,
           .fgColor = 0xFFFFFFFFU,
-          .bgColor = 0xFFFFA020U,
+          .bgColor = 0xFFA020FFU,
           .attackRadius = 0.F};
     default:
       return Appearance{.glyph = U'.',
           .radius = 6.F,
           .fgColor = 0xFFFFFFFFU,
-          .bgColor = 0xFFC0C0C0U,
+          .bgColor = 0xC0C0C0FFU,
           .attackRadius = 0.F};
     }
   }
@@ -1405,7 +1405,15 @@ private:
     std::get<std::optional<Appearance>>(tpl) = appearanceForProjectile(bullet);
     std::get<std::optional<DefenderBullet>>(tpl) = bullet;
     auto h = scene_.store_new_entity_from_mega({WorldTick::invalid}, tpl);
-    if (h) (void)markDirty(h.id());
+    if (h) {
+      // Stamp `modified` so the wire serializer includes the appearance on the
+      // first delta sent to clients. Without this, `app.modified` stays at
+      // `WorldTick::invalid` and the serializer silently omits the `app` block,
+      // leaving clients with no appearance data for bullets.
+      if (auto* app = scene_.try_get_component<Appearance>(h.id()))
+        app->modified = tick_;
+      (void)markDirty(h.id());
+    }
     return h;
   }
 

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -995,7 +995,7 @@ private:
     }
     defender.nextAttack = WorldTick{*tick_ + *defender.cooldown};
     (void)flashEntity(defenderId, 0xFFFFFFFF, WorldTick{5});
-    (void)setCooldown(defenderId, 0x7F000000U, defender.nextAttack);
+    (void)setCooldown(defenderId, 0x0000007FU, defender.nextAttack);
     return true;
   }
 
@@ -1084,7 +1084,7 @@ private:
     (void)spawnBullet(defenderPos, vel, bullet);
     defender.nextAttack = WorldTick{*tick_ + *defender.cooldown};
     (void)flashEntity(defenderId, 0xFFFFFFFF, WorldTick{5});
-    (void)setCooldown(defenderId, 0x7F000000U, defender.nextAttack);
+    (void)setCooldown(defenderId, 0x0000007FU, defender.nextAttack);
     return true;
   }
 
@@ -1130,7 +1130,7 @@ private:
 
     defender.nextAttack = WorldTick{*tick_ + *defender.cooldown};
     (void)flashEntity(defenderId, hitscan.beamColor, hitscan.beamDuration);
-    (void)setCooldown(defenderId, 0x7F000000U, defender.nextAttack);
+    (void)setCooldown(defenderId, 0x0000007FU, defender.nextAttack);
     return true;
   }
 

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -774,22 +774,22 @@ public:
 
   // Destructively extract upserts and erasures.
   //
-  // Call back `cbUpserts(EntityId, Position, Appearance, VisualEffects)` for
-  // each changed entity that has a `Position` and `Appearance` and has
-  // changed since the last tick, and `cbErased(EntityId)` for each entity
-  // that has been erased since the last tick. The visual effects pointer is
-  // null for archetypes that do not carry that component. These callbacks will
-  // be interleaved.
+  // Call back `cbUpserts(EntityId, Position, Appearance, VisualEffects,
+  // Health)` for each changed entity that has a `Position` and `Appearance`
+  // and has changed since the last tick, and `cbErased(EntityId)` for each
+  // entity that has been erased since the last tick. The visual effects
+  // pointer is null for archetypes that do not carry that component. These
+  // callbacks will be interleaved.
   [[nodiscard]] bool
   extractUpdatedEntities(auto&& cbUpserts, auto&& cbErased) {
     static constexpr VisualEffects nfx;
+    static constexpr Health nhp;
     auto& reg = scene_.registry();
     for (auto id : updatedEntities_) {
-      const auto [pos, app, fx] =
-          scene_.try_get_some_components<Position, Appearance, VisualEffects>(
-              id);
+      const auto [pos, app, fx, hp] = scene_.try_get_some_components<Position,
+          Appearance, VisualEffects, Health>(id);
       if (pos && app) {
-        (void)cbUpserts(id, *pos, *app, fx ? *fx : nfx);
+        (void)cbUpserts(id, *pos, *app, fx ? *fx : nfx, hp ? *hp : nhp);
       } else if (reg.get_location(id).store_id == sidStaging) {
         (void)cbErased(id);
         (void)scene_.erase_entity(id);
@@ -901,10 +901,12 @@ public:
       (void)markDirty(id);
       if (strategy == update_strategy::incremental) return true;
 
-      auto [app, fx] =
-          scene_.try_get_some_components<Appearance, VisualEffects>(id);
+      auto [app, fx, hp] =
+          scene_.try_get_some_components<Appearance, VisualEffects, Health>(
+              id);
       if (app) app->modified = tick_;
       if (fx) fx->modified = tick_;
+      if (hp) hp->modified = tick_;
       return true;
     });
     return true;

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -490,15 +490,31 @@ public:
     return true;
   }
 
+  // Look up a registered entity template by label.
+  [[nodiscard]] auto findEntityTemplate(std::string_view label) const {
+    return find_opt(entityTemplates_, label);
+  }
+
   // Spawn an entity by label. Looks up the pre-registered template.
   [[nodiscard]] Handle spawnEntity(std::string_view label) {
-    return spawnEntity(find_opt(entityTemplates_, label));
+    return spawnEntity(findEntityTemplate(label));
+  }
+
+  // Assert helper for validating entity template indices.
+  template<typename Component>
+  [[nodiscard]] bool
+  hasValidEntityTemplateIndex(const WorldScene::megatuple_t& megatuple) const {
+    const auto& component = std::get<std::optional<Component>>(megatuple);
+    if (!component) return true;
+    return component->entityTemplateIndex < entityTemplateLabels_.size();
   }
 
   // Spawn an entity by definition. Stamps `tick_` into any `modified` fields,
   // marks the entity dirty, and returns its handle.
   [[nodiscard]] Handle spawnEntity(const WorldScene::megatuple_t* megatuple) {
     if (!megatuple) return {};
+    assert(hasValidEntityTemplateIndex<Defender>(*megatuple));
+    assert(hasValidEntityTemplateIndex<Invader>(*megatuple));
     auto h =
         scene_.store_new_entity_from_mega({WorldTick::invalid}, *megatuple);
     if (!h) return {};

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -964,8 +964,8 @@ private:
   // components as `entityTemplateIndex_`.
   std::vector<std::string> entityTemplateLabels_;
 
-  [[nodiscard]] static const Appearance&
-  appearanceForProjectile(const DefenderBullet& bullet) {
+  [[nodiscard]] static const Appearance& appearanceForProjectile(
+      const DefenderBullet& bullet) {
     static constexpr Appearance kType1{.glyph = U'*',
         .radius = 8.F,
         .fgColor = 0xFFFFFFFFU,

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -292,11 +292,12 @@ struct Pathing {
 // TODO: Add field for sprite selection.
 struct Appearance {
   WorldTick modified{WorldTick::invalid}; // Tick when last modified.
-  char32_t glyph{};     // A Unicode character to display, if any.
-  float radius{5.F};    // World-space radius of the rendered shape.
-  uint32_t fgColor{};   // RGBA.
-  uint32_t bgColor{};   // RGBA.
-  float attackRadius{}; // Display-only (world units).
+  char32_t glyph{};      // A Unicode character to display, if any.
+  float radius{5.F};     // World-space radius of the rendered shape.
+  uint32_t fgColor{};    // RGBA.
+  uint32_t bgColor{};    // RGBA.
+  float attackRadius{};  // Display-only (world units).
+  uint32_t trailColor{}; // RGBA.
 };
 
 // Health component. Applies to both defenders and invaders. The two health
@@ -969,13 +970,15 @@ private:
           .radius = 8.F,
           .fgColor = 0xFFFFFFFFU,
           .bgColor = 0xFFA020FFU,
-          .attackRadius = 0.F};
+          .attackRadius = 0.F,
+          .trailColor = 0xFFA020FFU};
     default:
       return Appearance{.glyph = U'.',
           .radius = 6.F,
           .fgColor = 0xFFFFFFFFU,
           .bgColor = 0xC0C0C0FFU,
-          .attackRadius = 0.F};
+          .attackRadius = 0.F,
+          .trailColor = 0xC0C0C0FFU};
     }
   }
 
@@ -1406,10 +1409,6 @@ private:
     std::get<std::optional<DefenderBullet>>(tpl) = bullet;
     auto h = scene_.store_new_entity_from_mega({WorldTick::invalid}, tpl);
     if (h) {
-      // Stamp `modified` so the wire serializer includes the appearance on the
-      // first delta sent to clients. Without this, `app.modified` stays at
-      // `WorldTick::invalid` and the serializer silently omits the `app` block,
-      // leaving clients with no appearance data for bullets.
       if (auto* app = scene_.try_get_component<Appearance>(h.id()))
         app->modified = tick_;
       (void)markDirty(h.id());

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -322,6 +322,33 @@ struct VisualEffects {
   WorldTick cooldownExpiry{WorldTick::invalid};
 };
 
+// Fire-and-forget, display-only explosion streamed once to the client.
+// `expiry` is absolute for emitted instances; when embedded as a template it
+// stores the desired duration to add to the current tick.
+struct TransientExplosion {
+  float x{};
+  float y{};
+  WorldTick expiry{WorldTick::invalid};
+  uint32_t primaryColor{};
+  uint32_t secondaryColor{};
+  float radius{};
+};
+
+// Fire-and-forget, display-only beam streamed once to the client.
+// `expiry` is absolute for emitted instances; when embedded as a template it
+// stores the desired duration to add to the current tick.
+struct TransientBeam {
+  float x{};
+  float y{};
+  float startDistance{};
+  WorldTick expiry{WorldTick::invalid};
+  uint32_t primaryColor{};
+  uint32_t secondaryColor{};
+  float targetX{};
+  float targetY{};
+  float lineWidth{};
+};
+
 // Defensive component, common across all defenders.
 struct Defender {
   uint16_t entityTemplateIndex{std::numeric_limits<uint16_t>::max()};
@@ -351,9 +378,7 @@ struct DefenderAoe {
 // target instantly, rather than spawning a projectile that travels to the
 // target.
 struct DefenderHitscan {
-  uint32_t beamColor{}; // RGBA.
-  WorldTick beamDuration{};
-  int beamType{}; // Eventually an enum.
+  TransientBeam transientTemplate{};
 };
 
 // Projectile component for `DefenderShooter`. Used as part of its own
@@ -462,6 +487,8 @@ public:
     updatedEntities_.clear();
     pathEscapees_.clear();
     pendingKills_.clear();
+    pendingTransientExplosions_.clear();
+    pendingTransientBeams_.clear();
     entityTemplates_.clear();
     entityTemplateLabels_.clear();
     tick_ = {};
@@ -769,6 +796,23 @@ public:
     return true;
   }
 
+  // Destructively extract fire-and-forget transient beams emitted this
+  // frame, calling `cbBeam(TransientBeam)` for each.
+  [[nodiscard]] bool extractTransientBeams(auto&& cbBeam) {
+    for (const auto& beam : pendingTransientBeams_) (void)cbBeam(beam);
+    pendingTransientBeams_.clear();
+    return true;
+  }
+
+  // Destructively extract fire-and-forget transient explosions emitted this
+  // frame, calling `cbExplosion(TransientExplosion)` for each.
+  [[nodiscard]] bool extractTransientExplosions(auto&& cbExplosion) {
+    for (const auto& explosion : pendingTransientExplosions_)
+      (void)cbExplosion(explosion);
+    pendingTransientExplosions_.clear();
+    return true;
+  }
+
   // Call back `cbPath(PathId, Position)` for all joints of the path
   // identified by `pathId`.
   [[nodiscard]] bool obtainPath(auto&& cbPath, PathId pathId) const {
@@ -812,7 +856,16 @@ public:
   [[nodiscard]] bool resolveKills(auto&& cbKill) {
     for (auto id : pendingKills_) {
       auto [pos, inv] = scene_.try_get_components<Position, Invader>(id);
-      if (pos && cbKill(id, *pos, *inv)) (void)tombstoneEntity(id);
+      if (pos && cbKill(id, *pos, *inv)) {
+        pendingTransientExplosions_.emplace_back(TransientExplosion{
+            .x = pos->x,
+            .y = pos->y,
+            .expiry = WorldTick{*tick_ + 6},
+            .primaryColor = 0xFFB040E6U,
+            .secondaryColor = 0xFFFFD080U,
+            .radius = inv->hitCircleRadius});
+        (void)tombstoneEntity(id);
+      }
     }
     pendingKills_.clear();
     return true;
@@ -896,6 +949,8 @@ private:
   std::vector<EntityId> updatedEntities_;
   std::vector<EntityId> pathEscapees_;
   std::vector<EntityId> pendingKills_;
+  std::vector<TransientExplosion> pendingTransientExplosions_;
+  std::vector<TransientBeam> pendingTransientBeams_;
 
   // Entity type definitions: label -> component template.
   string_unordered_map<WorldScene::megatuple_t> entityTemplates_;
@@ -1161,10 +1216,9 @@ private:
     return h;
   }
 
-  // Apply hitscan damage to the best single target instantly, using
-  // `hitscan.beamColor` and `hitscan.beamDuration` for the flash on both
-  // defender and target. Puts the defender on cooldown.
-  // TODO: Spawn a transient beam line from the defender to the target.
+  // Apply hitscan damage to the best single target instantly and emit a
+  // transient beam copy from the stored template. Puts the defender on
+  // cooldown.
   [[nodiscard]] bool attackWithHitscan(EntityId defenderId, Defender& defender,
       DefenderStats& stats, const std::vector<InvaderCandidate>& candidates,
       const DefenderHitscan& hitscan) {
@@ -1182,13 +1236,25 @@ private:
     if (hp->currentHealth <= 0.F) {
       pendingKills_.push_back(targetId);
       stats.totalKills += 1.F;
-    } else {
-      (void)flashEntity(targetId, hitscan.beamColor, hitscan.beamDuration);
     }
     stats.totalDamageDealt += actualDamage;
 
+    const auto* defenderPos = scene_.try_get_component<Position>(defenderId);
+    const auto* targetPos = scene_.try_get_component<Position>(targetId);
+    if (!defenderPos || !targetPos) return false;
+
+    pendingTransientBeams_.emplace_back(TransientBeam{.x = defenderPos->x,
+        .y = defenderPos->y,
+        .startDistance = hitscan.transientTemplate.startDistance,
+        .expiry = WorldTick{*tick_ + *hitscan.transientTemplate.expiry},
+        .primaryColor = hitscan.transientTemplate.primaryColor,
+        .secondaryColor = hitscan.transientTemplate.secondaryColor,
+        .targetX = targetPos->x,
+        .targetY = targetPos->y,
+        .lineWidth = hitscan.transientTemplate.lineWidth});
+
     defender.nextAttack = WorldTick{*tick_ + *defender.cooldown};
-    (void)flashEntity(defenderId, hitscan.beamColor, hitscan.beamDuration);
+    (void)flashEntity(defenderId, 0xFFFFFFFF, WorldTick{5});
     (void)setCooldown(defenderId, 0x0000007FU, defender.nextAttack);
     return true;
   }

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -289,8 +289,8 @@ struct VisualEffects {
   WorldTick modified{WorldTick::invalid}; // Tick when last modified.
   uint32_t selectionColor{};              // RGBA.
   float rangeRadius{};
-  uint32_t rangeColor{};    // RGBA.
-  uint32_t flashColor{};    // RGBA.
+  uint32_t rangeColor{}; // RGBA.
+  uint32_t flashColor{}; // RGBA.
   WorldTick flashExpiry{WorldTick::invalid};
   uint32_t cooldownColor{}; // RGBA. Active from fire time until `nextAttack`.
   WorldTick cooldownExpiry{WorldTick::invalid};
@@ -560,8 +560,8 @@ public:
 
   // Set a cooldown overlay on a defender. `absoluteExpiry` is an absolute tick
   // (typically `defender.nextAttack`) at which the overlay clears.
-  [[nodiscard]] bool setCooldown(EntityId id, uint32_t color,
-      WorldTick absoluteExpiry) {
+  [[nodiscard]] bool
+  setCooldown(EntityId id, uint32_t color, WorldTick absoluteExpiry) {
     auto* effects = changeVisualEffects(id);
     if (!effects) return false;
     effects->cooldownColor = color;
@@ -981,7 +981,8 @@ private:
     for (const auto& cand : candidates) {
       auto* hp = scene_.try_get_component<Health>(cand.id);
       if (!hp) continue;
-      const float actualDamage = std::min(defender.attackDamage, cand.currentHealth);
+      const float actualDamage =
+          std::min(defender.attackDamage, cand.currentHealth);
       hp->modified = tick_;
       hp->currentHealth -= defender.attackDamage;
       (void)markDirty(cand.id);
@@ -1116,7 +1117,8 @@ private:
     auto* hp = scene_.try_get_component<Health>(targetId);
     if (!hp) return false;
 
-    const float actualDamage = std::min(defender.attackDamage, hp->currentHealth);
+    const float actualDamage =
+        std::min(defender.attackDamage, hp->currentHealth);
     hp->modified = tick_;
     hp->currentHealth -= defender.attackDamage;
     (void)markDirty(targetId);
@@ -1144,20 +1146,21 @@ private:
           auto& [defenderPos, defender, stats] = defenderComps;
           if (tick_ < defender.nextAttack) return true;
 
-          if (!collectCandidates(defenderPos, defender.attackRadius, candidates))
+          if (!collectCandidates(defenderPos, defender.attackRadius,
+                  candidates))
             return true;
 
-          auto [aoe, shooter, hitscan] =
-              scene_.try_get_some_components<DefenderAoe, DefenderShooter,
-                  DefenderHitscan>(defenderId);
+          auto [aoe, shooter,
+              hitscan] = scene_.try_get_some_components<DefenderAoe,
+              DefenderShooter, DefenderHitscan>(defenderId);
           if (aoe)
             (void)attackWithAoe(defenderId, defender, stats, candidates, *aoe);
           else if (shooter)
             (void)attackWithShooter(defenderId, defender, defenderPos,
                 candidates, *shooter);
           else if (hitscan)
-            (void)attackWithHitscan(
-                defenderId, defender, stats, candidates, *hitscan);
+            (void)attackWithHitscan(defenderId, defender, stats, candidates,
+                *hitscan);
 
           return true;
         });

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -1090,6 +1090,15 @@ private:
   [[nodiscard]] bool attackWithAoe(EntityId defenderId, Defender& defender,
       DefenderStats& stats, const std::vector<InvaderCandidate>& candidates,
       const DefenderAoe&) {
+    const auto* defenderPos = scene_.try_get_component<Position>(defenderId);
+    assert(defenderPos);
+    pendingTransientExplosions_.emplace_back(TransientExplosion{
+        .x = defenderPos->x,
+        .y = defenderPos->y,
+        .expiry = WorldTick{*tick_ + 1},
+        .primaryColor = withAlpha(defender.rangeColor, 0x30U),
+        .secondaryColor = withAlpha(defender.rangeColor, 0x10U),
+        .radius = defender.attackRadius});
     for (const auto& cand : candidates) {
       auto* hp = scene_.try_get_component<Health>(cand.id);
       if (!hp) continue;
@@ -1293,6 +1302,11 @@ private:
 
   [[nodiscard]] static constexpr bool isVisibleColor(uint32_t color) noexcept {
     return (color & 0xFFU) != 0U;
+  }
+
+  [[nodiscard]] static constexpr uint32_t
+  withAlpha(uint32_t color, uint8_t alpha) noexcept {
+    return (color & 0xFFFFFF00U) | alpha;
   }
 };
 }} // namespace corvid::sim

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -472,6 +472,31 @@ using ArchDefenderHitscan = archetype_storage<WorldReg,
 using WorldScene = archetype_scene<WorldReg, ArchInvaderAlpha, ArchDefenderAoe,
     ArchBullet, ArchDefenderShooter, ArchDefenderHitscan>;
 
+// Per-map entity template storage. The map is keyed by label, but we also keep
+// a list of labels separately so that this index can be stored in the ECS,
+// avoiding strings. This is particularly relevant for projectiles, which need
+// to know which defender spawned them in order to get full credit for their
+// kills.
+struct EntityTemplateStore {
+  string_unordered_map<WorldScene::megatuple_t> templates;
+  std::vector<std::string> labels;
+
+  [[nodiscard]] bool
+  registerEntity(std::string label, WorldScene::megatuple_t tpl) {
+    auto [it, inserted] =
+        templates.insert_or_assign(std::move(label), std::move(tpl));
+    if (!inserted) return false;
+    auto& [key, value] = *it;
+    labels.push_back(key);
+    auto idx = static_cast<uint16_t>(labels.size() - 1);
+    if (auto& defender = std::get<std::optional<Defender>>(value); defender)
+      defender->entityTemplateIndex = idx;
+    else if (auto& invader = std::get<std::optional<Invader>>(value); invader)
+      invader->entityTemplateIndex = idx;
+    return true;
+  }
+};
+
 // Simulation world: encapsulates all ECS entity state for the game and
 // provides physics.
 //
@@ -497,37 +522,19 @@ public:
     pendingKills_.clear();
     pendingTransientExplosions_.clear();
     pendingTransientBeams_.clear();
-    entityTemplates_.clear();
-    entityTemplateLabels_.clear();
+    entityTemplateStore_ = nullptr;
     tick_ = {};
   }
 
-  // Register a named entity type from a `megatuple_t` template. The set of
-  // optionals that have values must exactly match one archetype's
-  // components.
-  [[nodiscard]] bool
-  registerEntity(std::string label, WorldScene::megatuple_t tpl) {
-    auto [it, inserted] =
-        entityTemplates_.insert_or_assign(std::move(label), std::move(tpl));
-    if (!inserted) return false;
-
-    // Track index for cheap lookup.
-    auto& [key, value] = *it;
-    entityTemplateLabels_.push_back(key);
-    auto entityTemplateIndex =
-        static_cast<uint16_t>(entityTemplateLabels_.size() - 1);
-
-    // Store index in component.
-    if (auto& defender = std::get<std::optional<Defender>>(value); defender)
-      defender->entityTemplateIndex = entityTemplateIndex;
-    else if (auto& invader = std::get<std::optional<Invader>>(value); invader)
-      invader->entityTemplateIndex = entityTemplateIndex;
-    return true;
+  // Point this world at a map's entity template store.
+  // Used primarily for testing.
+  void setEntityTemplateStore(const EntityTemplateStore* store) {
+    entityTemplateStore_ = store;
   }
 
   // Look up a registered entity template by label.
   [[nodiscard]] auto findEntityTemplate(std::string_view label) const {
-    return find_opt(entityTemplates_, label);
+    return find_opt(entityTemplateStore_->templates, label);
   }
 
   // Spawn an entity by label. Looks up the pre-registered template.
@@ -535,13 +542,15 @@ public:
     return spawnEntity(findEntityTemplate(label));
   }
 
-  // Assert helper for validating entity template indices.
+  // Assert helper for validating entity template indices. It returns true if
+  // the component isn't present, as a convenience for assertions.
   template<typename Component>
   [[nodiscard]] bool
   hasValidEntityTemplateIndex(const WorldScene::megatuple_t& megatuple) const {
     const auto& component = std::get<std::optional<Component>>(megatuple);
     if (!component) return true;
-    return component->entityTemplateIndex < entityTemplateLabels_.size();
+    return component->entityTemplateIndex <
+           entityTemplateStore_->labels.size();
   }
 
   // Spawn an entity by definition. Stamps `tick_` into any `modified` fields,
@@ -597,8 +606,8 @@ public:
   // Get the label for an entity template by its index.
   [[nodiscard]] std::string_view getEntityTemplateLabel(
       uint16_t entityTemplateIndex) const {
-    if (entityTemplateIndex >= entityTemplateLabels_.size()) return {};
-    return entityTemplateLabels_[entityTemplateIndex];
+    if (entityTemplateIndex >= entityTemplateStore_->labels.size()) return {};
+    return entityTemplateStore_->labels[entityTemplateIndex];
   }
 
   // Obtain a pointer to the `Appearance` for the entity. It is already
@@ -961,12 +970,7 @@ private:
   std::vector<TransientExplosion> pendingTransientExplosions_;
   std::vector<TransientBeam> pendingTransientBeams_;
 
-  // Entity type definitions: label -> component template.
-  string_unordered_map<WorldScene::megatuple_t> entityTemplates_;
-
-  // List of entity labels. The index is used in the `Defender` or `Invader`
-  // components as `entityTemplateIndex_`.
-  std::vector<std::string> entityTemplateLabels_;
+  const EntityTemplateStore* entityTemplateStore_{};
 
   [[nodiscard]] static const Appearance& appearanceForProjectile(
       const DefenderBullet& bullet) {

--- a/corvid/sim/sim_world.h
+++ b/corvid/sim/sim_world.h
@@ -60,6 +60,9 @@ enum class WorldTick : uint32_t {
   invalid = std::numeric_limits<uint32_t>::max()
 };
 
+// Targeting modes for defenders.
+enum class TargetMode : uint8_t { first, last, closest, strongest, weakest };
+
 }} // namespace corvid::sim
 
 template<>
@@ -71,6 +74,11 @@ template<>
 constexpr auto corvid::enums::registry::enum_spec_v<corvid::sim::WorldTick> =
     corvid::enums::sequence::make_sequence_enum_spec<corvid::sim::WorldTick,
         "">();
+
+template<>
+constexpr auto corvid::enums::registry::enum_spec_v<corvid::sim::TargetMode> =
+    corvid::enums::sequence::make_sequence_enum_spec<corvid::sim::TargetMode,
+        "first, last, closest, strongest, weakest">();
 
 namespace corvid { inline namespace sim {
 
@@ -169,11 +177,22 @@ struct SegmentedPath {
     Position back;
     float length;          // Euclidean distance from `front` to `back`.
     float cumulativeStart; // Sum of lengths of all preceding segments.
+    float angle{};         // Direction from `front` to `back`, in radians.
   };
 
   std::vector<Segment> segments;
   float totalLength{};
   float width{};
+
+  // Return the segment that contains `progress`, clamping `progress` to
+  // `[0, totalLength]` in place. Assumes `segments` is non-empty.
+  [[nodiscard]] const Segment& segmentAtProgress(float& progress) const {
+    progress = std::clamp(progress, 0.F, totalLength);
+    auto it = std::ranges::upper_bound(segments, progress, {},
+        &Segment::cumulativeStart);
+    if (it != segments.begin()) --it;
+    return *it;
+  }
 
   // Map a distance traveled (`progress`) to a world-space `Position`.
   // `progress` is clamped to `[0, totalLength]`.
@@ -181,13 +200,7 @@ struct SegmentedPath {
   [[nodiscard]] Position
   calculatePositionFromProgress(float progress, float previousProgress) const {
     if (segments.empty()) return {};
-    progress = std::clamp(progress, 0.F, totalLength);
-
-    // Find the last segment whose cumulativeStart <= progress.
-    auto it = std::ranges::upper_bound(segments, progress, {},
-        &SegmentedPath::Segment::cumulativeStart);
-    if (it != segments.begin()) --it;
-    const auto& seg = *it;
+    const auto& seg = segmentAtProgress(progress);
 
     // If `previousProgress` was on an earlier segment, emit the joint position
     // first, so that fast-moving entities visibly take corners instead of
@@ -201,6 +214,13 @@ struct SegmentedPath {
 
     return {lerp(seg.front.x, seg.back.x, t),
         lerp(seg.front.y, seg.back.y, t)};
+  }
+
+  // Return the direction angle (radians) of the segment containing
+  // `progress`. Returns `NaN` if `segments` is empty.
+  [[nodiscard]] float angleAtProgress(float progress) const {
+    if (segments.empty()) return std::numeric_limits<float>::quiet_NaN();
+    return segmentAtProgress(progress).angle;
   }
 
   // Convert authored `PathJoints` into a `SegmentedPath`.
@@ -221,7 +241,9 @@ struct SegmentedPath {
       const float dx = back.x - front.x;
       const float dy = back.y - front.y;
       const float len = std::hypot(dx, dy);
-      sp.segments.push_back({front, back, len, cumulative});
+      assert(len != 0.F);
+      const float angle = std::atan2(dy, dx);
+      sp.segments.push_back({front, back, len, cumulative, angle});
       cumulative += len;
     }
     sp.totalLength = cumulative;
@@ -281,6 +303,7 @@ struct Defender {
   float attackDamage{};  // Interpretation depends on the defender type.
   WorldTick cooldown{};
   WorldTick nextAttack{}; // Updated when the defender attacks.
+  TargetMode targetMode{TargetMode::first};
 };
 
 // Stats for defenders, shown when selecting a defender.
@@ -359,11 +382,17 @@ struct Invader {
 //                               spawned projectiles
 //                               (Position + Velocity + DefenderBullet)
 //
-//   `sidDefenderShooter` = 4 -> `ArchDefenderShooter`
-//                               projectile-firing defenders
-//                               (Position + Appearance + VisualEffects +
-//                               Defender + DefenderStats + Health +
-//                               DefenderShooter)
+//   `sidDefenderShooter`  = 4 -> `ArchDefenderShooter`
+//                                projectile-firing defenders
+//                                (Position + Appearance + VisualEffects +
+//                                Defender + DefenderStats + Health +
+//                                DefenderShooter)
+//
+//   `sidDefenderHitscan`  = 5 -> `ArchDefenderHitscan`
+//                                instant-hit single-target defenders
+//                                (Position + Appearance + VisualEffects +
+//                                Defender + DefenderStats + Health +
+//                                DefenderHitscan)
 using WorldReg = entity_registry<WorldTick>;
 using WorldSid = WorldReg::store_id_t;
 using ArchInvaderAlpha = archetype_storage<WorldReg,
@@ -376,8 +405,11 @@ using ArchBullet = archetype_storage<WorldReg,
 using ArchDefenderShooter = archetype_storage<WorldReg,
     std::tuple<Position, Appearance, VisualEffects, Defender, DefenderStats,
         Health, DefenderShooter>>;
+using ArchDefenderHitscan = archetype_storage<WorldReg,
+    std::tuple<Position, Appearance, VisualEffects, Defender, DefenderStats,
+        Health, DefenderHitscan>>;
 using WorldScene = archetype_scene<WorldReg, ArchInvaderAlpha, ArchDefenderAoe,
-    ArchBullet, ArchDefenderShooter>;
+    ArchBullet, ArchDefenderShooter, ArchDefenderHitscan>;
 
 // Simulation world: encapsulates all ECS entity state for the game and
 // provides physics.
@@ -396,12 +428,14 @@ public:
   static constexpr WorldSid sidDefenderAoe{2};
   static constexpr WorldSid sidBullet{3};
   static constexpr WorldSid sidDefenderShooter{4};
+  static constexpr WorldSid sidDefenderHitscan{5};
 
   void clear() {
     scene_.clear();
     paths_.clear();
     updatedEntities_.clear();
     pathEscapees_.clear();
+    pendingKills_.clear();
     entityTemplates_.clear();
     entityTemplateLabels_.clear();
     tick_ = {};
@@ -699,6 +733,24 @@ public:
     return true;
   }
 
+  // Resolve pending kills by calling `cbKill(EntityId, const Position&, const
+  // Invader&)` for each. If `cbKill` returns true the entity is tombstoned;
+  // if false it is left alive so the caller can migrate it (e.g. to a
+  // transient death animation).
+  //
+  // Destructively iterates the pending-kills list.
+  [[nodiscard]] bool resolveKills(auto&& cbKill) {
+    for (auto id : pendingKills_) {
+      if (!scene_.registry().is_valid(id)) continue;
+      auto [pos, inv] = scene_.try_get_components<Position, Invader>(id);
+      if (!pos || !inv) continue;
+      if (!cbKill(id, *pos, *inv)) continue;
+      (void)tombstoneEntity(id);
+    }
+    pendingKills_.clear();
+    return true;
+  }
+
   // Marks an entity as dirty so that it will be included in the next delta
   // snapshot.
   [[nodiscard]] bool markDirty(EntityId id) {
@@ -773,6 +825,7 @@ private:
 
   std::vector<EntityId> updatedEntities_;
   std::vector<EntityId> pathEscapees_;
+  std::vector<EntityId> pendingKills_;
 
   // Entity type definitions: label -> component template.
   string_unordered_map<WorldScene::megatuple_t> entityTemplates_;
@@ -849,40 +902,239 @@ private:
     return true;
   }
 
-  [[nodiscard]] bool defendersAttack() {
-    // Range over all defenders. For each defender, range over all enemies
-    // and check for hits. If an enemy is in range and the defender is off
-    // cooldown, apply damage and trigger a flash on both.
-    scene_.for_each<Position, Defender>(
-        [&](auto defenderId, auto defenderComps) {
-          auto& [defenderPos, defender] = defenderComps;
-          if (tick_ < defender.nextAttack) return true;
+  // Candidate invader collected during target search.
+  struct InvaderCandidate {
+    EntityId id;
+    float progress{};      // Distance along path; used by `first` and `last`.
+    float currentHealth{}; // Used by `strongest` and `weakest`.
+    float distSq{};        // Squared distance to defender; used by `closest`.
+  };
 
-          scene_.for_each<Position, Invader>(
-              [&](auto enemyId, auto enemyComps) {
-                auto& [enemyPos, invader] = enemyComps;
-                if (!circlesOverlap(defenderPos, defender.attackRadius,
-                        enemyPos, invader.hitCircleRadius))
-                  return true;
+  // Collect all invaders whose hit circle overlaps the defender's attack
+  // circle, recording the fields needed for target selection. Clears
+  // `candidates` first so the caller can reuse its allocation. Returns the
+  // number of candidates found.
+  [[nodiscard]] size_t collectCandidates(const Position& defenderPos,
+      float attackRadius, std::vector<InvaderCandidate>& candidates) {
+    candidates.clear();
+    scene_.for_each<Position, Invader, Pathing, Health>(
+        [&](auto enemyId, auto comps) {
+          const auto& [enemyPos, invader, pf, hp] = comps;
+          const float dSq = distanceSquared(defenderPos, enemyPos);
+          const float r = attackRadius + invader.hitCircleRadius;
+          if (dSq > r * r) return true;
 
-                (void)flashEntity(defenderId, 0xFFFFFFFF, WorldTick{5});
-                (void)flashEntity(enemyId, 0xFF7F7FFF, WorldTick{5});
-                return true;
-#if 0
-        invader.health -= defender.attackDamage;
-        defender.nextAttack = WorldTick{*tick_ + *defender.cooldown};
-        (void)flashEntity(defenderId, 0xFFFFFFFF);
-        if (invader.health <= 0.F) {
-          (void)tombstoneEntity(enemyId);
-        } else {
-          (void)flashEntity(enemyId, 0xFF0000FF);
-        }
-        return false; // Stop after first hit per defender per tick.
-#endif
-              });
-
+          candidates.push_back({enemyId, pf.progress, hp.currentHealth, dSq});
           return true;
         });
+    return candidates.size();
+  }
+
+  // Return the id of the best candidate according to `mode`.
+  [[nodiscard]] static EntityId selectTarget(
+      const std::vector<InvaderCandidate>& candidates, TargetMode mode) {
+    if (candidates.empty()) return EntityId::invalid;
+    auto it = candidates.cbegin();
+    switch (mode) {
+    case TargetMode::first:
+      it = std::ranges::max_element(candidates, {},
+          &InvaderCandidate::progress);
+      break;
+    case TargetMode::last:
+      it = std::ranges::min_element(candidates, {},
+          &InvaderCandidate::progress);
+      break;
+    case TargetMode::closest:
+      it = std::ranges::min_element(candidates, {}, &InvaderCandidate::distSq);
+      break;
+    case TargetMode::strongest:
+      it = std::ranges::max_element(candidates, {},
+          &InvaderCandidate::currentHealth);
+      break;
+    case TargetMode::weakest:
+      it = std::ranges::min_element(candidates, {},
+          &InvaderCandidate::currentHealth);
+      break;
+    }
+    return it->id;
+  }
+
+  // Damage every candidate. Those whose health drops to zero are added to
+  // `pendingKills_` for `SimGame` to resolve (bounty, death animation, etc.).
+  // Then put the defender on cooldown.
+  [[nodiscard]] bool attackWithAoe(EntityId defenderId, Defender& defender,
+      const std::vector<InvaderCandidate>& candidates, const DefenderAoe&) {
+    for (const auto& cand : candidates) {
+      auto* hp = scene_.try_get_component<Health>(cand.id);
+      if (!hp) continue;
+      hp->modified = tick_;
+      hp->currentHealth -= defender.attackDamage;
+      (void)markDirty(cand.id);
+      if (hp->currentHealth <= 0.F)
+        pendingKills_.push_back(cand.id);
+      else
+        (void)flashEntity(cand.id, 0xFF7F7FFF, WorldTick{5});
+    }
+    defender.nextAttack = WorldTick{*tick_ + *defender.cooldown};
+    (void)flashEntity(defenderId, 0xFFFFFFFF, WorldTick{5});
+    return true;
+  }
+
+  // Solve for the earliest positive intercept time `t`, given the defender
+  // position `D`, the target position `T` moving at (`tvx`, `tvy`), and a
+  // bullet at `bulletSpeed`. Returns `NaN` if no positive solution exists (the
+  // bullet can never catch the target on its current heading).
+  //
+  // Derivation: `|T + V_t*t - D|^2 = (bulletSpeed*t)^2`, expanded as a
+  // quadratic in `t` with:
+  // a` = `|V_t|^2 - bulletSpeed^2`, `b` = `2*(T-D).V_t`, c = `|T-D|^2`.
+  //
+  // The smallest positive root is the intercept time.
+  [[nodiscard]] static float computeInterceptTime(const Position& defenderPos,
+      const Position& targetPos, float tvx, float tvy, float bulletSpeed) {
+    constexpr float nan = std::numeric_limits<float>::quiet_NaN();
+    const float dx = targetPos.x - defenderPos.x;
+    const float dy = targetPos.y - defenderPos.y;
+    const float a = (tvx * tvx) + (tvy * tvy) - (bulletSpeed * bulletSpeed);
+    const float b = 2.F * ((dx * tvx) + (dy * tvy));
+    const float c = (dx * dx) + (dy * dy);
+
+    // Degenerate: target and bullet at the same speed. Linear in `t`.
+    if (std::abs(a) < 1e-4F) return (b < -1e-4F) ? (-c / b) : nan;
+
+    const float disc = (b * b) - (4.F * a * c);
+    if (disc < 0.F) return nan; // No real solution.
+
+    const float sq = std::sqrt(disc);
+    const float t1 = (-b + sq) / (2.F * a);
+    const float t2 = (-b - sq) / (2.F * a);
+
+    // Return the smallest positive root, or `NaN` if neither qualifies.
+    if (t1 > 0.F && (t2 <= 0.F || t1 < t2)) return t1;
+    if (t2 > 0.F) return t2;
+    return nan;
+  }
+
+  // Spawn a bullet aimed at the predicted intercept position of the best
+  // single target, then put the defender on cooldown. If the intercept
+  // calculation determines the bullet can never reach the target, does not
+  // fire and does not start the cooldown.
+  [[nodiscard]] bool attackWithShooter(EntityId defenderId, Defender& defender,
+      const Position& defenderPos,
+      const std::vector<InvaderCandidate>& candidates,
+      const DefenderShooter& shooter) {
+    const auto targetId = selectTarget(candidates, defender.targetMode);
+    if (targetId == EntityId::invalid) return false;
+
+    const auto [targetPos, targetPathing] =
+        scene_.try_get_components<Position, Pathing>(targetId);
+    if (!targetPos) return false;
+
+    // Compute the target's current velocity from its path segment and speed.
+    float tvx{};
+    float tvy{};
+    if (const auto* path = getPath(targetPathing->pathId)) {
+      const float angle = path->angleAtProgress(targetPathing->progress);
+      tvx = targetPathing->speed * std::cos(angle);
+      tvy = targetPathing->speed * std::sin(angle);
+    }
+
+    const float t = computeInterceptTime(defenderPos, *targetPos, tvx, tvy,
+        shooter.bulletTemplate.speed);
+    // TODO: Right now, if the "best" target is outrunning the bullet, we
+    // simply do not fire. A smarter algorithm would remove the bad target and
+    // try again.
+    if (std::isnan(t)) return false; // Target is outrunning the bullet.
+
+    const Position aimPos{targetPos->x + (tvx * t), targetPos->y + (tvy * t)};
+
+    const float adx = aimPos.x - defenderPos.x;
+    const float ady = aimPos.y - defenderPos.y;
+    const float dist = std::sqrt((adx * adx) + (ady * ady));
+
+    Velocity vel{};
+    if (dist > 0.F) {
+      vel.vx = (adx / dist) * shooter.bulletTemplate.speed;
+      vel.vy = (ady / dist) * shooter.bulletTemplate.speed;
+    }
+
+    // `bulletTemplate.expiry` stores TTL; convert to an absolute tick.
+    auto bullet = shooter.bulletTemplate;
+    bullet.expiry = WorldTick{*tick_ + *shooter.bulletTemplate.expiry};
+
+    (void)spawnBullet(defenderPos, vel, bullet);
+    defender.nextAttack = WorldTick{*tick_ + *defender.cooldown};
+    (void)flashEntity(defenderId, 0xFFFFFFFF, WorldTick{5});
+    return true;
+  }
+
+  // Spawn a bullet entity directly, bypassing the label-based template
+  // system by using the template in the defender itself
+  [[nodiscard]] Handle spawnBullet(const Position& pos, const Velocity& vel,
+      const DefenderBullet& bullet) {
+    // TODO: This is dumb. We shouldn't create a fake megatuple just to spawn
+    // the bullet.
+    WorldScene::megatuple_t tpl{};
+    std::get<std::optional<Position>>(tpl) = pos;
+    std::get<std::optional<Velocity>>(tpl) = vel;
+    std::get<std::optional<DefenderBullet>>(tpl) = bullet;
+    auto h = scene_.store_new_entity_from_mega({tick_}, tpl);
+    if (h) (void)markDirty(h.id());
+    return h;
+  }
+
+  // Apply hitscan damage to the best single target instantly, using
+  // `hitscan.beamColor` and `hitscan.beamDuration` for the flash on both
+  // defender and target. Puts the defender on cooldown.
+  // TODO: Spawn a transient beam line from the defender to the target.
+  [[nodiscard]] bool attackWithHitscan(EntityId defenderId, Defender& defender,
+      const std::vector<InvaderCandidate>& candidates,
+      const DefenderHitscan& hitscan) {
+    const auto targetId = selectTarget(candidates, defender.targetMode);
+    if (targetId == EntityId::invalid) return false;
+
+    auto* hp = scene_.try_get_component<Health>(targetId);
+    if (!hp) return false;
+
+    hp->modified = tick_;
+    hp->currentHealth -= defender.attackDamage;
+    (void)markDirty(targetId);
+    if (hp->currentHealth <= 0.F)
+      pendingKills_.push_back(targetId);
+    else
+      (void)flashEntity(targetId, hitscan.beamColor, hitscan.beamDuration);
+
+    defender.nextAttack = WorldTick{*tick_ + *defender.cooldown};
+    (void)flashEntity(defenderId, hitscan.beamColor, hitscan.beamDuration);
+    return true;
+  }
+
+  // For each defender that is off cooldown and has targets in range, dispatch
+  // to the appropriate attack handler based on the defender's attack type.
+  // Cooldown is only reset when the defender actually fires.
+  [[nodiscard]] bool defendersAttack() {
+    std::vector<InvaderCandidate> candidates;
+    scene_.for_each<Position,
+        Defender>([&](auto defenderId, auto defenderComps) {
+      auto& [defenderPos, defender] = defenderComps;
+      if (tick_ < defender.nextAttack) return true;
+
+      if (!collectCandidates(defenderPos, defender.attackRadius, candidates))
+        return true;
+
+      auto comp = scene_.try_get_some_components<DefenderAoe, DefenderShooter,
+          DefenderHitscan>(defenderId);
+      auto [aoe, shooter, hitscan] = comp;
+      if (aoe)
+        (void)attackWithAoe(defenderId, defender, candidates, *aoe);
+      else if (shooter)
+        (void)attackWithShooter(defenderId, defender, defenderPos, candidates,
+            *shooter);
+      else if (hitscan)
+        (void)attackWithHitscan(defenderId, defender, candidates, *hitscan);
+
+      return true;
+    });
 
     return true;
   }

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -111,14 +111,16 @@ private:
   [[nodiscard]] bool do_ui_canvas(json_object_view msg) {
     const auto input = parseUiCanvasMessage(msg);
     if (!input) return true; // malformed, ignore
-    game_.handleUiCanvas(*input);
+    if (const auto response = game_.handleUiCanvas(*input))
+      return websocket().send_text(buildSimUiResponseJson(*response));
     return true;
   }
 
   [[nodiscard]] bool do_ui_action(json_object_view msg) {
     const auto input = parseUiActionMessage(msg);
     if (!input) return true; // malformed, ignore
-    game_.handleUiAction(*input);
+    if (const auto response = game_.handleUiAction(*input))
+      return websocket().send_text(buildSimUiResponseJson(*response));
     return true;
   }
 

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -90,7 +90,7 @@ private:
   WorldTick current_tick_{};       // updated each frame; loop-thread only
   SimGame game_;                   // all simulation entity state
   update_strategy send_strategy_{update_strategy::full};
-  sim_game_state_json json_buffer_; // persistent buffer and high-watermark
+  SimGameStateJson json_buffer_; // persistent buffer and high-watermark
 
   // Handle an incoming text frame by classifying and forwarding the message.
   [[nodiscard]] bool do_message(http_websocket& ws, std::string&& msg) {
@@ -99,7 +99,7 @@ private:
 
     switch (classifySimClientMessage(*root)) {
     case SimClientMessageKind::hello:
-      if (!ws.send_text(build_sim_hello_ack_json())) return false;
+      if (!ws.send_text(buildSimHelloAckJson())) return false;
       return do_arm_tick();
     case SimClientMessageKind::ui_canvas: return do_ui_canvas(*root);
     case SimClientMessageKind::ui_action: return do_ui_action(*root);
@@ -118,7 +118,7 @@ private:
   [[nodiscard]] bool do_ui_action(json_object_view msg) {
     const auto input = parseUiActionMessage(msg);
     if (!input) return true; // malformed, ignore
-    game_.handle_UiAction(*input);
+    game_.handleUiAction(*input);
     return true;
   }
 
@@ -160,7 +160,7 @@ private:
   // Stream snapshot of game state to the client as JSON. Uses deltas when
   // possible.
   [[nodiscard]] bool send_game_state() {
-    (void)build_sim_game_state_json(json_buffer_, game_, send_strategy_);
+    (void)buildSimGameStateJson(json_buffer_, game_, send_strategy_);
 
     std::string header_buf;
     (void)ws_frame_lens::build(header_buf,

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -69,7 +69,7 @@ public:
       do_close();
     };
     (void)enable_keepalive(loop, wheel, 20s, 5s);
-    game_.loadMap();
+    (void)game_.loadMap();
     std::cout << "WebSocket client connected\n";
   }
 
@@ -111,17 +111,13 @@ private:
   [[nodiscard]] bool do_ui_canvas(json_object_view msg) {
     const auto input = parseUiCanvasMessage(msg);
     if (!input) return true; // malformed, ignore
-    if (const auto response = game_.handleUiCanvas(*input))
-      return websocket().send_text(buildSimUiResponseJson(*response));
-    return true;
+    return game_.handleUiCanvas(*input);
   }
 
   [[nodiscard]] bool do_ui_action(json_object_view msg) {
     const auto input = parseUiActionMessage(msg);
     if (!input) return true; // malformed, ignore
-    if (const auto response = game_.handleUiAction(*input))
-      return websocket().send_text(buildSimUiResponseJson(*response));
-    return true;
+    return game_.handleUiAction(*input);
   }
 
   static void do_close() { std::cout << "WebSocket client disconnected\n"; }

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -71,7 +71,7 @@ public:
       do_close();
     };
     (void)enable_keepalive(loop, wheel, 20s, 5s);
-    (void)game_.loadMap();
+    if (!game_.loadMap()) throw std::runtime_error("Failed to load map");
     std::cout << "WebSocket client connected\n";
   }
 

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -96,8 +96,8 @@ private:
   SimGameStateJson json_buffer_; // persistent buffer and high-watermark
 
   // "Temporary" diagnostics.
-  clock_t::time_point last_tick_fire_time_{};
-  clock_t::time_point stats_window_start_{};
+  clock_t::time_point last_tick_fire_time_;
+  clock_t::time_point stats_window_start_;
   size_t tick_fires_in_window_{};
   double interval_sum_ms_{};
   size_t payload_bytes_in_window_{};
@@ -208,7 +208,8 @@ private:
             .count();
     const double measured_hz =
         elapsed_ms > 0.0 && tick_fires_in_window_ > 1
-            ? ((tick_fires_in_window_ - 1) * 1000.0) / elapsed_ms
+            ? (static_cast<double>(tick_fires_in_window_ - 1) * 1000.0) /
+                  elapsed_ms
             : 0.0;
     const double avg_interval_ms =
         tick_fires_in_window_ > 1

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
+#include <cstddef>
 #include <iostream>
 #include <memory>
 
@@ -85,12 +87,21 @@ public:
 
 private:
   using Fuse = timer_fuse<http_transaction>;
+  using clock_t = std::chrono::steady_clock;
 
   std::atomic<uint64_t> tick_seq_; // Uses for sequencing tick timers
   WorldTick current_tick_{};       // updated each frame; loop-thread only
   SimGame game_;                   // all simulation entity state
   update_strategy send_strategy_{update_strategy::full};
   SimGameStateJson json_buffer_; // persistent buffer and high-watermark
+
+  // "Temporary" diagnostics.
+  clock_t::time_point last_tick_fire_time_{};
+  clock_t::time_point stats_window_start_{};
+  size_t tick_fires_in_window_{};
+  double interval_sum_ms_{};
+  size_t payload_bytes_in_window_{};
+  size_t last_payload_bytes_{};
 
   // Handle an incoming text frame by classifying and forwarding the message.
   [[nodiscard]] bool do_message(http_websocket& ws, std::string&& msg) {
@@ -148,10 +159,24 @@ private:
     if (websocket().is_close_started()) return true;
     if (websocket().is_send_in_fragment()) return do_arm_tick();
 
+    // "Temporary" diagnostics.
+    const auto now = clock_t::now();
+    if (stats_window_start_ == clock_t::time_point{})
+      stats_window_start_ = now;
+    if (last_tick_fire_time_ != clock_t::time_point{}) {
+      interval_sum_ms_ +=
+          std::chrono::duration<double, std::milli>(now - last_tick_fire_time_)
+              .count();
+    }
+    last_tick_fire_time_ = now;
+
     (void)game_.next();
     if (!send_game_state()) return false;
+    payload_bytes_in_window_ += last_payload_bytes_;
+    ++tick_fires_in_window_;
     send_strategy_ = update_strategy::incremental;
     current_tick_ = game_.tick();
+    maybe_log_tick_stats(now);
     return do_arm_tick();
   }
 
@@ -159,6 +184,7 @@ private:
   // possible.
   [[nodiscard]] bool send_game_state() {
     (void)buildSimGameStateJson(json_buffer_, game_, send_strategy_);
+    last_payload_bytes_ = json_buffer_.body.size();
 
     std::string header_buf;
     (void)ws_frame_lens::build(header_buf,
@@ -170,6 +196,38 @@ private:
       return false;
 
     return true;
+  }
+
+  // "Temporary" diagnostics.
+  void maybe_log_tick_stats(clock_t::time_point now) {
+    constexpr size_t stats_window_ticks = 20;
+    if (tick_fires_in_window_ < stats_window_ticks) return;
+
+    const auto elapsed_ms =
+        std::chrono::duration<double, std::milli>(now - stats_window_start_)
+            .count();
+    const double measured_hz =
+        elapsed_ms > 0.0 && tick_fires_in_window_ > 1
+            ? ((tick_fires_in_window_ - 1) * 1000.0) / elapsed_ms
+            : 0.0;
+    const double avg_interval_ms =
+        tick_fires_in_window_ > 1
+            ? interval_sum_ms_ / static_cast<double>(tick_fires_in_window_ - 1)
+            : 0.0;
+    const double avg_payload_bytes =
+        tick_fires_in_window_ > 0
+            ? static_cast<double>(payload_bytes_in_window_) /
+                  static_cast<double>(tick_fires_in_window_)
+            : 0.0;
+
+    std::cout << "Sim tick stats: tick=" << *current_tick_ << " measured_hz="
+              << measured_hz << " avg_interval_ms=" << avg_interval_ms
+              << " avg_payload_bytes=" << avg_payload_bytes << '\n';
+
+    stats_window_start_ = {};
+    tick_fires_in_window_ = 0;
+    interval_sum_ms_ = 0.0;
+    payload_bytes_in_window_ = 0;
   }
 };
 }} // namespace corvid::proto

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -122,13 +122,15 @@ private:
   [[nodiscard]] bool do_ui_canvas(json_object_view msg) {
     const auto input = parseUiCanvasMessage(msg);
     if (!input) return true; // malformed, ignore
-    return game_.handleUiCanvas(*input);
+    (void)game_.handleUiCanvas(*input);
+    return true;
   }
 
   [[nodiscard]] bool do_ui_action(json_object_view msg) {
     const auto input = parseUiActionMessage(msg);
     if (!input) return true; // malformed, ignore
-    return game_.handleUiAction(*input);
+    (void)game_.handleUiAction(*input);
+    return true;
   }
 
   static void do_close() { std::cout << "WebSocket client disconnected\n"; }

--- a/corvid/sim/web/index.html
+++ b/corvid/sim/web/index.html
@@ -35,6 +35,12 @@
       height="540"
       style="position:absolute;inset:0"
     ></canvas>
+    <canvas
+      id="overlay-canvas"
+      width="280"
+      height="540"
+      style="position:absolute;top:0;display:none"
+    ></canvas>
   </div>
   <h2>Log</h2>
   <pre id="log" style="height:200px;overflow-y:auto;border:1px solid #ccc;padding:4px"></pre>

--- a/corvid/sim/web/index.html
+++ b/corvid/sim/web/index.html
@@ -5,45 +5,208 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>CorvidSim</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      font-family: "Iosevka", "SFMono-Regular", "Consolas", monospace;
+      background:
+        radial-gradient(circle at top, rgba(59, 130, 246, 0.2), transparent 40%),
+        linear-gradient(180deg, #0b1220 0%, #09111c 100%);
+      color: #e5eefc;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      padding: 24px;
+      background: transparent;
+    }
+
+    .sim-app {
+      display: grid;
+      gap: 16px;
+      max-width: 1280px;
+      margin: 0 auto;
+    }
+
+    .sim-heading {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .sim-heading h1,
+    .sim-heading h2,
+    p {
+      margin: 0;
+    }
+
+    .status-grid {
+      display: grid;
+      gap: 8px;
+    }
+
+    .control-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+    }
+
+    button {
+      border: 1px solid rgba(191, 219, 254, 0.35);
+      background: rgba(15, 23, 42, 0.88);
+      color: inherit;
+      border-radius: 999px;
+      padding: 10px 16px;
+      cursor: pointer;
+      font: inherit;
+    }
+
+    button:hover {
+      background: rgba(30, 41, 59, 0.96);
+    }
+
+    .viewport-shell {
+      display: grid;
+      gap: 12px;
+      padding: 14px;
+      border: 1px solid rgba(148, 163, 184, 0.26);
+      border-radius: 24px;
+      background: rgba(9, 16, 28, 0.76);
+      backdrop-filter: blur(10px);
+      box-shadow: 0 24px 80px rgba(0, 0, 0, 0.3);
+    }
+
+    .viewport-shell:fullscreen {
+      width: 100%;
+      height: 100%;
+      max-width: none;
+      margin: 0;
+      border-radius: 0;
+      padding: 20px;
+      background: rgba(5, 10, 18, 0.98);
+    }
+
+    .viewport-toolbar {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    .viewport-host {
+      width: 100%;
+      min-height: 540px;
+      display: grid;
+      place-items: center;
+    }
+
+    .viewport-frame {
+      position: relative;
+      width: 960px;
+      height: 540px;
+      max-width: 100%;
+      border: 1px solid rgba(148, 163, 184, 0.5);
+      border-radius: 18px;
+      overflow: hidden;
+      background:
+        linear-gradient(135deg, rgba(15, 23, 42, 0.94), rgba(12, 18, 26, 0.94));
+    }
+
+    canvas {
+      display: block;
+    }
+
+    #background-canvas,
+    #foreground-canvas {
+      position: absolute;
+      inset: 0;
+    }
+
+    #overlay-canvas {
+      position: absolute;
+      top: 0;
+      display: none;
+      pointer-events: auto;
+    }
+
+    #log {
+      height: 200px;
+      overflow-y: auto;
+      border: 1px solid rgba(148, 163, 184, 0.26);
+      border-radius: 16px;
+      padding: 12px;
+      margin: 0;
+      background: rgba(7, 12, 20, 0.78);
+    }
+
+    @media (max-width: 900px) {
+      body {
+        padding: 16px;
+      }
+
+      .viewport-host {
+        min-height: min(540px, 55vh);
+      }
+    }
+  </style>
   <script type="module" src="/src/main.ts"></script>
 </head>
 
 <body>
-  <h1>CorvidSim</h1>
-  <p>Status: <span id="status">disconnected</span></p>
-  <p>Latest tick: <span id="tick">--</span></p>
-  <p>
-    Lives: <span id="lives">--</span>
-    Resources: <span id="resources">--</span>
-    Phase: <span id="phase">--</span>
-  </p>
-  <p>
-    <button type="button" data-action="start_wave">Start Wave</button>
-  </p>
-  <div
-    style="position:relative;width:960px;height:540px;border:1px solid gray"
-  >
-    <canvas
-      id="background-canvas"
-      width="960"
-      height="540"
-      style="position:absolute;inset:0"
-    ></canvas>
-    <canvas
-      id="foreground-canvas"
-      width="960"
-      height="540"
-      style="position:absolute;inset:0"
-    ></canvas>
-    <canvas
-      id="overlay-canvas"
-      width="280"
-      height="540"
-      style="position:absolute;top:0;display:none"
-    ></canvas>
-  </div>
-  <h2>Log</h2>
-  <pre id="log" style="height:200px;overflow-y:auto;border:1px solid #ccc;padding:4px"></pre>
+  <main class="sim-app">
+    <section class="sim-heading">
+      <h1>CorvidSim</h1>
+    </section>
+
+    <section class="status-grid">
+      <p>Status: <span id="status">disconnected</span></p>
+      <p>Latest tick: <span id="tick">--</span></p>
+      <p>
+        Lives: <span id="lives">--</span>
+        Resources: <span id="resources">--</span>
+        Phase: <span id="phase">--</span>
+      </p>
+      <div class="control-row">
+        <button type="button" data-action="start_wave">Start Wave</button>
+      </div>
+    </section>
+
+    <section id="viewport-shell" class="viewport-shell">
+      <div class="viewport-toolbar">
+        <button id="fullscreen-toggle" type="button">Expand View</button>
+      </div>
+      <div id="viewport-host" class="viewport-host">
+        <div id="viewport-frame" class="viewport-frame">
+          <canvas
+            id="background-canvas"
+            width="960"
+            height="540"
+          ></canvas>
+          <canvas
+            id="foreground-canvas"
+            width="960"
+            height="540"
+          ></canvas>
+          <canvas
+            id="overlay-canvas"
+            width="280"
+            height="540"
+          ></canvas>
+        </div>
+      </div>
+    </section>
+
+    <section class="status-grid">
+      <h2>Log</h2>
+      <pre id="log"></pre>
+    </section>
+  </main>
 </body>
 
 </html>

--- a/corvid/sim/web/index.html
+++ b/corvid/sim/web/index.html
@@ -131,8 +131,9 @@
     #overlay-canvas {
       position: absolute;
       top: 0;
-      display: none;
-      pointer-events: auto;
+      pointer-events: none;
+      visibility: hidden;
+      transition: transform 220ms ease;
     }
 
     #log {

--- a/corvid/sim/web/index.html
+++ b/corvid/sim/web/index.html
@@ -146,6 +146,19 @@
       background: rgba(7, 12, 20, 0.78);
     }
 
+    .metrics-strip {
+      display: grid;
+      gap: 6px;
+      padding: 12px 14px;
+      border: 1px solid rgba(148, 163, 184, 0.26);
+      border-radius: 16px;
+      background: rgba(7, 12, 20, 0.78);
+    }
+
+    .metrics-strip p {
+      margin: 0;
+    }
+
     @media (max-width: 900px) {
       body {
         padding: 16px;
@@ -167,12 +180,6 @@
 
     <section class="status-grid">
       <p>Status: <span id="status">disconnected</span></p>
-      <p>Latest tick: <span id="tick">--</span></p>
-      <p>
-        Lives: <span id="lives">--</span>
-        Resources: <span id="resources">--</span>
-        Phase: <span id="phase">--</span>
-      </p>
       <div class="control-row">
         <button type="button" data-action="start_wave">Start Wave</button>
       </div>
@@ -201,6 +208,12 @@
           ></canvas>
         </div>
       </div>
+    </section>
+
+    <section class="metrics-strip" aria-label="Client metrics">
+      <p>Latest tick: <span id="tick">--</span></p>
+      <p>Measured tick rate: <span id="tick-rate">--</span></p>
+      <p>Avg frame size: <span id="frame-size">--</span></p>
     </section>
 
     <section class="status-grid">

--- a/corvid/sim/web/index.html
+++ b/corvid/sim/web/index.html
@@ -96,7 +96,7 @@
 
     .viewport-toolbar {
       display: flex;
-      justify-content: flex-end;
+      justify-content: space-between;
     }
 
     .viewport-host {
@@ -180,13 +180,11 @@
 
     <section class="status-grid">
       <p>Status: <span id="status">disconnected</span></p>
-      <div class="control-row">
-        <button type="button" data-action="start_wave">Start Wave</button>
-      </div>
     </section>
 
     <section id="viewport-shell" class="viewport-shell">
       <div class="viewport-toolbar">
+        <button type="button" data-action="start_wave">Start Wave</button>
         <button id="fullscreen-toggle" type="button">Expand View</button>
       </div>
       <div id="viewport-host" class="viewport-host">

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -327,6 +327,7 @@ let currentPhase = 'build'
 let mouseOverOverlay = false
 let overlayStayOpen = false
 let currentPanelSide: PanelSide = 'right'
+let overlaySideSwapFrame = 0
 
 const SIDE_PANEL_TRIGGER_RATIO = 0.25
 const SIDE_PANEL_TRIGGER_MIN_PX = 72
@@ -401,7 +402,9 @@ const PANEL_PEEK_PX = 18
 type OverlayLevel = 'hidden' | 'peek' | 'open'
 
 function hasPinnedOpenPanel(): boolean {
-  return ghostState?.pending === true || overlayStayOpen
+  return ghostState?.pending === true ||
+    findSelectedTower() !== null ||
+    overlayStayOpen
 }
 
 function getTargetSide(): PanelSide {
@@ -438,10 +441,26 @@ function isPointerOverPeekActivation(event: MouseEvent): boolean {
   return bounds !== null && isPointInRect(event.clientX, event.clientY, bounds)
 }
 
+function getOverlayTransform(
+  side: PanelSide,
+  level: OverlayLevel,
+): string {
+  if (side === 'right') {
+    if (level === 'hidden') return 'translateX(100%)'
+    if (level === 'peek') return `translateX(calc(100% - ${PANEL_PEEK_PX}px))`
+    return 'translateX(0)'
+  }
+
+  if (level === 'hidden') return 'translateX(-100%)'
+  if (level === 'peek') return `translateX(calc(-100% + ${PANEL_PEEK_PX}px))`
+  return 'translateX(0)'
+}
+
 function applyOverlayPosition(): void {
   const level = getOverlayLevel()
   const targetSide = getTargetSide()
   const sideChanged = targetSide !== currentPanelSide
+  const transitionMs = menuDragActive ? 100 : 220
 
   // Update the side whenever the panel is not fully open, so hovering the left
   // edge correctly switches to the left panel. When fully open, keep the current
@@ -455,17 +474,22 @@ function applyOverlayPosition(): void {
     : Math.max(foregroundCssWidth - overlayCssWidth, 0)
   overlayCanvas.style.left = `${leftPx}px`
   overlayCanvas.style.right = ''
-  const transitionMs = sideChanged ? 0 : (menuDragActive ? 100 : 220)
-  overlayCanvas.style.transitionDuration = `${transitionMs}ms`
+  if (overlaySideSwapFrame !== 0) {
+    cancelAnimationFrame(overlaySideSwapFrame)
+    overlaySideSwapFrame = 0
+  }
 
-  if (currentPanelSide === 'right') {
-    if (level === 'hidden') overlayCanvas.style.transform = 'translateX(100%)'
-    else if (level === 'peek') overlayCanvas.style.transform = `translateX(calc(100% - ${PANEL_PEEK_PX}px))`
-    else overlayCanvas.style.transform = 'translateX(0)'
+  if (sideChanged && level !== 'hidden') {
+    overlayCanvas.style.transitionDuration = '0ms'
+    overlayCanvas.style.transform = getOverlayTransform(currentPanelSide, 'hidden')
+    overlaySideSwapFrame = requestAnimationFrame(() => {
+      overlaySideSwapFrame = 0
+      overlayCanvas.style.transitionDuration = `${transitionMs}ms`
+      overlayCanvas.style.transform = getOverlayTransform(currentPanelSide, level)
+    })
   } else {
-    if (level === 'hidden') overlayCanvas.style.transform = 'translateX(-100%)'
-    else if (level === 'peek') overlayCanvas.style.transform = `translateX(calc(-100% + ${PANEL_PEEK_PX}px))`
-    else overlayCanvas.style.transform = 'translateX(0)'
+    overlayCanvas.style.transitionDuration = `${transitionMs}ms`
+    overlayCanvas.style.transform = getOverlayTransform(currentPanelSide, level)
   }
 
   // pointer-events: none when hidden so the off-screen canvas doesn't eat clicks.
@@ -1365,6 +1389,10 @@ function resetClientWorldState(): void {
   mouseOverOverlay = false
   overlayStayOpen = false
   currentPanelSide = 'right'
+  if (overlaySideSwapFrame !== 0) {
+    cancelAnimationFrame(overlaySideSwapFrame)
+    overlaySideSwapFrame = 0
+  }
 
   bgCtx.clearRect(0, 0, backgroundCanvas.width, backgroundCanvas.height)
   fgCtx.clearRect(0, 0, foregroundCanvas.width, foregroundCanvas.height)

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -892,7 +892,7 @@ function findSelectedDefender(): RenderEntityUpsert | null {
   return null
 }
 
-function findTowerAtWorld(worldX: number, worldY: number): RenderEntityUpsert | null {
+function findDefenderAtWorld(worldX: number, worldY: number): RenderEntityUpsert | null {
   const hitPos = { x: worldX, y: worldY }
   for (const entity of currEntitiesById.values()) {
     if (entity.app.attackRadius <= 0) continue
@@ -971,7 +971,7 @@ function getPendingGhostPanelModel(): SidePanelModel | null {
   const side: PanelSide = ghostCanvasX < foregroundCanvas.width / 2 ? 'right' : 'left'
   return {
     side,
-    title: 'Place Tower',
+    title: 'Place Defender',
     lines: [
       ghostState.displayName,
       '',
@@ -1737,7 +1737,7 @@ foregroundCanvas.addEventListener('dblclick', (event: MouseEvent) => {
     !menuDragActive &&
     currentPhase === 'build' &&
     defenderMenuItems.length > 0 &&
-    findTowerAtWorld(sample.worldX, sample.worldY) === null
+    findDefenderAtWorld(sample.worldX, sample.worldY) === null
   ) {
     edgeHoverSide = currentPanelSide
     mouseOverOverlay = true

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -330,8 +330,9 @@ let lives = 0
 let resources = 0
 let lastFpsOverlayUpdateTime = 0
 let hudDirty = true
+let currentPathWidth = 40
 const glyphFontSizeCache = new Map<string, number>()
-// Entity appearances come from a small, mostly fixed set of tower/enemy visuals,
+// Entity appearances come from a small, mostly fixed set of defender/enemy visuals,
 // so we memoize prerendered sprites for the lifetime of the page instead of
 // paying per-frame draw costs or maintaining an eviction policy.
 const entitySpriteCache = new Map<string, SpriteCacheEntry>()
@@ -368,14 +369,20 @@ function lerp(a: number, b: number, t: number): number {
   return a + (b - a) * t
 }
 
-function drawBackground(pathPoints: Array<{ x: number; y: number }>): void {
+function drawBackground(
+  pathPoints: Array<{ x: number; y: number }>,
+  pathWidth = currentPathWidth,
+): void {
   currentPathPoints = pathPoints
+  currentPathWidth = pathWidth
   bgCtx.clearRect(0, 0, backgroundCanvas.width, backgroundCanvas.height)
   if (pathPoints.length <= 1) return
 
   bgCtx.save()
   bgCtx.strokeStyle = '#3b82f6'
-  bgCtx.lineWidth = 2
+  bgCtx.lineWidth = Math.max(2, worldLengthToCanvas(pathWidth))
+  bgCtx.lineCap = 'round'
+  bgCtx.lineJoin = 'round'
   bgCtx.beginPath()
   const [startX, startY] = worldToCanvas(pathPoints[0].x, pathPoints[0].y)
   bgCtx.moveTo(startX, startY)
@@ -855,9 +862,9 @@ function panelSideFromCanvasX(canvasX: number): PanelSide | null {
   const cssWidth = foregroundCanvas.clientWidth
   const triggerCssPx = cssWidth > 0
     ? Math.max(
-        SIDE_PANEL_TRIGGER_MIN_PX,
-        Math.min(SIDE_PANEL_TRIGGER_MAX_PX, cssWidth * SIDE_PANEL_TRIGGER_RATIO),
-      )
+      SIDE_PANEL_TRIGGER_MIN_PX,
+      Math.min(SIDE_PANEL_TRIGGER_MAX_PX, cssWidth * SIDE_PANEL_TRIGGER_RATIO),
+    )
     : SIDE_PANEL_TRIGGER_MIN_PX
   const triggerPx = cssWidth > 0
     ? triggerCssPx * (foregroundCanvas.width / cssWidth)
@@ -1031,7 +1038,7 @@ function drawSidePanel(ctx: CanvasRenderingContext2D, panel: SidePanelModel): vo
       continue
     }
     ctx.fillStyle = line.startsWith('Left click') || line.startsWith('Double click') ||
-        line.startsWith('Right click') || line.startsWith('Use Start Wave')
+      line.startsWith('Right click') || line.startsWith('Use Start Wave')
       ? 'rgba(181, 201, 224, 0.92)'
       : 'rgba(255, 255, 255, 0.92)'
     const wrappedLines = wrapPanelText(ctx, line, textWidth)
@@ -1440,6 +1447,7 @@ function finishSnapshotUpdate(): void {
 
 function resetClientWorldState(): void {
   currentPathPoints = []
+  currentPathWidth = 40
   currEntitiesById.clear()
   prevRenderStateById.clear()
   glyphFontSizeCache.clear()
@@ -1551,6 +1559,7 @@ function isServerMsg(value: unknown): value is ServerMsg {
         typeof md === 'object' &&
         typeof md.backgroundSprite === 'string' &&
         typeof md.foregroundSprite === 'string' &&
+        typeof md.pathWidth === 'number' &&
         Array.isArray(md.paths) &&
         md.paths.every(isPoint) &&
         Array.isArray(v.defenderMenu) &&
@@ -1601,7 +1610,7 @@ ws.onmessage = (event: MessageEvent<string>) => {
     case 'world_snapshot':
       resetClientWorldState()
       defenderMenuItems = parsed.defenderMenu
-      drawBackground(parsed.mapDesign.paths)
+      drawBackground(parsed.mapDesign.paths, parsed.mapDesign.pathWidth)
       applyWorldDelta(parsed.delta)
       break
   }
@@ -1747,10 +1756,10 @@ window.addEventListener('mouseup', (event: MouseEvent) => {
       const ovRect = overlayCanvas.getBoundingClientRect()
       const overOverlay =
         event.clientX >= ovRect.left && event.clientX <= ovRect.right &&
-        event.clientY >= ovRect.top  && event.clientY <= ovRect.bottom
+        event.clientY >= ovRect.top && event.clientY <= ovRect.bottom
       const overFg =
         event.clientX >= fgRect.left && event.clientX <= fgRect.right &&
-        event.clientY >= fgRect.top  && event.clientY <= fgRect.bottom
+        event.clientY >= fgRect.top && event.clientY <= fgRect.bottom
       if (overFg && !overOverlay) {
         sendPlacementPreview('dragend', ghostStateToSample(ghostState, event), ghostState.entityName)
         ghostState.pending = true
@@ -1782,7 +1791,7 @@ foregroundCanvas.addEventListener('contextmenu', (event: MouseEvent) => {
   const sample = eventToCanvasSample(event)
   if (ghostState?.pending) {
     if (!ghostState.placeable) return
-    // Right-click while ghost is pending: place the tower.
+    // Right-click while ghost is pending: place the defender.
     const entityName = ghostState.entityName
     const ghostSample = ghostStateToSample(ghostState, event, 2, 2)
     ghostState = null

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -1248,8 +1248,7 @@ function updateSidePanelOverlay(): void {
   overlayCtx.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height)
 
   const panel = getSidePanelModel()
-  const showBuildMenu =
-    defenderMenuItems.length > 0 && currentPhase === 'build' && !menuDragActive
+  const showBuildMenu = shouldShowBuildMenu()
 
   if (panel) {
     drawSidePanel(overlayCtx, panel)
@@ -1258,6 +1257,15 @@ function updateSidePanelOverlay(): void {
   }
 
   sidePanelDirty = false
+}
+
+function shouldShowBuildMenu(): boolean {
+  return (
+    getSidePanelModel() === null &&
+    defenderMenuItems.length > 0 &&
+    currentPhase === 'build' &&
+    !menuDragActive
+  )
 }
 
 function frame(now: number): void {
@@ -1935,8 +1943,8 @@ window.addEventListener('mousemove', (event: MouseEvent) => {
 // Overlay mousedown: select a build menu cell and arm a drag (ghost appears on
 // first mousemove so it never flashes at the canvas origin).
 overlayCanvas.addEventListener('mousedown', (event: MouseEvent) => {
-  if (event.button !== 0 || defenderMenuItems.length === 0) return
-  if (currentPhase !== 'build') return
+  if (event.button !== 0) return
+  if (!shouldShowBuildMenu()) return
   event.preventDefault()
 
   const panelScale = Math.min(

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -325,9 +325,12 @@ let ghostState: GhostState | null = null
 let menuDragActive = false
 let currentPhase = 'build'
 let mouseOverOverlay = false
+let overlayStayOpen = false
 let currentPanelSide: PanelSide = 'right'
 
-const SIDE_PANEL_TRIGGER_PX = 48
+const SIDE_PANEL_TRIGGER_RATIO = 0.25
+const SIDE_PANEL_TRIGGER_MIN_PX = 72
+const SIDE_PANEL_TRIGGER_MAX_PX = 180
 const MENU_COLS = 2
 const MENU_VISIBLE_ROWS = 4
 const SIDE_PANEL_RADIUS = 18
@@ -393,32 +396,57 @@ function updateFpsOverlay(now: number): void {
 }
 
 // How far the panel peeks out from the edge (CSS pixels).
-const PANEL_PEEK_PX = 10
+const PANEL_PEEK_PX = 18
 
 type OverlayLevel = 'hidden' | 'peek' | 'open'
 
+function hasPinnedOpenPanel(): boolean {
+  return ghostState?.pending === true || overlayStayOpen
+}
+
 function getTargetSide(): PanelSide {
-  // Auto-panel side takes priority; otherwise follow whichever edge is hovered.
+  // A pinned panel (like pending placement) owns the side. Otherwise follow
+  // the current edge hover so the peek/open transition stays on one edge.
   return getSidePanelModel()?.side ?? edgeHoverSide ?? currentPanelSide
 }
 
 function getOverlayLevel(): OverlayLevel {
   if (menuDragActive) return 'hidden'
-  const hasAutoPanel = getSidePanelModel() !== null
+  const hasPanelContent = getSidePanelModel() !== null
   const hasBuildMenu = currentPhase === 'build' && defenderMenuItems.length > 0
-  if (!hasAutoPanel && !hasBuildMenu) return 'hidden'
-  if (mouseOverOverlay || hasAutoPanel) return 'open'
+  if (!hasPanelContent && !hasBuildMenu) return 'hidden'
+  if (hasPinnedOpenPanel() || mouseOverOverlay) return 'open'
   if (edgeHoverSide !== null) return 'peek'
   return 'hidden'
 }
 
+function getOverlayPeekActivationBounds(): DOMRect | null {
+  if (getOverlayLevel() !== 'peek') return null
+  const rect = overlayCanvas.getBoundingClientRect()
+  if (currentPanelSide === 'left') {
+    return new DOMRect(rect.right - PANEL_PEEK_PX, rect.top, PANEL_PEEK_PX, rect.height)
+  }
+  return new DOMRect(rect.left, rect.top, PANEL_PEEK_PX, rect.height)
+}
+
+function isPointInRect(x: number, y: number, rect: DOMRect): boolean {
+  return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom
+}
+
+function isPointerOverPeekActivation(event: MouseEvent): boolean {
+  const bounds = getOverlayPeekActivationBounds()
+  return bounds !== null && isPointInRect(event.clientX, event.clientY, bounds)
+}
+
 function applyOverlayPosition(): void {
   const level = getOverlayLevel()
+  const targetSide = getTargetSide()
+  const sideChanged = targetSide !== currentPanelSide
 
   // Update the side whenever the panel is not fully open, so hovering the left
   // edge correctly switches to the left panel. When fully open, keep the current
   // side so the panel never jumps mid-flight.
-  if (level !== 'open') currentPanelSide = getTargetSide()
+  if (level !== 'open' || hasPinnedOpenPanel()) currentPanelSide = targetSide
 
   const foregroundCssWidth = foregroundCanvas.clientWidth
   const overlayCssWidth = overlayCanvas.clientWidth
@@ -427,6 +455,8 @@ function applyOverlayPosition(): void {
     : Math.max(foregroundCssWidth - overlayCssWidth, 0)
   overlayCanvas.style.left = `${leftPx}px`
   overlayCanvas.style.right = ''
+  const transitionMs = sideChanged ? 0 : (menuDragActive ? 100 : 220)
+  overlayCanvas.style.transitionDuration = `${transitionMs}ms`
 
   if (currentPanelSide === 'right') {
     if (level === 'hidden') overlayCanvas.style.transform = 'translateX(100%)'
@@ -452,6 +482,10 @@ function setEdgeHoverSide(nextSide: PanelSide | null): void {
   if (edgeHoverSide === nextSide) return
   edgeHoverSide = nextSide
   invalidateSidePanel()
+}
+
+function clearMenuSelection(): void {
+  selectedMenuIndex = null
 }
 
 function packedRgbaToRenderColor(color: number): RenderColor {
@@ -762,15 +796,22 @@ function drawHud(ctx: CanvasRenderingContext2D): void {
 
 function panelSideFromCanvasX(canvasX: number): PanelSide | null {
   const cssWidth = foregroundCanvas.clientWidth
+  const triggerCssPx = cssWidth > 0
+    ? Math.max(
+        SIDE_PANEL_TRIGGER_MIN_PX,
+        Math.min(SIDE_PANEL_TRIGGER_MAX_PX, cssWidth * SIDE_PANEL_TRIGGER_RATIO),
+      )
+    : SIDE_PANEL_TRIGGER_MIN_PX
   const triggerPx = cssWidth > 0
-    ? SIDE_PANEL_TRIGGER_PX * (foregroundCanvas.width / cssWidth)
-    : SIDE_PANEL_TRIGGER_PX
+    ? triggerCssPx * (foregroundCanvas.width / cssWidth)
+    : triggerCssPx
   if (canvasX <= triggerPx) return 'left'
   if (canvasX >= foregroundCanvas.width - triggerPx) return 'right'
   return null
 }
 
 function updateEdgeHover(sample: CanvasPointerSample): void {
+  overlayStayOpen = false
   if (menuDragActive || ghostState || currentPhase !== 'build') {
     setEdgeHoverSide(null)
     return
@@ -852,8 +893,8 @@ function getPendingGhostPanelModel(): SidePanelModel | null {
       ghostState.displayName,
       '',
       'Right-click to place',
-      'Left-click to move',
-      'Click outside to cancel',
+      'Left-click ghost to move',
+      'Any other click cancels',
     ],
   }
 }
@@ -1322,6 +1363,7 @@ function resetClientWorldState(): void {
   menuDragActive = false
   currentPhase = 'build'
   mouseOverOverlay = false
+  overlayStayOpen = false
   currentPanelSide = 'right'
 
   bgCtx.clearRect(0, 0, backgroundCanvas.width, backgroundCanvas.height)
@@ -1490,8 +1532,8 @@ foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   const sample = eventToCanvasSample(event)
   updateEdgeHover(sample)
 
-  // While a ghost is pending, left-click either picks it up (on the ghost) or
-  // cancels it (anywhere else on the canvas).
+  // While a ghost is pending, left-click on the ghost picks it back up and
+  // any other non-right click cancels placement.
   if (event.button === 0 && ghostState?.pending) {
     const [gx, gy] = worldToCanvas(ghostState.worldX, ghostState.worldY)
     const hitRadius = worldLengthToCanvas(ghostState.appearance.radius) * 2
@@ -1500,8 +1542,12 @@ foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
     if (dx * dx + dy * dy <= hitRadius * hitRadius) {
       ghostState.pending = false
       menuDragActive = true
+      mouseOverOverlay = false
+      overlayStayOpen = false
     } else {
       ghostState = null
+      clearMenuSelection()
+      overlayStayOpen = false
     }
     invalidateSidePanel()
     return
@@ -1544,27 +1590,30 @@ foregroundCanvas.addEventListener('mouseleave', () => {
 })
 
 overlayCanvas.addEventListener('mouseenter', () => {
-  mouseOverOverlay = true
+  if (getOverlayLevel() !== 'peek') mouseOverOverlay = true
+  overlayStayOpen = false
+  applyOverlayPosition()
+})
+
+overlayCanvas.addEventListener('mousemove', (event: MouseEvent) => {
+  const shouldOpen = getOverlayLevel() !== 'peek' || isPointerOverPeekActivation(event)
+  if (mouseOverOverlay === shouldOpen) return
+  mouseOverOverlay = shouldOpen
+  if (shouldOpen) overlayStayOpen = false
   applyOverlayPosition()
 })
 
 overlayCanvas.addEventListener('mouseleave', (event: MouseEvent) => {
   mouseOverOverlay = false
-  // Only close the panel when the mouse re-enters the foreground canvas
-  // (i.e. moves away from the edge, back into the game area). Leaving to
-  // anywhere else (outside the viewport, browser chrome) keeps it open.
   const toFg = event.relatedTarget === foregroundCanvas
-  if (toFg && !findSelectedTower() && !ghostState?.pending) {
-    setEdgeHoverSide(null)
+  if (toFg) {
+    overlayStayOpen = false
+    if (!ghostState?.pending) setEdgeHoverSide(currentPanelSide)
   } else {
-    // Mouse left to somewhere other than the fg canvas interior (outside the
-    // viewport, browser chrome, etc.). Keep the panel peeking so it does not
-    // vanish when the user moves the cursor slightly off the page. If the side
-    // was only determined by an auto-panel (edgeHoverSide is null), anchor it
-    // to the current panel side so the peek position is correct.
+    overlayStayOpen = true
     if (edgeHoverSide === null) edgeHoverSide = currentPanelSide
-    applyOverlayPosition()
   }
+  invalidateSidePanel()
 })
 
 window.addEventListener('mouseup', (event: MouseEvent) => {
@@ -1582,8 +1631,12 @@ window.addEventListener('mouseup', (event: MouseEvent) => {
         event.clientY >= fgRect.top  && event.clientY <= fgRect.bottom
       if (overFg && !overOverlay) {
         ghostState.pending = true
+        mouseOverOverlay = false
+        overlayStayOpen = false
       } else {
         ghostState = null
+        clearMenuSelection()
+        overlayStayOpen = false
       }
     }
     invalidateSidePanel()
@@ -1608,7 +1661,10 @@ foregroundCanvas.addEventListener('contextmenu', (event: MouseEvent) => {
     // Right-click while ghost is pending: place the tower.
     const entityName = ghostState.entityName
     ghostState = null
+    clearMenuSelection()
     menuDragActive = false
+    mouseOverOverlay = false
+    overlayStayOpen = false
     invalidateSidePanel()
     sendCanvasMsg('click', sample, 'spawn', [entityName])
     return
@@ -1651,12 +1707,45 @@ document.addEventListener('submit', (event: SubmitEvent) => {
 
 // Cancel ghost on right-click outside the foreground canvas.
 document.addEventListener('contextmenu', (event: MouseEvent) => {
-  if (ghostState && event.target !== foregroundCanvas) {
+  if (event.defaultPrevented || !ghostState) return
+
+  const fgRect = foregroundCanvas.getBoundingClientRect()
+  const insideFg = isPointInRect(event.clientX, event.clientY, fgRect)
+  if (ghostState.pending && insideFg) {
+    const sample = eventToCanvasSample(event)
+    const entityName = ghostState.entityName
     event.preventDefault()
     ghostState = null
+    clearMenuSelection()
     menuDragActive = false
+    mouseOverOverlay = false
+    overlayStayOpen = false
+    invalidateSidePanel()
+    sendCanvasMsg('click', sample, 'spawn', [entityName])
+    return
+  }
+
+  if (event.target !== foregroundCanvas) {
+    event.preventDefault()
+    ghostState = null
+    clearMenuSelection()
+    menuDragActive = false
+    mouseOverOverlay = false
+    overlayStayOpen = false
     invalidateSidePanel()
   }
+})
+
+// Any non-right-click outside the canvas cancels pending placement.
+document.addEventListener('mousedown', (event: MouseEvent) => {
+  if (event.button === 2 || !ghostState?.pending) return
+  if (event.target === foregroundCanvas) return
+  ghostState = null
+  clearMenuSelection()
+  menuDragActive = false
+  mouseOverOverlay = false
+  overlayStayOpen = false
+  invalidateSidePanel()
 })
 
 // Track ghost world position globally during a menu drag.
@@ -1707,6 +1796,8 @@ overlayCanvas.addEventListener('mousedown', (event: MouseEvent) => {
 
   selectedMenuIndex = index
   menuDragActive = true
+  mouseOverOverlay = false
+  overlayStayOpen = false
 
   // Create the ghost immediately at the current mouse position so it appears
   // as soon as the mouse enters the foreground canvas, with no lag.
@@ -1724,6 +1815,7 @@ overlayCanvas.addEventListener('mousedown', (event: MouseEvent) => {
     attackRadius: item.appearance.attackRadius,
     pending: false,
   }
+  clearMenuSelection()
   invalidateSidePanel()
 })
 

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -5,6 +5,7 @@ import type {
   EntityPosition,
   EntityUpsert,
   EntityVisualEffects,
+  Position,
   ServerMsg,
   UiCanvasMsg,
   UiState,
@@ -354,7 +355,7 @@ let overlayStayOpen = false
 let currentPanelSide: PanelSide = 'right'
 let overlaySideSwapFrame = 0
 let selectedDefenderSummary: DefenderMenuItem | null = null
-let defenderSelected = false
+let selectedDefenderPosition: Position | null = null
 
 const SIDE_PANEL_TRIGGER_RATIO = 0.25
 const SIDE_PANEL_TRIGGER_MIN_PX = 72
@@ -436,7 +437,7 @@ type OverlayLevel = 'hidden' | 'peek' | 'open'
 
 function hasPinnedOpenPanel(): boolean {
   return ghostState?.pending === true ||
-    defenderSelected ||
+    selectedDefenderPosition !== null ||
     overlayStayOpen
 }
 
@@ -908,6 +909,10 @@ function formatPanelNumber(value: number): string {
   return Number.isInteger(value) ? String(value) : value.toFixed(1)
 }
 
+function getOppositePanelSideForCanvasX(canvasX: number): PanelSide {
+  return canvasX < foregroundCanvas.width / 2 ? 'right' : 'left'
+}
+
 function wrapPanelText(
   ctx: CanvasRenderingContext2D,
   text: string,
@@ -935,10 +940,14 @@ function wrapPanelText(
 }
 
 function getSelectedDefenderPanelModel(): SidePanelModel | null {
-  if (!defenderSelected || !selectedDefenderSummary) return null
+  if (!selectedDefenderPosition || !selectedDefenderSummary) return null
+
+  const side = getOppositePanelSideForCanvasX(
+    worldToCanvas(selectedDefenderPosition.x, selectedDefenderPosition.y)[0],
+  )
 
   return {
-    side: currentPanelSide,
+    side,
     title: 'Defender Selected',
     lines: [
       selectedDefenderSummary.displayName,
@@ -957,9 +966,8 @@ function getSelectedDefenderPanelModel(): SidePanelModel | null {
 
 function getPendingGhostPanelModel(): SidePanelModel | null {
   if (!ghostState?.pending) return null
-  // Put the panel on whichever side the ghost is NOT on.
   const [ghostCanvasX] = worldToCanvas(ghostState.worldX, ghostState.worldY)
-  const side: PanelSide = ghostCanvasX < foregroundCanvas.width / 2 ? 'right' : 'left'
+  const side = getOppositePanelSideForCanvasX(ghostCanvasX)
   return {
     side,
     title: 'Place Defender',
@@ -1449,7 +1457,7 @@ function isUiState(value: unknown): value is UiState {
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof v.defenderSelected === 'boolean' &&
+    (v.selectedDefender === undefined || isPoint(v.selectedDefender)) &&
     (v.placementAllowed === undefined || typeof v.placementAllowed === 'boolean') &&
     (v.spawnAllowed === undefined || typeof v.spawnAllowed === 'boolean') &&
     (v.defenderSummary === undefined || isDefenderMenuItem(v.defenderSummary))
@@ -1477,8 +1485,8 @@ function applyUiState(uiState: UiState): void {
     }
   }
 
-  defenderSelected = uiState.defenderSelected
-  if (!defenderSelected) {
+  selectedDefenderPosition = uiState.selectedDefender ?? null
+  if (!selectedDefenderPosition) {
     selectedDefenderSummary = null
   } else if (uiState.defenderSummary) {
     selectedDefenderSummary = uiState.defenderSummary
@@ -1520,7 +1528,7 @@ function resetClientWorldState(): void {
   overlayStayOpen = false
   currentPanelSide = 'right'
   selectedDefenderSummary = null
-  defenderSelected = false
+  selectedDefenderPosition = null
   if (overlaySideSwapFrame !== 0) {
     cancelAnimationFrame(overlaySideSwapFrame)
     overlaySideSwapFrame = 0

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -102,6 +102,10 @@ function requireEl<T extends HTMLElement>(
 const statusEl = requireEl('status', HTMLElement)
 const tickEl = requireEl('tick', HTMLElement)
 const logEl = requireEl('log', HTMLElement)
+const viewportShell = requireEl('viewport-shell', HTMLElement)
+const viewportHost = requireEl('viewport-host', HTMLElement)
+const viewportFrame = requireEl('viewport-frame', HTMLElement)
+const fullscreenToggle = requireEl('fullscreen-toggle', HTMLButtonElement)
 const backgroundCanvas = requireEl('background-canvas', HTMLCanvasElement)
 const foregroundCanvas = requireEl('foreground-canvas', HTMLCanvasElement)
 const overlayCanvas = requireEl('overlay-canvas', HTMLCanvasElement)
@@ -138,6 +142,89 @@ const fpsCtx: CanvasRenderingContext2D = maybeFpsCtx
 // letterboxing needed.
 const WORLD_W = 1920
 const WORLD_H = 1080
+const DEFAULT_CANVAS_W = 960
+const DEFAULT_CANVAS_H = 540
+const DEFAULT_OVERLAY_W = 280
+const OVERLAY_WIDTH_RATIO = DEFAULT_OVERLAY_W / DEFAULT_CANVAS_W
+
+function setCanvasSize(
+  canvas: HTMLCanvasElement,
+  cssWidth: number,
+  cssHeight: number,
+  pixelWidth: number,
+  pixelHeight: number,
+): void {
+  canvas.style.width = `${cssWidth}px`
+  canvas.style.height = `${cssHeight}px`
+  if (canvas.width !== pixelWidth) canvas.width = pixelWidth
+  if (canvas.height !== pixelHeight) canvas.height = pixelHeight
+}
+
+function fitCanvasRect(availableWidth: number, availableHeight: number): [number, number] {
+  const aspect = WORLD_W / WORLD_H
+  let width = Math.max(1, Math.floor(availableWidth))
+  let height = Math.max(1, Math.floor(width / aspect))
+
+  if (height > availableHeight) {
+    height = Math.max(1, Math.floor(availableHeight))
+    width = Math.max(1, Math.floor(height * aspect))
+  }
+
+  return [width, height]
+}
+
+function updateFullscreenButtonLabel(): void {
+  fullscreenToggle.textContent = document.fullscreenElement === viewportShell
+    ? 'Exit Fullscreen'
+    : 'Expand View'
+}
+
+let currentPathPoints: Array<{ x: number; y: number }> = []
+
+function resizeViewport(): void {
+  const isFullscreen = document.fullscreenElement === viewportShell
+  const availableWidth = isFullscreen
+    ? viewportHost.clientWidth
+    : Math.min(viewportHost.clientWidth, DEFAULT_CANVAS_W)
+  const availableHeight = isFullscreen
+    ? viewportHost.clientHeight
+    : DEFAULT_CANVAS_H
+  const [cssWidth, cssHeight] = fitCanvasRect(availableWidth, availableHeight)
+  const deviceScale = window.devicePixelRatio || 1
+  const pixelWidth = Math.max(1, Math.round(cssWidth * deviceScale))
+  const pixelHeight = Math.max(1, Math.round(cssHeight * deviceScale))
+  const overlayCssWidth = Math.max(
+    1,
+    Math.min(
+      cssWidth,
+      Math.max(
+        Math.min(220, cssWidth),
+        Math.min(Math.round(cssWidth * 0.4), Math.round(cssWidth * OVERLAY_WIDTH_RATIO)),
+      ),
+    ),
+  )
+  const overlayPixelWidth = Math.max(1, Math.round(overlayCssWidth * deviceScale))
+  const canvasSizeChanged =
+    backgroundCanvas.width !== pixelWidth ||
+    backgroundCanvas.height !== pixelHeight
+
+  viewportFrame.style.width = `${cssWidth}px`
+  viewportFrame.style.height = `${cssHeight}px`
+
+  setCanvasSize(backgroundCanvas, cssWidth, cssHeight, pixelWidth, pixelHeight)
+  setCanvasSize(foregroundCanvas, cssWidth, cssHeight, pixelWidth, pixelHeight)
+  setCanvasSize(overlayCanvas, overlayCssWidth, cssHeight, overlayPixelWidth, pixelHeight)
+  setCanvasSize(hudCanvas, cssWidth, cssHeight, pixelWidth, pixelHeight)
+  setCanvasSize(fpsCanvas, cssWidth, cssHeight, pixelWidth, pixelHeight)
+
+  if (canvasSizeChanged) {
+    glyphFontSizeCache.clear()
+    entitySpriteCache.clear()
+  }
+  if (currentPathPoints.length > 1) drawBackground(currentPathPoints)
+  invalidateHud()
+  invalidateSidePanel()
+}
 
 function worldToCanvas(wx: number, wy: number): [number, number] {
   return [
@@ -229,6 +316,7 @@ function lerp(a: number, b: number, t: number): number {
 }
 
 function drawBackground(pathPoints: Array<{ x: number; y: number }>): void {
+  currentPathPoints = pathPoints
   bgCtx.clearRect(0, 0, backgroundCanvas.width, backgroundCanvas.height)
   if (pathPoints.length <= 1) return
 
@@ -356,6 +444,10 @@ function getGlyphFontSize(glyph: string, radius: number): number {
   return fontSize
 }
 
+function getEntityBorderWidth(radius: number): number {
+  return Math.max(1, radius * 0.18)
+}
+
 function drawGlyphOnContext(
   ctx: CanvasRenderingContext2D,
   glyph: string,
@@ -410,6 +502,16 @@ function getEntitySprite(app: RenderAppearance, radius: number): SpriteCacheEntr
   if (!spriteCtx) return null
 
   if (app.bg.alpha !== 0) drawFilledCircleOnContext(spriteCtx, offset, offset, roundedRadius, app.bg)
+  if (app.fg.alpha !== 0) {
+    drawStrokedCircleOnContext(
+      spriteCtx,
+      offset,
+      offset,
+      Math.max(roundedRadius - getEntityBorderWidth(roundedRadius) * 0.5, 0),
+      app.fg,
+      getEntityBorderWidth(roundedRadius),
+    )
+  }
   if (app.fg.alpha !== 0) drawGlyphOnContext(spriteCtx, app.glyph, offset, offset, roundedRadius, app.fg)
 
   const sprite = { canvas, offset }
@@ -581,8 +683,12 @@ function drawHud(ctx: CanvasRenderingContext2D): void {
 }
 
 function panelSideFromCanvasX(canvasX: number): PanelSide | null {
-  if (canvasX <= SIDE_PANEL_TRIGGER_PX) return 'left'
-  if (canvasX >= foregroundCanvas.width - SIDE_PANEL_TRIGGER_PX) return 'right'
+  const cssWidth = foregroundCanvas.clientWidth
+  const triggerPx = cssWidth > 0
+    ? SIDE_PANEL_TRIGGER_PX * (foregroundCanvas.width / cssWidth)
+    : SIDE_PANEL_TRIGGER_PX
+  if (canvasX <= triggerPx) return 'left'
+  if (canvasX >= foregroundCanvas.width - triggerPx) return 'right'
   return null
 }
 
@@ -702,36 +808,48 @@ function drawSidePanel(ctx: CanvasRenderingContext2D, panel: SidePanelModel): vo
   const y = 0
   const width = overlayCanvas.width
   const height = overlayCanvas.height
-  const textX = x + SIDE_PANEL_TEXT_MARGIN
-  const textWidth = width - SIDE_PANEL_TEXT_MARGIN * 2
+  const panelScale = Math.min(
+    foregroundCanvas.width / DEFAULT_CANVAS_W,
+    foregroundCanvas.height / DEFAULT_CANVAS_H,
+  )
+  const cornerRadius = SIDE_PANEL_RADIUS * panelScale
+  const textMargin = SIDE_PANEL_TEXT_MARGIN * panelScale
+  const titleFontSize = 24 * panelScale
+  const bodyFontSize = 16 * panelScale
+  const lineHeight = SIDE_PANEL_LINE_HEIGHT * panelScale
+  const titleTop = 20 * panelScale
+  const dividerY = 56 * panelScale
+  const bodyTop = 74 * panelScale
+  const textX = x + textMargin
+  const textWidth = width - textMargin * 2
 
   ctx.save()
-  drawRoundedPanelPath(ctx, x, y, width, height, SIDE_PANEL_RADIUS)
+  drawRoundedPanelPath(ctx, x, y, width, height, cornerRadius)
   const gradient = ctx.createLinearGradient(x, y, x + width, y + height)
   gradient.addColorStop(0, 'rgba(12, 18, 26, 0.92)')
   gradient.addColorStop(1, 'rgba(18, 27, 39, 0.84)')
   ctx.fillStyle = gradient
   ctx.fill()
   ctx.strokeStyle = 'rgba(255, 255, 255, 0.16)'
-  ctx.lineWidth = 1.5
+  ctx.lineWidth = Math.max(1, 1.5 * panelScale)
   ctx.stroke()
 
   ctx.fillStyle = 'rgba(255, 255, 255, 0.96)'
-  ctx.font = 'bold 24px monospace'
+  ctx.font = `bold ${titleFontSize}px monospace`
   ctx.textBaseline = 'top'
-  ctx.fillText(panel.title, textX, y + 20, textWidth)
+  ctx.fillText(panel.title, textX, y + titleTop, textWidth)
 
   ctx.strokeStyle = 'rgba(255, 255, 255, 0.12)'
   ctx.beginPath()
-  ctx.moveTo(textX, y + 56)
-  ctx.lineTo(textX + textWidth, y + 56)
+  ctx.moveTo(textX, y + dividerY)
+  ctx.lineTo(textX + textWidth, y + dividerY)
   ctx.stroke()
 
-  ctx.font = '16px monospace'
-  let lineY = y + 74
+  ctx.font = `${bodyFontSize}px monospace`
+  let lineY = y + bodyTop
   for (const line of panel.lines) {
     if (line.length === 0) {
-      lineY += SIDE_PANEL_LINE_HEIGHT * 0.65
+      lineY += lineHeight * 0.65
       continue
     }
     ctx.fillStyle = line.startsWith('Left click') || line.startsWith('Double click') ||
@@ -741,7 +859,7 @@ function drawSidePanel(ctx: CanvasRenderingContext2D, panel: SidePanelModel): vo
     const wrappedLines = wrapPanelText(ctx, line, textWidth)
     for (const wrappedLine of wrappedLines) {
       ctx.fillText(wrappedLine, textX, lineY, textWidth)
-      lineY += SIDE_PANEL_LINE_HEIGHT
+      lineY += lineHeight
     }
   }
   ctx.restore()
@@ -759,9 +877,11 @@ function updateSidePanelOverlay(): void {
   }
 
   overlayCanvas.style.display = 'block'
+  const foregroundCssWidth = foregroundCanvas.clientWidth
+  const overlayCssWidth = overlayCanvas.clientWidth
   overlayCanvas.style.left = panel.side === 'left'
     ? '0'
-    : `${foregroundCanvas.width - overlayCanvas.width}px`
+    : `${Math.max(foregroundCssWidth - overlayCssWidth, 0)}px`
   overlayCanvas.style.right = ''
   drawSidePanel(overlayCtx, panel)
   sidePanelDirty = false
@@ -937,6 +1057,7 @@ function finishSnapshotUpdate(): void {
 }
 
 function resetClientWorldState(): void {
+  currentPathPoints = []
   currEntitiesById.clear()
   prevRenderStateById.clear()
   glyphFontSizeCache.clear()
@@ -1076,6 +1197,34 @@ ws.onerror = () => {
   log('WebSocket error')
 }
 
+fullscreenToggle.addEventListener('click', async () => {
+  try {
+    if (document.fullscreenElement === viewportShell) {
+      await document.exitFullscreen()
+      return
+    }
+    await viewportShell.requestFullscreen()
+  } catch {
+    log('Could not change fullscreen state')
+  }
+})
+
+document.addEventListener('fullscreenchange', () => {
+  updateFullscreenButtonLabel()
+  resizeViewport()
+})
+
+window.addEventListener('resize', () => {
+  resizeViewport()
+})
+
+if (typeof ResizeObserver !== 'undefined') {
+  const resizeObserver = new ResizeObserver(() => {
+    resizeViewport()
+  })
+  resizeObserver.observe(viewportHost)
+}
+
 foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   const sample = eventToCanvasSample(event)
   updateEdgeHover(sample)
@@ -1179,4 +1328,6 @@ document.addEventListener('submit', (event: SubmitEvent) => {
   sendUiAction(action, formDataToFields(new FormData(target)))
 })
 
+updateFullscreenButtonLabel()
+resizeViewport()
 requestAnimationFrame(frame)

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -32,6 +32,7 @@ interface GhostState {
   worldX: number
   worldY: number
   entityName: string
+  displayName: string
   appearance: RenderAppearance
   attackRadius: number  // world units, from Appearance.attackRadius
   pending: boolean      // true = dropped on map, awaiting confirmation click
@@ -322,8 +323,9 @@ let selectedMenuIndex: number | null = null
 let menuScrollOffset = 0
 let ghostState: GhostState | null = null
 let menuDragActive = false
-let pendingMenuDragItem: DefenderMenuItem | null = null
 let currentPhase = 'build'
+let mouseOverOverlay = false
+let currentPanelSide: PanelSide = 'right'
 
 const SIDE_PANEL_TRIGGER_PX = 48
 const MENU_COLS = 2
@@ -390,8 +392,60 @@ function updateFpsOverlay(now: number): void {
   lastFpsOverlayUpdateTime = now
 }
 
+// How far the panel peeks out from the edge (CSS pixels).
+const PANEL_PEEK_PX = 10
+
+type OverlayLevel = 'hidden' | 'peek' | 'open'
+
+function getTargetSide(): PanelSide {
+  // Auto-panel side takes priority; otherwise follow whichever edge is hovered.
+  return getSidePanelModel()?.side ?? edgeHoverSide ?? currentPanelSide
+}
+
+function getOverlayLevel(): OverlayLevel {
+  if (menuDragActive) return 'hidden'
+  const hasAutoPanel = getSidePanelModel() !== null
+  const hasBuildMenu = currentPhase === 'build' && defenderMenuItems.length > 0
+  if (!hasAutoPanel && !hasBuildMenu) return 'hidden'
+  if (mouseOverOverlay || hasAutoPanel) return 'open'
+  if (edgeHoverSide !== null) return 'peek'
+  return 'hidden'
+}
+
+function applyOverlayPosition(): void {
+  const level = getOverlayLevel()
+
+  // Update the side whenever the panel is not fully open, so hovering the left
+  // edge correctly switches to the left panel. When fully open, keep the current
+  // side so the panel never jumps mid-flight.
+  if (level !== 'open') currentPanelSide = getTargetSide()
+
+  const foregroundCssWidth = foregroundCanvas.clientWidth
+  const overlayCssWidth = overlayCanvas.clientWidth
+  const leftPx = currentPanelSide === 'left'
+    ? 0
+    : Math.max(foregroundCssWidth - overlayCssWidth, 0)
+  overlayCanvas.style.left = `${leftPx}px`
+  overlayCanvas.style.right = ''
+
+  if (currentPanelSide === 'right') {
+    if (level === 'hidden') overlayCanvas.style.transform = 'translateX(100%)'
+    else if (level === 'peek') overlayCanvas.style.transform = `translateX(calc(100% - ${PANEL_PEEK_PX}px))`
+    else overlayCanvas.style.transform = 'translateX(0)'
+  } else {
+    if (level === 'hidden') overlayCanvas.style.transform = 'translateX(-100%)'
+    else if (level === 'peek') overlayCanvas.style.transform = `translateX(calc(-100% + ${PANEL_PEEK_PX}px))`
+    else overlayCanvas.style.transform = 'translateX(0)'
+  }
+
+  // pointer-events: none when hidden so the off-screen canvas doesn't eat clicks.
+  overlayCanvas.style.pointerEvents = level === 'hidden' ? 'none' : 'auto'
+  overlayCanvas.style.visibility = 'visible'
+}
+
 function invalidateSidePanel(): void {
   sidePanelDirty = true
+  applyOverlayPosition()
 }
 
 function setEdgeHoverSide(nextSide: PanelSide | null): void {
@@ -788,15 +842,18 @@ function getSelectedTowerPanelModel(): SidePanelModel | null {
 
 function getPendingGhostPanelModel(): SidePanelModel | null {
   if (!ghostState?.pending) return null
+  // Put the panel on whichever side the ghost is NOT on.
+  const [ghostCanvasX] = worldToCanvas(ghostState.worldX, ghostState.worldY)
+  const side: PanelSide = ghostCanvasX < foregroundCanvas.width / 2 ? 'right' : 'left'
   return {
-    side: 'right',
+    side,
     title: 'Place Tower',
     lines: [
-      ghostState.entityName,
+      ghostState.displayName,
       '',
-      'Double-click to place',
+      'Right-click to place',
       'Left-click to move',
-      'Right-click to cancel',
+      'Click outside to cancel',
     ],
   }
 }
@@ -1051,41 +1108,18 @@ function drawGhost(): void {
 function updateSidePanelOverlay(): void {
   if (!sidePanelDirty) return
 
-  // Hide everything while a drag is actively in progress.
-  if (menuDragActive) {
-    overlayCtx.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height)
-    overlayCanvas.style.display = 'none'
-    sidePanelDirty = false
-    return
-  }
+  overlayCtx.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height)
 
   const panel = getSidePanelModel()
   const showBuildMenu =
-    edgeHoverSide !== null &&
-    defenderMenuItems.length > 0 &&
-    currentPhase === 'build'
-  overlayCtx.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height)
-
-  if (!panel && !showBuildMenu) {
-    overlayCanvas.style.display = 'none'
-    sidePanelDirty = false
-    return
-  }
-
-  overlayCanvas.style.display = 'block'
-  const foregroundCssWidth = foregroundCanvas.clientWidth
-  const overlayCssWidth = overlayCanvas.clientWidth
-  const side: PanelSide = edgeHoverSide ?? (panel?.side ?? 'right')
-  overlayCanvas.style.left = side === 'left'
-    ? '0'
-    : `${Math.max(foregroundCssWidth - overlayCssWidth, 0)}px`
-  overlayCanvas.style.right = ''
+    defenderMenuItems.length > 0 && currentPhase === 'build' && !menuDragActive
 
   if (panel) {
     drawSidePanel(overlayCtx, panel)
-  } else {
+  } else if (showBuildMenu) {
     drawBuildMenu(overlayCtx)
   }
+
   sidePanelDirty = false
 }
 
@@ -1286,15 +1320,16 @@ function resetClientWorldState(): void {
   menuScrollOffset = 0
   ghostState = null
   menuDragActive = false
-  pendingMenuDragItem = null
   currentPhase = 'build'
+  mouseOverOverlay = false
+  currentPanelSide = 'right'
 
   bgCtx.clearRect(0, 0, backgroundCanvas.width, backgroundCanvas.height)
   fgCtx.clearRect(0, 0, foregroundCanvas.width, foregroundCanvas.height)
   overlayCtx.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height)
-  overlayCanvas.style.display = 'none'
   hudCtx.clearRect(0, 0, hudCanvas.width, hudCanvas.height)
   fpsCtx.clearRect(0, 0, fpsCanvas.width, fpsCanvas.height)
+  applyOverlayPosition()
 }
 
 function applyWorldDelta(delta: WorldDelta): void {
@@ -1455,10 +1490,19 @@ foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   const sample = eventToCanvasSample(event)
   updateEdgeHover(sample)
 
-  // Left-click with a pending ghost: pick it up and resume dragging.
+  // While a ghost is pending, left-click either picks it up (on the ghost) or
+  // cancels it (anywhere else on the canvas).
   if (event.button === 0 && ghostState?.pending) {
-    ghostState.pending = false
-    menuDragActive = true
+    const [gx, gy] = worldToCanvas(ghostState.worldX, ghostState.worldY)
+    const hitRadius = worldLengthToCanvas(ghostState.appearance.radius) * 2
+    const dx = sample.canvasX - gx
+    const dy = sample.canvasY - gy
+    if (dx * dx + dy * dy <= hitRadius * hitRadius) {
+      ghostState.pending = false
+      menuDragActive = true
+    } else {
+      ghostState = null
+    }
     invalidateSidePanel()
     return
   }
@@ -1492,26 +1536,41 @@ foregroundCanvas.addEventListener('mousemove', (event: MouseEvent) => {
   scheduleDragMoveFlush()
 })
 
-foregroundCanvas.addEventListener('mouseleave', (event: MouseEvent) => {
-  if (event.relatedTarget === overlayCanvas) return
-  setEdgeHoverSide(null)
+foregroundCanvas.addEventListener('mouseleave', () => {
+  // Do NOT clear edgeHoverSide here — moving off the canvas edge (e.g. towards
+  // the panel or outside the viewport) should keep the panel visible. Only
+  // moving to the canvas interior clears it (handled in updateEdgeHover via
+  // mousemove). The overlay's own mouseleave handler clears it when appropriate.
 })
 
 overlayCanvas.addEventListener('mouseenter', () => {
-  if (menuDragActive || ghostState || currentPhase !== 'build') return
-  if (edgeHoverSide === null) setEdgeHoverSide('right')
+  mouseOverOverlay = true
+  applyOverlayPosition()
 })
 
-overlayCanvas.addEventListener('mouseleave', () => {
-  if (findSelectedTower()) return
-  setEdgeHoverSide(null)
+overlayCanvas.addEventListener('mouseleave', (event: MouseEvent) => {
+  mouseOverOverlay = false
+  // Only close the panel when the mouse re-enters the foreground canvas
+  // (i.e. moves away from the edge, back into the game area). Leaving to
+  // anywhere else (outside the viewport, browser chrome) keeps it open.
+  const toFg = event.relatedTarget === foregroundCanvas
+  if (toFg && !findSelectedTower() && !ghostState?.pending) {
+    setEdgeHoverSide(null)
+  } else {
+    // Mouse left to somewhere other than the fg canvas interior (outside the
+    // viewport, browser chrome, etc.). Keep the panel peeking so it does not
+    // vanish when the user moves the cursor slightly off the page. If the side
+    // was only determined by an auto-panel (edgeHoverSide is null), anchor it
+    // to the current panel side so the peek position is correct.
+    if (edgeHoverSide === null) edgeHoverSide = currentPanelSide
+    applyOverlayPosition()
+  }
 })
 
 window.addEventListener('mouseup', (event: MouseEvent) => {
   // Handle menu drag commit/cancel.
   if (menuDragActive) {
     menuDragActive = false
-    pendingMenuDragItem = null
     if (ghostState) {
       const fgRect = foregroundCanvas.getBoundingClientRect()
       const ovRect = overlayCanvas.getBoundingClientRect()
@@ -1542,25 +1601,18 @@ window.addEventListener('mouseup', (event: MouseEvent) => {
   if (wasDragging) sendCanvasMsg('dragend', sample)
 })
 
-foregroundCanvas.addEventListener('dblclick', (event: MouseEvent) => {
-  if (!ghostState?.pending) return
-  const sample = eventToCanvasSample(event)
-  const entityName = ghostState.entityName
-  ghostState = null
-  menuDragActive = false
-  invalidateSidePanel()
-  sendCanvasMsg('click', sample, 'spawn', [entityName])
-})
-
 foregroundCanvas.addEventListener('contextmenu', (event: MouseEvent) => {
   event.preventDefault()
-  if (ghostState) {
+  const sample = eventToCanvasSample(event)
+  if (ghostState?.pending) {
+    // Right-click while ghost is pending: place the tower.
+    const entityName = ghostState.entityName
     ghostState = null
     menuDragActive = false
     invalidateSidePanel()
+    sendCanvasMsg('click', sample, 'spawn', [entityName])
     return
   }
-  const sample = eventToCanvasSample(event)
   updateEdgeHover(sample)
   sendCanvasMsg('click', withPointerButton(sample, 2, 2))
 })
@@ -1603,33 +1655,19 @@ document.addEventListener('contextmenu', (event: MouseEvent) => {
     event.preventDefault()
     ghostState = null
     menuDragActive = false
-    pendingMenuDragItem = null
     invalidateSidePanel()
   }
 })
 
-// Track ghost position globally during a menu drag. The ghost is created here
-// on the first move so it never appears at the canvas origin.
+// Track ghost world position globally during a menu drag.
 window.addEventListener('mousemove', (event: MouseEvent) => {
-  if (!menuDragActive) return
+  if (!menuDragActive || !ghostState) return
   const rect = foregroundCanvas.getBoundingClientRect()
   const canvasX = (event.clientX - rect.left) * (foregroundCanvas.width / rect.width)
   const canvasY = (event.clientY - rect.top) * (foregroundCanvas.height / rect.height)
   const [worldX, worldY] = canvasToWorld(canvasX, canvasY)
-  if (!ghostState && pendingMenuDragItem) {
-    const item = pendingMenuDragItem
-    ghostState = {
-      worldX,
-      worldY,
-      entityName: item.entityName,
-      appearance: appearanceToRender(item.appearance),
-      attackRadius: item.appearance.attackRadius,
-      pending: false,
-    }
-  } else if (ghostState) {
-    ghostState.worldX = worldX
-    ghostState.worldY = worldY
-  }
+  ghostState.worldX = worldX
+  ghostState.worldY = worldY
 })
 
 // Overlay mousedown: select a build menu cell and arm a drag (ghost appears on
@@ -1649,18 +1687,43 @@ overlayCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   const localX = (event.clientX - rect.left) * (overlayCanvas.width / rect.width)
   const localY = (event.clientY - rect.top) * (overlayCanvas.height / rect.height)
 
-  if (localY < bodyTop) return
+  if (localY < bodyTop) {
+    // Click above grid area (title bar) — deselect.
+    selectedMenuIndex = null
+    invalidateSidePanel()
+    return
+  }
   const col = Math.floor(localX / cellSize)
   const row = Math.floor((localY - bodyTop) / cellSize)
   if (col < 0 || col >= MENU_COLS) return
 
   const index = menuScrollOffset * MENU_COLS + row * MENU_COLS + col
-  if (index >= defenderMenuItems.length) return
+  if (index >= defenderMenuItems.length) {
+    // Click below last populated cell — deselect.
+    selectedMenuIndex = null
+    invalidateSidePanel()
+    return
+  }
 
   selectedMenuIndex = index
-  pendingMenuDragItem = defenderMenuItems[index]
   menuDragActive = true
-  ghostState = null  // created on first mousemove
+
+  // Create the ghost immediately at the current mouse position so it appears
+  // as soon as the mouse enters the foreground canvas, with no lag.
+  const item = defenderMenuItems[index]
+  const fgRect = foregroundCanvas.getBoundingClientRect()
+  const fgCanvasX = (event.clientX - fgRect.left) * (foregroundCanvas.width / fgRect.width)
+  const fgCanvasY = (event.clientY - fgRect.top) * (foregroundCanvas.height / fgRect.height)
+  const [worldX, worldY] = canvasToWorld(fgCanvasX, fgCanvasY)
+  ghostState = {
+    worldX,
+    worldY,
+    entityName: item.entityName,
+    displayName: item.displayName,
+    appearance: appearanceToRender(item.appearance),
+    attackRadius: item.appearance.attackRadius,
+    pending: false,
+  }
   invalidateSidePanel()
 })
 

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -1049,17 +1049,12 @@ function getSelectedDefenderPanelModel(): SidePanelModel | null {
 
   return {
     side,
-    title: 'Defender Selected',
+    title: selectedDefenderSummary.displayName,
     lines: [
-      selectedDefenderSummary.displayName,
       selectedDefenderSummary.flavorText,
       '',
-      `Glyph ${selectedDefenderSummary.appearance.glyph === 0 ? '?' : String.fromCodePoint(selectedDefenderSummary.appearance.glyph)}`,
       `Body radius ${formatPanelNumber(selectedDefenderSummary.appearance.radius)}`,
       `Attack radius ${formatPanelNumber(selectedDefenderSummary.appearance.attackRadius)}`,
-      '',
-      `Phase ${phaseEl?.textContent ?? '--'}`,
-      `Resources $${resources}`,
       'Left click empty space to dismiss',
     ],
   }
@@ -1113,14 +1108,18 @@ function drawRoundedPanelPath(
 
 // Draw a textual side panel such as defender inspection or pending placement.
 function drawSidePanel(ctx: CanvasRenderingContext2D, panel: SidePanelModel): void {
-  const x = 0
-  const y = 0
   const width = overlayCanvas.width
   const height = overlayCanvas.height
   const panelScale = Math.min(
     foregroundCanvas.width / DEFAULT_CANVAS_W,
     foregroundCanvas.height / DEFAULT_CANVAS_H,
   )
+  const panelBorderWidth = Math.max(2, 2.5 * panelScale)
+  const panelInset = panelBorderWidth * 0.5
+  const x = panelInset
+  const y = panelInset
+  const panelWidth = Math.max(width - panelBorderWidth, 1)
+  const panelHeight = Math.max(height - panelBorderWidth, 1)
   const cornerRadius = SIDE_PANEL_RADIUS * panelScale
   const textMargin = SIDE_PANEL_TEXT_MARGIN * panelScale
   const titleFontSize = 24 * panelScale
@@ -1130,17 +1129,43 @@ function drawSidePanel(ctx: CanvasRenderingContext2D, panel: SidePanelModel): vo
   const dividerY = 56 * panelScale
   const bodyTop = 74 * panelScale
   const textX = x + textMargin
-  const textWidth = width - textMargin * 2
+  const textWidth = panelWidth - textMargin * 2
 
   ctx.save()
-  drawRoundedPanelPath(ctx, x, y, width, height, cornerRadius)
-  const gradient = ctx.createLinearGradient(x, y, x + width, y + height)
+  drawRoundedPanelPath(ctx, x, y, panelWidth, panelHeight, cornerRadius)
+  const gradient = ctx.createLinearGradient(x, y, x + panelWidth, y + panelHeight)
   gradient.addColorStop(0, 'rgba(12, 18, 26, 0.92)')
   gradient.addColorStop(1, 'rgba(18, 27, 39, 0.84)')
   ctx.fillStyle = gradient
   ctx.fill()
-  ctx.strokeStyle = 'rgba(255, 255, 255, 0.16)'
-  ctx.lineWidth = Math.max(1, 1.5 * panelScale)
+
+  // Fill the tiny attached bottom-corner gap that results from insetting the
+  // shell for stroke rendering while still keeping the panel visually flush
+  // against the viewport edge.
+  ctx.fillStyle = 'rgba(18, 27, 39, 0.84)'
+  if (panel.side === 'left') {
+    ctx.beginPath()
+    ctx.moveTo(0, height)
+    ctx.lineTo(0, height - cornerRadius - panelInset)
+    ctx.lineTo(x + panelBorderWidth, height - cornerRadius - panelInset)
+    ctx.lineTo(x + panelBorderWidth, height)
+    ctx.closePath()
+    ctx.fill()
+  } else {
+    ctx.beginPath()
+    ctx.moveTo(width, height)
+    ctx.lineTo(width, height - cornerRadius - panelInset)
+    ctx.lineTo(width - x - panelBorderWidth, height - cornerRadius - panelInset)
+    ctx.lineTo(width - x - panelBorderWidth, height)
+    ctx.closePath()
+    ctx.fill()
+  }
+
+  drawRoundedPanelPath(ctx, x, y, panelWidth, panelHeight, cornerRadius)
+  ctx.strokeStyle = 'rgba(255, 242, 63, 0.85)'
+  ctx.lineWidth = panelBorderWidth
+  ctx.lineJoin = 'round'
+  ctx.lineCap = 'round'
   ctx.stroke()
 
   ctx.fillStyle = 'rgba(255, 255, 255, 0.96)'
@@ -1182,34 +1207,63 @@ function drawBuildMenu(ctx: CanvasRenderingContext2D): void {
   )
   const width = overlayCanvas.width
   const height = overlayCanvas.height
+  const panelBorderWidth = Math.max(2, 2.5 * panelScale)
+  const panelInset = panelBorderWidth * 0.5
+  const x = panelInset
+  const y = panelInset
+  const panelWidth = Math.max(width - panelBorderWidth, 1)
+  const panelHeight = Math.max(height - panelBorderWidth, 1)
   const cornerRadius = SIDE_PANEL_RADIUS * panelScale
   const titleFontSize = 24 * panelScale
   const titleTop = 20 * panelScale
   const dividerY = 56 * panelScale
   const bodyTop = 70 * panelScale
   const textMargin = SIDE_PANEL_TEXT_MARGIN * panelScale
-  const textWidth = width - textMargin * 2
+  const textWidth = panelWidth - textMargin * 2
 
   ctx.save()
-  drawRoundedPanelPath(ctx, 0, 0, width, height, cornerRadius)
-  const gradient = ctx.createLinearGradient(0, 0, width, height)
+  drawRoundedPanelPath(ctx, x, y, panelWidth, panelHeight, cornerRadius)
+  const gradient = ctx.createLinearGradient(x, y, x + panelWidth, y + panelHeight)
   gradient.addColorStop(0, 'rgba(12, 18, 26, 0.92)')
   gradient.addColorStop(1, 'rgba(18, 27, 39, 0.84)')
   ctx.fillStyle = gradient
   ctx.fill()
-  ctx.strokeStyle = 'rgba(255, 255, 255, 0.16)'
-  ctx.lineWidth = Math.max(1, 1.5 * panelScale)
+
+  ctx.fillStyle = 'rgba(18, 27, 39, 0.84)'
+  if (currentPanelSide === 'left') {
+    ctx.beginPath()
+    ctx.moveTo(0, height)
+    ctx.lineTo(0, height - cornerRadius - panelInset)
+    ctx.lineTo(x + panelBorderWidth, height - cornerRadius - panelInset)
+    ctx.lineTo(x + panelBorderWidth, height)
+    ctx.closePath()
+    ctx.fill()
+  } else {
+    ctx.beginPath()
+    ctx.moveTo(width, height)
+    ctx.lineTo(width, height - cornerRadius - panelInset)
+    ctx.lineTo(width - x - panelBorderWidth, height - cornerRadius - panelInset)
+    ctx.lineTo(width - x - panelBorderWidth, height)
+    ctx.closePath()
+    ctx.fill()
+  }
+
+  drawRoundedPanelPath(ctx, x, y, panelWidth, panelHeight, cornerRadius)
+  ctx.strokeStyle = 'rgba(255, 242, 63, 0.85)'
+  ctx.lineWidth = panelBorderWidth
+  ctx.lineJoin = 'round'
+  ctx.lineCap = 'round'
   ctx.stroke()
 
   ctx.fillStyle = 'rgba(255, 255, 255, 0.96)'
   ctx.font = `bold ${titleFontSize}px monospace`
   ctx.textBaseline = 'top'
-  ctx.fillText('Select Defender', textMargin, titleTop, textWidth)
+  ctx.fillText('Select Defender', x + textMargin, y + titleTop, textWidth)
 
   ctx.strokeStyle = 'rgba(255, 255, 255, 0.12)'
   ctx.beginPath()
-  ctx.moveTo(textMargin, dividerY)
-  ctx.lineTo(textMargin + textWidth, dividerY)
+  ctx.moveTo(x + textMargin, y + dividerY)
+  ctx.lineTo(x + textMargin + textWidth, y + dividerY)
   ctx.stroke()
 
   const cellSize = Math.floor((width - 2) / MENU_COLS)
@@ -1223,8 +1277,8 @@ function drawBuildMenu(ctx: CanvasRenderingContext2D): void {
     const item = visibleItems[i]
     const col = i % MENU_COLS
     const row = Math.floor(i / MENU_COLS)
-    const cellX = 1 + col * cellSize
-    const cellY = bodyTop + row * cellSize
+    const cellX = x + 1 + col * cellSize
+    const cellY = y + bodyTop + row * cellSize
     const isSelected = (startIndex + i) === selectedMenuIndex
 
     ctx.fillStyle = isSelected

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -1,10 +1,12 @@
 import type {
   ClientMsg,
+  DefenderMenuItem,
   EntityAppearance,
   EntityPosition,
   EntityUpsert,
   EntityVisualEffects,
   ServerMsg,
+  UiCanvasMsg,
   WorldDelta,
 } from './types.js'
 
@@ -23,6 +25,16 @@ interface RenderAppearance {
   radius: number
   fg: RenderColor
   bg: RenderColor
+  attackRadius: number
+}
+
+interface GhostState {
+  worldX: number
+  worldY: number
+  entityName: string
+  appearance: RenderAppearance
+  attackRadius: number  // world units, from Appearance.attackRadius
+  pending: boolean      // true = dropped on map, awaiting confirmation click
 }
 
 interface RenderVisualEffects {
@@ -72,6 +84,7 @@ const DEFAULT_RENDER_APPEARANCE: RenderAppearance = {
   radius: 5,
   fg: { css: 'rgba(255, 255, 255, 1)', alpha: 1 },
   bg: { css: 'rgba(0, 0, 0, 1)', alpha: 1 },
+  attackRadius: 0,
 }
 
 const TRANSPARENT_RENDER_COLOR: RenderColor = {
@@ -304,8 +317,17 @@ let pendingDragMove: CanvasPointerSample | null = null
 let dragMoveFrameRequested = false
 let sidePanelDirty = true
 let edgeHoverSide: PanelSide | null = null
+let defenderMenuItems: DefenderMenuItem[] = []
+let selectedMenuIndex: number | null = null
+let menuScrollOffset = 0
+let ghostState: GhostState | null = null
+let menuDragActive = false
+let pendingMenuDragItem: DefenderMenuItem | null = null
+let currentPhase = 'build'
 
 const SIDE_PANEL_TRIGGER_PX = 48
+const MENU_COLS = 2
+const MENU_VISIBLE_ROWS = 4
 const SIDE_PANEL_RADIUS = 18
 const SIDE_PANEL_LINE_HEIGHT = 22
 const SIDE_PANEL_TEXT_MARGIN = 28
@@ -349,6 +371,7 @@ function renderInterpolated(now: number): void {
     const radius = worldLengthToCanvas(lerp(prevApp.radius, e.app.radius, t))
     drawEntity(x, y, radius, e.app, e.fx, now)
   }
+  drawGhost()
 }
 
 function updateHudOverlay(): void {
@@ -606,6 +629,7 @@ function appearanceToRender(app: EntityAppearance): RenderAppearance {
     radius: app.radius,
     fg: packedRgbaToRenderColor(app.fg),
     bg: packedRgbaToRenderColor(app.bg),
+    attackRadius: app.attackRadius,
   }
 }
 
@@ -693,6 +717,10 @@ function panelSideFromCanvasX(canvasX: number): PanelSide | null {
 }
 
 function updateEdgeHover(sample: CanvasPointerSample): void {
+  if (menuDragActive || ghostState || currentPhase !== 'build') {
+    setEdgeHoverSide(null)
+    return
+  }
   setEdgeHoverSide(panelSideFromCanvasX(sample.canvasX))
 }
 
@@ -758,27 +786,23 @@ function getSelectedTowerPanelModel(): SidePanelModel | null {
   }
 }
 
-function getHoverPanelModel(): SidePanelModel | null {
-  if (!edgeHoverSide) return null
-
+function getPendingGhostPanelModel(): SidePanelModel | null {
+  if (!ghostState?.pending) return null
   return {
-    side: edgeHoverSide,
-    title: 'Build Panel',
+    side: 'right',
+    title: 'Place Tower',
     lines: [
-      `Phase ${phaseEl?.textContent ?? '--'}`,
-      `Lives ${lives}`,
-      `Resources $${resources}`,
+      ghostState.entityName,
       '',
-      'Double click to place a tower',
-      'Left click to select a tower',
-      'Right click to flash an entity',
-      'Use Start Wave to begin the next push',
+      'Double-click to place',
+      'Left-click to move',
+      'Right-click to cancel',
     ],
   }
 }
 
 function getSidePanelModel(): SidePanelModel | null {
-  return getSelectedTowerPanelModel() ?? getHoverPanelModel()
+  return getPendingGhostPanelModel() ?? getSelectedTowerPanelModel()
 }
 
 function drawRoundedPanelPath(
@@ -865,12 +889,184 @@ function drawSidePanel(ctx: CanvasRenderingContext2D, panel: SidePanelModel): vo
   ctx.restore()
 }
 
+function drawBuildMenu(ctx: CanvasRenderingContext2D): void {
+  const panelScale = Math.min(
+    foregroundCanvas.width / DEFAULT_CANVAS_W,
+    foregroundCanvas.height / DEFAULT_CANVAS_H,
+  )
+  const width = overlayCanvas.width
+  const height = overlayCanvas.height
+  const cornerRadius = SIDE_PANEL_RADIUS * panelScale
+  const titleFontSize = 24 * panelScale
+  const titleTop = 20 * panelScale
+  const dividerY = 56 * panelScale
+  const bodyTop = 70 * panelScale
+  const textMargin = SIDE_PANEL_TEXT_MARGIN * panelScale
+  const textWidth = width - textMargin * 2
+
+  ctx.save()
+  drawRoundedPanelPath(ctx, 0, 0, width, height, cornerRadius)
+  const gradient = ctx.createLinearGradient(0, 0, width, height)
+  gradient.addColorStop(0, 'rgba(12, 18, 26, 0.92)')
+  gradient.addColorStop(1, 'rgba(18, 27, 39, 0.84)')
+  ctx.fillStyle = gradient
+  ctx.fill()
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.16)'
+  ctx.lineWidth = Math.max(1, 1.5 * panelScale)
+  ctx.stroke()
+
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.96)'
+  ctx.font = `bold ${titleFontSize}px monospace`
+  ctx.textBaseline = 'top'
+  ctx.fillText('Build Menu', textMargin, titleTop, textWidth)
+
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.12)'
+  ctx.beginPath()
+  ctx.moveTo(textMargin, dividerY)
+  ctx.lineTo(textMargin + textWidth, dividerY)
+  ctx.stroke()
+
+  const cellSize = Math.floor((width - 2) / MENU_COLS)
+  const startIndex = menuScrollOffset * MENU_COLS
+  const visibleItems = defenderMenuItems.slice(
+    startIndex,
+    startIndex + MENU_VISIBLE_ROWS * MENU_COLS,
+  )
+
+  for (let i = 0; i < visibleItems.length; i++) {
+    const item = visibleItems[i]
+    const col = i % MENU_COLS
+    const row = Math.floor(i / MENU_COLS)
+    const cellX = 1 + col * cellSize
+    const cellY = bodyTop + row * cellSize
+    const isSelected = (startIndex + i) === selectedMenuIndex
+
+    ctx.fillStyle = isSelected
+      ? 'rgba(255, 242, 182, 0.18)'
+      : 'rgba(255, 255, 255, 0.06)'
+    ctx.fillRect(cellX, cellY, cellSize, cellSize)
+
+    if (isSelected) {
+      ctx.strokeStyle = 'rgba(255, 242, 63, 0.85)'
+      ctx.lineWidth = 2 * panelScale
+      ctx.strokeRect(cellX + 1, cellY + 1, cellSize - 2, cellSize - 2)
+    }
+
+    const app = appearanceToRender(item.appearance)
+    const circleX = cellX + cellSize / 2
+    const circleY = cellY + cellSize * 0.40
+    const circleR = Math.min(
+      worldLengthToCanvas(app.radius) * 2,
+      cellSize * 0.30,
+    )
+
+    if (app.bg.alpha !== 0) drawFilledCircleOnContext(ctx, circleX, circleY, circleR, app.bg)
+    if (app.fg.alpha !== 0) {
+      drawStrokedCircleOnContext(
+        ctx,
+        circleX,
+        circleY,
+        Math.max(circleR - getEntityBorderWidth(circleR) * 0.5, 0),
+        app.fg,
+        getEntityBorderWidth(circleR),
+      )
+    }
+    if (app.glyph && app.fg.alpha !== 0) {
+      drawGlyphOnContext(ctx, app.glyph, circleX, circleY, circleR, app.fg)
+    }
+
+    const nameFontSize = Math.max(9, 11 * panelScale)
+    ctx.font = `${nameFontSize}px monospace`
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'alphabetic'
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.85)'
+    ctx.fillText(item.displayName, circleX, cellY + cellSize * 0.76, cellSize - 4)
+    ctx.fillStyle = 'rgba(181, 201, 224, 0.85)'
+    ctx.fillText(`$${item.resourceCost}`, circleX, cellY + cellSize * 0.92, cellSize - 4)
+  }
+
+  ctx.restore()
+}
+
+function drawGhost(): void {
+  if (!ghostState) return
+  const [x, y] = worldToCanvas(ghostState.worldX, ghostState.worldY)
+  const radius = worldLengthToCanvas(ghostState.appearance.radius)
+  const attackPx = worldLengthToCanvas(ghostState.attackRadius)
+
+  fgCtx.save()
+  fgCtx.globalAlpha = ghostState.pending ? 0.85 : 0.55
+
+  if (ghostState.appearance.bg.alpha !== 0) {
+    drawFilledCircleOnContext(fgCtx, x, y, radius, ghostState.appearance.bg)
+  }
+  if (ghostState.appearance.fg.alpha !== 0) {
+    drawStrokedCircleOnContext(
+      fgCtx,
+      x,
+      y,
+      Math.max(radius - getEntityBorderWidth(radius) * 0.5, 0),
+      ghostState.appearance.fg,
+      getEntityBorderWidth(radius),
+    )
+    if (ghostState.appearance.glyph) {
+      drawGlyphOnContext(
+        fgCtx,
+        ghostState.appearance.glyph,
+        x,
+        y,
+        radius,
+        ghostState.appearance.fg,
+      )
+    }
+  }
+
+  if (attackPx > 0) {
+    fgCtx.globalAlpha = ghostState.pending ? 0.55 : 0.35
+    const rangeColor: RenderColor = {
+      css: ghostState.pending
+        ? 'rgba(255, 0, 127, 0.6)'
+        : 'rgba(255, 255, 100, 0.4)',
+      alpha: ghostState.pending ? 0.6 : 0.4,
+    }
+    drawFilledCircleOnContext(fgCtx, x, y, attackPx, rangeColor)
+  }
+
+  if (ghostState.pending) {
+    fgCtx.globalAlpha = 0.9
+    const lineWidth = Math.max(3, radius * 0.35)
+    drawStrokedCircleOnContext(
+      fgCtx,
+      x,
+      y,
+      radius + lineWidth * 0.5,
+      { css: 'rgba(255, 242, 63, 0.9)', alpha: 0.9 },
+      lineWidth,
+    )
+  }
+
+  fgCtx.restore()
+}
+
 function updateSidePanelOverlay(): void {
   if (!sidePanelDirty) return
 
+  // Hide everything while a drag is actively in progress.
+  if (menuDragActive) {
+    overlayCtx.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height)
+    overlayCanvas.style.display = 'none'
+    sidePanelDirty = false
+    return
+  }
+
   const panel = getSidePanelModel()
+  const showBuildMenu =
+    edgeHoverSide !== null &&
+    defenderMenuItems.length > 0 &&
+    currentPhase === 'build'
   overlayCtx.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height)
-  if (!panel) {
+
+  if (!panel && !showBuildMenu) {
     overlayCanvas.style.display = 'none'
     sidePanelDirty = false
     return
@@ -879,11 +1075,17 @@ function updateSidePanelOverlay(): void {
   overlayCanvas.style.display = 'block'
   const foregroundCssWidth = foregroundCanvas.clientWidth
   const overlayCssWidth = overlayCanvas.clientWidth
-  overlayCanvas.style.left = panel.side === 'left'
+  const side: PanelSide = edgeHoverSide ?? (panel?.side ?? 'right')
+  overlayCanvas.style.left = side === 'left'
     ? '0'
     : `${Math.max(foregroundCssWidth - overlayCssWidth, 0)}px`
   overlayCanvas.style.right = ''
-  drawSidePanel(overlayCtx, panel)
+
+  if (panel) {
+    drawSidePanel(overlayCtx, panel)
+  } else {
+    drawBuildMenu(overlayCtx)
+  }
   sidePanelDirty = false
 }
 
@@ -936,8 +1138,13 @@ function sendClientMsg(msg: ClientMsg): void {
   ws.send(JSON.stringify(msg))
 }
 
-function sendCanvasMsg(eventName: 'click' | 'dblclick' | 'contextmenu' | 'dragstart' | 'dragmove' | 'dragend', sample: CanvasPointerSample): void {
-  sendClientMsg({
+function sendCanvasMsg(
+  eventName: 'click' | 'dblclick' | 'contextmenu' | 'dragstart' | 'dragmove' | 'dragend',
+  sample: CanvasPointerSample,
+  command?: string,
+  parameters?: string[],
+): void {
+  const msg: UiCanvasMsg = {
     type: 'ui_canvas',
     seq: nextClientSeq++,
     event: eventName,
@@ -951,7 +1158,10 @@ function sendCanvasMsg(eventName: 'click' | 'dblclick' | 'contextmenu' | 'dragst
     ctrl: sample.ctrl,
     alt: sample.alt,
     meta: sample.meta,
-  })
+  }
+  if (command) msg.command = command
+  if (parameters?.length) msg.parameters = parameters
+  sendClientMsg(msg)
 }
 
 function flushPendingDragMove(): void {
@@ -1071,6 +1281,13 @@ function resetClientWorldState(): void {
   hudDirty = true
   sidePanelDirty = true
   edgeHoverSide = null
+  defenderMenuItems = []
+  selectedMenuIndex = null
+  menuScrollOffset = 0
+  ghostState = null
+  menuDragActive = false
+  pendingMenuDragItem = null
+  currentPhase = 'build'
 
   bgCtx.clearRect(0, 0, backgroundCanvas.width, backgroundCanvas.height)
   fgCtx.clearRect(0, 0, foregroundCanvas.width, foregroundCanvas.height)
@@ -1104,7 +1321,8 @@ function applyWorldDelta(delta: WorldDelta): void {
   invalidateSidePanel()
   setTextIfElement(livesEl, String(delta.lives))
   setTextIfElement(resourcesEl, String(delta.resources))
-  setTextIfElement(phaseEl, getDeltaPhase(delta))
+  currentPhase = getDeltaPhase(delta)
+  setTextIfElement(phaseEl, currentPhase)
 }
 
 // --- Message validation ---
@@ -1188,6 +1406,7 @@ ws.onmessage = (event: MessageEvent<string>) => {
       break
     case 'world_snapshot':
       resetClientWorldState()
+      defenderMenuItems = parsed.defenderMenu
       drawBackground(parsed.mapDesign.paths)
       applyWorldDelta(parsed.delta)
       break
@@ -1235,6 +1454,15 @@ if (typeof ResizeObserver !== 'undefined') {
 foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   const sample = eventToCanvasSample(event)
   updateEdgeHover(sample)
+
+  // Left-click with a pending ghost: pick it up and resume dragging.
+  if (event.button === 0 && ghostState?.pending) {
+    ghostState.pending = false
+    menuDragActive = true
+    invalidateSidePanel()
+    return
+  }
+
   canvasPointerState = {
     button: sample.button,
     buttons: sample.buttons,
@@ -1270,8 +1498,8 @@ foregroundCanvas.addEventListener('mouseleave', (event: MouseEvent) => {
 })
 
 overlayCanvas.addEventListener('mouseenter', () => {
-  const panel = getSidePanelModel()
-  if (panel) setEdgeHoverSide(panel.side)
+  if (menuDragActive || ghostState || currentPhase !== 'build') return
+  if (edgeHoverSide === null) setEdgeHoverSide('right')
 })
 
 overlayCanvas.addEventListener('mouseleave', () => {
@@ -1280,6 +1508,29 @@ overlayCanvas.addEventListener('mouseleave', () => {
 })
 
 window.addEventListener('mouseup', (event: MouseEvent) => {
+  // Handle menu drag commit/cancel.
+  if (menuDragActive) {
+    menuDragActive = false
+    pendingMenuDragItem = null
+    if (ghostState) {
+      const fgRect = foregroundCanvas.getBoundingClientRect()
+      const ovRect = overlayCanvas.getBoundingClientRect()
+      const overOverlay =
+        event.clientX >= ovRect.left && event.clientX <= ovRect.right &&
+        event.clientY >= ovRect.top  && event.clientY <= ovRect.bottom
+      const overFg =
+        event.clientX >= fgRect.left && event.clientX <= fgRect.right &&
+        event.clientY >= fgRect.top  && event.clientY <= fgRect.bottom
+      if (overFg && !overOverlay) {
+        ghostState.pending = true
+      } else {
+        ghostState = null
+      }
+    }
+    invalidateSidePanel()
+    return
+  }
+
   if (!canvasPointerState) return
   const sample = withPointerButton(
     eventToCanvasSample(event),
@@ -1291,18 +1542,29 @@ window.addEventListener('mouseup', (event: MouseEvent) => {
   if (wasDragging) sendCanvasMsg('dragend', sample)
 })
 
+foregroundCanvas.addEventListener('dblclick', (event: MouseEvent) => {
+  if (!ghostState?.pending) return
+  const sample = eventToCanvasSample(event)
+  const entityName = ghostState.entityName
+  ghostState = null
+  menuDragActive = false
+  invalidateSidePanel()
+  sendCanvasMsg('click', sample, 'spawn', [entityName])
+})
+
 foregroundCanvas.addEventListener('contextmenu', (event: MouseEvent) => {
   event.preventDefault()
+  if (ghostState) {
+    ghostState = null
+    menuDragActive = false
+    invalidateSidePanel()
+    return
+  }
   const sample = eventToCanvasSample(event)
   updateEdgeHover(sample)
   sendCanvasMsg('click', withPointerButton(sample, 2, 2))
 })
 
-foregroundCanvas.addEventListener('dblclick', (event: MouseEvent) => {
-  const sample = eventToCanvasSample(event)
-  updateEdgeHover(sample)
-  sendCanvasMsg('dblclick', sample)
-})
 
 document.addEventListener('click', (event: MouseEvent) => {
   const target = event.target
@@ -1334,6 +1596,84 @@ document.addEventListener('submit', (event: SubmitEvent) => {
   event.preventDefault()
   sendUiAction(action, formDataToFields(new FormData(target)))
 })
+
+// Cancel ghost on right-click outside the foreground canvas.
+document.addEventListener('contextmenu', (event: MouseEvent) => {
+  if (ghostState && event.target !== foregroundCanvas) {
+    event.preventDefault()
+    ghostState = null
+    menuDragActive = false
+    pendingMenuDragItem = null
+    invalidateSidePanel()
+  }
+})
+
+// Track ghost position globally during a menu drag. The ghost is created here
+// on the first move so it never appears at the canvas origin.
+window.addEventListener('mousemove', (event: MouseEvent) => {
+  if (!menuDragActive) return
+  const rect = foregroundCanvas.getBoundingClientRect()
+  const canvasX = (event.clientX - rect.left) * (foregroundCanvas.width / rect.width)
+  const canvasY = (event.clientY - rect.top) * (foregroundCanvas.height / rect.height)
+  const [worldX, worldY] = canvasToWorld(canvasX, canvasY)
+  if (!ghostState && pendingMenuDragItem) {
+    const item = pendingMenuDragItem
+    ghostState = {
+      worldX,
+      worldY,
+      entityName: item.entityName,
+      appearance: appearanceToRender(item.appearance),
+      attackRadius: item.appearance.attackRadius,
+      pending: false,
+    }
+  } else if (ghostState) {
+    ghostState.worldX = worldX
+    ghostState.worldY = worldY
+  }
+})
+
+// Overlay mousedown: select a build menu cell and arm a drag (ghost appears on
+// first mousemove so it never flashes at the canvas origin).
+overlayCanvas.addEventListener('mousedown', (event: MouseEvent) => {
+  if (event.button !== 0 || defenderMenuItems.length === 0) return
+  if (currentPhase !== 'build') return
+  event.preventDefault()
+
+  const panelScale = Math.min(
+    foregroundCanvas.width / DEFAULT_CANVAS_W,
+    foregroundCanvas.height / DEFAULT_CANVAS_H,
+  )
+  const cellSize = Math.floor((overlayCanvas.width - 2) / MENU_COLS)
+  const bodyTop = 70 * panelScale
+  const rect = overlayCanvas.getBoundingClientRect()
+  const localX = (event.clientX - rect.left) * (overlayCanvas.width / rect.width)
+  const localY = (event.clientY - rect.top) * (overlayCanvas.height / rect.height)
+
+  if (localY < bodyTop) return
+  const col = Math.floor(localX / cellSize)
+  const row = Math.floor((localY - bodyTop) / cellSize)
+  if (col < 0 || col >= MENU_COLS) return
+
+  const index = menuScrollOffset * MENU_COLS + row * MENU_COLS + col
+  if (index >= defenderMenuItems.length) return
+
+  selectedMenuIndex = index
+  pendingMenuDragItem = defenderMenuItems[index]
+  menuDragActive = true
+  ghostState = null  // created on first mousemove
+  invalidateSidePanel()
+})
+
+// Scroll the build menu with the mouse wheel.
+overlayCanvas.addEventListener('wheel', (event: WheelEvent) => {
+  event.preventDefault()
+  if (defenderMenuItems.length === 0) return
+  const totalRows = Math.ceil(defenderMenuItems.length / MENU_COLS)
+  const maxScroll = Math.max(0, totalRows - MENU_VISIBLE_ROWS)
+  menuScrollOffset = Math.max(0, Math.min(maxScroll,
+    menuScrollOffset + (event.deltaY > 0 ? 1 : -1)))
+  invalidateSidePanel()
+}, { passive: false })
 
 updateFullscreenButtonLabel()
 resizeViewport()

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -441,6 +441,14 @@ function isPointerOverPeekActivation(event: MouseEvent): boolean {
   return bounds !== null && isPointInRect(event.clientX, event.clientY, bounds)
 }
 
+function didExitCanvasViaPanelEdge(event: MouseEvent): boolean {
+  const rect = foregroundCanvas.getBoundingClientRect()
+  return (
+    (edgeHoverSide === 'left' && event.clientX <= rect.left) ||
+    (edgeHoverSide === 'right' && event.clientX >= rect.right)
+  )
+}
+
 function getOverlayTransform(
   side: PanelSide,
   level: OverlayLevel,
@@ -1610,11 +1618,15 @@ foregroundCanvas.addEventListener('mousemove', (event: MouseEvent) => {
   scheduleDragMoveFlush()
 })
 
-foregroundCanvas.addEventListener('mouseleave', () => {
-  // Do NOT clear edgeHoverSide here — moving off the canvas edge (e.g. towards
-  // the panel or outside the viewport) should keep the panel visible. Only
-  // moving to the canvas interior clears it (handled in updateEdgeHover via
-  // mousemove). The overlay's own mouseleave handler clears it when appropriate.
+foregroundCanvas.addEventListener('mouseleave', (event: MouseEvent) => {
+  // Fast motion can skip the overlay's peek strip entirely. If the pointer
+  // leaves through the active panel edge, open the panel as though the user
+  // had crossed onto the peeking portion.
+  if (didExitCanvasViaPanelEdge(event)) {
+    mouseOverOverlay = true
+    overlayStayOpen = true
+    applyOverlayPosition()
+  }
 })
 
 overlayCanvas.addEventListener('mouseenter', () => {

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -1135,12 +1135,19 @@ function isServerMsg(value: unknown): value is ServerMsg {
       return typeof v.message === 'string'
     case 'world_delta':
       return isWorldDelta(v)
-    case 'world_snapshot':
+    case 'world_snapshot': {
+      const md = v.mapDesign as Record<string, unknown> | undefined
       return (
-        Array.isArray(v.paths) &&
-        v.paths.every(isPoint) &&
+        !!md &&
+        typeof md === 'object' &&
+        typeof md.backgroundSprite === 'string' &&
+        typeof md.foregroundSprite === 'string' &&
+        Array.isArray(md.paths) &&
+        md.paths.every(isPoint) &&
+        Array.isArray(v.defenderMenu) &&
         isWorldDelta(v.delta)
       )
+    }
     default:
       return false
   }
@@ -1181,7 +1188,7 @@ ws.onmessage = (event: MessageEvent<string>) => {
       break
     case 'world_snapshot':
       resetClientWorldState()
-      drawBackground(parsed.paths)
+      drawBackground(parsed.mapDesign.paths)
       applyWorldDelta(parsed.delta)
       break
   }

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -12,24 +12,29 @@ import type {
   WorldDelta,
 } from './types.js'
 
+// Canvas-friendly color representation derived from packed RGBA wire values.
 interface RenderColor {
   css: string
   alpha: number
 }
 
+// Cached offscreen sprite bitmap plus the origin offset needed to center it.
 interface SpriteCacheEntry {
   canvas: HTMLCanvasElement
   offset: number
 }
 
+// Client-side appearance data derived from `EntityAppearance` and normalized
+// for rendering entities and menu items.
 interface RenderAppearance {
   glyph: string
-  radius: number
+  radius: number // Radius of entity
   fg: RenderColor
   bg: RenderColor
-  attackRadius: number
+  attackRadius: number // Radius of attack
 }
 
+// Local placement-preview state for a defender being dragged or staged to spawn.
 interface GhostState {
   worldX: number
   worldY: number
@@ -38,10 +43,11 @@ interface GhostState {
   appearance: RenderAppearance
   attackRadius: number  // world units, from Appearance.attackRadius
   pending: boolean      // true = dropped on map, awaiting confirmation click
-  placeable: boolean
-  spawnPending: boolean
+  placeable: boolean    // true = can be placed at the current position
+  spawnPending: boolean // true = dropped and clicked, awaiting server confirmation
 }
 
+// Client-side visual effects derived from `EntityVisualEffects`.
 interface RenderVisualEffects {
   selection: RenderColor
   rangeRadius: number
@@ -51,18 +57,22 @@ interface RenderVisualEffects {
   flashStartedAt: number
 }
 
+// Fully materialized render snapshot for one entity id, derived from
+// `EntityUpsert`.
 interface RenderEntityUpsert {
   pos: EntityPosition
   app: RenderAppearance
   fx: RenderVisualEffects
 }
 
+// Pointer bookkeeping for an in-progress foreground-canvas interaction.
 interface CanvasPointerState {
   button: number
   buttons: number
   dragging: boolean
 }
 
+// Mouse event sample expressed in both canvas-space and world-space coordinates.
 interface CanvasPointerSample {
   button: number
   buttons: number
@@ -78,6 +88,7 @@ interface CanvasPointerSample {
 
 type PanelSide = 'left' | 'right'
 
+// Textual content and attachment side for the overlay panel renderer.
 interface SidePanelModel {
   side: PanelSide
   title: string
@@ -108,6 +119,8 @@ const DEFAULT_RENDER_VISUAL_EFFECTS: RenderVisualEffects = {
 
 // --- DOM setup ---
 
+// Look up a required DOM node and fail fast if the page shape does not match
+// what this client expects.
 function requireEl<T extends HTMLElement>(
   id: string,
   type: abstract new (...args: any[]) => T,
@@ -141,6 +154,8 @@ const fgCtx: CanvasRenderingContext2D = maybeFgCtx
 const maybeOverlayCtx = overlayCanvas.getContext('2d')
 if (!maybeOverlayCtx) throw new Error('Could not get 2D overlay canvas context')
 const overlayCtx: CanvasRenderingContext2D = maybeOverlayCtx
+// HUD and FPS are composited from offscreen canvases so they can redraw at
+// their own cadence without forcing the world layer to rebuild extra state.
 const hudCanvas = document.createElement('canvas')
 hudCanvas.width = foregroundCanvas.width
 hudCanvas.height = foregroundCanvas.height
@@ -165,6 +180,7 @@ const DEFAULT_CANVAS_H = 540
 const DEFAULT_OVERLAY_W = 280
 const OVERLAY_WIDTH_RATIO = DEFAULT_OVERLAY_W / DEFAULT_CANVAS_W
 
+// Keep a canvas element's CSS box and backing pixel buffer in sync.
 function setCanvasSize(
   canvas: HTMLCanvasElement,
   cssWidth: number,
@@ -178,6 +194,7 @@ function setCanvasSize(
   if (canvas.height !== pixelHeight) canvas.height = pixelHeight
 }
 
+// Fit the fixed-aspect simulation viewport inside the available host area.
 function fitCanvasRect(availableWidth: number, availableHeight: number): [number, number] {
   const aspect = WORLD_W / WORLD_H
   let width = Math.max(1, Math.floor(availableWidth))
@@ -191,6 +208,7 @@ function fitCanvasRect(availableWidth: number, availableHeight: number): [number
   return [width, height]
 }
 
+// Reflect the browser fullscreen state in the button label.
 function updateFullscreenButtonLabel(): void {
   fullscreenToggle.textContent = document.fullscreenElement === viewportShell
     ? 'Exit Fullscreen'
@@ -199,6 +217,8 @@ function updateFullscreenButtonLabel(): void {
 
 let currentPathPoints: Array<{ x: number; y: number }> = []
 
+// Recompute every canvas size when the viewport host or fullscreen state
+// changes, then invalidate cached overlay/HUD rendering.
 function resizeViewport(): void {
   const isFullscreen = document.fullscreenElement === viewportShell
   const availableWidth = isFullscreen
@@ -244,6 +264,7 @@ function resizeViewport(): void {
   invalidateSidePanel()
 }
 
+// Convert world-space coordinates from the simulation into canvas pixels.
 function worldToCanvas(wx: number, wy: number): [number, number] {
   return [
     (wx + WORLD_W / 2) * foregroundCanvas.width / WORLD_W,
@@ -251,6 +272,7 @@ function worldToCanvas(wx: number, wy: number): [number, number] {
   ]
 }
 
+// Convert canvas pixels back into simulation world coordinates.
 function canvasToWorld(cx: number, cy: number): [number, number] {
   return [
     (cx - foregroundCanvas.width / 2) * WORLD_W / foregroundCanvas.width,
@@ -258,10 +280,13 @@ function canvasToWorld(cx: number, cy: number): [number, number] {
   ]
 }
 
+// Convert a world-space distance into the current canvas scale.
 function worldLengthToCanvas(length: number): number {
   return length * foregroundCanvas.width / WORLD_W
 }
 
+// Sample a mouse event once and package both canvas-space and world-space
+// coordinates for downstream input handling and server messages.
 function eventToCanvasSample(event: MouseEvent): CanvasPointerSample {
   const rect = foregroundCanvas.getBoundingClientRect()
   const canvasX = (event.clientX - rect.left) * (foregroundCanvas.width / rect.width)
@@ -281,6 +306,8 @@ function eventToCanvasSample(event: MouseEvent): CanvasPointerSample {
   }
 }
 
+// Reuse an existing pointer sample while overriding button bookkeeping for
+// synthesized drag events.
 function withPointerButton(
   sample: CanvasPointerSample,
   button: number,
@@ -293,6 +320,8 @@ function withPointerButton(
   }
 }
 
+// Build a pointer sample from the ghost's current world position instead of the
+// literal mouse location.
 function ghostStateToSample(
   ghost: GhostState,
   event: MouseEvent,
@@ -321,6 +350,13 @@ let lastFrameTime = 0
 
 // --- Interpolation state ---
 
+// The server streams discrete snapshots. We retain both the last committed
+// render state and the newest one so each animation frame can blend between
+// them instead of stepping entity motion every network tick.
+// `currEntitiesById` holds the latest authoritative render state for every
+// entity we know about. `prevRenderStateById` only keeps the immediately prior
+// render state for entities touched by the most recent delta, which is enough
+// to interpolate from the old snapshot toward the new one.
 const currEntitiesById = new Map<number, RenderEntityUpsert>()
 const prevRenderStateById = new Map<number, RenderEntityUpsert>()
 let prevSnapshotTime = 0
@@ -332,8 +368,9 @@ let lastFpsOverlayUpdateTime = 0
 let hudDirty = true
 let currentPathWidth = 40
 const glyphFontSizeCache = new Map<string, number>()
-// Entity appearances come from a small, mostly fixed set of defender/enemy visuals,
-// so we memoize prerendered sprites for the lifetime of the page instead of
+// Entity appearances come from a small, mostly fixed set of defender/enemy
+// visuals, so we memoize prerendered sprites across frames and world updates.
+// The cache is cleared when a resize changes the render scale, rather than
 // paying per-frame draw costs or maintaining an eviction policy.
 const entitySpriteCache = new Map<string, SpriteCacheEntry>()
 const FPS_OVERLAY_INTERVAL_MS = 100
@@ -366,11 +403,12 @@ const SIDE_PANEL_RADIUS = 18
 const SIDE_PANEL_LINE_HEIGHT = 22
 const SIDE_PANEL_TEXT_MARGIN = 28
 
-// Linear interpolation calculator
+// Interpolate linearly between two numeric values.
 function lerp(a: number, b: number, t: number): number {
   return a + (b - a) * t
 }
 
+// Draw the static path layer onto the background canvas.
 function drawBackground(
   pathPoints: Array<{ x: number; y: number }>,
   pathWidth = currentPathWidth,
@@ -396,6 +434,8 @@ function drawBackground(
   bgCtx.restore()
 }
 
+// Render a frame by interpolating entity positions between the previous and
+// current snapshots, then drawing any active placement ghost on top.
 function renderInterpolated(now: number): void {
   const interval = Math.max(snapshotIntervalMs, 1)
   const t = Math.min((now - currSnapshotTime) / interval, 1)
@@ -414,6 +454,7 @@ function renderInterpolated(now: number): void {
   drawGhost()
 }
 
+// Rebuild the cached HUD overlay only when marked dirty.
 function updateHudOverlay(): void {
   if (!hudDirty) return
 
@@ -422,6 +463,7 @@ function updateHudOverlay(): void {
   hudDirty = false
 }
 
+// Refresh the FPS overlay at a throttled cadence instead of every frame.
 function updateFpsOverlay(now: number): void {
   if (now - lastFpsOverlayUpdateTime < FPS_OVERLAY_INTERVAL_MS) return
 
@@ -435,19 +477,25 @@ const PANEL_PEEK_PX = 18
 
 type OverlayLevel = 'hidden' | 'peek' | 'open'
 
+// Report whether overlay content should remain open even without direct hover.
 function hasPinnedOpenPanel(): boolean {
   return ghostState?.pending === true ||
     selectedDefenderPosition !== null ||
     overlayStayOpen
 }
 
+// Choose which screen edge the overlay should currently attach to.
 function getTargetSide(): PanelSide {
   // A pinned panel (like pending placement) owns the side. Otherwise follow
   // the current edge hover so the peek/open transition stays on one edge.
   return getSidePanelModel()?.side ?? edgeHoverSide ?? currentPanelSide
 }
 
+// Decide whether the overlay is hidden, peeking, or fully open.
 function getOverlayLevel(): OverlayLevel {
+  // The overlay behaves like a tiny state machine:
+  // hidden when irrelevant, peek when edge-hovering, and open when hovered or
+  // when a pinned interaction (selected defender / pending placement) owns it.
   if (menuDragActive) return 'hidden'
   const hasPanelContent = getSidePanelModel() !== null
   const hasBuildMenu = currentPhase === 'build' && defenderMenuItems.length > 0
@@ -457,6 +505,7 @@ function getOverlayLevel(): OverlayLevel {
   return 'hidden'
 }
 
+// Return the narrow strip that can turn a peeking panel into a fully open one.
 function getOverlayPeekActivationBounds(): DOMRect | null {
   if (getOverlayLevel() !== 'peek') return null
   const rect = overlayCanvas.getBoundingClientRect()
@@ -466,15 +515,19 @@ function getOverlayPeekActivationBounds(): DOMRect | null {
   return new DOMRect(rect.left, rect.top, PANEL_PEEK_PX, rect.height)
 }
 
+// Test whether a screen-space point lies inside a rectangle.
 function isPointInRect(x: number, y: number, rect: DOMRect): boolean {
   return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom
 }
 
+// Check whether the pointer is inside the visible "peek" activation strip.
 function isPointerOverPeekActivation(event: MouseEvent): boolean {
   const bounds = getOverlayPeekActivationBounds()
   return bounds !== null && isPointInRect(event.clientX, event.clientY, bounds)
 }
 
+// Detect whether the cursor left the foreground canvas through the edge that
+// currently owns the overlay.
 function didExitCanvasViaPanelEdge(event: MouseEvent): boolean {
   const rect = foregroundCanvas.getBoundingClientRect()
   return (
@@ -483,6 +536,7 @@ function didExitCanvasViaPanelEdge(event: MouseEvent): boolean {
   )
 }
 
+// Compute the CSS transform that positions the overlay for a given side/state.
 function getOverlayTransform(
   side: PanelSide,
   level: OverlayLevel,
@@ -498,6 +552,8 @@ function getOverlayTransform(
   return 'translateX(0)'
 }
 
+// Apply the current overlay state to the DOM, including side swaps and
+// transition timing.
 function applyOverlayPosition(): void {
   const level = getOverlayLevel()
   const targetSide = getTargetSide()
@@ -524,6 +580,8 @@ function applyOverlayPosition(): void {
   if (sideChanged && level !== 'hidden') {
     overlayCanvas.style.transitionDuration = '0ms'
     overlayCanvas.style.transform = getOverlayTransform(currentPanelSide, 'hidden')
+    // Wait one frame so the browser commits the off-screen position before
+    // animating the overlay back in on its new side.
     overlaySideSwapFrame = requestAnimationFrame(() => {
       overlaySideSwapFrame = 0
       overlayCanvas.style.transitionDuration = `${transitionMs}ms`
@@ -539,21 +597,26 @@ function applyOverlayPosition(): void {
   overlayCanvas.style.visibility = 'visible'
 }
 
+// Mark the overlay canvas dirty and immediately re-evaluate its DOM position.
 function invalidateSidePanel(): void {
   sidePanelDirty = true
   applyOverlayPosition()
 }
 
+// Update which screen edge is currently hover-armed for the side panel.
 function setEdgeHoverSide(nextSide: PanelSide | null): void {
   if (edgeHoverSide === nextSide) return
   edgeHoverSide = nextSide
   invalidateSidePanel()
 }
 
+// Clear the currently highlighted build-menu cell.
 function clearMenuSelection(): void {
   selectedMenuIndex = null
 }
 
+// Convert packed RGBA integers from the wire format into canvas-friendly color
+// objects.
 function packedRgbaToRenderColor(color: number): RenderColor {
   const r = (color >>> 24) & 0xff
   const g = (color >>> 16) & 0xff
@@ -565,10 +628,12 @@ function packedRgbaToRenderColor(color: number): RenderColor {
   }
 }
 
+// Report whether a render color is fully transparent.
 function isTransparent(color: RenderColor): boolean {
   return color.alpha === 0
 }
 
+// Draw a filled circle if its radius and alpha make it visible.
 function drawFilledCircleOnContext(
   ctx: CanvasRenderingContext2D,
   x: number,
@@ -584,6 +649,7 @@ function drawFilledCircleOnContext(
   ctx.fill()
 }
 
+// Draw a stroked circle if its radius, width, and alpha make it visible.
 function drawStrokedCircleOnContext(
   ctx: CanvasRenderingContext2D,
   x: number,
@@ -601,6 +667,7 @@ function drawStrokedCircleOnContext(
   ctx.stroke()
 }
 
+// Pick a glyph font size that fits inside a circular defender/enemy body.
 function getGlyphFontSize(glyph: string, radius: number): number {
   const roundedRadius = Math.max(1, Math.round(radius))
   const cacheKey = `${glyph}:${roundedRadius}`
@@ -621,10 +688,12 @@ function getGlyphFontSize(glyph: string, radius: number): number {
   return fontSize
 }
 
+// Choose a border width proportional to sprite size while remaining legible.
 function getEntityBorderWidth(radius: number): number {
   return Math.max(1, radius * 0.18)
 }
 
+// Draw a centered glyph into a circular sprite or menu icon.
 function drawGlyphOnContext(
   ctx: CanvasRenderingContext2D,
   glyph: string,
@@ -646,6 +715,7 @@ function drawGlyphOnContext(
   ctx.restore()
 }
 
+// Create a stable cache key for prerendered sprite variants.
 function getSpriteCacheKey(app: RenderAppearance, radius: number): string {
   const roundedRadius = Math.max(1, Math.round(radius))
   return [
@@ -656,6 +726,7 @@ function getSpriteCacheKey(app: RenderAppearance, radius: number): string {
   ].join('|')
 }
 
+// Fetch or build an offscreen sprite canvas for a particular appearance/size.
 function getEntitySprite(app: RenderAppearance, radius: number): SpriteCacheEntry | null {
   const roundedRadius = Math.max(1, Math.round(radius))
   if (roundedRadius <= 0) return null
@@ -696,12 +767,14 @@ function getEntitySprite(app: RenderAppearance, radius: number): SpriteCacheEntr
   return sprite
 }
 
+// Blit a prerendered entity sprite onto the foreground canvas.
 function drawEntitySprite(x: number, y: number, radius: number, app: RenderAppearance): void {
   const sprite = getEntitySprite(app, radius)
   if (!sprite) return
   fgCtx.drawImage(sprite.canvas, x - sprite.offset, y - sprite.offset)
 }
 
+// Draw the semi-transparent attack range for a selected defender.
 function drawRangeCircle(
   x: number,
   y: number,
@@ -715,6 +788,7 @@ function drawRangeCircle(
   fgCtx.restore()
 }
 
+// Draw the selection ring that highlights the active defender.
 function drawSelectionOutline(
   x: number,
   y: number,
@@ -736,11 +810,13 @@ function drawSelectionOutline(
   fgCtx.restore()
 }
 
+// Determine whether a flashing effect should currently be visible.
 function isFlashVisible(fx: RenderVisualEffects, now: number): boolean {
   const elapsed = Math.max(now - fx.flashStartedAt, 0)
   return Math.floor(elapsed / FLASH_FLICKER_INTERVAL_MS) % 2 === 0
 }
 
+// Draw a transient flash overlay and expire it locally once its timer ends.
 function drawFlashOverlay(
   x: number,
   y: number,
@@ -763,6 +839,7 @@ function drawFlashOverlay(
   fgCtx.restore()
 }
 
+// Draw one entity and all of its client-side visual effects.
 function drawEntity(
   x: number,
   y: number,
@@ -777,6 +854,7 @@ function drawEntity(
   drawFlashOverlay(x, y, radius, fx, now)
 }
 
+// Convert wire-format appearance data into client render state.
 function appearanceToRender(app: EntityAppearance): RenderAppearance {
   return {
     glyph: app.glyph === 0 ? '' : String.fromCodePoint(app.glyph),
@@ -787,6 +865,8 @@ function appearanceToRender(app: EntityAppearance): RenderAppearance {
   }
 }
 
+// Convert wire-format visual effects into client render state, preserving flash
+// phase across repeated delta updates when appropriate.
 function visualEffectsToRender(
   fx: EntityVisualEffects,
   now: number,
@@ -805,12 +885,16 @@ function visualEffectsToRender(
     range: packedRgbaToRenderColor(fx.range),
     flash,
     flashExpiry,
+    // Preserve the original flash phase while the server keeps extending the
+    // effect, so flicker timing does not restart on every delta packet.
     flashStartedAt: flashExpiry > 0
       ? (keepExistingFlashPhase ? prevFx.flashStartedAt : now)
       : 0,
   }
 }
 
+// Merge a server upsert with previously known appearance/effect state so
+// partial updates remain renderable.
 function upsertToRenderEntity(
   upsert: EntityUpsert,
   now: number,
@@ -826,6 +910,7 @@ function upsertToRenderEntity(
   }
 }
 
+// Draw the small FPS meter in the lower-right corner.
 function drawFps(ctx: CanvasRenderingContext2D): void {
   ctx.save()
   const label = `${fps.toFixed(1)} FPS`
@@ -842,6 +927,7 @@ function drawFps(ctx: CanvasRenderingContext2D): void {
   ctx.restore()
 }
 
+// Draw the top HUD bar that displays lives and resources.
 function drawHud(ctx: CanvasRenderingContext2D): void {
   ctx.save()
   ctx.font = '20px monospace'
@@ -860,7 +946,12 @@ function drawHud(ctx: CanvasRenderingContext2D): void {
   ctx.restore()
 }
 
+// Decide whether the pointer is close enough to the left or right edge to arm
+// the build menu panel.
 function panelSideFromCanvasX(canvasX: number): PanelSide | null {
+  // Trigger zones scale with the viewport, but stay clamped so the edge-hover
+  // affordance is still reachable on tiny windows and not overly eager on wide
+  // monitors.
   const cssWidth = foregroundCanvas.clientWidth
   const triggerCssPx = cssWidth > 0
     ? Math.max(
@@ -876,6 +967,7 @@ function panelSideFromCanvasX(canvasX: number): PanelSide | null {
   return null
 }
 
+// Update edge-hover state based on the current pointer sample.
 function updateEdgeHover(sample: CanvasPointerSample): void {
   overlayStayOpen = false
   if (menuDragActive || ghostState || currentPhase !== 'build') {
@@ -885,6 +977,7 @@ function updateEdgeHover(sample: CanvasPointerSample): void {
   setEdgeHoverSide(panelSideFromCanvasX(sample.canvasX))
 }
 
+// Hit-test defender bodies in world space using the current render snapshot.
 function findDefenderAtWorld(worldX: number, worldY: number): RenderEntityUpsert | null {
   const hitPos = { x: worldX, y: worldY }
   for (const entity of currEntitiesById.values()) {
@@ -896,6 +989,7 @@ function findDefenderAtWorld(worldX: number, worldY: number): RenderEntityUpsert
   return null
 }
 
+// Compute squared distance without paying for a square root.
 function SimWorldDistanceSquared(
   a: { x: number; y: number },
   b: { x: number; y: number },
@@ -905,14 +999,18 @@ function SimWorldDistanceSquared(
   return dx * dx + dy * dy
 }
 
+// Format panel numbers without trailing decimals for integer values.
 function formatPanelNumber(value: number): string {
   return Number.isInteger(value) ? String(value) : value.toFixed(1)
 }
 
+// Place side panels on the opposite half of the screen from the subject they
+// describe.
 function getOppositePanelSideForCanvasX(canvasX: number): PanelSide {
   return canvasX < foregroundCanvas.width / 2 ? 'right' : 'left'
 }
 
+// Wrap panel body text to the available width using the current canvas font.
 function wrapPanelText(
   ctx: CanvasRenderingContext2D,
   text: string,
@@ -939,9 +1037,12 @@ function wrapPanelText(
   return lines
 }
 
+// Build the overlay model for the currently selected defender, if any.
 function getSelectedDefenderPanelModel(): SidePanelModel | null {
   if (!selectedDefenderPosition || !selectedDefenderSummary) return null
 
+  // Put the panel opposite the selected unit so it reads like an inspector
+  // without covering the thing the user just clicked.
   const side = getOppositePanelSideForCanvasX(
     worldToCanvas(selectedDefenderPosition.x, selectedDefenderPosition.y)[0],
   )
@@ -964,6 +1065,7 @@ function getSelectedDefenderPanelModel(): SidePanelModel | null {
   }
 }
 
+// Build the overlay model for a dropped-but-not-yet-confirmed placement ghost.
 function getPendingGhostPanelModel(): SidePanelModel | null {
   if (!ghostState?.pending) return null
   const [ghostCanvasX] = worldToCanvas(ghostState.worldX, ghostState.worldY)
@@ -981,10 +1083,12 @@ function getPendingGhostPanelModel(): SidePanelModel | null {
   }
 }
 
+// Choose the highest-priority pinned side panel to display, if any.
 function getSidePanelModel(): SidePanelModel | null {
   return getPendingGhostPanelModel() ?? getSelectedDefenderPanelModel()
 }
 
+// Trace a rounded-rectangle path used by both panel and build-menu backdrops.
 function drawRoundedPanelPath(
   ctx: CanvasRenderingContext2D,
   x: number,
@@ -1007,6 +1111,7 @@ function drawRoundedPanelPath(
   ctx.closePath()
 }
 
+// Draw a textual side panel such as defender inspection or pending placement.
 function drawSidePanel(ctx: CanvasRenderingContext2D, panel: SidePanelModel): void {
   const x = 0
   const y = 0
@@ -1069,6 +1174,7 @@ function drawSidePanel(ctx: CanvasRenderingContext2D, panel: SidePanelModel): vo
   ctx.restore()
 }
 
+// Draw the build-menu overlay grid containing available defender types.
 function drawBuildMenu(ctx: CanvasRenderingContext2D): void {
   const panelScale = Math.min(
     foregroundCanvas.width / DEFAULT_CANVAS_W,
@@ -1168,6 +1274,7 @@ function drawBuildMenu(ctx: CanvasRenderingContext2D): void {
   ctx.restore()
 }
 
+// Draw the draggable or pending placement ghost on top of the world layer.
 function drawGhost(): void {
   if (!ghostState) return
   const [x, y] = worldToCanvas(ghostState.worldX, ghostState.worldY)
@@ -1241,6 +1348,7 @@ function drawGhost(): void {
   fgCtx.restore()
 }
 
+// Redraw the overlay canvas when its contents have changed.
 function updateSidePanelOverlay(): void {
   if (!sidePanelDirty) return
 
@@ -1249,6 +1357,8 @@ function updateSidePanelOverlay(): void {
   const panel = getSidePanelModel()
   const showBuildMenu = shouldShowBuildMenu()
 
+  // The overlay only ever shows one mode at a time: pinned side panel wins,
+  // otherwise the build menu can occupy the same canvas.
   if (panel) {
     drawSidePanel(overlayCtx, panel)
   } else if (showBuildMenu) {
@@ -1258,6 +1368,7 @@ function updateSidePanelOverlay(): void {
   sidePanelDirty = false
 }
 
+// Report whether the build-menu overlay should be visible right now.
 function shouldShowBuildMenu(): boolean {
   return (
     getSidePanelModel() === null &&
@@ -1267,6 +1378,8 @@ function shouldShowBuildMenu(): boolean {
   )
 }
 
+// Main animation loop: update time-derived overlays, render the world, and
+// composite the cached layers.
 function frame(now: number): void {
   if (lastFrameTime !== 0) {
     const dt = now - lastFrameTime
@@ -1285,19 +1398,23 @@ function frame(now: number): void {
 
 // --- Logging ---
 
+// Append a line to the on-page debug log.
 function log(line: string): void {
   logEl.textContent += line + '\n'
   logEl.scrollTop = logEl.scrollHeight
 }
 
+// Set text content on an element when it exists.
 function setTextIfElement(el: HTMLElement | null, value: string): void {
   if (el) el.textContent = value
 }
 
+// Mark the HUD overlay for regeneration on the next frame.
 function invalidateHud(): void {
   hudDirty = true
 }
 
+// Translate DOM mouse button codes into the wire-format button names.
 function buttonNameFromNumber(button: number): 'left' | 'middle' | 'right' | 'other' {
   switch (button) {
     case 0:
@@ -1311,11 +1428,14 @@ function buttonNameFromNumber(button: number): 'left' | 'middle' | 'right' | 'ot
   }
 }
 
+// Send a client message if the websocket is currently connected.
 function sendClientMsg(msg: ClientMsg): void {
   if (ws.readyState !== WebSocket.OPEN) return
   ws.send(JSON.stringify(msg))
 }
 
+// Serialize a canvas interaction into the websocket protocol and return its
+// client sequence number.
 function sendCanvasMsg(
   eventName: 'click' | 'dblclick' | 'contextmenu' | 'dragstart' | 'dragmove' | 'dragend',
   sample: CanvasPointerSample,
@@ -1344,6 +1464,7 @@ function sendCanvasMsg(
   return seq
 }
 
+// Send the most recent coalesced drag-move sample, if one is pending.
 function flushPendingDragMove(): void {
   dragMoveFrameRequested = false
   if (!pendingDragMove) return
@@ -1351,6 +1472,7 @@ function flushPendingDragMove(): void {
   pendingDragMove = null
 }
 
+// Send a placement-preview event for the current ghost entity.
 function sendPlacementPreview(
   eventName: 'dragstart' | 'dragmove' | 'dragend',
   sample: CanvasPointerSample,
@@ -1360,14 +1482,18 @@ function sendPlacementPreview(
   sendCanvasMsg(eventName, sample, 'placing', [entityName])
 }
 
+// Coalesce drag-move websocket traffic to at most once per animation frame.
 function scheduleDragMoveFlush(): void {
   if (dragMoveFrameRequested) return
   dragMoveFrameRequested = true
+  // Push at most one drag update per animation frame even if the pointer is
+  // moving faster than the display refresh rate.
   requestAnimationFrame(() => {
     flushPendingDragMove()
   })
 }
 
+// Convert submitted form data into the string-only field map used by UI actions.
 function formDataToFields(formData: FormData): Record<string, string> | undefined {
   const fields: Record<string, string> = {}
   for (const [key, value] of formData.entries()) {
@@ -1376,6 +1502,7 @@ function formDataToFields(formData: FormData): Record<string, string> | undefine
   return Object.keys(fields).length === 0 ? undefined : fields
 }
 
+// Send a generic UI action such as pressing a control button.
 function sendUiAction(action: string, fields?: Record<string, string>): void {
   const msg: ClientMsg = {
     type: 'ui_action',
@@ -1386,6 +1513,7 @@ function sendUiAction(action: string, fields?: Record<string, string>): void {
   sendClientMsg(msg)
 }
 
+// Narrow an unknown value to a simple `{x, y}` point.
 function isPoint(value: unknown): value is { x: number; y: number } {
   return (
     typeof value === 'object' &&
@@ -1395,6 +1523,7 @@ function isPoint(value: unknown): value is { x: number; y: number } {
   )
 }
 
+// Narrow an unknown value to the entity-position wire type.
 function isEntityPosition(value: unknown): value is EntityPosition {
   return (
     typeof value === 'object' &&
@@ -1405,6 +1534,7 @@ function isEntityPosition(value: unknown): value is EntityPosition {
   )
 }
 
+// Narrow an unknown value to the entity-appearance wire type.
 function isEntityAppearance(value: unknown): value is EntityAppearance {
   return (
     typeof value === 'object' &&
@@ -1416,6 +1546,7 @@ function isEntityAppearance(value: unknown): value is EntityAppearance {
   )
 }
 
+// Narrow an unknown value to the entity-visual-effects wire type.
 function isEntityVisualEffects(value: unknown): value is EntityVisualEffects {
   return (
     typeof value === 'object' &&
@@ -1428,6 +1559,7 @@ function isEntityVisualEffects(value: unknown): value is EntityVisualEffects {
   )
 }
 
+// Narrow an unknown value to an entity upsert payload.
 function isEntityUpsert(value: unknown): value is EntityUpsert {
   const maybeApp = (value as Record<string, unknown>).app
   const maybeVfx = (value as Record<string, unknown>).vfx
@@ -1440,6 +1572,7 @@ function isEntityUpsert(value: unknown): value is EntityUpsert {
   )
 }
 
+// Narrow an unknown value to a defender menu entry.
 function isDefenderMenuItem(value: unknown): value is DefenderMenuItem {
   return (
     typeof value === 'object' &&
@@ -1452,6 +1585,7 @@ function isDefenderMenuItem(value: unknown): value is DefenderMenuItem {
   )
 }
 
+// Narrow an unknown value to the UI-state payload carried inside world deltas.
 function isUiState(value: unknown): value is UiState {
   const v = value as Record<string, unknown>
   return (
@@ -1464,18 +1598,23 @@ function isUiState(value: unknown): value is UiState {
   )
 }
 
+// Read the phase string from a delta, tolerating older payload shapes.
 function getDeltaPhase(delta: WorldDelta): string {
   const maybePhase = (delta as WorldDelta & { phase?: unknown }).phase
   if (typeof maybePhase === 'string') return maybePhase
   return delta.phase
 }
 
+// Apply server-provided UI state to client-side selection and placement state.
 function applyUiState(uiState: UiState): void {
   if (uiState.placementAllowed !== undefined && ghostState) {
     ghostState.placeable = uiState.placementAllowed
   }
 
   if (uiState.spawnAllowed !== undefined && ghostState?.spawnPending) {
+    // Spawn requests are optimistic on the client: we keep the ghost in a
+    // temporary "awaiting verdict" state until the server confirms whether the
+    // placement was legal.
     ghostState.spawnPending = false
     if (uiState.spawnAllowed) {
       ghostState = null
@@ -1493,6 +1632,7 @@ function applyUiState(uiState: UiState): void {
   }
 }
 
+// Advance snapshot timing bookkeeping after consuming a world update.
 function finishSnapshotUpdate(): void {
   prevSnapshotTime = currSnapshotTime
   currSnapshotTime = performance.now()
@@ -1502,6 +1642,8 @@ function finishSnapshotUpdate(): void {
   }
 }
 
+// Reset all client-side world, overlay, and interpolation state after a fresh
+// snapshot (as opposed to delta) replaces the current session state.
 function resetClientWorldState(): void {
   currentPathPoints = []
   currentPathWidth = 40
@@ -1542,10 +1684,15 @@ function resetClientWorldState(): void {
   applyOverlayPosition()
 }
 
+// Apply an incremental world update from the server and invalidate derived
+// overlays that depend on the new state.
 function applyWorldDelta(delta: WorldDelta): void {
   const now = performance.now()
   prevRenderStateById.clear()
 
+  // Delta updates rewrite the current authoritative render state in-place while
+  // preserving the previous render copy for interpolation during the next
+  // animation frames.
   for (const entity of delta.upserts) {
     const prevEntity = currEntitiesById.get(entity.pos.id)
     const nextEntity =
@@ -1573,6 +1720,7 @@ function applyWorldDelta(delta: WorldDelta): void {
 
 // --- Message validation ---
 
+// Narrow an unknown payload to the `world_delta` message shape.
 function isWorldDelta(value: unknown): value is WorldDelta {
   if (!value || typeof value !== 'object') return false
   const v = value as Record<string, unknown>
@@ -1586,15 +1734,19 @@ function isWorldDelta(value: unknown): value is WorldDelta {
     typeof v.phase === 'string' &&
     isUiState(v.uiState) &&
     v.upserts.every(isEntityUpsert) &&
+    // Erase entries are just numeric entity ids.
     v.erased.every((id) => typeof id === 'number')
   )
 }
 
+// Narrow an unknown websocket payload to one of the supported server messages.
 function isServerMsg(value: unknown): value is ServerMsg {
   if (!value || typeof value !== 'object') return false
   const v = value as Record<string, unknown>
   if (typeof v.type !== 'string') return false
 
+  // Validate websocket payloads at the edge so the rest of the file can treat
+  // incoming messages as strongly typed data instead of defensive blobs.
   switch (v.type) {
     case 'hello_ack':
       return typeof v.message === 'string'
@@ -1625,6 +1777,7 @@ function isServerMsg(value: unknown): value is ServerMsg {
 const protocol = location.protocol === 'https:' ? 'wss' : 'ws'
 const ws = new WebSocket(`${protocol}://${location.host}/ws`)
 
+// Announce a fresh websocket connection and send the browser hello packet.
 ws.onopen = () => {
   statusEl.textContent = 'connected'
   log('Connected')
@@ -1632,6 +1785,7 @@ ws.onopen = () => {
   sendClientMsg(hello)
 }
 
+// Parse, validate, and dispatch every inbound websocket message.
 ws.onmessage = (event: MessageEvent<string>) => {
   let parsed: unknown
   try {
@@ -1662,16 +1816,19 @@ ws.onmessage = (event: MessageEvent<string>) => {
   }
 }
 
+// Reflect websocket shutdown in the visible connection status.
 ws.onclose = () => {
   statusEl.textContent = 'disconnected'
   log('Disconnected')
 }
 
+// Surface websocket transport errors in the small on-page status UI.
 ws.onerror = () => {
   statusEl.textContent = 'error'
   log('WebSocket error')
 }
 
+// Toggle fullscreen mode for the viewport shell.
 fullscreenToggle.addEventListener('click', async () => {
   try {
     if (document.fullscreenElement === viewportShell) {
@@ -1684,25 +1841,44 @@ fullscreenToggle.addEventListener('click', async () => {
   }
 })
 
+// Recompute labels and canvas sizing after fullscreen transitions.
 document.addEventListener('fullscreenchange', () => {
   updateFullscreenButtonLabel()
   resizeViewport()
 })
 
+// Resize canvases when the browser window changes size.
 window.addEventListener('resize', () => {
   resizeViewport()
 })
 
 if (typeof ResizeObserver !== 'undefined') {
+  // Resize canvases when the host element changes size for reasons other than
+  // the global window, such as layout changes.
   const resizeObserver = new ResizeObserver(() => {
     resizeViewport()
   })
   resizeObserver.observe(viewportHost)
 }
 
+// Start clicks, ghost pickup/cancel, and drag tracking on the foreground world.
 foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   const sample = eventToCanvasSample(event)
   updateEdgeHover(sample)
+
+  // A transient build panel opened from the background should collapse when
+  // the user clicks empty world space again.
+  if (
+    event.button === 0 &&
+    !ghostState &&
+    !menuDragActive &&
+    selectedDefenderPosition === null &&
+    findDefenderAtWorld(sample.worldX, sample.worldY) === null
+  ) {
+    mouseOverOverlay = false
+    overlayStayOpen = false
+    setEdgeHoverSide(null)
+  }
 
   // While a ghost is pending, left-click on the ghost picks it back up and
   // any other non-right click cancels placement.
@@ -1735,6 +1911,8 @@ foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   if (sample.button !== 2) sendCanvasMsg('click', sample)
 })
 
+// Convert foreground pointer motion into either edge-hover updates or drag
+// preview traffic.
 foregroundCanvas.addEventListener('mousemove', (event: MouseEvent) => {
   const sample = eventToCanvasSample(event)
   updateEdgeHover(sample)
@@ -1755,6 +1933,8 @@ foregroundCanvas.addEventListener('mousemove', (event: MouseEvent) => {
   scheduleDragMoveFlush()
 })
 
+// Open the build menu directly from empty build space on double-click, then
+// still forward the gesture to the server.
 foregroundCanvas.addEventListener('dblclick', (event: MouseEvent) => {
   const sample = eventToCanvasSample(event)
   if (
@@ -1765,6 +1945,8 @@ foregroundCanvas.addEventListener('dblclick', (event: MouseEvent) => {
     defenderMenuItems.length > 0 &&
     findDefenderAtWorld(sample.worldX, sample.worldY) === null
   ) {
+    // Double-clicking empty build space is a shortcut to fully open the menu
+    // on the current side without requiring an edge-hover first.
     edgeHoverSide = currentPanelSide
     mouseOverOverlay = true
     overlayStayOpen = false
@@ -1773,6 +1955,7 @@ foregroundCanvas.addEventListener('dblclick', (event: MouseEvent) => {
   sendCanvasMsg('dblclick', sample)
 })
 
+// Keep the overlay open when the pointer leaves through the armed panel edge.
 foregroundCanvas.addEventListener('mouseleave', (event: MouseEvent) => {
   // Fast motion can skip the overlay's peek strip entirely. If the pointer
   // leaves through the active panel edge, open the panel as though the user
@@ -1784,12 +1967,15 @@ foregroundCanvas.addEventListener('mouseleave', (event: MouseEvent) => {
   }
 })
 
+// Mark the overlay as hovered once the pointer enters its visible area.
 overlayCanvas.addEventListener('mouseenter', () => {
   if (getOverlayLevel() !== 'peek') mouseOverOverlay = true
   overlayStayOpen = false
   applyOverlayPosition()
 })
 
+// Promote a peeking overlay to fully open only while the pointer is over the
+// visible activation strip.
 overlayCanvas.addEventListener('mousemove', (event: MouseEvent) => {
   const shouldOpen = getOverlayLevel() !== 'peek' || isPointerOverPeekActivation(event)
   if (mouseOverOverlay === shouldOpen) return
@@ -1798,6 +1984,8 @@ overlayCanvas.addEventListener('mousemove', (event: MouseEvent) => {
   applyOverlayPosition()
 })
 
+// Decide whether leaving the overlay should keep it latched open or hand hover
+// control back to the foreground canvas.
 overlayCanvas.addEventListener('mouseleave', (event: MouseEvent) => {
   mouseOverOverlay = false
   const toFg = event.relatedTarget === foregroundCanvas
@@ -1811,6 +1999,7 @@ overlayCanvas.addEventListener('mouseleave', (event: MouseEvent) => {
   invalidateSidePanel()
 })
 
+// Finish menu drags and normal canvas drags when the mouse button is released.
 window.addEventListener('mouseup', (event: MouseEvent) => {
   // Handle menu drag commit/cancel.
   if (menuDragActive) {
@@ -1825,6 +2014,8 @@ window.addEventListener('mouseup', (event: MouseEvent) => {
         event.clientX >= fgRect.left && event.clientX <= fgRect.right &&
         event.clientY >= fgRect.top && event.clientY <= fgRect.bottom
       if (overFg && !overOverlay) {
+        // Dropping onto the playfield creates a pending ghost first; a later
+        // right-click turns that preview into an actual spawn command.
         sendPlacementPreview('dragend', ghostStateToSample(ghostState, event), ghostState.entityName)
         ghostState.pending = true
         mouseOverOverlay = false
@@ -1850,6 +2041,8 @@ window.addEventListener('mouseup', (event: MouseEvent) => {
   if (wasDragging) sendCanvasMsg('dragend', sample)
 })
 
+// Use right-click on the foreground canvas for placement confirmation or to
+// forward a normal context-style click to the server.
 foregroundCanvas.addEventListener('contextmenu', (event: MouseEvent) => {
   event.preventDefault()
   const sample = eventToCanvasSample(event)
@@ -1867,6 +2060,7 @@ foregroundCanvas.addEventListener('contextmenu', (event: MouseEvent) => {
 })
 
 
+// Convert DOM controls carrying `data-action` into protocol-level UI actions.
 document.addEventListener('click', (event: MouseEvent) => {
   const target = event.target
   if (!(target instanceof Element)) return
@@ -1887,6 +2081,8 @@ document.addEventListener('click', (event: MouseEvent) => {
   sendUiAction(action, fields)
 })
 
+// Convert form submissions carrying `data-action` into protocol-level UI
+// actions instead of letting the browser navigate away.
 document.addEventListener('submit', (event: SubmitEvent) => {
   const target = event.target
   if (!(target instanceof HTMLFormElement)) return
@@ -2023,6 +2219,8 @@ overlayCanvas.addEventListener('wheel', (event: WheelEvent) => {
   invalidateSidePanel()
 }, { passive: false })
 
+// Bring the UI into sync with the current DOM/layout state before the first
+// animation frame.
 updateFullscreenButtonLabel()
 resizeViewport()
 requestAnimationFrame(frame)

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -6,8 +6,8 @@ import type {
   EntityUpsert,
   EntityVisualEffects,
   ServerMsg,
-  UiResponseMsg,
   UiCanvasMsg,
+  UiState,
   WorldDelta,
 } from './types.js'
 
@@ -38,8 +38,7 @@ interface GhostState {
   attackRadius: number  // world units, from Appearance.attackRadius
   pending: boolean      // true = dropped on map, awaiting confirmation click
   placeable: boolean
-  placementSeq: number
-  placementResponseSeq: number
+  spawnPending: boolean
 }
 
 interface RenderVisualEffects {
@@ -354,6 +353,8 @@ let mouseOverOverlay = false
 let overlayStayOpen = false
 let currentPanelSide: PanelSide = 'right'
 let overlaySideSwapFrame = 0
+let selectedDefenderSummary: DefenderMenuItem | null = null
+let defenderSelected = false
 
 const SIDE_PANEL_TRIGGER_RATIO = 0.25
 const SIDE_PANEL_TRIGGER_MIN_PX = 72
@@ -435,7 +436,7 @@ type OverlayLevel = 'hidden' | 'peek' | 'open'
 
 function hasPinnedOpenPanel(): boolean {
   return ghostState?.pending === true ||
-    findSelectedDefender() !== null ||
+    defenderSelected ||
     overlayStayOpen
 }
 
@@ -883,15 +884,6 @@ function updateEdgeHover(sample: CanvasPointerSample): void {
   setEdgeHoverSide(panelSideFromCanvasX(sample.canvasX))
 }
 
-function findSelectedDefender(): RenderEntityUpsert | null {
-  for (const entity of currEntitiesById.values()) {
-    if (!isTransparent(entity.fx.selection) || entity.fx.rangeRadius > 0) {
-      return entity
-    }
-  }
-  return null
-}
-
 function findDefenderAtWorld(worldX: number, worldY: number): RenderEntityUpsert | null {
   const hitPos = { x: worldX, y: worldY }
   for (const entity of currEntitiesById.values()) {
@@ -943,19 +935,18 @@ function wrapPanelText(
 }
 
 function getSelectedDefenderPanelModel(): SidePanelModel | null {
-  const selectedDefender = findSelectedDefender()
-  if (!selectedDefender) return null
+  if (!defenderSelected || !selectedDefenderSummary) return null
 
-  const side: PanelSide = selectedDefender.pos.x <= 0 ? 'right' : 'left'
   return {
-    side,
+    side: currentPanelSide,
     title: 'Defender Selected',
     lines: [
-      `Entity #${selectedDefender.pos.id}`,
-      `World ${formatPanelNumber(selectedDefender.pos.x)}, ${formatPanelNumber(selectedDefender.pos.y)}`,
-      `Glyph ${selectedDefender.app.glyph || '?'}`,
-      `Body radius ${formatPanelNumber(selectedDefender.app.radius)}`,
-      `Attack radius ${formatPanelNumber(selectedDefender.fx.rangeRadius)}`,
+      selectedDefenderSummary.displayName,
+      selectedDefenderSummary.flavorText,
+      '',
+      `Glyph ${selectedDefenderSummary.appearance.glyph === 0 ? '?' : String.fromCodePoint(selectedDefenderSummary.appearance.glyph)}`,
+      `Body radius ${formatPanelNumber(selectedDefenderSummary.appearance.radius)}`,
+      `Attack radius ${formatPanelNumber(selectedDefenderSummary.appearance.attackRadius)}`,
       '',
       `Phase ${phaseEl?.textContent ?? '--'}`,
       `Resources $${resources}`,
@@ -1358,8 +1349,7 @@ function sendPlacementPreview(
   entityName: string,
 ): void {
   if (!ghostState) return
-  ghostState.placementSeq =
-    sendCanvasMsg(eventName, sample, 'placing', [entityName])
+  sendCanvasMsg(eventName, sample, 'placing', [entityName])
 }
 
 function scheduleDragMoveFlush(): void {
@@ -1442,19 +1432,27 @@ function isEntityUpsert(value: unknown): value is EntityUpsert {
   )
 }
 
-function isUiResponseMsg(value: unknown): value is UiResponseMsg {
+function isDefenderMenuItem(value: unknown): value is DefenderMenuItem {
   return (
     typeof value === 'object' &&
     value !== null &&
-    (value as Record<string, unknown>).type === 'ui_response' &&
-    typeof (value as Record<string, unknown>).seq === 'number' &&
-    typeof (value as Record<string, unknown>).ok === 'boolean' &&
-    typeof (value as Record<string, unknown>).response === 'string' &&
-    ((value as Record<string, unknown>).reason === undefined ||
-      typeof (value as Record<string, unknown>).reason === 'string') &&
-    ((value as Record<string, unknown>).fields === undefined ||
-      (typeof (value as Record<string, unknown>).fields === 'object' &&
-        (value as Record<string, unknown>).fields !== null))
+    typeof (value as Record<string, unknown>).entityName === 'string' &&
+    typeof (value as Record<string, unknown>).displayName === 'string' &&
+    typeof (value as Record<string, unknown>).flavorText === 'string' &&
+    typeof (value as Record<string, unknown>).resourceCost === 'number' &&
+    isEntityAppearance((value as Record<string, unknown>).appearance)
+  )
+}
+
+function isUiState(value: unknown): value is UiState {
+  const v = value as Record<string, unknown>
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof v.defenderSelected === 'boolean' &&
+    (v.placementAllowed === undefined || typeof v.placementAllowed === 'boolean') &&
+    (v.spawnAllowed === undefined || typeof v.spawnAllowed === 'boolean') &&
+    (v.defenderSummary === undefined || isDefenderMenuItem(v.defenderSummary))
   )
 }
 
@@ -1462,6 +1460,29 @@ function getDeltaPhase(delta: WorldDelta): string {
   const maybePhase = (delta as WorldDelta & { phase?: unknown }).phase
   if (typeof maybePhase === 'string') return maybePhase
   return delta.phase
+}
+
+function applyUiState(uiState: UiState): void {
+  if (uiState.placementAllowed !== undefined && ghostState) {
+    ghostState.placeable = uiState.placementAllowed
+  }
+
+  if (uiState.spawnAllowed !== undefined && ghostState?.spawnPending) {
+    ghostState.spawnPending = false
+    if (uiState.spawnAllowed) {
+      ghostState = null
+      clearMenuSelection()
+      mouseOverOverlay = false
+      overlayStayOpen = false
+    }
+  }
+
+  defenderSelected = uiState.defenderSelected
+  if (!defenderSelected) {
+    selectedDefenderSummary = null
+  } else if (uiState.defenderSummary) {
+    selectedDefenderSummary = uiState.defenderSummary
+  }
 }
 
 function finishSnapshotUpdate(): void {
@@ -1498,6 +1519,8 @@ function resetClientWorldState(): void {
   mouseOverOverlay = false
   overlayStayOpen = false
   currentPanelSide = 'right'
+  selectedDefenderSummary = null
+  defenderSelected = false
   if (overlaySideSwapFrame !== 0) {
     cancelAnimationFrame(overlaySideSwapFrame)
     overlaySideSwapFrame = 0
@@ -1531,23 +1554,13 @@ function applyWorldDelta(delta: WorldDelta): void {
   tickEl.textContent = String(delta.tick)
   lives = delta.lives
   resources = delta.resources
+  applyUiState(delta.uiState)
   invalidateHud()
   invalidateSidePanel()
   setTextIfElement(livesEl, String(delta.lives))
   setTextIfElement(resourcesEl, String(delta.resources))
   currentPhase = getDeltaPhase(delta)
   setTextIfElement(phaseEl, currentPhase)
-}
-
-function applyUiResponse(response: UiResponseMsg): void {
-  if (
-    response.response === 'placement' &&
-    ghostState &&
-    response.seq > ghostState.placementResponseSeq
-  ) {
-    ghostState.placeable = response.fields?.valid === 'true'
-    ghostState.placementResponseSeq = response.seq
-  }
 }
 
 // --- Message validation ---
@@ -1563,6 +1576,7 @@ function isWorldDelta(value: unknown): value is WorldDelta {
     typeof v.lives === 'number' &&
     typeof v.resources === 'number' &&
     typeof v.phase === 'string' &&
+    isUiState(v.uiState) &&
     v.upserts.every(isEntityUpsert) &&
     v.erased.every((id) => typeof id === 'number')
   )
@@ -1576,8 +1590,6 @@ function isServerMsg(value: unknown): value is ServerMsg {
   switch (v.type) {
     case 'hello_ack':
       return typeof v.message === 'string'
-    case 'ui_response':
-      return isUiResponseMsg(v)
     case 'world_delta':
       return isWorldDelta(v)
     case 'world_snapshot': {
@@ -1591,6 +1603,7 @@ function isServerMsg(value: unknown): value is ServerMsg {
         Array.isArray(md.paths) &&
         md.paths.every(isPoint) &&
         Array.isArray(v.defenderMenu) &&
+        v.defenderMenu.every(isDefenderMenuItem) &&
         isWorldDelta(v.delta)
       )
     }
@@ -1628,9 +1641,6 @@ ws.onmessage = (event: MessageEvent<string>) => {
   switch (parsed.type) {
     case 'hello_ack':
       log(`Server says: ${parsed.message}`)
-      break
-    case 'ui_response':
-      applyUiResponse(parsed)
       break
     case 'world_delta':
       applyWorldDelta(parsed)
@@ -1836,16 +1846,11 @@ foregroundCanvas.addEventListener('contextmenu', (event: MouseEvent) => {
   event.preventDefault()
   const sample = eventToCanvasSample(event)
   if (ghostState?.pending) {
-    if (!ghostState.placeable) return
+    if (!ghostState.placeable || ghostState.spawnPending) return
     // Right-click while ghost is pending: place the defender.
     const entityName = ghostState.entityName
     const ghostSample = ghostStateToSample(ghostState, event, 2, 2)
-    ghostState = null
-    clearMenuSelection()
-    menuDragActive = false
-    mouseOverOverlay = false
-    overlayStayOpen = false
-    invalidateSidePanel()
+    ghostState.spawnPending = true
     sendCanvasMsg('click', ghostSample, 'spawn', [entityName])
     return
   }
@@ -1895,12 +1900,7 @@ document.addEventListener('contextmenu', (event: MouseEvent) => {
     const sample = eventToCanvasSample(event)
     const entityName = ghostState.entityName
     event.preventDefault()
-    ghostState = null
-    clearMenuSelection()
-    menuDragActive = false
-    mouseOverOverlay = false
-    overlayStayOpen = false
-    invalidateSidePanel()
+    ghostState.spawnPending = true
     sendCanvasMsg('click', sample, 'spawn', [entityName])
     return
   }
@@ -1996,8 +1996,7 @@ overlayCanvas.addEventListener('mousedown', (event: MouseEvent) => {
     attackRadius: item.appearance.attackRadius,
     pending: false,
     placeable: true,
-    placementSeq: 0,
-    placementResponseSeq: 0,
+    spawnPending: false,
   }
   const sample = eventToCanvasSample(event)
   sendPlacementPreview('dragstart', sample, item.entityName)

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -6,6 +6,7 @@ import type {
   EntityUpsert,
   EntityVisualEffects,
   ServerMsg,
+  UiResponseMsg,
   UiCanvasMsg,
   WorldDelta,
 } from './types.js'
@@ -36,6 +37,9 @@ interface GhostState {
   appearance: RenderAppearance
   attackRadius: number  // world units, from Appearance.attackRadius
   pending: boolean      // true = dropped on map, awaiting confirmation click
+  placeable: boolean
+  placementSeq: number
+  placementResponseSeq: number
 }
 
 interface RenderVisualEffects {
@@ -286,6 +290,27 @@ function withPointerButton(
     ...sample,
     button,
     buttons,
+  }
+}
+
+function ghostStateToSample(
+  ghost: GhostState,
+  event: MouseEvent,
+  button = event.button,
+  buttons = event.buttons,
+): CanvasPointerSample {
+  const [canvasX, canvasY] = worldToCanvas(ghost.worldX, ghost.worldY)
+  return {
+    button,
+    buttons,
+    canvasX: Math.round(canvasX),
+    canvasY: Math.round(canvasY),
+    worldX: Math.round(ghost.worldX),
+    worldY: Math.round(ghost.worldY),
+    shift: event.shiftKey,
+    ctrl: event.ctrlKey,
+    alt: event.altKey,
+    meta: event.metaKey,
   }
 }
 
@@ -894,8 +919,7 @@ function getSelectedTowerPanelModel(): SidePanelModel | null {
   const selectedTower = findSelectedTower()
   if (!selectedTower) return null
 
-  const defaultSide: PanelSide = selectedTower.pos.x <= 0 ? 'right' : 'left'
-  const side: PanelSide = edgeHoverSide ?? defaultSide
+  const side: PanelSide = selectedTower.pos.x <= 0 ? 'right' : 'left'
   return {
     side,
     title: 'Tower Selected',
@@ -1123,6 +1147,7 @@ function drawGhost(): void {
   const [x, y] = worldToCanvas(ghostState.worldX, ghostState.worldY)
   const radius = worldLengthToCanvas(ghostState.appearance.radius)
   const attackPx = worldLengthToCanvas(ghostState.attackRadius)
+  const isPlaceable = ghostState.placeable
 
   fgCtx.save()
   fgCtx.globalAlpha = ghostState.pending ? 0.85 : 0.55
@@ -1154,12 +1179,22 @@ function drawGhost(): void {
   if (attackPx > 0) {
     fgCtx.globalAlpha = ghostState.pending ? 0.55 : 0.35
     const rangeColor: RenderColor = {
-      css: ghostState.pending
-        ? 'rgba(255, 0, 127, 0.6)'
-        : 'rgba(255, 255, 100, 0.4)',
-      alpha: ghostState.pending ? 0.6 : 0.4,
+      css: isPlaceable
+        ? 'rgba(72, 159, 255, 0.45)'
+        : 'rgba(255, 76, 76, 0.45)',
+      alpha: 0.45,
     }
     drawFilledCircleOnContext(fgCtx, x, y, attackPx, rangeColor)
+    drawStrokedCircleOnContext(
+      fgCtx,
+      x,
+      y,
+      attackPx,
+      isPlaceable
+        ? { css: 'rgba(72, 159, 255, 0.85)', alpha: 0.85 }
+        : { css: 'rgba(255, 76, 76, 0.85)', alpha: 0.85 },
+      Math.max(2, radius * 0.08),
+    )
   }
 
   if (ghostState.pending) {
@@ -1170,7 +1205,9 @@ function drawGhost(): void {
       x,
       y,
       radius + lineWidth * 0.5,
-      { css: 'rgba(255, 242, 63, 0.9)', alpha: 0.9 },
+      isPlaceable
+        ? { css: 'rgba(255, 242, 63, 0.9)', alpha: 0.9 }
+        : { css: 'rgba(255, 76, 76, 0.9)', alpha: 0.9 },
       lineWidth,
     )
   }
@@ -1250,10 +1287,11 @@ function sendCanvasMsg(
   sample: CanvasPointerSample,
   command?: string,
   parameters?: string[],
-): void {
+): number {
+  const seq = nextClientSeq++
   const msg: UiCanvasMsg = {
     type: 'ui_canvas',
-    seq: nextClientSeq++,
+    seq,
     event: eventName,
     button: buttonNameFromNumber(sample.button),
     buttons: sample.buttons,
@@ -1269,6 +1307,7 @@ function sendCanvasMsg(
   if (command) msg.command = command
   if (parameters?.length) msg.parameters = parameters
   sendClientMsg(msg)
+  return seq
 }
 
 function flushPendingDragMove(): void {
@@ -1276,6 +1315,16 @@ function flushPendingDragMove(): void {
   if (!pendingDragMove) return
   sendCanvasMsg('dragmove', pendingDragMove)
   pendingDragMove = null
+}
+
+function sendPlacementPreview(
+  eventName: 'dragstart' | 'dragmove' | 'dragend',
+  sample: CanvasPointerSample,
+  entityName: string,
+): void {
+  if (!ghostState) return
+  ghostState.placementSeq =
+    sendCanvasMsg(eventName, sample, 'placing', [entityName])
 }
 
 function scheduleDragMoveFlush(): void {
@@ -1355,6 +1404,22 @@ function isEntityUpsert(value: unknown): value is EntityUpsert {
     isEntityPosition((value as Record<string, unknown>).pos) &&
     (maybeApp === undefined || isEntityAppearance(maybeApp)) &&
     (maybeVfx === undefined || isEntityVisualEffects(maybeVfx))
+  )
+}
+
+function isUiResponseMsg(value: unknown): value is UiResponseMsg {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as Record<string, unknown>).type === 'ui_response' &&
+    typeof (value as Record<string, unknown>).seq === 'number' &&
+    typeof (value as Record<string, unknown>).ok === 'boolean' &&
+    typeof (value as Record<string, unknown>).response === 'string' &&
+    ((value as Record<string, unknown>).reason === undefined ||
+      typeof (value as Record<string, unknown>).reason === 'string') &&
+    ((value as Record<string, unknown>).fields === undefined ||
+      (typeof (value as Record<string, unknown>).fields === 'object' &&
+        (value as Record<string, unknown>).fields !== null))
   )
 }
 
@@ -1438,6 +1503,17 @@ function applyWorldDelta(delta: WorldDelta): void {
   setTextIfElement(phaseEl, currentPhase)
 }
 
+function applyUiResponse(response: UiResponseMsg): void {
+  if (
+    response.response === 'placement' &&
+    ghostState &&
+    response.seq > ghostState.placementResponseSeq
+  ) {
+    ghostState.placeable = response.fields?.valid === 'true'
+    ghostState.placementResponseSeq = response.seq
+  }
+}
+
 // --- Message validation ---
 
 function isWorldDelta(value: unknown): value is WorldDelta {
@@ -1464,6 +1540,8 @@ function isServerMsg(value: unknown): value is ServerMsg {
   switch (v.type) {
     case 'hello_ack':
       return typeof v.message === 'string'
+    case 'ui_response':
+      return isUiResponseMsg(v)
     case 'world_delta':
       return isWorldDelta(v)
     case 'world_snapshot': {
@@ -1513,6 +1591,9 @@ ws.onmessage = (event: MessageEvent<string>) => {
   switch (parsed.type) {
     case 'hello_ack':
       log(`Server says: ${parsed.message}`)
+      break
+    case 'ui_response':
+      applyUiResponse(parsed)
       break
     case 'world_delta':
       applyWorldDelta(parsed)
@@ -1580,6 +1661,7 @@ foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
       menuDragActive = true
       mouseOverOverlay = false
       overlayStayOpen = false
+      sendPlacementPreview('dragstart', sample, ghostState.entityName)
     } else {
       ghostState = null
       clearMenuSelection()
@@ -1670,6 +1752,7 @@ window.addEventListener('mouseup', (event: MouseEvent) => {
         event.clientX >= fgRect.left && event.clientX <= fgRect.right &&
         event.clientY >= fgRect.top  && event.clientY <= fgRect.bottom
       if (overFg && !overOverlay) {
+        sendPlacementPreview('dragend', ghostStateToSample(ghostState, event), ghostState.entityName)
         ghostState.pending = true
         mouseOverOverlay = false
         overlayStayOpen = false
@@ -1698,15 +1781,17 @@ foregroundCanvas.addEventListener('contextmenu', (event: MouseEvent) => {
   event.preventDefault()
   const sample = eventToCanvasSample(event)
   if (ghostState?.pending) {
+    if (!ghostState.placeable) return
     // Right-click while ghost is pending: place the tower.
     const entityName = ghostState.entityName
+    const ghostSample = ghostStateToSample(ghostState, event, 2, 2)
     ghostState = null
     clearMenuSelection()
     menuDragActive = false
     mouseOverOverlay = false
     overlayStayOpen = false
     invalidateSidePanel()
-    sendCanvasMsg('click', sample, 'spawn', [entityName])
+    sendCanvasMsg('click', ghostSample, 'spawn', [entityName])
     return
   }
   updateEdgeHover(sample)
@@ -1797,6 +1882,7 @@ window.addEventListener('mousemove', (event: MouseEvent) => {
   const [worldX, worldY] = canvasToWorld(canvasX, canvasY)
   ghostState.worldX = worldX
   ghostState.worldY = worldY
+  sendPlacementPreview('dragmove', eventToCanvasSample(event), ghostState.entityName)
 })
 
 // Overlay mousedown: select a build menu cell and arm a drag (ghost appears on
@@ -1854,7 +1940,12 @@ overlayCanvas.addEventListener('mousedown', (event: MouseEvent) => {
     appearance: appearanceToRender(item.appearance),
     attackRadius: item.appearance.attackRadius,
     pending: false,
+    placeable: true,
+    placementSeq: 0,
+    placementResponseSeq: 0,
   }
+  const sample = eventToCanvasSample(event)
+  sendPlacementPreview('dragstart', sample, item.entityName)
   clearMenuSelection()
   invalidateSidePanel()
 })

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -435,7 +435,7 @@ type OverlayLevel = 'hidden' | 'peek' | 'open'
 
 function hasPinnedOpenPanel(): boolean {
   return ghostState?.pending === true ||
-    findSelectedTower() !== null ||
+    findSelectedDefender() !== null ||
     overlayStayOpen
 }
 
@@ -883,13 +883,33 @@ function updateEdgeHover(sample: CanvasPointerSample): void {
   setEdgeHoverSide(panelSideFromCanvasX(sample.canvasX))
 }
 
-function findSelectedTower(): RenderEntityUpsert | null {
+function findSelectedDefender(): RenderEntityUpsert | null {
   for (const entity of currEntitiesById.values()) {
     if (!isTransparent(entity.fx.selection) || entity.fx.rangeRadius > 0) {
       return entity
     }
   }
   return null
+}
+
+function findTowerAtWorld(worldX: number, worldY: number): RenderEntityUpsert | null {
+  const hitPos = { x: worldX, y: worldY }
+  for (const entity of currEntitiesById.values()) {
+    if (entity.app.attackRadius <= 0) continue
+    if (SimWorldDistanceSquared(entity.pos, hitPos) <= entity.app.radius * entity.app.radius) {
+      return entity
+    }
+  }
+  return null
+}
+
+function SimWorldDistanceSquared(
+  a: { x: number; y: number },
+  b: { x: number; y: number },
+): number {
+  const dx = a.x - b.x
+  const dy = a.y - b.y
+  return dx * dx + dy * dy
 }
 
 function formatPanelNumber(value: number): string {
@@ -922,20 +942,20 @@ function wrapPanelText(
   return lines
 }
 
-function getSelectedTowerPanelModel(): SidePanelModel | null {
-  const selectedTower = findSelectedTower()
-  if (!selectedTower) return null
+function getSelectedDefenderPanelModel(): SidePanelModel | null {
+  const selectedDefender = findSelectedDefender()
+  if (!selectedDefender) return null
 
-  const side: PanelSide = selectedTower.pos.x <= 0 ? 'right' : 'left'
+  const side: PanelSide = selectedDefender.pos.x <= 0 ? 'right' : 'left'
   return {
     side,
-    title: 'Tower Selected',
+    title: 'Defender Selected',
     lines: [
-      `Entity #${selectedTower.pos.id}`,
-      `World ${formatPanelNumber(selectedTower.pos.x)}, ${formatPanelNumber(selectedTower.pos.y)}`,
-      `Glyph ${selectedTower.app.glyph || '?'}`,
-      `Body radius ${formatPanelNumber(selectedTower.app.radius)}`,
-      `Attack radius ${formatPanelNumber(selectedTower.fx.rangeRadius)}`,
+      `Entity #${selectedDefender.pos.id}`,
+      `World ${formatPanelNumber(selectedDefender.pos.x)}, ${formatPanelNumber(selectedDefender.pos.y)}`,
+      `Glyph ${selectedDefender.app.glyph || '?'}`,
+      `Body radius ${formatPanelNumber(selectedDefender.app.radius)}`,
+      `Attack radius ${formatPanelNumber(selectedDefender.fx.rangeRadius)}`,
       '',
       `Phase ${phaseEl?.textContent ?? '--'}`,
       `Resources $${resources}`,
@@ -963,7 +983,7 @@ function getPendingGhostPanelModel(): SidePanelModel | null {
 }
 
 function getSidePanelModel(): SidePanelModel | null {
-  return getPendingGhostPanelModel() ?? getSelectedTowerPanelModel()
+  return getPendingGhostPanelModel() ?? getSelectedDefenderPanelModel()
 }
 
 function drawRoundedPanelPath(
@@ -1079,7 +1099,7 @@ function drawBuildMenu(ctx: CanvasRenderingContext2D): void {
   ctx.fillStyle = 'rgba(255, 255, 255, 0.96)'
   ctx.font = `bold ${titleFontSize}px monospace`
   ctx.textBaseline = 'top'
-  ctx.fillText('Build Menu', textMargin, titleTop, textWidth)
+  ctx.fillText('Select Defender', textMargin, titleTop, textWidth)
 
   ctx.strokeStyle = 'rgba(255, 255, 255, 0.12)'
   ctx.beginPath()
@@ -1187,7 +1207,7 @@ function drawGhost(): void {
     fgCtx.globalAlpha = ghostState.pending ? 0.55 : 0.35
     const rangeColor: RenderColor = {
       css: isPlaceable
-        ? 'rgba(72, 159, 255, 0.45)'
+        ? 'rgba(255, 242, 63, 0.28)'
         : 'rgba(255, 76, 76, 0.45)',
       alpha: 0.45,
     }
@@ -1198,7 +1218,7 @@ function drawGhost(): void {
       y,
       attackPx,
       isPlaceable
-        ? { css: 'rgba(72, 159, 255, 0.85)', alpha: 0.85 }
+        ? { css: 'rgba(255, 242, 63, 0.85)', alpha: 0.85 }
         : { css: 'rgba(255, 76, 76, 0.85)', alpha: 0.85 },
       Math.max(2, radius * 0.08),
     )
@@ -1707,6 +1727,24 @@ foregroundCanvas.addEventListener('mousemove', (event: MouseEvent) => {
 
   pendingDragMove = dragSample
   scheduleDragMoveFlush()
+})
+
+foregroundCanvas.addEventListener('dblclick', (event: MouseEvent) => {
+  const sample = eventToCanvasSample(event)
+  if (
+    event.button === 0 &&
+    !ghostState &&
+    !menuDragActive &&
+    currentPhase === 'build' &&
+    defenderMenuItems.length > 0 &&
+    findTowerAtWorld(sample.worldX, sample.worldY) === null
+  ) {
+    edgeHoverSide = currentPanelSide
+    mouseOverOverlay = true
+    overlayStayOpen = false
+    invalidateSidePanel()
+  }
+  sendCanvasMsg('dblclick', sample)
 })
 
 foregroundCanvas.addEventListener('mouseleave', (event: MouseEvent) => {

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -1106,6 +1106,29 @@ function drawRoundedPanelPath(
   ctx.closePath()
 }
 
+// Reinforce the bottom outer corner stroke that sits flush against the viewport
+// edge, where antialiasing can otherwise leave a tiny visible notch.
+function strokeAttachedBottomCorner(
+  ctx: CanvasRenderingContext2D,
+  side: PanelSide,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+): void {
+  const r = Math.min(radius, width / 2, height / 2)
+  const cx = side === 'left' ? x + r : x + width - r
+  const cy = y + height - r
+  ctx.beginPath()
+  if (side === 'left') {
+    ctx.arc(cx, cy, r, Math.PI, Math.PI / 2, true)
+  } else {
+    ctx.arc(cx, cy, r, Math.PI / 2, 0, true)
+  }
+  ctx.stroke()
+}
+
 // Draw a textual side panel such as defender inspection or pending placement.
 function drawSidePanel(ctx: CanvasRenderingContext2D, panel: SidePanelModel): void {
   const width = overlayCanvas.width
@@ -1167,6 +1190,7 @@ function drawSidePanel(ctx: CanvasRenderingContext2D, panel: SidePanelModel): vo
   ctx.lineJoin = 'round'
   ctx.lineCap = 'round'
   ctx.stroke()
+  strokeAttachedBottomCorner(ctx, panel.side, x, y, panelWidth, panelHeight, cornerRadius)
 
   ctx.fillStyle = 'rgba(255, 255, 255, 0.96)'
   ctx.font = `bold ${titleFontSize}px monospace`
@@ -1254,6 +1278,7 @@ function drawBuildMenu(ctx: CanvasRenderingContext2D): void {
   ctx.lineJoin = 'round'
   ctx.lineCap = 'round'
   ctx.stroke()
+  strokeAttachedBottomCorner(ctx, currentPanelSide, x, y, panelWidth, panelHeight, cornerRadius)
 
   ctx.fillStyle = 'rgba(255, 255, 255, 0.96)'
   ctx.font = `bold ${titleFontSize}px monospace`

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -59,6 +59,14 @@ interface CanvasPointerSample {
   meta: boolean
 }
 
+type PanelSide = 'left' | 'right'
+
+interface SidePanelModel {
+  side: PanelSide
+  title: string
+  lines: string[]
+}
+
 const DEFAULT_RENDER_APPEARANCE: RenderAppearance = {
   glyph: '?',
   radius: 5,
@@ -96,6 +104,7 @@ const tickEl = requireEl('tick', HTMLElement)
 const logEl = requireEl('log', HTMLElement)
 const backgroundCanvas = requireEl('background-canvas', HTMLCanvasElement)
 const foregroundCanvas = requireEl('foreground-canvas', HTMLCanvasElement)
+const overlayCanvas = requireEl('overlay-canvas', HTMLCanvasElement)
 const livesEl = document.getElementById('lives')
 const resourcesEl = document.getElementById('resources')
 const phaseEl = document.getElementById('phase')
@@ -107,6 +116,9 @@ const bgCtx: CanvasRenderingContext2D = maybeBgCtx
 const maybeFgCtx = foregroundCanvas.getContext('2d')
 if (!maybeFgCtx) throw new Error('Could not get 2D foreground canvas context')
 const fgCtx: CanvasRenderingContext2D = maybeFgCtx
+const maybeOverlayCtx = overlayCanvas.getContext('2d')
+if (!maybeOverlayCtx) throw new Error('Could not get 2D overlay canvas context')
+const overlayCtx: CanvasRenderingContext2D = maybeOverlayCtx
 const hudCanvas = document.createElement('canvas')
 hudCanvas.width = foregroundCanvas.width
 hudCanvas.height = foregroundCanvas.height
@@ -119,7 +131,6 @@ fpsCanvas.height = foregroundCanvas.height
 const maybeFpsCtx = fpsCanvas.getContext('2d')
 if (!maybeFpsCtx) throw new Error('Could not get 2D FPS canvas context')
 const fpsCtx: CanvasRenderingContext2D = maybeFpsCtx
-
 // --- World / canvas coordinate mapping ---
 //
 // The server simulation runs in a 1920x1080 world space. The canvas is sized
@@ -204,6 +215,13 @@ let nextClientSeq = 1
 let canvasPointerState: CanvasPointerState | null = null
 let pendingDragMove: CanvasPointerSample | null = null
 let dragMoveFrameRequested = false
+let sidePanelDirty = true
+let edgeHoverSide: PanelSide | null = null
+
+const SIDE_PANEL_TRIGGER_PX = 48
+const SIDE_PANEL_RADIUS = 18
+const SIDE_PANEL_LINE_HEIGHT = 22
+const SIDE_PANEL_TEXT_MARGIN = 28
 
 // Linear interpolation calculator
 function lerp(a: number, b: number, t: number): number {
@@ -259,6 +277,16 @@ function updateFpsOverlay(now: number): void {
   fpsCtx.clearRect(0, 0, fpsCanvas.width, fpsCanvas.height)
   drawFps(fpsCtx)
   lastFpsOverlayUpdateTime = now
+}
+
+function invalidateSidePanel(): void {
+  sidePanelDirty = true
+}
+
+function setEdgeHoverSide(nextSide: PanelSide | null): void {
+  if (edgeHoverSide === nextSide) return
+  edgeHoverSide = nextSide
+  invalidateSidePanel()
 }
 
 function packedRgbaToRenderColor(color: number): RenderColor {
@@ -552,6 +580,193 @@ function drawHud(ctx: CanvasRenderingContext2D): void {
   ctx.restore()
 }
 
+function panelSideFromCanvasX(canvasX: number): PanelSide | null {
+  if (canvasX <= SIDE_PANEL_TRIGGER_PX) return 'left'
+  if (canvasX >= foregroundCanvas.width - SIDE_PANEL_TRIGGER_PX) return 'right'
+  return null
+}
+
+function updateEdgeHover(sample: CanvasPointerSample): void {
+  setEdgeHoverSide(panelSideFromCanvasX(sample.canvasX))
+}
+
+function findSelectedTower(): RenderEntityUpsert | null {
+  for (const entity of currEntitiesById.values()) {
+    if (!isTransparent(entity.fx.selection) || entity.fx.rangeRadius > 0) {
+      return entity
+    }
+  }
+  return null
+}
+
+function formatPanelNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1)
+}
+
+function wrapPanelText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+): string[] {
+  if (text.length === 0) return ['']
+
+  const words = text.split(/\s+/)
+  const lines: string[] = []
+  let currentLine = ''
+
+  for (const word of words) {
+    const candidate = currentLine.length === 0 ? word : `${currentLine} ${word}`
+    if (ctx.measureText(candidate).width <= maxWidth || currentLine.length === 0) {
+      currentLine = candidate
+      continue
+    }
+
+    lines.push(currentLine)
+    currentLine = word
+  }
+
+  if (currentLine.length > 0) lines.push(currentLine)
+  return lines
+}
+
+function getSelectedTowerPanelModel(): SidePanelModel | null {
+  const selectedTower = findSelectedTower()
+  if (!selectedTower) return null
+
+  const defaultSide: PanelSide = selectedTower.pos.x <= 0 ? 'right' : 'left'
+  const side: PanelSide = edgeHoverSide ?? defaultSide
+  return {
+    side,
+    title: 'Tower Selected',
+    lines: [
+      `Entity #${selectedTower.pos.id}`,
+      `World ${formatPanelNumber(selectedTower.pos.x)}, ${formatPanelNumber(selectedTower.pos.y)}`,
+      `Glyph ${selectedTower.app.glyph || '?'}`,
+      `Body radius ${formatPanelNumber(selectedTower.app.radius)}`,
+      `Attack radius ${formatPanelNumber(selectedTower.fx.rangeRadius)}`,
+      '',
+      `Phase ${phaseEl?.textContent ?? '--'}`,
+      `Resources $${resources}`,
+      'Left click empty space to dismiss',
+    ],
+  }
+}
+
+function getHoverPanelModel(): SidePanelModel | null {
+  if (!edgeHoverSide) return null
+
+  return {
+    side: edgeHoverSide,
+    title: 'Build Panel',
+    lines: [
+      `Phase ${phaseEl?.textContent ?? '--'}`,
+      `Lives ${lives}`,
+      `Resources $${resources}`,
+      '',
+      'Double click to place a tower',
+      'Left click to select a tower',
+      'Right click to flash an entity',
+      'Use Start Wave to begin the next push',
+    ],
+  }
+}
+
+function getSidePanelModel(): SidePanelModel | null {
+  return getSelectedTowerPanelModel() ?? getHoverPanelModel()
+}
+
+function drawRoundedPanelPath(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+): void {
+  const r = Math.min(radius, width / 2, height / 2)
+  ctx.beginPath()
+  ctx.moveTo(x + r, y)
+  ctx.lineTo(x + width - r, y)
+  ctx.quadraticCurveTo(x + width, y, x + width, y + r)
+  ctx.lineTo(x + width, y + height - r)
+  ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height)
+  ctx.lineTo(x + r, y + height)
+  ctx.quadraticCurveTo(x, y + height, x, y + height - r)
+  ctx.lineTo(x, y + r)
+  ctx.quadraticCurveTo(x, y, x + r, y)
+  ctx.closePath()
+}
+
+function drawSidePanel(ctx: CanvasRenderingContext2D, panel: SidePanelModel): void {
+  const x = 0
+  const y = 0
+  const width = overlayCanvas.width
+  const height = overlayCanvas.height
+  const textX = x + SIDE_PANEL_TEXT_MARGIN
+  const textWidth = width - SIDE_PANEL_TEXT_MARGIN * 2
+
+  ctx.save()
+  drawRoundedPanelPath(ctx, x, y, width, height, SIDE_PANEL_RADIUS)
+  const gradient = ctx.createLinearGradient(x, y, x + width, y + height)
+  gradient.addColorStop(0, 'rgba(12, 18, 26, 0.92)')
+  gradient.addColorStop(1, 'rgba(18, 27, 39, 0.84)')
+  ctx.fillStyle = gradient
+  ctx.fill()
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.16)'
+  ctx.lineWidth = 1.5
+  ctx.stroke()
+
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.96)'
+  ctx.font = 'bold 24px monospace'
+  ctx.textBaseline = 'top'
+  ctx.fillText(panel.title, textX, y + 20, textWidth)
+
+  ctx.strokeStyle = 'rgba(255, 255, 255, 0.12)'
+  ctx.beginPath()
+  ctx.moveTo(textX, y + 56)
+  ctx.lineTo(textX + textWidth, y + 56)
+  ctx.stroke()
+
+  ctx.font = '16px monospace'
+  let lineY = y + 74
+  for (const line of panel.lines) {
+    if (line.length === 0) {
+      lineY += SIDE_PANEL_LINE_HEIGHT * 0.65
+      continue
+    }
+    ctx.fillStyle = line.startsWith('Left click') || line.startsWith('Double click') ||
+        line.startsWith('Right click') || line.startsWith('Use Start Wave')
+      ? 'rgba(181, 201, 224, 0.92)'
+      : 'rgba(255, 255, 255, 0.92)'
+    const wrappedLines = wrapPanelText(ctx, line, textWidth)
+    for (const wrappedLine of wrappedLines) {
+      ctx.fillText(wrappedLine, textX, lineY, textWidth)
+      lineY += SIDE_PANEL_LINE_HEIGHT
+    }
+  }
+  ctx.restore()
+}
+
+function updateSidePanelOverlay(): void {
+  if (!sidePanelDirty) return
+
+  const panel = getSidePanelModel()
+  overlayCtx.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height)
+  if (!panel) {
+    overlayCanvas.style.display = 'none'
+    sidePanelDirty = false
+    return
+  }
+
+  overlayCanvas.style.display = 'block'
+  overlayCanvas.style.left = panel.side === 'left'
+    ? '0'
+    : `${foregroundCanvas.width - overlayCanvas.width}px`
+  overlayCanvas.style.right = ''
+  drawSidePanel(overlayCtx, panel)
+  sidePanelDirty = false
+}
+
 function frame(now: number): void {
   if (lastFrameTime !== 0) {
     const dt = now - lastFrameTime
@@ -562,6 +777,7 @@ function frame(now: number): void {
   renderInterpolated(now)
   updateHudOverlay()
   updateFpsOverlay(now)
+  updateSidePanelOverlay()
   fgCtx.drawImage(hudCanvas, 0, 0)
   fgCtx.drawImage(fpsCanvas, 0, 0)
   requestAnimationFrame(frame)
@@ -732,9 +948,13 @@ function resetClientWorldState(): void {
   resources = 0
   lastFpsOverlayUpdateTime = 0
   hudDirty = true
+  sidePanelDirty = true
+  edgeHoverSide = null
 
   bgCtx.clearRect(0, 0, backgroundCanvas.width, backgroundCanvas.height)
   fgCtx.clearRect(0, 0, foregroundCanvas.width, foregroundCanvas.height)
+  overlayCtx.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height)
+  overlayCanvas.style.display = 'none'
   hudCtx.clearRect(0, 0, hudCanvas.width, hudCanvas.height)
   fpsCtx.clearRect(0, 0, fpsCanvas.width, fpsCanvas.height)
 }
@@ -760,6 +980,7 @@ function applyWorldDelta(delta: WorldDelta): void {
   lives = delta.lives
   resources = delta.resources
   invalidateHud()
+  invalidateSidePanel()
   setTextIfElement(livesEl, String(delta.lives))
   setTextIfElement(resourcesEl, String(delta.resources))
   setTextIfElement(phaseEl, getDeltaPhase(delta))
@@ -857,6 +1078,7 @@ ws.onerror = () => {
 
 foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   const sample = eventToCanvasSample(event)
+  updateEdgeHover(sample)
   canvasPointerState = {
     button: sample.button,
     buttons: sample.buttons,
@@ -867,8 +1089,9 @@ foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
 })
 
 foregroundCanvas.addEventListener('mousemove', (event: MouseEvent) => {
-  if (!canvasPointerState) return
   const sample = eventToCanvasSample(event)
+  updateEdgeHover(sample)
+  if (!canvasPointerState) return
   canvasPointerState.buttons = sample.buttons
 
   if (canvasPointerState.button !== 0) return
@@ -885,6 +1108,21 @@ foregroundCanvas.addEventListener('mousemove', (event: MouseEvent) => {
   scheduleDragMoveFlush()
 })
 
+foregroundCanvas.addEventListener('mouseleave', (event: MouseEvent) => {
+  if (event.relatedTarget === overlayCanvas) return
+  setEdgeHoverSide(null)
+})
+
+overlayCanvas.addEventListener('mouseenter', () => {
+  const panel = getSidePanelModel()
+  if (panel) setEdgeHoverSide(panel.side)
+})
+
+overlayCanvas.addEventListener('mouseleave', () => {
+  if (findSelectedTower()) return
+  setEdgeHoverSide(null)
+})
+
 window.addEventListener('mouseup', (event: MouseEvent) => {
   if (!canvasPointerState) return
   const sample = withPointerButton(
@@ -899,11 +1137,15 @@ window.addEventListener('mouseup', (event: MouseEvent) => {
 
 foregroundCanvas.addEventListener('contextmenu', (event: MouseEvent) => {
   event.preventDefault()
-  sendCanvasMsg('click', withPointerButton(eventToCanvasSample(event), 2, 2))
+  const sample = eventToCanvasSample(event)
+  updateEdgeHover(sample)
+  sendCanvasMsg('click', withPointerButton(sample, 2, 2))
 })
 
 foregroundCanvas.addEventListener('dblclick', (event: MouseEvent) => {
-  sendCanvasMsg('dblclick', eventToCanvasSample(event))
+  const sample = eventToCanvasSample(event)
+  updateEdgeHover(sample)
+  sendCanvasMsg('dblclick', sample)
 })
 
 document.addEventListener('click', (event: MouseEvent) => {

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -1,5 +1,6 @@
 import type {
   CategoryItem,
+  Circle,
   ClientMsg,
   DefenderMenuItem,
   EntityAppearance,
@@ -41,12 +42,10 @@ interface RenderAppearance {
 
 // Local placement-preview state for a defender being dragged or staged to spawn.
 interface GhostState {
-  worldX: number
-  worldY: number
   entityName: string
   displayName: string
   appearance: RenderAppearance
-  attackRadius: number  // world units, from Appearance.attackRadius
+  worldCircle: Circle
   confirmCommand: 'spawn' | 'moving'
   pending: boolean      // true = dropped on map, awaiting confirmation click
   placeable: boolean    // true = can be placed at the current position
@@ -76,24 +75,19 @@ interface RenderEntityUpsert {
 }
 
 interface RenderTransientExplosion {
-  x: number
-  y: number
+  circle: Circle
   expiry: number
   primary: RenderColor
   secondary: RenderColor
-  radius: number
   startedAt: number
 }
 
 interface RenderTransientBeam {
-  x: number
-  y: number
+  circle: Circle
   expiry: number
   primary: RenderColor
   secondary: RenderColor
-  targetX: number
-  targetY: number
-  startDistance: number
+  targetPos: Position
   lineWidth: number
   startedAt: number
   halfAngleDeg: number
@@ -374,14 +368,14 @@ function ghostStateToSample(
   button = event.button,
   buttons = event.buttons,
 ): CanvasPointerSample {
-  const [canvasX, canvasY] = worldToCanvas(ghost.worldX, ghost.worldY)
+  const [canvasX, canvasY] = worldToCanvas(ghost.worldCircle.x, ghost.worldCircle.y)
   return {
     button,
     buttons,
     canvasX: Math.round(canvasX),
     canvasY: Math.round(canvasY),
-    worldX: Math.round(ghost.worldX),
-    worldY: Math.round(ghost.worldY),
+    worldX: Math.round(ghost.worldCircle.x),
+    worldY: Math.round(ghost.worldCircle.y),
     shift: event.shiftKey,
     ctrl: event.ctrlKey,
     alt: event.altKey,
@@ -743,12 +737,14 @@ function closeBuildMenuFromKeyboard(): void {
 function dropDefenderGhostAtPointer(item: DefenderMenuItem): void {
   const sample = getPointerAnchorSample()
   ghostState = {
-    worldX: sample.worldX,
-    worldY: sample.worldY,
     entityName: item.entityName,
     displayName: item.displayName,
     appearance: appearanceToRender(item.appearance),
-    attackRadius: item.appearance.attackRadius,
+    worldCircle: {
+      x: sample.worldX,
+      y: sample.worldY,
+      radius: item.appearance.attackRadius,
+    },
     confirmCommand: 'spawn',
     pending: true,
     placeable: true,
@@ -986,8 +982,8 @@ function isTransientFlashPrimary(now: number, startedAt: number): boolean {
 }
 
 function drawExplosionTransient(transient: RenderTransientExplosion, now: number): void {
-  const [x, y] = worldToCanvas(transient.x, transient.y)
-  const radius = worldLengthToCanvas(transient.radius)
+  const [x, y] = worldToCanvas(transient.circle.x, transient.circle.y)
+  const radius = worldLengthToCanvas(transient.circle.radius)
   const color = isTransientFlashPrimary(now, transient.startedAt)
     ? transient.primary
     : transient.secondary
@@ -1000,15 +996,15 @@ function drawExplosionTransient(transient: RenderTransientExplosion, now: number
 }
 
 function drawBeamTransient(transient: RenderTransientBeam, now: number): void {
-  const dx = transient.targetX - transient.x
-  const dy = transient.targetY - transient.y
+  const dx = transient.targetPos.x - transient.circle.x
+  const dy = transient.targetPos.y - transient.circle.y
   const length = Math.sqrt((dx * dx) + (dy * dy))
   if (length <= 0) return
 
   const ux = dx / length
   const uy = dy / length
-  const startX = transient.x + ux * transient.startDistance
-  const startY = transient.y + uy * transient.startDistance
+  const startX = transient.circle.x + ux * transient.circle.radius
+  const startY = transient.circle.y + uy * transient.circle.radius
 
   if (transient.halfAngleDeg > 0) {
     // Cone mode: filled wedge fading linearly from opaque to transparent.
@@ -1034,7 +1030,7 @@ function drawBeamTransient(transient: RenderTransientBeam, now: number): void {
     // Line mode: flickering stroke between primary and secondary colours.
     const [canvasStartX, canvasStartY] = worldToCanvas(startX, startY)
     const [canvasTargetX, canvasTargetY] =
-      worldToCanvas(transient.targetX, transient.targetY)
+      worldToCanvas(transient.targetPos.x, transient.targetPos.y)
     const color = isTransientFlashPrimary(now, transient.startedAt)
       ? transient.primary
       : transient.secondary
@@ -1228,12 +1224,10 @@ function explosionToRender(
   currentTick: number,
 ): RenderTransientExplosion {
   return {
-    x: transient.x,
-    y: transient.y,
+    circle: transient.circle,
     expiry: tickExpiryToWallMs(transient.expiryTick, currentTick, now),
     primary: packedRgbaToRenderColor(transient.primaryColor),
     secondary: packedRgbaToRenderColor(transient.secondaryColor),
-    radius: transient.radius,
     startedAt: now,
   }
 }
@@ -1244,14 +1238,11 @@ function beamToRender(
   currentTick: number,
 ): RenderTransientBeam {
   return {
-    x: transient.x,
-    y: transient.y,
+    circle: transient.circle,
     expiry: tickExpiryToWallMs(transient.expiryTick, currentTick, now),
     primary: packedRgbaToRenderColor(transient.primaryColor),
     secondary: packedRgbaToRenderColor(transient.secondaryColor),
-    targetX: transient.targetX,
-    targetY: transient.targetY,
-    startDistance: transient.startDistance,
+    targetPos: transient.targetPos,
     lineWidth: transient.lineWidth,
     startedAt: now,
     halfAngleDeg: transient.halfAngleDeg,
@@ -1479,7 +1470,7 @@ function getSelectedDefenderPanelModel(): SidePanelModel | null {
 // Build the overlay model for a dropped-but-not-yet-confirmed placement ghost.
 function getPendingGhostPanelModel(): SidePanelModel | null {
   if (!ghostState?.pending) return null
-  const [ghostCanvasX] = worldToCanvas(ghostState.worldX, ghostState.worldY)
+  const [ghostCanvasX] = worldToCanvas(ghostState.worldCircle.x, ghostState.worldCircle.y)
   const side = getOppositePanelSideForCanvasX(ghostCanvasX)
   const isMoveGhost = ghostState.confirmCommand === 'moving'
   return {
@@ -1855,9 +1846,9 @@ function drawBuildMenu(ctx: CanvasRenderingContext2D): void {
 // Draw the draggable or pending placement ghost on top of the world layer.
 function drawGhost(): void {
   if (!ghostState) return
-  const [x, y] = worldToCanvas(ghostState.worldX, ghostState.worldY)
+  const [x, y] = worldToCanvas(ghostState.worldCircle.x, ghostState.worldCircle.y)
   const radius = worldLengthToCanvas(ghostState.appearance.radius)
-  const attackPx = worldLengthToCanvas(ghostState.attackRadius)
+  const attackPx = worldLengthToCanvas(ghostState.worldCircle.radius)
   const isPlaceable = ghostState.placeable
 
   fgCtx.save()
@@ -2195,12 +2186,14 @@ function isTransientExplosion(value: unknown): value is TransientExplosion {
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof (value as Record<string, unknown>).x === 'number' &&
-    typeof (value as Record<string, unknown>).y === 'number' &&
+    typeof (value as Record<string, unknown>).circle === 'object' &&
+    (value as Record<string, unknown>).circle !== null &&
+    typeof ((value as Record<string, unknown>).circle as Record<string, unknown>).x === 'number' &&
+    typeof ((value as Record<string, unknown>).circle as Record<string, unknown>).y === 'number' &&
+    typeof ((value as Record<string, unknown>).circle as Record<string, unknown>).radius === 'number' &&
     typeof (value as Record<string, unknown>).expiryTick === 'number' &&
     typeof (value as Record<string, unknown>).primaryColor === 'number' &&
-    typeof (value as Record<string, unknown>).secondaryColor === 'number' &&
-    typeof (value as Record<string, unknown>).radius === 'number'
+    typeof (value as Record<string, unknown>).secondaryColor === 'number'
   )
 }
 
@@ -2208,14 +2201,18 @@ function isTransientBeam(value: unknown): value is TransientBeam {
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof (value as Record<string, unknown>).x === 'number' &&
-    typeof (value as Record<string, unknown>).y === 'number' &&
+    typeof (value as Record<string, unknown>).circle === 'object' &&
+    (value as Record<string, unknown>).circle !== null &&
+    typeof ((value as Record<string, unknown>).circle as Record<string, unknown>).x === 'number' &&
+    typeof ((value as Record<string, unknown>).circle as Record<string, unknown>).y === 'number' &&
+    typeof ((value as Record<string, unknown>).circle as Record<string, unknown>).radius === 'number' &&
     typeof (value as Record<string, unknown>).expiryTick === 'number' &&
     typeof (value as Record<string, unknown>).primaryColor === 'number' &&
     typeof (value as Record<string, unknown>).secondaryColor === 'number' &&
-    typeof (value as Record<string, unknown>).targetX === 'number' &&
-    typeof (value as Record<string, unknown>).targetY === 'number' &&
-    typeof (value as Record<string, unknown>).startDistance === 'number' &&
+    typeof (value as Record<string, unknown>).targetPos === 'object' &&
+    (value as Record<string, unknown>).targetPos !== null &&
+    typeof ((value as Record<string, unknown>).targetPos as Record<string, unknown>).x === 'number' &&
+    typeof ((value as Record<string, unknown>).targetPos as Record<string, unknown>).y === 'number' &&
     typeof (value as Record<string, unknown>).lineWidth === 'number'
   )
 }
@@ -2380,11 +2377,13 @@ function applyWorldDelta(delta: WorldDelta): void {
   }
   for (const transient of delta.transientExplosions) {
     const rendered = explosionToRender(transient, now, delta.tick)
-    transientExplosionsByPos.set(transientDisplayKey(transient.x, transient.y), rendered)
+    transientExplosionsByPos.set(
+      transientDisplayKey(transient.circle.x, transient.circle.y), rendered)
   }
   for (const transient of delta.transientBeams) {
     const rendered = beamToRender(transient, now, delta.tick)
-    transientBeamsByPos.set(transientDisplayKey(transient.x, transient.y), rendered)
+    transientBeamsByPos.set(
+      transientDisplayKey(transient.circle.x, transient.circle.y), rendered)
   }
 
   finishSnapshotUpdate()
@@ -2580,7 +2579,7 @@ foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   // While a ghost is pending, left-click on the ghost picks it back up and
   // any other non-right click cancels placement.
   if (event.button === 0 && ghostState?.pending) {
-    const [gx, gy] = worldToCanvas(ghostState.worldX, ghostState.worldY)
+    const [gx, gy] = worldToCanvas(ghostState.worldCircle.x, ghostState.worldCircle.y)
     const hitRadius = worldLengthToCanvas(ghostState.appearance.radius) * 2
     const dx = sample.canvasX - gx
     const dy = sample.canvasY - gy
@@ -2682,12 +2681,14 @@ foregroundCanvas.addEventListener('mousemove', (event: MouseEvent) => {
         findDefenderAtWorld(selectedDefenderPosition.x, selectedDefenderPosition.y)
       if (selectedEntity !== null) {
         ghostState = {
-          worldX: dragSample.worldX,
-          worldY: dragSample.worldY,
           entityName: selectedDefenderSummary.entityName,
           displayName: selectedDefenderSummary.displayName,
           appearance: selectedEntity.app,
-          attackRadius: selectedDefenderSummary.appearance.attackRadius,
+          worldCircle: {
+            x: dragSample.worldX,
+            y: dragSample.worldY,
+            radius: selectedDefenderSummary.appearance.attackRadius,
+          },
           confirmCommand: 'moving',
           pending: false,
           placeable: true,
@@ -2955,8 +2956,8 @@ window.addEventListener('mousemove', (event: MouseEvent) => {
   const canvasX = (event.clientX - rect.left) * (foregroundCanvas.width / rect.width)
   const canvasY = (event.clientY - rect.top) * (foregroundCanvas.height / rect.height)
   const [worldX, worldY] = canvasToWorld(canvasX, canvasY)
-  ghostState.worldX = worldX
-  ghostState.worldY = worldY
+  ghostState.worldCircle.x = worldX
+  ghostState.worldCircle.y = worldY
   if (menuDragActive) {
     sendPlacementPreview('dragmove', eventToCanvasSample(event), ghostState.entityName)
   } else if (moveDragActive) {
@@ -3043,12 +3044,14 @@ overlayCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   const fgCanvasY = (event.clientY - fgRect.top) * (foregroundCanvas.height / fgRect.height)
   const [worldX, worldY] = canvasToWorld(fgCanvasX, fgCanvasY)
   ghostState = {
-    worldX,
-    worldY,
     entityName: item.entityName,
     displayName: item.displayName,
     appearance: appearanceToRender(item.appearance),
-    attackRadius: item.appearance.attackRadius,
+    worldCircle: {
+      x: worldX,
+      y: worldY,
+      radius: item.appearance.attackRadius,
+    },
     confirmCommand: 'spawn',
     pending: false,
     placeable: true,

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -72,6 +72,7 @@ interface CanvasPointerState {
   button: number
   buttons: number
   dragging: boolean
+  isMoveDrag: boolean // true when the drag started on the selected defender
 }
 
 // Mouse event sample expressed in both canvas-space and world-space coordinates.
@@ -398,6 +399,7 @@ let selectedMenuIndex: number | null = null
 let menuScrollOffset = 0
 let ghostState: GhostState | null = null
 let menuDragActive = false
+let moveDragActive = false // true while dragging a selected defender to reposition it
 let currentPhase = 'build'
 let mouseOverOverlay = false
 let overlayStayOpen = false
@@ -974,11 +976,11 @@ function drawFps(ctx: CanvasRenderingContext2D): void {
 function getWaveStatusText(): string {
   const waveNum = currentWave + 1
   switch (currentPhase) {
-    case 'build':    return `Prepare for Wave ${waveNum}`
-    case 'wave':     return `Wave ${waveNum}`
+    case 'build': return `Prepare for Wave ${waveNum}`
+    case 'wave': return `Wave ${waveNum}`
     case 'game_over': return 'Game Over'
-    case 'victory':  return 'Invaders Thwarted!'
-    default:         return ''
+    case 'victory': return 'Invaders Thwarted!'
+    default: return ''
   }
 }
 
@@ -1121,6 +1123,8 @@ function getSelectedDefenderPanelModel(): SidePanelModel | null {
     lines.push(`Damage dealt: ${formatPanelNumber(selectedDefenderSummary.totalDamageDealt)}`)
     lines.push(`Kills: ${selectedDefenderSummary.totalKills ?? 0}`)
   }
+  lines.push('')
+  if (currentPhase === 'build') lines.push('Drag to reposition')
   lines.push('Left click empty space to dismiss')
 
   return { side, title: selectedDefenderSummary.displayName, lines }
@@ -2060,14 +2064,16 @@ foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   const sample = eventToCanvasSample(event)
   updateEdgeHover(sample)
 
-  // A transient build panel opened from the background should collapse when
-  // the user clicks empty world space again.
+  // Collapse the build-menu overlay whenever the user left-clicks on the
+  // canvas without a selection already active. This covers both empty-space
+  // clicks AND clicks on an unselected defender — in the latter case the
+  // overlay will reopen with the defender panel once the server confirms the
+  // selection, so the build menu must not be visible in the interim.
   if (
     event.button === 0 &&
     !ghostState &&
     !menuDragActive &&
-    selectedDefenderPosition === null &&
-    findDefenderAtWorld(sample.worldX, sample.worldY) === null
+    selectedDefenderPosition === null
   ) {
     mouseOverOverlay = false
     overlayStayOpen = false
@@ -2096,10 +2102,25 @@ foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
     return
   }
 
+  // Detect whether this left-click starts on the currently selected defender
+  // so that a subsequent drag relocates it rather than sending a generic drag.
+  let isMoveDrag = false
+  if (event.button === 0 && currentPhase === 'build' &&
+    selectedDefenderPosition !== null && !ghostState) {
+    const clickedDefender = findDefenderAtWorld(sample.worldX, sample.worldY)
+    if (clickedDefender !== null) {
+      const selectedEntity =
+        findDefenderAtWorld(selectedDefenderPosition.x, selectedDefenderPosition.y)
+      if (selectedEntity !== null && clickedDefender.pos.id === selectedEntity.pos.id)
+        isMoveDrag = true
+    }
+  }
+
   canvasPointerState = {
     button: sample.button,
     buttons: sample.buttons,
     dragging: false,
+    isMoveDrag,
   }
 
   if (sample.button !== 2) sendCanvasMsg('click', sample)
@@ -2119,12 +2140,40 @@ foregroundCanvas.addEventListener('mousemove', (event: MouseEvent) => {
 
   if (!canvasPointerState.dragging) {
     canvasPointerState.dragging = true
+    if (canvasPointerState.isMoveDrag &&
+      selectedDefenderPosition !== null && selectedDefenderSummary !== null) {
+      // Start a move drag: create a ghost representing the defender being
+      // relocated and send a "moving" dragstart so the server can validate.
+      const selectedEntity =
+        findDefenderAtWorld(selectedDefenderPosition.x, selectedDefenderPosition.y)
+      if (selectedEntity !== null) {
+        ghostState = {
+          worldX: dragSample.worldX,
+          worldY: dragSample.worldY,
+          entityName: selectedDefenderSummary.entityName,
+          displayName: selectedDefenderSummary.displayName,
+          appearance: selectedEntity.app,
+          attackRadius: selectedDefenderSummary.appearance.attackRadius,
+          pending: false,
+          placeable: true,
+          spawnPending: false,
+        }
+        moveDragActive = true
+        sendCanvasMsg('dragstart', dragSample, 'moving')
+        invalidateSidePanel()
+        return
+      }
+    }
     sendCanvasMsg('dragstart', dragSample)
     return
   }
 
-  pendingDragMove = dragSample
-  scheduleDragMoveFlush()
+  // Do not send a generic dragmove while a move-drag is in progress; the
+  // global window mousemove handler sends "moving" dragmove events instead.
+  if (!moveDragActive) {
+    pendingDragMove = dragSample
+    scheduleDragMoveFlush()
+  }
 })
 
 // Open the build menu directly from empty build space on double-click, then
@@ -2195,6 +2244,18 @@ overlayCanvas.addEventListener('mouseleave', (event: MouseEvent) => {
 
 // Finish menu drags and normal canvas drags when the mouse button is released.
 window.addEventListener('mouseup', (event: MouseEvent) => {
+  // Commit or cancel a move drag (relocating a placed defender).
+  if (moveDragActive) {
+    moveDragActive = false
+    if (ghostState) {
+      sendCanvasMsg('dragend', eventToCanvasSample(event), 'moving')
+      ghostState = null
+    }
+    canvasPointerState = null
+    invalidateSidePanel()
+    return
+  }
+
   // Handle menu drag commit/cancel.
   if (menuDragActive) {
     menuDragActive = false
@@ -2326,22 +2387,42 @@ document.addEventListener('mousedown', (event: MouseEvent) => {
   invalidateSidePanel()
 })
 
-// Track ghost world position globally during a menu drag.
+// Track ghost world position globally during a menu drag or a move drag.
 window.addEventListener('mousemove', (event: MouseEvent) => {
-  if (!menuDragActive || !ghostState) return
+  if (!ghostState) return
   const rect = foregroundCanvas.getBoundingClientRect()
   const canvasX = (event.clientX - rect.left) * (foregroundCanvas.width / rect.width)
   const canvasY = (event.clientY - rect.top) * (foregroundCanvas.height / rect.height)
   const [worldX, worldY] = canvasToWorld(canvasX, canvasY)
   ghostState.worldX = worldX
   ghostState.worldY = worldY
-  sendPlacementPreview('dragmove', eventToCanvasSample(event), ghostState.entityName)
+  if (menuDragActive) {
+    sendPlacementPreview('dragmove', eventToCanvasSample(event), ghostState.entityName)
+  } else if (moveDragActive) {
+    sendCanvasMsg('dragmove', eventToCanvasSample(event), 'moving')
+  }
 })
 
 // Overlay mousedown: select a build menu cell and arm a drag (ghost appears on
 // first mousemove so it never flashes at the canvas origin).
 overlayCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   if (event.button !== 0) return
+
+  // When the build menu is open, a click whose world-space coordinates land on
+  // a defender should select that defender rather than interact with the menu.
+  // This handles the case where a placed defender sits behind the overlay panel.
+  if (!ghostState && !menuDragActive && currentPhase === 'build') {
+    const sample = eventToCanvasSample(event)
+    if (findDefenderAtWorld(sample.worldX, sample.worldY) !== null) {
+      event.preventDefault()
+      sendCanvasMsg('click', sample)
+      mouseOverOverlay = false
+      overlayStayOpen = false
+      invalidateSidePanel()
+      return
+    }
+  }
+
   if (!shouldShowBuildMenu()) return
   event.preventDefault()
 

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -34,6 +34,7 @@ interface RenderAppearance {
   fg: RenderColor
   bg: RenderColor
   attackRadius: number // Radius of attack
+  trail: RenderColor  // Transparent = no trail; otherwise drawn prev->curr tick.
 }
 
 // Local placement-preview state for a defender being dragged or staged to spawn.
@@ -129,17 +130,18 @@ interface SidePanelModel {
   lines: string[]
 }
 
+const TRANSPARENT_RENDER_COLOR: RenderColor = {
+  css: 'rgba(0, 0, 0, 0)',
+  alpha: 0,
+}
+
 const DEFAULT_RENDER_APPEARANCE: RenderAppearance = {
   glyph: '?',
   radius: 5,
   fg: { css: 'rgba(255, 255, 255, 1)', alpha: 1 },
   bg: { css: 'rgba(0, 0, 0, 1)', alpha: 1 },
   attackRadius: 0,
-}
-
-const TRANSPARENT_RENDER_COLOR: RenderColor = {
-  css: 'rgba(0, 0, 0, 0)',
-  alpha: 0,
+  trail: TRANSPARENT_RENDER_COLOR,
 }
 
 const DEFAULT_RENDER_VISUAL_EFFECTS: RenderVisualEffects = {
@@ -394,9 +396,6 @@ let lastFrameTime = 0
 // to interpolate from the old snapshot toward the new one.
 const currEntitiesById = new Map<number, RenderEntityUpsert>()
 const prevRenderStateById = new Map<number, RenderEntityUpsert>()
-// Tracks entity IDs known to be bullets (glyph '*'=42 or '.'=46), so erasure
-// logging can identify bullet deaths without needing the appearance data.
-const bulletEntityIds = new Set<number>()
 let prevSnapshotTime = 0
 let currSnapshotTime = 0
 let snapshotIntervalMs = 50
@@ -498,6 +497,10 @@ function renderInterpolated(now: number): void {
     const wy = prevPos ? lerp(prevPos.y, e.pos.y, t) : e.pos.y
     const [x, y] = worldToCanvas(wx, wy)
     const radius = worldLengthToCanvas(lerp(prevApp.radius, e.app.radius, t))
+    if (prevPos && !isTransparent(e.app.trail)) {
+      const [px, py] = worldToCanvas(prevPos.x, prevPos.y)
+      drawTrail(px, py, x, y, radius, e.app.trail)
+    }
     drawEntity(x, y, radius, e.app, e.fx, now)
   }
   drawTransientDisplays(now)
@@ -981,6 +984,32 @@ function drawCooldownOverlay(
   fgCtx.restore()
 }
 
+// Draw a motion trail as a gradient line from `(x1,y1)` to `(x2,y2)`.
+// The tail end `(x1,y1)` is transparent; the head `(x2,y2)` is fully opaque.
+// `lineWidth` should be the entity's canvas-pixel radius.
+function drawTrail(
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  lineWidth: number,
+  color: RenderColor,
+): void {
+  if (isTransparent(color)) return
+  const grad = fgCtx.createLinearGradient(x1, y1, x2, y2)
+  grad.addColorStop(0, `rgba(0,0,0,0)`)
+  grad.addColorStop(1, color.css)
+  fgCtx.save()
+  fgCtx.strokeStyle = grad
+  fgCtx.lineWidth = Math.max(1, lineWidth)
+  fgCtx.lineCap = 'round'
+  fgCtx.beginPath()
+  fgCtx.moveTo(x1, y1)
+  fgCtx.lineTo(x2, y2)
+  fgCtx.stroke()
+  fgCtx.restore()
+}
+
 // Draw one entity and all of its client-side visual effects.
 function drawEntity(
   x: number,
@@ -1005,6 +1034,7 @@ function appearanceToRender(app: EntityAppearance): RenderAppearance {
     fg: packedRgbaToRenderColor(app.fg),
     bg: packedRgbaToRenderColor(app.bg),
     attackRadius: app.attackRadius,
+    trail: app.trailColor ? packedRgbaToRenderColor(app.trailColor) : TRANSPARENT_RENDER_COLOR,
   }
 }
 
@@ -2073,25 +2103,12 @@ function applyWorldDelta(delta: WorldDelta): void {
   // animation frames.
   for (const entity of delta.upserts) {
     const prevEntity = currEntitiesById.get(entity.pos.id)
-    if (!prevEntity && entity.app) {
-      const g = entity.app.glyph
-      if (g === 42 || g === 46) {
-        // '*' (42) or '.' (46) -- this is a bullet.
-        const { id, x, y } = entity.pos
-        log(`tick ${delta.tick}: bullet id=${id} glyph=${String.fromCodePoint(g)} (${x},${y}) r=${entity.app.radius}`)
-        bulletEntityIds.add(id)
-      }
-    }
     const nextEntity =
       upsertToRenderEntity(entity, now, prevEntity?.app, prevEntity?.fx)
     if (prevEntity) prevRenderStateById.set(entity.pos.id, prevEntity)
     currEntitiesById.set(entity.pos.id, nextEntity)
   }
   for (const entityId of delta.erased) {
-    if (bulletEntityIds.has(entityId)) {
-      log(`tick ${delta.tick}: bullet erased id=${entityId}`)
-      bulletEntityIds.delete(entityId)
-    }
     currEntitiesById.delete(entityId)
     prevRenderStateById.delete(entityId)
   }

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -1047,17 +1047,20 @@ function getSelectedDefenderPanelModel(): SidePanelModel | null {
     worldToCanvas(selectedDefenderPosition.x, selectedDefenderPosition.y)[0],
   )
 
-  return {
-    side,
-    title: selectedDefenderSummary.displayName,
-    lines: [
-      selectedDefenderSummary.flavorText,
-      '',
-      `Body radius ${formatPanelNumber(selectedDefenderSummary.appearance.radius)}`,
-      `Attack radius ${formatPanelNumber(selectedDefenderSummary.appearance.attackRadius)}`,
-      'Left click empty space to dismiss',
-    ],
+  const lines: string[] = [
+    selectedDefenderSummary.flavorText,
+    '',
+    `Body radius ${formatPanelNumber(selectedDefenderSummary.appearance.radius)}`,
+    `Attack radius ${formatPanelNumber(selectedDefenderSummary.appearance.attackRadius)}`,
+  ]
+  if (selectedDefenderSummary.totalDamageDealt !== undefined) {
+    lines.push('')
+    lines.push(`Damage dealt: ${formatPanelNumber(selectedDefenderSummary.totalDamageDealt)}`)
+    lines.push(`Kills: ${selectedDefenderSummary.totalKills ?? 0}`)
   }
+  lines.push('Left click empty space to dismiss')
+
+  return { side, title: selectedDefenderSummary.displayName, lines }
 }
 
 // Build the overlay model for a dropped-but-not-yet-confirmed placement ghost.

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -42,6 +42,7 @@ interface GhostState {
   displayName: string
   appearance: RenderAppearance
   attackRadius: number  // world units, from Appearance.attackRadius
+  confirmCommand: 'spawn' | 'moving'
   pending: boolean      // true = dropped on map, awaiting confirmation click
   placeable: boolean    // true = can be placed at the current position
   spawnPending: boolean // true = dropped and clicked, awaiting server confirmation
@@ -1104,7 +1105,11 @@ function wrapPanelText(
 
 // Build the overlay model for the currently selected defender, if any.
 function getSelectedDefenderPanelModel(): SidePanelModel | null {
-  if (!selectedDefenderPosition || !selectedDefenderSummary) return null
+  if (!selectedDefenderPosition) return null
+
+  const selectedEntity =
+    findDefenderAtWorld(selectedDefenderPosition.x, selectedDefenderPosition.y)
+  if (!selectedDefenderSummary && selectedEntity === null) return null
 
   // Put the panel opposite the selected unit so it reads like an inspector
   // without covering the thing the user just clicked.
@@ -1112,13 +1117,20 @@ function getSelectedDefenderPanelModel(): SidePanelModel | null {
     worldToCanvas(selectedDefenderPosition.x, selectedDefenderPosition.y)[0],
   )
 
-  const lines: string[] = [
-    selectedDefenderSummary.flavorText,
-    '',
-    `Body radius ${formatPanelNumber(selectedDefenderSummary.appearance.radius)}`,
-    `Attack radius ${formatPanelNumber(selectedDefenderSummary.appearance.attackRadius)}`,
-  ]
-  if (selectedDefenderSummary.totalDamageDealt !== undefined) {
+  const bodyRadius = selectedDefenderSummary?.appearance.radius ??
+    selectedEntity?.app.radius ?? 0
+  const attackRadius = selectedDefenderSummary?.appearance.attackRadius ??
+    selectedEntity?.app.attackRadius ?? 0
+
+  const lines: string[] = []
+  if (selectedDefenderSummary?.flavorText) {
+    lines.push(selectedDefenderSummary.flavorText, '')
+  }
+  lines.push(
+    `Body radius ${formatPanelNumber(bodyRadius)}`,
+    `Attack radius ${formatPanelNumber(attackRadius)}`,
+  )
+  if (selectedDefenderSummary?.totalDamageDealt !== undefined) {
     lines.push('')
     lines.push(`Damage dealt: ${formatPanelNumber(selectedDefenderSummary.totalDamageDealt)}`)
     lines.push(`Kills: ${selectedDefenderSummary.totalKills ?? 0}`)
@@ -1127,7 +1139,11 @@ function getSelectedDefenderPanelModel(): SidePanelModel | null {
   if (currentPhase === 'build') lines.push('Drag to reposition')
   lines.push('Left click empty space to dismiss')
 
-  return { side, title: selectedDefenderSummary.displayName, lines }
+  return {
+    side,
+    title: selectedDefenderSummary?.displayName ?? 'Selected Defender',
+    lines,
+  }
 }
 
 // Build the overlay model for a dropped-but-not-yet-confirmed placement ghost.
@@ -1135,13 +1151,14 @@ function getPendingGhostPanelModel(): SidePanelModel | null {
   if (!ghostState?.pending) return null
   const [ghostCanvasX] = worldToCanvas(ghostState.worldX, ghostState.worldY)
   const side = getOppositePanelSideForCanvasX(ghostCanvasX)
+  const isMoveGhost = ghostState.confirmCommand === 'moving'
   return {
     side,
-    title: 'Place Defender',
+    title: isMoveGhost ? 'Move Defender' : 'Place Defender',
     lines: [
       ghostState.displayName,
       '',
-      'Right-click to place',
+      isMoveGhost ? 'Right-click to confirm move' : 'Right-click to place',
       'Left-click ghost to move',
       'Any other click cancels',
     ],
@@ -1521,6 +1538,7 @@ function updateSidePanelOverlay(): void {
 function shouldShowBuildMenu(): boolean {
   return (
     getSidePanelModel() === null &&
+    selectedDefenderPosition === null &&
     defenderMenuItems.length > 0 &&
     currentPhase === 'build' &&
     !menuDragActive
@@ -2126,6 +2144,38 @@ foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   if (sample.button !== 2) sendCanvasMsg('click', sample)
 })
 
+// Arm a potential move-drag when the user presses a defender through the
+// overlay canvas. This mirrors the foreground-canvas path so defenders remain
+// movable even while the build menu panel is open above them.
+function armOverlayDefenderInteraction(sample: CanvasPointerSample): boolean {
+  if (ghostState || menuDragActive || currentPhase !== 'build') return false
+
+  const clickedDefender = findDefenderAtWorld(sample.worldX, sample.worldY)
+  if (clickedDefender === null) return false
+
+  let isMoveDrag = false
+  if (selectedDefenderPosition !== null && !ghostState) {
+    const selectedEntity =
+      findDefenderAtWorld(selectedDefenderPosition.x, selectedDefenderPosition.y)
+    if (selectedEntity !== null && clickedDefender.pos.id === selectedEntity.pos.id) {
+      isMoveDrag = true
+    }
+  }
+
+  canvasPointerState = {
+    button: sample.button,
+    buttons: sample.buttons,
+    dragging: false,
+    isMoveDrag,
+  }
+  sendCanvasMsg('click', sample)
+  mouseOverOverlay = false
+  overlayStayOpen = false
+  setEdgeHoverSide(null)
+  invalidateSidePanel()
+  return true
+}
+
 // Convert foreground pointer motion into either edge-hover updates or drag
 // preview traffic.
 foregroundCanvas.addEventListener('mousemove', (event: MouseEvent) => {
@@ -2154,6 +2204,7 @@ foregroundCanvas.addEventListener('mousemove', (event: MouseEvent) => {
           displayName: selectedDefenderSummary.displayName,
           appearance: selectedEntity.app,
           attackRadius: selectedDefenderSummary.appearance.attackRadius,
+          confirmCommand: 'moving',
           pending: false,
           placeable: true,
           spawnPending: false,
@@ -2248,8 +2299,22 @@ window.addEventListener('mouseup', (event: MouseEvent) => {
   if (moveDragActive) {
     moveDragActive = false
     if (ghostState) {
-      sendCanvasMsg('dragend', eventToCanvasSample(event), 'moving')
-      ghostState = null
+      const fgRect = foregroundCanvas.getBoundingClientRect()
+      const ovRect = overlayCanvas.getBoundingClientRect()
+      const overOverlay =
+        event.clientX >= ovRect.left && event.clientX <= ovRect.right &&
+        event.clientY >= ovRect.top && event.clientY <= ovRect.bottom
+      const overFg =
+        event.clientX >= fgRect.left && event.clientX <= fgRect.right &&
+        event.clientY >= fgRect.top && event.clientY <= fgRect.bottom
+      if (overFg && !overOverlay) {
+        sendCanvasMsg('dragmove', ghostStateToSample(ghostState, event), 'moving')
+        ghostState.pending = true
+        mouseOverOverlay = false
+        overlayStayOpen = false
+      } else {
+        ghostState = null
+      }
     }
     canvasPointerState = null
     invalidateSidePanel()
@@ -2303,9 +2368,15 @@ foregroundCanvas.addEventListener('contextmenu', (event: MouseEvent) => {
   const sample = eventToCanvasSample(event)
   if (ghostState?.pending) {
     if (!ghostState.placeable || ghostState.spawnPending) return
+    const ghostSample = ghostStateToSample(ghostState, event, 2, 2)
+    if (ghostState.confirmCommand === 'moving') {
+      sendCanvasMsg('dragend', ghostSample, 'moving')
+      ghostState = null
+      invalidateSidePanel()
+      return
+    }
     // Right-click while ghost is pending: place the defender.
     const entityName = ghostState.entityName
-    const ghostSample = ghostStateToSample(ghostState, event, 2, 2)
     ghostState.spawnPending = true
     sendCanvasMsg('click', ghostSample, 'spawn', [entityName])
     return
@@ -2356,9 +2427,15 @@ document.addEventListener('contextmenu', (event: MouseEvent) => {
   const fgRect = foregroundCanvas.getBoundingClientRect()
   const insideFg = isPointInRect(event.clientX, event.clientY, fgRect)
   if (ghostState.pending && insideFg) {
-    const sample = eventToCanvasSample(event)
-    const entityName = ghostState.entityName
     event.preventDefault()
+    const sample = ghostStateToSample(ghostState, event, 2, 2)
+    if (ghostState.confirmCommand === 'moving') {
+      sendCanvasMsg('dragend', sample, 'moving')
+      ghostState = null
+      invalidateSidePanel()
+      return
+    }
+    const entityName = ghostState.entityName
     ghostState.spawnPending = true
     sendCanvasMsg('click', sample, 'spawn', [entityName])
     return
@@ -2389,7 +2466,7 @@ document.addEventListener('mousedown', (event: MouseEvent) => {
 
 // Track ghost world position globally during a menu drag or a move drag.
 window.addEventListener('mousemove', (event: MouseEvent) => {
-  if (!ghostState) return
+  if (!ghostState || (!menuDragActive && !moveDragActive)) return
   const rect = foregroundCanvas.getBoundingClientRect()
   const canvasX = (event.clientX - rect.left) * (foregroundCanvas.width / rect.width)
   const canvasY = (event.clientY - rect.top) * (foregroundCanvas.height / rect.height)
@@ -2411,16 +2488,10 @@ overlayCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   // When the build menu is open, a click whose world-space coordinates land on
   // a defender should select that defender rather than interact with the menu.
   // This handles the case where a placed defender sits behind the overlay panel.
-  if (!ghostState && !menuDragActive && currentPhase === 'build') {
-    const sample = eventToCanvasSample(event)
-    if (findDefenderAtWorld(sample.worldX, sample.worldY) !== null) {
-      event.preventDefault()
-      sendCanvasMsg('click', sample)
-      mouseOverOverlay = false
-      overlayStayOpen = false
-      invalidateSidePanel()
-      return
-    }
+  const sample = eventToCanvasSample(event)
+  if (armOverlayDefenderInteraction(sample)) {
+    event.preventDefault()
+    return
   }
 
   if (!shouldShowBuildMenu()) return
@@ -2473,11 +2544,11 @@ overlayCanvas.addEventListener('mousedown', (event: MouseEvent) => {
     displayName: item.displayName,
     appearance: appearanceToRender(item.appearance),
     attackRadius: item.appearance.attackRadius,
+    confirmCommand: 'spawn',
     pending: false,
     placeable: true,
     spawnPending: false,
   }
-  const sample = eventToCanvasSample(event)
   sendPlacementPreview('dragstart', sample, item.entityName)
   clearMenuSelection()
   invalidateSidePanel()

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -1,4 +1,5 @@
 import type {
+  CategoryItem,
   ClientMsg,
   DefenderMenuItem,
   EntityAppearance,
@@ -95,6 +96,8 @@ interface RenderTransientBeam {
   startDistance: number
   lineWidth: number
   startedAt: number
+  halfAngleDeg: number
+  coneRadius: number
 }
 
 // Pointer bookkeeping for an in-progress foreground-canvas interaction.
@@ -426,8 +429,11 @@ let pendingDragMove: CanvasPointerSample | null = null
 let dragMoveFrameRequested = false
 let sidePanelDirty = true
 let edgeHoverSide: PanelSide | null = null
+let categoryItems: CategoryItem[] = []
 let defenderMenuItems: DefenderMenuItem[] = []
+let selectedCategory: string | null = null
 let selectedMenuIndex: number | null = null
+let hoveredMenuIndex: number | null = null
 let menuScrollOffset = 0
 let ghostState: GhostState | null = null
 let menuDragActive = false
@@ -919,23 +925,47 @@ function drawBeamTransient(transient: RenderTransientBeam, now: number): void {
   const uy = dy / length
   const startX = transient.x + ux * transient.startDistance
   const startY = transient.y + uy * transient.startDistance
-  const [canvasStartX, canvasStartY] = worldToCanvas(startX, startY)
-  const [canvasTargetX, canvasTargetY] =
-    worldToCanvas(transient.targetX, transient.targetY)
-  const color = isTransientFlashPrimary(now, transient.startedAt)
-    ? transient.primary
-    : transient.secondary
-  if (isTransparent(color)) return
 
-  fgCtx.save()
-  fgCtx.strokeStyle = color.css
-  fgCtx.lineWidth = Math.max(2, worldLengthToCanvas(transient.lineWidth))
-  fgCtx.lineCap = 'round'
-  fgCtx.beginPath()
-  fgCtx.moveTo(canvasStartX, canvasStartY)
-  fgCtx.lineTo(canvasTargetX, canvasTargetY)
-  fgCtx.stroke()
-  fgCtx.restore()
+  if (transient.halfAngleDeg > 0) {
+    // Cone mode: filled wedge fading linearly from opaque to transparent.
+    if (isTransparent(transient.primary)) return
+    const duration = transient.expiry - transient.startedAt
+    if (duration <= 0) return
+    const progress = Math.max(0, Math.min(1, (now - transient.startedAt) / duration))
+    const [cx, cy] = worldToCanvas(startX, startY)
+    const coneR = worldLengthToCanvas(transient.coneRadius)
+    const angle = Math.atan2(uy, ux)
+    const half = transient.halfAngleDeg * Math.PI / 180
+
+    fgCtx.save()
+    fgCtx.globalAlpha = 1 - progress
+    fgCtx.fillStyle = transient.primary.css
+    fgCtx.beginPath()
+    fgCtx.moveTo(cx, cy)
+    fgCtx.arc(cx, cy, coneR, angle - half, angle + half)
+    fgCtx.closePath()
+    fgCtx.fill()
+    fgCtx.restore()
+  } else {
+    // Line mode: flickering stroke between primary and secondary colours.
+    const [canvasStartX, canvasStartY] = worldToCanvas(startX, startY)
+    const [canvasTargetX, canvasTargetY] =
+      worldToCanvas(transient.targetX, transient.targetY)
+    const color = isTransientFlashPrimary(now, transient.startedAt)
+      ? transient.primary
+      : transient.secondary
+    if (isTransparent(color)) return
+
+    fgCtx.save()
+    fgCtx.strokeStyle = color.css
+    fgCtx.lineWidth = Math.max(2, worldLengthToCanvas(transient.lineWidth))
+    fgCtx.lineCap = 'round'
+    fgCtx.beginPath()
+    fgCtx.moveTo(canvasStartX, canvasStartY)
+    fgCtx.lineTo(canvasTargetX, canvasTargetY)
+    fgCtx.stroke()
+    fgCtx.restore()
+  }
 }
 
 function drawTransientDisplays(now: number): void {
@@ -983,7 +1013,7 @@ function drawCooldownOverlay(
   fgCtx.fillStyle = fx.cooldown.css
   fgCtx.beginPath()
   fgCtx.moveTo(x, y)
-  fgCtx.arc(x, y, radius, startAngle, endAngle, true)
+  fgCtx.arc(x, y, radius, startAngle, endAngle, false)
   fgCtx.closePath()
   fgCtx.fill()
   fgCtx.restore()
@@ -1132,6 +1162,8 @@ function beamToRender(
     startDistance: transient.startDistance,
     lineWidth: transient.lineWidth,
     startedAt: now,
+    halfAngleDeg: transient.halfAngleDeg,
+    coneRadius: transient.coneRadius,
   }
 }
 
@@ -1515,7 +1547,75 @@ function drawSidePanel(ctx: CanvasRenderingContext2D, panel: SidePanelModel): vo
   ctx.restore()
 }
 
-// Draw the build-menu overlay grid containing available defender types.
+// Return the items for the current menu level: category items at top level,
+// filtered defender items at the defender level.
+function currentMenuItems(): (CategoryItem | DefenderMenuItem)[] {
+  if (selectedCategory !== null)
+    return defenderMenuItems.filter(item => item.category === selectedCategory)
+  return categoryItems
+}
+
+// Draw one item cell (shared by both category and defender levels).
+function drawMenuCell(
+  ctx: CanvasRenderingContext2D,
+  item: CategoryItem | DefenderMenuItem,
+  cellX: number,
+  cellY: number,
+  cellSize: number,
+  isSelected: boolean,
+  isHovered: boolean,
+  panelScale: number,
+): void {
+  ctx.fillStyle = isSelected
+    ? 'rgba(255, 242, 182, 0.18)'
+    : isHovered
+      ? 'rgba(255, 255, 255, 0.10)'
+      : 'rgba(255, 255, 255, 0.06)'
+  ctx.fillRect(cellX, cellY, cellSize, cellSize)
+
+  if (isSelected) {
+    ctx.strokeStyle = 'rgba(255, 242, 63, 0.85)'
+    ctx.lineWidth = 2 * panelScale
+    ctx.strokeRect(cellX + 1, cellY + 1, cellSize - 2, cellSize - 2)
+  }
+
+  const app = appearanceToRender(item.appearance)
+  const circleX = cellX + cellSize / 2
+  const circleY = cellY + cellSize * 0.40
+  const circleR = Math.min(worldLengthToCanvas(app.radius) * 2, cellSize * 0.30)
+
+  if (app.bg.alpha !== 0) drawFilledCircleOnContext(ctx, circleX, circleY, circleR, app.bg)
+  if (app.fg.alpha !== 0) {
+    drawStrokedCircleOnContext(
+      ctx, circleX, circleY,
+      Math.max(circleR - getEntityBorderWidth(circleR) * 0.5, 0),
+      app.fg, getEntityBorderWidth(circleR),
+    )
+  }
+  if (app.glyph && app.fg.alpha !== 0) {
+    drawGlyphOnContext(ctx, app.glyph, circleX, circleY, circleR, app.fg)
+  }
+
+  const nameFontSize = Math.max(9, 11 * panelScale)
+  ctx.font = `${nameFontSize}px monospace`
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'alphabetic'
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.85)'
+  ctx.fillText(item.displayName, circleX, cellY + cellSize * 0.76, cellSize - 4)
+
+  // Bottom line: cost for defenders, chevron for categories.
+  ctx.fillStyle = 'rgba(181, 201, 224, 0.85)'
+  const isDefender = 'resourceCost' in item
+  ctx.fillText(
+    isDefender ? `$${(item as DefenderMenuItem).resourceCost}` : '>',
+    circleX,
+    cellY + cellSize * 0.92,
+    cellSize - 4,
+  )
+}
+
+// Draw the build-menu overlay grid with a two-level nested layout:
+// top level shows categories; clicking a category shows its defenders.
 function drawBuildMenu(ctx: CanvasRenderingContext2D): void {
   const panelScale = Math.min(
     foregroundCanvas.width / DEFAULT_CANVAS_W,
@@ -1532,8 +1632,10 @@ function drawBuildMenu(ctx: CanvasRenderingContext2D): void {
   const cornerRadius = SIDE_PANEL_RADIUS * panelScale
   const titleFontSize = 24 * panelScale
   const titleTop = 20 * panelScale
+  const backFontSize = Math.max(9, 13 * panelScale)
   const dividerY = 56 * panelScale
   const bodyTop = 70 * panelScale
+  const infoBoxHeight = Math.max(28, 32 * panelScale)
   const textMargin = SIDE_PANEL_TEXT_MARGIN * panelScale
   const textWidth = panelWidth - textMargin * 2
 
@@ -1572,10 +1674,26 @@ function drawBuildMenu(ctx: CanvasRenderingContext2D): void {
   ctx.stroke()
   strokeAttachedBottomCorner(ctx, currentPanelSide, x, y, panelWidth, panelHeight, cornerRadius)
 
-  ctx.fillStyle = 'rgba(255, 255, 255, 0.96)'
-  ctx.font = `bold ${titleFontSize}px monospace`
+  // Title line: "< Back" link at defender level, category/title text.
   ctx.textBaseline = 'top'
-  ctx.fillText('Select Defender', x + textMargin, y + titleTop, textWidth)
+  if (selectedCategory !== null) {
+    ctx.font = `${backFontSize}px monospace`
+    ctx.fillStyle = 'rgba(181, 201, 224, 0.85)'
+    ctx.textAlign = 'left'
+    ctx.fillText('< Back', x + textMargin, y + titleTop + (titleFontSize - backFontSize) * 0.5)
+
+    const cat = categoryItems.find(c => c.name === selectedCategory)
+    const titleLabel = cat ? cat.displayName : selectedCategory
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.96)'
+    ctx.font = `bold ${titleFontSize}px monospace`
+    ctx.textAlign = 'right'
+    ctx.fillText(titleLabel, x + panelWidth - textMargin, y + titleTop, textWidth * 0.6)
+  } else {
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.96)'
+    ctx.font = `bold ${titleFontSize}px monospace`
+    ctx.textAlign = 'left'
+    ctx.fillText('Select Type', x + textMargin, y + titleTop, textWidth)
+  }
 
   ctx.strokeStyle = 'rgba(255, 255, 255, 0.12)'
   ctx.beginPath()
@@ -1583,12 +1701,10 @@ function drawBuildMenu(ctx: CanvasRenderingContext2D): void {
   ctx.lineTo(x + textMargin + textWidth, y + dividerY)
   ctx.stroke()
 
+  const items = currentMenuItems()
   const cellSize = Math.floor((width - 2) / MENU_COLS)
   const startIndex = menuScrollOffset * MENU_COLS
-  const visibleItems = defenderMenuItems.slice(
-    startIndex,
-    startIndex + MENU_VISIBLE_ROWS * MENU_COLS,
-  )
+  const visibleItems = items.slice(startIndex, startIndex + MENU_VISIBLE_ROWS * MENU_COLS)
 
   for (let i = 0; i < visibleItems.length; i++) {
     const item = visibleItems[i]
@@ -1596,50 +1712,34 @@ function drawBuildMenu(ctx: CanvasRenderingContext2D): void {
     const row = Math.floor(i / MENU_COLS)
     const cellX = x + 1 + col * cellSize
     const cellY = y + bodyTop + row * cellSize
-    const isSelected = (startIndex + i) === selectedMenuIndex
-
-    ctx.fillStyle = isSelected
-      ? 'rgba(255, 242, 182, 0.18)'
-      : 'rgba(255, 255, 255, 0.06)'
-    ctx.fillRect(cellX, cellY, cellSize, cellSize)
-
-    if (isSelected) {
-      ctx.strokeStyle = 'rgba(255, 242, 63, 0.85)'
-      ctx.lineWidth = 2 * panelScale
-      ctx.strokeRect(cellX + 1, cellY + 1, cellSize - 2, cellSize - 2)
-    }
-
-    const app = appearanceToRender(item.appearance)
-    const circleX = cellX + cellSize / 2
-    const circleY = cellY + cellSize * 0.40
-    const circleR = Math.min(
-      worldLengthToCanvas(app.radius) * 2,
-      cellSize * 0.30,
+    const absIndex = startIndex + i
+    drawMenuCell(
+      ctx, item, cellX, cellY, cellSize,
+      absIndex === selectedMenuIndex,
+      absIndex === hoveredMenuIndex,
+      panelScale,
     )
+  }
 
-    if (app.bg.alpha !== 0) drawFilledCircleOnContext(ctx, circleX, circleY, circleR, app.bg)
-    if (app.fg.alpha !== 0) {
-      drawStrokedCircleOnContext(
-        ctx,
-        circleX,
-        circleY,
-        Math.max(circleR - getEntityBorderWidth(circleR) * 0.5, 0),
-        app.fg,
-        getEntityBorderWidth(circleR),
-      )
-    }
-    if (app.glyph && app.fg.alpha !== 0) {
-      drawGlyphOnContext(ctx, app.glyph, circleX, circleY, circleR, app.fg)
-    }
-
-    const nameFontSize = Math.max(9, 11 * panelScale)
-    ctx.font = `${nameFontSize}px monospace`
+  // Info box: flavor text of the hovered item.
+  const hoveredItem = hoveredMenuIndex !== null ? items[hoveredMenuIndex] : null
+  const flavorText = hoveredItem ? hoveredItem.flavorText : ''
+  if (flavorText) {
+    const infoY = y + panelHeight - infoBoxHeight
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.35)'
+    ctx.fillRect(x + 1, infoY, panelWidth - 2, infoBoxHeight)
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.08)'
+    ctx.lineWidth = 1
+    ctx.beginPath()
+    ctx.moveTo(x + textMargin, infoY)
+    ctx.lineTo(x + textMargin + textWidth, infoY)
+    ctx.stroke()
+    const infoFontSize = Math.max(9, 11 * panelScale)
+    ctx.font = `${infoFontSize}px monospace`
     ctx.textAlign = 'center'
-    ctx.textBaseline = 'alphabetic'
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.85)'
-    ctx.fillText(item.displayName, circleX, cellY + cellSize * 0.76, cellSize - 4)
-    ctx.fillStyle = 'rgba(181, 201, 224, 0.85)'
-    ctx.fillText(`$${item.resourceCost}`, circleX, cellY + cellSize * 0.92, cellSize - 4)
+    ctx.textBaseline = 'middle'
+    ctx.fillStyle = 'rgba(200, 220, 255, 0.90)'
+    ctx.fillText(flavorText, x + panelWidth / 2, infoY + infoBoxHeight / 2, textWidth)
   }
 
   ctx.restore()
@@ -2013,6 +2113,18 @@ function isTransientBeam(value: unknown): value is TransientBeam {
   )
 }
 
+// Narrow an unknown value to a category menu entry.
+function isCategoryItem(value: unknown): value is CategoryItem {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).name === 'string' &&
+    typeof (value as Record<string, unknown>).displayName === 'string' &&
+    typeof (value as Record<string, unknown>).flavorText === 'string' &&
+    isEntityAppearance((value as Record<string, unknown>).appearance)
+  )
+}
+
 // Narrow an unknown value to a defender menu entry.
 function isDefenderMenuItem(value: unknown): value is DefenderMenuItem {
   return (
@@ -2020,6 +2132,7 @@ function isDefenderMenuItem(value: unknown): value is DefenderMenuItem {
     value !== null &&
     typeof (value as Record<string, unknown>).entityName === 'string' &&
     typeof (value as Record<string, unknown>).displayName === 'string' &&
+    typeof (value as Record<string, unknown>).category === 'string' &&
     typeof (value as Record<string, unknown>).flavorText === 'string' &&
     typeof (value as Record<string, unknown>).resourceCost === 'number' &&
     isEntityAppearance((value as Record<string, unknown>).appearance)
@@ -2107,8 +2220,11 @@ function resetClientWorldState(): void {
   hudDirty = true
   sidePanelDirty = true
   edgeHoverSide = null
+  categoryItems = []
   defenderMenuItems = []
+  selectedCategory = null
   selectedMenuIndex = null
+  hoveredMenuIndex = null
   menuScrollOffset = 0
   ghostState = null
   transientExplosionsByPos.clear()
@@ -2173,6 +2289,10 @@ function applyWorldDelta(delta: WorldDelta): void {
   invalidateHud()
   invalidateSidePanel()
   currentPhase = getDeltaPhase(delta)
+  if (currentPhase !== 'build') {
+    selectedCategory = null
+    hoveredMenuIndex = null
+  }
 }
 
 // --- Message validation ---
@@ -2226,6 +2346,8 @@ function isServerMsg(value: unknown): value is ServerMsg {
         md.paths.every(isPoint) &&
         Array.isArray(v.defenderMenu) &&
         v.defenderMenu.every(isDefenderMenuItem) &&
+        Array.isArray(v.categories) &&
+        v.categories.every(isCategoryItem) &&
         isWorldDelta(v.delta)
       )
     }
@@ -2273,6 +2395,7 @@ ws.onmessage = (event: MessageEvent<string>) => {
     case 'world_snapshot':
       updateAverageFrameSize(measureFrameSizeBytes(event.data))
       resetClientWorldState()
+      categoryItems = parsed.categories
       defenderMenuItems = parsed.defenderMenu
       drawBackground(parsed.mapDesign.paths, parsed.mapDesign.pathWidth)
       applyWorldDelta(parsed.delta)
@@ -2733,16 +2856,16 @@ window.addEventListener('mousemove', (event: MouseEvent) => {
 overlayCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   if (event.button !== 0) return
 
-  // When the build menu is open, a click whose world-space coordinates land on
-  // a defender should select that defender rather than interact with the menu.
-  // This handles the case where a placed defender sits behind the overlay panel.
   const sample = eventToCanvasSample(event)
-  if (armOverlayDefenderInteraction(sample)) {
-    event.preventDefault()
+
+  // When the build menu is not visible, allow a click whose world-space
+  // coordinates land on a defender to route to that defender instead.
+  // If the build menu IS visible it occupies the entire overlay canvas, so
+  // clicks must never pass through to defenders behind the panel.
+  if (!shouldShowBuildMenu()) {
+    if (armOverlayDefenderInteraction(sample)) event.preventDefault()
     return
   }
-
-  if (!shouldShowBuildMenu()) return
   event.preventDefault()
 
   const panelScale = Math.min(
@@ -2756,7 +2879,15 @@ overlayCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   const localY = (event.clientY - rect.top) * (overlayCanvas.height / rect.height)
 
   if (localY < bodyTop) {
-    // Click above grid area (title bar) — deselect.
+    // Click in title area. If at defender level and left half, go back.
+    if (selectedCategory !== null && localX < overlayCanvas.width * 0.5) {
+      selectedCategory = null
+      selectedMenuIndex = null
+      menuScrollOffset = 0
+      hoveredMenuIndex = null
+      invalidateSidePanel()
+      return
+    }
     selectedMenuIndex = null
     invalidateSidePanel()
     return
@@ -2765,14 +2896,27 @@ overlayCanvas.addEventListener('mousedown', (event: MouseEvent) => {
   const row = Math.floor((localY - bodyTop) / cellSize)
   if (col < 0 || col >= MENU_COLS) return
 
+  const items = currentMenuItems()
   const index = menuScrollOffset * MENU_COLS + row * MENU_COLS + col
-  if (index >= defenderMenuItems.length) {
+  if (index >= items.length) {
     // Click below last populated cell — deselect.
     selectedMenuIndex = null
     invalidateSidePanel()
     return
   }
 
+  if (selectedCategory === null) {
+    // Top level: navigate into the tapped category.
+    const cat = items[index] as CategoryItem
+    selectedCategory = cat.name
+    selectedMenuIndex = null
+    menuScrollOffset = 0
+    hoveredMenuIndex = null
+    invalidateSidePanel()
+    return
+  }
+
+  // Defender level: arm ghost drag.
   selectedMenuIndex = index
   menuDragActive = true
   mouseOverOverlay = false
@@ -2780,7 +2924,7 @@ overlayCanvas.addEventListener('mousedown', (event: MouseEvent) => {
 
   // Create the ghost immediately at the current mouse position so it appears
   // as soon as the mouse enters the foreground canvas, with no lag.
-  const item = defenderMenuItems[index]
+  const item = items[index] as DefenderMenuItem
   const fgRect = foregroundCanvas.getBoundingClientRect()
   const fgCanvasX = (event.clientX - fgRect.left) * (foregroundCanvas.width / fgRect.width)
   const fgCanvasY = (event.clientY - fgRect.top) * (foregroundCanvas.height / fgRect.height)
@@ -2805,13 +2949,80 @@ overlayCanvas.addEventListener('mousedown', (event: MouseEvent) => {
 // Scroll the build menu with the mouse wheel.
 overlayCanvas.addEventListener('wheel', (event: WheelEvent) => {
   event.preventDefault()
-  if (defenderMenuItems.length === 0) return
-  const totalRows = Math.ceil(defenderMenuItems.length / MENU_COLS)
+  const items = currentMenuItems()
+  if (items.length === 0) return
+  const totalRows = Math.ceil(items.length / MENU_COLS)
   const maxScroll = Math.max(0, totalRows - MENU_VISIBLE_ROWS)
   menuScrollOffset = Math.max(0, Math.min(maxScroll,
     menuScrollOffset + (event.deltaY > 0 ? 1 : -1)))
   invalidateSidePanel()
 }, { passive: false })
+
+// Track hovered menu cell for flavor-text info box.
+overlayCanvas.addEventListener('mousemove', (event: MouseEvent) => {
+  if (!shouldShowBuildMenu()) return
+  const panelScale = Math.min(
+    foregroundCanvas.width / DEFAULT_CANVAS_W,
+    foregroundCanvas.height / DEFAULT_CANVAS_H,
+  )
+  const cellSize = Math.floor((overlayCanvas.width - 2) / MENU_COLS)
+  const bodyTop = 70 * panelScale
+  const rect = overlayCanvas.getBoundingClientRect()
+  const localX = (event.clientX - rect.left) * (overlayCanvas.width / rect.width)
+  const localY = (event.clientY - rect.top) * (overlayCanvas.height / rect.height)
+
+  let newHovered: number | null = null
+  if (localY >= bodyTop) {
+    const col = Math.floor(localX / cellSize)
+    const row = Math.floor((localY - bodyTop) / cellSize)
+    if (col >= 0 && col < MENU_COLS) {
+      const index = menuScrollOffset * MENU_COLS + row * MENU_COLS + col
+      const items = currentMenuItems()
+      if (index < items.length) newHovered = index
+    }
+  }
+  if (newHovered !== hoveredMenuIndex) {
+    hoveredMenuIndex = newHovered
+    invalidateSidePanel()
+  }
+})
+
+overlayCanvas.addEventListener('mouseleave', () => {
+  if (hoveredMenuIndex !== null) {
+    hoveredMenuIndex = null
+    invalidateSidePanel()
+  }
+})
+
+// Glyph hotkeys navigate the two-level build menu during the build phase.
+document.addEventListener('keydown', (event: KeyboardEvent) => {
+  if (currentPhase !== 'build' || menuDragActive) return
+  if (!shouldShowBuildMenu()) return
+
+  const cp = event.key.codePointAt(0)
+  if (cp === undefined) return
+
+  if (selectedCategory === null) {
+    // Top level: navigate into the category whose glyph matches.
+    const cat = categoryItems.find(c => c.appearance.glyph === cp)
+    if (cat) {
+      selectedCategory = cat.name
+      selectedMenuIndex = null
+      menuScrollOffset = 0
+      hoveredMenuIndex = null
+      invalidateSidePanel()
+    }
+  } else {
+    // Defender level: select the first defender whose glyph matches.
+    const defenders = currentMenuItems() as DefenderMenuItem[]
+    const match = defenders.find(d => d.appearance.glyph === cp)
+    if (match) {
+      const index = defenders.indexOf(match)
+      selectedMenuIndex = index
+      invalidateSidePanel()
+    }
+  }
+})
 
 // Bring the UI into sync with the current DOM/layout state before the first
 // animation frame.

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -90,6 +90,11 @@ interface CanvasPointerSample {
 
 type PanelSide = 'left' | 'right'
 
+interface TickRateSample {
+  timeMs: number
+  tick: number
+}
+
 // Textual content and attachment side for the overlay panel renderer.
 interface SidePanelModel {
   side: PanelSide
@@ -136,6 +141,8 @@ function requireEl<T extends HTMLElement>(
 
 const statusEl = requireEl('status', HTMLElement)
 const tickEl = requireEl('tick', HTMLElement)
+const tickRateEl = requireEl('tick-rate', HTMLElement)
+const frameSizeEl = requireEl('frame-size', HTMLElement)
 const logEl = requireEl('log', HTMLElement)
 const viewportShell = requireEl('viewport-shell', HTMLElement)
 const viewportHost = requireEl('viewport-host', HTMLElement)
@@ -144,9 +151,6 @@ const fullscreenToggle = requireEl('fullscreen-toggle', HTMLButtonElement)
 const backgroundCanvas = requireEl('background-canvas', HTMLCanvasElement)
 const foregroundCanvas = requireEl('foreground-canvas', HTMLCanvasElement)
 const overlayCanvas = requireEl('overlay-canvas', HTMLCanvasElement)
-const livesEl = document.getElementById('lives')
-const resourcesEl = document.getElementById('resources')
-const phaseEl = document.getElementById('phase')
 
 const maybeBgCtx = backgroundCanvas.getContext('2d')
 if (!maybeBgCtx) throw new Error('Could not get 2D background canvas context')
@@ -368,6 +372,9 @@ let currSnapshotTime = 0
 let snapshotIntervalMs = 50
 let lives = 0
 let resources = 0
+let latestTick: number | null = null
+let measuredTickRate = 0
+let averageFrameBytes = 0
 let lastFpsOverlayUpdateTime = 0
 let hudDirty = true
 let currentPathWidth = 40
@@ -397,6 +404,10 @@ let currentPanelSide: PanelSide = 'right'
 let overlaySideSwapFrame = 0
 let selectedDefenderSummary: DefenderMenuItem | null = null
 let selectedDefenderPosition: Position | null = null
+const RECENT_TICK_TIMES_MAX = 60
+const RECENT_FRAME_SIZES_MAX = 60
+const recentTickSamples: TickRateSample[] = []
+const recentFrameSizes: number[] = []
 
 const SIDE_PANEL_TRIGGER_RATIO = 0.25
 const SIDE_PANEL_TRIGGER_MIN_PX = 72
@@ -1516,9 +1527,47 @@ function log(line: string): void {
   logEl.scrollTop = logEl.scrollHeight
 }
 
-// Set text content on an element when it exists.
-function setTextIfElement(el: HTMLElement | null, value: string): void {
-  if (el) el.textContent = value
+function updateMetricsDisplay(): void {
+  tickEl.textContent = latestTick !== null ? String(latestTick) : '--'
+  tickRateEl.textContent = measuredTickRate > 0
+    ? `${measuredTickRate.toFixed(1)} Hz`
+    : '--'
+  frameSizeEl.textContent = averageFrameBytes > 0
+    ? `${Math.round(averageFrameBytes).toLocaleString()} B`
+    : '--'
+}
+
+function pushRecentSample<T>(samples: T[], value: T, maxSize: number): void {
+  samples.push(value)
+  if (samples.length > maxSize) samples.shift()
+}
+
+function updateMeasuredTickRate(now: number, tick: number): void {
+  pushRecentSample(recentTickSamples, { timeMs: now, tick }, RECENT_TICK_TIMES_MAX)
+  if (recentTickSamples.length < 2) {
+    measuredTickRate = 0
+    updateMetricsDisplay()
+    return
+  }
+
+  const first = recentTickSamples[0]
+  const last = recentTickSamples[recentTickSamples.length - 1]
+  const elapsedMs = last.timeMs - first.timeMs
+  const elapsedTicks = last.tick - first.tick
+  measuredTickRate = elapsedMs > 0 && elapsedTicks >= 0
+    ? (elapsedTicks * 1000) / elapsedMs
+    : 0
+  updateMetricsDisplay()
+}
+
+function measureFrameSizeBytes(data: string): number {
+  return new TextEncoder().encode(data).length
+}
+
+function updateAverageFrameSize(frameBytes: number): void {
+  pushRecentSample(recentFrameSizes, frameBytes, RECENT_FRAME_SIZES_MAX)
+  averageFrameBytes = recentFrameSizes.reduce((sum, value) => sum + value, 0) / recentFrameSizes.length
+  updateMetricsDisplay()
 }
 
 // Mark the HUD overlay for regeneration on the next frame.
@@ -1770,6 +1819,11 @@ function resetClientWorldState(): void {
   snapshotIntervalMs = 50
   lives = 0
   resources = 0
+  latestTick = null
+  measuredTickRate = 0
+  averageFrameBytes = 0
+  recentTickSamples.length = 0
+  recentFrameSizes.length = 0
   lastFpsOverlayUpdateTime = 0
   hudDirty = true
   sidePanelDirty = true
@@ -1796,6 +1850,7 @@ function resetClientWorldState(): void {
   hudCtx.clearRect(0, 0, hudCanvas.width, hudCanvas.height)
   fpsCtx.clearRect(0, 0, fpsCanvas.width, fpsCanvas.height)
   applyOverlayPosition()
+  updateMetricsDisplay()
 }
 
 // Apply an incremental world update from the server and invalidate derived
@@ -1820,16 +1875,14 @@ function applyWorldDelta(delta: WorldDelta): void {
   }
 
   finishSnapshotUpdate()
-  tickEl.textContent = String(delta.tick)
+  latestTick = delta.tick
+  updateMeasuredTickRate(now, delta.tick)
   lives = delta.lives
   resources = delta.resources
   applyUiState(delta.uiState)
   invalidateHud()
   invalidateSidePanel()
-  setTextIfElement(livesEl, String(delta.lives))
-  setTextIfElement(resourcesEl, String(delta.resources))
   currentPhase = getDeltaPhase(delta)
-  setTextIfElement(phaseEl, currentPhase)
 }
 
 // --- Message validation ---
@@ -1919,9 +1972,11 @@ ws.onmessage = (event: MessageEvent<string>) => {
       log(`Server says: ${parsed.message}`)
       break
     case 'world_delta':
+      updateAverageFrameSize(measureFrameSizeBytes(event.data))
       applyWorldDelta(parsed)
       break
     case 'world_snapshot':
+      updateAverageFrameSize(measureFrameSizeBytes(event.data))
       resetClientWorldState()
       defenderMenuItems = parsed.defenderMenu
       drawBackground(parsed.mapDesign.paths, parsed.mapDesign.pathWidth)

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -336,7 +336,7 @@ function eventToCanvasSample(event: MouseEvent): CanvasPointerSample {
   const canvasX = (event.clientX - rect.left) * (foregroundCanvas.width / rect.width)
   const canvasY = (event.clientY - rect.top) * (foregroundCanvas.height / rect.height)
   const [worldX, worldY] = canvasToWorld(canvasX, canvasY)
-  return {
+  const sample = {
     button: event.button,
     buttons: event.buttons,
     canvasX: Math.round(canvasX),
@@ -348,6 +348,8 @@ function eventToCanvasSample(event: MouseEvent): CanvasPointerSample {
     alt: event.altKey,
     meta: event.metaKey,
   }
+  rememberPointerSample(sample)
+  return sample
 }
 
 // Reuse an existing pointer sample while overriding button bookkeeping for
@@ -447,6 +449,7 @@ let currentPanelSide: PanelSide = 'right'
 let overlaySideSwapFrame = 0
 let selectedDefenderSummary: DefenderMenuItem | null = null
 let selectedDefenderPosition: Position | null = null
+let lastPointerSample: CanvasPointerSample | null = null
 const RECENT_TICK_TIMES_MAX = 60
 const RECENT_FRAME_SIZES_MAX = 60
 const recentTickSamples: TickRateSample[] = []
@@ -676,6 +679,87 @@ function setEdgeHoverSide(nextSide: PanelSide | null): void {
 // Clear the currently highlighted build-menu cell.
 function clearMenuSelection(): void {
   selectedMenuIndex = null
+}
+
+// Return the most recent pointer sample, or the viewport center if the user
+// has not moved the mouse over the simulation yet.
+function getPointerAnchorSample(): CanvasPointerSample {
+  if (lastPointerSample) return lastPointerSample
+  const canvasX = Math.round(foregroundCanvas.width / 2)
+  const canvasY = Math.round(foregroundCanvas.height / 2)
+  const [worldX, worldY] = canvasToWorld(canvasX, canvasY)
+  return {
+    button: 0,
+    buttons: 0,
+    canvasX,
+    canvasY,
+    worldX: Math.round(worldX),
+    worldY: Math.round(worldY),
+    shift: false,
+    ctrl: false,
+    alt: false,
+    meta: false,
+  }
+}
+
+// Keep the most recent pointer anchor in sync for keyboard-driven actions.
+function rememberPointerSample(sample: CanvasPointerSample): void {
+  lastPointerSample = sample
+}
+
+// Keyboard-opened menus should appear on the opposite side from the cursor,
+// matching the hover-open behavior used elsewhere in the UI.
+function getKeyboardMenuSide(): PanelSide {
+  return getOppositePanelSideForCanvasX(getPointerAnchorSample().canvasX)
+}
+
+// Return the build menu to its top-level category grid.
+function resetBuildMenuToTopLevel(): void {
+  selectedCategory = null
+  selectedMenuIndex = null
+  hoveredMenuIndex = null
+  menuScrollOffset = 0
+}
+
+// Open the build menu as a latched overlay on the side opposite the cursor.
+function openBuildMenuFromKeyboard(): void {
+  if (currentPhase !== 'build' || defenderMenuItems.length === 0 || ghostState || menuDragActive) return
+  edgeHoverSide = getKeyboardMenuSide()
+  mouseOverOverlay = true
+  overlayStayOpen = true
+  invalidateSidePanel()
+}
+
+// Hide the build menu overlay without affecting pinned inspector panels.
+function closeBuildMenuFromKeyboard(): void {
+  if (getSidePanelModel() !== null) return
+  mouseOverOverlay = false
+  overlayStayOpen = false
+  setEdgeHoverSide(null)
+}
+
+// Create the same pending placement ghost that results from dragging a menu
+// item onto the map and releasing it under the cursor.
+function dropDefenderGhostAtPointer(item: DefenderMenuItem): void {
+  const sample = getPointerAnchorSample()
+  ghostState = {
+    worldX: sample.worldX,
+    worldY: sample.worldY,
+    entityName: item.entityName,
+    displayName: item.displayName,
+    appearance: appearanceToRender(item.appearance),
+    attackRadius: item.appearance.attackRadius,
+    confirmCommand: 'spawn',
+    pending: true,
+    placeable: true,
+    spawnPending: false,
+  }
+  clearMenuSelection()
+  mouseOverOverlay = false
+  overlayStayOpen = false
+  sendPlacementPreview('dragstart', sample, item.entityName)
+  sendPlacementPreview('dragend', sample, item.entityName)
+  invalidateSidePanel()
 }
 
 // Convert packed RGBA integers from the wire format into canvas-friendly color
@@ -1555,6 +1639,20 @@ function currentMenuItems(): (CategoryItem | DefenderMenuItem)[] {
   return categoryItems
 }
 
+// Convert a physical key press into the glyph-like hotkey string used by menu
+// items. Plain letters normalize to uppercase so visible glyphs like "A"
+// still match the common unshifted "a" key press.
+function normalizeMenuHotkey(key: string): string | null {
+  if ([...key].length !== 1) return null
+  const upper = key.toLocaleUpperCase()
+  return [...upper].length === 1 ? upper : key
+}
+
+// Check whether a menu item's glyph matches the provided keyboard hotkey.
+function menuGlyphMatchesHotkey(glyph: number, hotkey: string): boolean {
+  return String.fromCodePoint(glyph) === hotkey
+}
+
 // Draw one item cell (shared by both category and defender levels).
 function drawMenuCell(
   ctx: CanvasRenderingContext2D,
@@ -2172,7 +2270,7 @@ function applyUiState(uiState: UiState): void {
     ghostState.spawnPending = false
     if (uiState.spawnAllowed) {
       ghostState = null
-      clearMenuSelection()
+      resetBuildMenuToTopLevel()
       mouseOverOverlay = false
       overlayStayOpen = false
     }
@@ -2227,6 +2325,7 @@ function resetClientWorldState(): void {
   hoveredMenuIndex = null
   menuScrollOffset = 0
   ghostState = null
+  lastPointerSample = null
   transientExplosionsByPos.clear()
   transientBeamsByPos.clear()
   menuDragActive = false
@@ -3002,15 +3101,39 @@ overlayCanvas.addEventListener('mouseleave', () => {
 // Glyph hotkeys navigate the two-level build menu during the build phase.
 document.addEventListener('keydown', (event: KeyboardEvent) => {
   if (currentPhase !== 'build' || menuDragActive) return
-  if (!shouldShowBuildMenu()) return
+  if (event.ctrlKey || event.altKey || event.metaKey) return
 
-  const cp = event.key.codePointAt(0)
-  if (cp === undefined) return
+  if (event.key === 'Tab') {
+    if (getSidePanelModel() === null && defenderMenuItems.length === 0) return
+    event.preventDefault()
+    if (getSidePanelModel() === null) {
+      if (selectedCategory !== null) {
+        resetBuildMenuToTopLevel()
+        openBuildMenuFromKeyboard()
+      } else if (getOverlayLevel() !== 'hidden') {
+        closeBuildMenuFromKeyboard()
+      } else {
+        openBuildMenuFromKeyboard()
+      }
+    } else {
+      mouseOverOverlay = true
+      overlayStayOpen = true
+      invalidateSidePanel()
+    }
+    return
+  }
+
+  if (ghostState || selectedDefenderPosition !== null || defenderMenuItems.length === 0) return
+  openBuildMenuFromKeyboard()
+
+  const hotkey = normalizeMenuHotkey(event.key)
+  if (hotkey === null) return
 
   if (selectedCategory === null) {
     // Top level: navigate into the category whose glyph matches.
-    const cat = categoryItems.find(c => c.appearance.glyph === cp)
+    const cat = categoryItems.find(c => menuGlyphMatchesHotkey(c.appearance.glyph, hotkey))
     if (cat) {
+      event.preventDefault()
       selectedCategory = cat.name
       selectedMenuIndex = null
       menuScrollOffset = 0
@@ -3018,13 +3141,12 @@ document.addEventListener('keydown', (event: KeyboardEvent) => {
       invalidateSidePanel()
     }
   } else {
-    // Defender level: select the first defender whose glyph matches.
+    // Defender level: spawn the same pending ghost produced by a mouse drop.
     const defenders = currentMenuItems() as DefenderMenuItem[]
-    const match = defenders.find(d => d.appearance.glyph === cp)
+    const match = defenders.find(d => menuGlyphMatchesHotkey(d.appearance.glyph, hotkey))
     if (match) {
-      const index = defenders.indexOf(match)
-      selectedMenuIndex = index
-      invalidateSidePanel()
+      event.preventDefault()
+      dropDefenderGhostAtPointer(match)
     }
   }
 })

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -2,6 +2,7 @@ import type {
   ClientMsg,
   DefenderMenuItem,
   EntityAppearance,
+  EntityHealth,
   EntityPosition,
   EntityUpsert,
   EntityVisualEffects,
@@ -69,6 +70,7 @@ interface RenderEntityUpsert {
   pos: EntityPosition
   app: RenderAppearance
   fx: RenderVisualEffects
+  healthFraction: number  // 1.0 = full health or no health component
 }
 
 interface RenderTransientExplosion {
@@ -501,7 +503,7 @@ function renderInterpolated(now: number): void {
       const [px, py] = worldToCanvas(prevPos.x, prevPos.y)
       drawTrail(px, py, x, y, radius, e.app.trail)
     }
-    drawEntity(x, y, radius, e.app, e.fx, now)
+    drawEntity(x, y, radius, e.app, e.fx, now, e.healthFraction)
   }
   drawTransientDisplays(now)
   drawGhost()
@@ -803,16 +805,6 @@ function getEntitySprite(app: RenderAppearance, radius: number): SpriteCacheEntr
   if (!spriteCtx) return null
 
   if (app.bg.alpha !== 0) drawFilledCircleOnContext(spriteCtx, offset, offset, roundedRadius, app.bg)
-  if (app.fg.alpha !== 0) {
-    drawStrokedCircleOnContext(
-      spriteCtx,
-      offset,
-      offset,
-      Math.max(roundedRadius - getEntityBorderWidth(roundedRadius) * 0.5, 0),
-      app.fg,
-      getEntityBorderWidth(roundedRadius),
-    )
-  }
   if (app.fg.alpha !== 0) drawGlyphOnContext(spriteCtx, app.glyph, offset, offset, roundedRadius, app.fg)
 
   const sprite = { canvas, offset }
@@ -1010,6 +1002,32 @@ function drawTrail(
   fgCtx.restore()
 }
 
+// Draw the fg border as a partial arc proportional to health: full circle at
+// 1.0, clockwise arc from the top at intermediate values, nothing at 0.
+function drawHealthArc(
+  x: number,
+  y: number,
+  radius: number,
+  color: RenderColor,
+  healthFraction: number,
+): void {
+  if (radius <= 0 || isTransparent(color) || healthFraction <= 0) return
+
+  const lineWidth = getEntityBorderWidth(radius)
+  const arcRadius = Math.max(radius - lineWidth * 0.5, 0)
+  const startAngle = -Math.PI / 2
+  const endAngle = startAngle + Math.min(healthFraction, 1) * 2 * Math.PI
+
+  fgCtx.save()
+  fgCtx.strokeStyle = color.css
+  fgCtx.lineWidth = lineWidth
+  fgCtx.lineCap = 'round'
+  fgCtx.beginPath()
+  fgCtx.arc(x, y, arcRadius, startAngle, endAngle)
+  fgCtx.stroke()
+  fgCtx.restore()
+}
+
 // Draw one entity and all of its client-side visual effects.
 function drawEntity(
   x: number,
@@ -1018,9 +1036,11 @@ function drawEntity(
   app: RenderAppearance,
   fx: RenderVisualEffects,
   now: number,
+  healthFraction: number,
 ): void {
   drawRangeCircle(x, y, fx)
   drawEntitySprite(x, y, radius, app)
+  drawHealthArc(x, y, radius, app.fg, healthFraction)
   drawSelectionOutline(x, y, radius, fx)
   drawCooldownOverlay(x, y, radius, fx, now)
   drawFlashOverlay(x, y, radius, fx, now)
@@ -1103,11 +1123,16 @@ function beamToRender(
 
 // Merge a server upsert with previously known appearance/effect state so
 // partial updates remain renderable.
+function healthToFraction(health: EntityHealth): number {
+  return health.max > 0 ? Math.min(health.current / health.max, 1) : 1
+}
+
 function upsertToRenderEntity(
   upsert: EntityUpsert,
   now: number,
   prevApp?: RenderAppearance,
   prevFx?: RenderVisualEffects,
+  prevHealthFraction?: number,
 ): RenderEntityUpsert {
   return {
     pos: upsert.pos,
@@ -1115,6 +1140,9 @@ function upsertToRenderEntity(
     fx: upsert.vfx
       ? visualEffectsToRender(upsert.vfx, now, prevFx)
       : (prevFx ?? DEFAULT_RENDER_VISUAL_EFFECTS),
+    healthFraction: upsert.health
+      ? healthToFraction(upsert.health)
+      : (prevHealthFraction ?? 1),
   }
 }
 
@@ -2104,7 +2132,7 @@ function applyWorldDelta(delta: WorldDelta): void {
   for (const entity of delta.upserts) {
     const prevEntity = currEntitiesById.get(entity.pos.id)
     const nextEntity =
-      upsertToRenderEntity(entity, now, prevEntity?.app, prevEntity?.fx)
+      upsertToRenderEntity(entity, now, prevEntity?.app, prevEntity?.fx, prevEntity?.healthFraction)
     if (prevEntity) prevRenderStateById.set(entity.pos.id, prevEntity)
     currEntitiesById.set(entity.pos.id, nextEntity)
   }

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -394,6 +394,9 @@ let lastFrameTime = 0
 // to interpolate from the old snapshot toward the new one.
 const currEntitiesById = new Map<number, RenderEntityUpsert>()
 const prevRenderStateById = new Map<number, RenderEntityUpsert>()
+// Tracks entity IDs known to be bullets (glyph '*'=42 or '.'=46), so erasure
+// logging can identify bullet deaths without needing the appearance data.
+const bulletEntityIds = new Set<number>()
 let prevSnapshotTime = 0
 let currSnapshotTime = 0
 let snapshotIntervalMs = 50
@@ -2070,12 +2073,25 @@ function applyWorldDelta(delta: WorldDelta): void {
   // animation frames.
   for (const entity of delta.upserts) {
     const prevEntity = currEntitiesById.get(entity.pos.id)
+    if (!prevEntity && entity.app) {
+      const g = entity.app.glyph
+      if (g === 42 || g === 46) {
+        // '*' (42) or '.' (46) -- this is a bullet.
+        const { id, x, y } = entity.pos
+        log(`tick ${delta.tick}: bullet id=${id} glyph=${String.fromCodePoint(g)} (${x},${y}) r=${entity.app.radius}`)
+        bulletEntityIds.add(id)
+      }
+    }
     const nextEntity =
       upsertToRenderEntity(entity, now, prevEntity?.app, prevEntity?.fx)
     if (prevEntity) prevRenderStateById.set(entity.pos.id, prevEntity)
     currEntitiesById.set(entity.pos.id, nextEntity)
   }
   for (const entityId of delta.erased) {
+    if (bulletEntityIds.has(entityId)) {
+      log(`tick ${delta.tick}: bullet erased id=${entityId}`)
+      bulletEntityIds.delete(entityId)
+    }
     currEntitiesById.delete(entityId)
     prevRenderStateById.delete(entityId)
   }

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -2478,10 +2478,15 @@ foregroundCanvas.addEventListener('mousedown', (event: MouseEvent) => {
     const dy = sample.canvasY - gy
     if (dx * dx + dy * dy <= hitRadius * hitRadius) {
       ghostState.pending = false
-      menuDragActive = true
       mouseOverOverlay = false
       overlayStayOpen = false
-      sendPlacementPreview('dragstart', sample, ghostState.entityName)
+      if (ghostState.confirmCommand === 'moving') {
+        moveDragActive = true
+        sendCanvasMsg('dragstart', ghostStateToSample(ghostState, event), 'moving')
+      } else {
+        menuDragActive = true
+        sendPlacementPreview('dragstart', sample, ghostState.entityName)
+      }
     } else {
       ghostState = null
       clearMenuSelection()

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -7,6 +7,8 @@ import type {
   EntityVisualEffects,
   Position,
   ServerMsg,
+  TransientBeam,
+  TransientExplosion,
   UiCanvasMsg,
   UiState,
   WorldDelta,
@@ -66,6 +68,29 @@ interface RenderEntityUpsert {
   pos: EntityPosition
   app: RenderAppearance
   fx: RenderVisualEffects
+}
+
+interface RenderTransientExplosion {
+  x: number
+  y: number
+  expiry: number
+  primary: RenderColor
+  secondary: RenderColor
+  radius: number
+  startedAt: number
+}
+
+interface RenderTransientBeam {
+  x: number
+  y: number
+  expiry: number
+  primary: RenderColor
+  secondary: RenderColor
+  targetX: number
+  targetY: number
+  startDistance: number
+  lineWidth: number
+  startedAt: number
 }
 
 // Pointer bookkeeping for an in-progress foreground-canvas interaction.
@@ -401,6 +426,8 @@ let menuScrollOffset = 0
 let ghostState: GhostState | null = null
 let menuDragActive = false
 let moveDragActive = false // true while dragging a selected defender to reposition it
+const transientExplosionsByPos = new Map<string, RenderTransientExplosion>()
+const transientBeamsByPos = new Map<string, RenderTransientBeam>()
 let currentPhase = 'build'
 let mouseOverOverlay = false
 let overlayStayOpen = false
@@ -470,6 +497,7 @@ function renderInterpolated(now: number): void {
     const radius = worldLengthToCanvas(lerp(prevApp.radius, e.app.radius, t))
     drawEntity(x, y, radius, e.app, e.fx, now)
   }
+  drawTransientDisplays(now)
   drawGhost()
 }
 
@@ -858,6 +886,75 @@ function drawFlashOverlay(
   fgCtx.restore()
 }
 
+function transientDisplayKey(x: number, y: number): string {
+  return `${x},${y}`
+}
+
+function isTransientFlashPrimary(now: number, startedAt: number): boolean {
+  const elapsed = Math.max(now - startedAt, 0)
+  return Math.floor(elapsed / FLASH_FLICKER_INTERVAL_MS) % 2 === 0
+}
+
+function drawExplosionTransient(transient: RenderTransientExplosion, now: number): void {
+  const [x, y] = worldToCanvas(transient.x, transient.y)
+  const radius = worldLengthToCanvas(transient.radius)
+  const color = isTransientFlashPrimary(now, transient.startedAt)
+    ? transient.primary
+    : transient.secondary
+  if (radius <= 0 || isTransparent(color)) return
+
+  fgCtx.save()
+  drawFilledCircleOnContext(fgCtx, x, y, radius, color)
+  drawStrokedCircleOnContext(fgCtx, x, y, radius, transient.secondary, Math.max(2, radius * 0.15))
+  fgCtx.restore()
+}
+
+function drawBeamTransient(transient: RenderTransientBeam, now: number): void {
+  const dx = transient.targetX - transient.x
+  const dy = transient.targetY - transient.y
+  const length = Math.sqrt((dx * dx) + (dy * dy))
+  if (length <= 0) return
+
+  const ux = dx / length
+  const uy = dy / length
+  const startX = transient.x + ux * transient.startDistance
+  const startY = transient.y + uy * transient.startDistance
+  const [canvasStartX, canvasStartY] = worldToCanvas(startX, startY)
+  const [canvasTargetX, canvasTargetY] =
+    worldToCanvas(transient.targetX, transient.targetY)
+  const color = isTransientFlashPrimary(now, transient.startedAt)
+    ? transient.primary
+    : transient.secondary
+  if (isTransparent(color)) return
+
+  fgCtx.save()
+  fgCtx.strokeStyle = color.css
+  fgCtx.lineWidth = Math.max(2, worldLengthToCanvas(transient.lineWidth))
+  fgCtx.lineCap = 'round'
+  fgCtx.beginPath()
+  fgCtx.moveTo(canvasStartX, canvasStartY)
+  fgCtx.lineTo(canvasTargetX, canvasTargetY)
+  fgCtx.stroke()
+  fgCtx.restore()
+}
+
+function drawTransientDisplays(now: number): void {
+  for (const [key, transient] of transientExplosionsByPos) {
+    if (now >= transient.expiry) {
+      transientExplosionsByPos.delete(key)
+      continue
+    }
+    drawExplosionTransient(transient, now)
+  }
+  for (const [key, transient] of transientBeamsByPos) {
+    if (now >= transient.expiry) {
+      transientBeamsByPos.delete(key)
+      continue
+    }
+    drawBeamTransient(transient, now)
+  }
+}
+
 // Draw a steady cooldown overlay and clear it locally once its timer ends.
 function drawCooldownOverlay(
   x: number,
@@ -935,6 +1032,39 @@ function visualEffectsToRender(
       : 0,
     cooldown: packedRgbaToRenderColor(fx.cooldown),
     cooldownExpiry: fx.cooldownExpiryMs <= 0 ? 0 : now + fx.cooldownExpiryMs,
+  }
+}
+
+function explosionToRender(
+  transient: TransientExplosion,
+  now: number,
+): RenderTransientExplosion {
+  return {
+    x: transient.x,
+    y: transient.y,
+    expiry: transient.expiryMs <= 0 ? 0 : now + transient.expiryMs,
+    primary: packedRgbaToRenderColor(transient.primaryColor),
+    secondary: packedRgbaToRenderColor(transient.secondaryColor),
+    radius: transient.radius,
+    startedAt: now,
+  }
+}
+
+function beamToRender(
+  transient: TransientBeam,
+  now: number,
+): RenderTransientBeam {
+  return {
+    x: transient.x,
+    y: transient.y,
+    expiry: transient.expiryMs <= 0 ? 0 : now + transient.expiryMs,
+    primary: packedRgbaToRenderColor(transient.primaryColor),
+    secondary: packedRgbaToRenderColor(transient.secondaryColor),
+    targetX: transient.targetX,
+    targetY: transient.targetY,
+    startDistance: transient.startDistance,
+    lineWidth: transient.lineWidth,
+    startedAt: now,
   }
 }
 
@@ -1779,6 +1909,35 @@ function isEntityUpsert(value: unknown): value is EntityUpsert {
   )
 }
 
+function isTransientExplosion(value: unknown): value is TransientExplosion {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).x === 'number' &&
+    typeof (value as Record<string, unknown>).y === 'number' &&
+    typeof (value as Record<string, unknown>).expiryMs === 'number' &&
+    typeof (value as Record<string, unknown>).primaryColor === 'number' &&
+    typeof (value as Record<string, unknown>).secondaryColor === 'number' &&
+    typeof (value as Record<string, unknown>).radius === 'number'
+  )
+}
+
+function isTransientBeam(value: unknown): value is TransientBeam {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).x === 'number' &&
+    typeof (value as Record<string, unknown>).y === 'number' &&
+    typeof (value as Record<string, unknown>).expiryMs === 'number' &&
+    typeof (value as Record<string, unknown>).primaryColor === 'number' &&
+    typeof (value as Record<string, unknown>).secondaryColor === 'number' &&
+    typeof (value as Record<string, unknown>).targetX === 'number' &&
+    typeof (value as Record<string, unknown>).targetY === 'number' &&
+    typeof (value as Record<string, unknown>).startDistance === 'number' &&
+    typeof (value as Record<string, unknown>).lineWidth === 'number'
+  )
+}
+
 // Narrow an unknown value to a defender menu entry.
 function isDefenderMenuItem(value: unknown): value is DefenderMenuItem {
   return (
@@ -1877,6 +2036,8 @@ function resetClientWorldState(): void {
   selectedMenuIndex = null
   menuScrollOffset = 0
   ghostState = null
+  transientExplosionsByPos.clear()
+  transientBeamsByPos.clear()
   menuDragActive = false
   currentPhase = 'build'
   mouseOverOverlay = false
@@ -1918,6 +2079,14 @@ function applyWorldDelta(delta: WorldDelta): void {
     currEntitiesById.delete(entityId)
     prevRenderStateById.delete(entityId)
   }
+  for (const transient of delta.transientExplosions) {
+    const rendered = explosionToRender(transient, now)
+    transientExplosionsByPos.set(transientDisplayKey(transient.x, transient.y), rendered)
+  }
+  for (const transient of delta.transientBeams) {
+    const rendered = beamToRender(transient, now)
+    transientBeamsByPos.set(transientDisplayKey(transient.x, transient.y), rendered)
+  }
 
   finishSnapshotUpdate()
   latestTick = delta.tick
@@ -1943,11 +2112,15 @@ function isWorldDelta(value: unknown): value is WorldDelta {
     typeof v.currentWave === 'number' &&
     Array.isArray(v.upserts) &&
     Array.isArray(v.erased) &&
+    Array.isArray(v.transientExplosions) &&
+    Array.isArray(v.transientBeams) &&
     typeof v.lives === 'number' &&
     typeof v.resources === 'number' &&
     typeof v.phase === 'string' &&
     isUiState(v.uiState) &&
     v.upserts.every(isEntityUpsert) &&
+    v.transientExplosions.every(isTransientExplosion) &&
+    v.transientBeams.every(isTransientBeam) &&
     // Erase entries are just numeric entity ids.
     v.erased.every((id) => typeof id === 'number')
   )

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -55,6 +55,8 @@ interface RenderVisualEffects {
   flash: RenderColor
   flashExpiry: number
   flashStartedAt: number
+  cooldown: RenderColor
+  cooldownExpiry: number
 }
 
 // Fully materialized render snapshot for one entity id, derived from
@@ -115,6 +117,8 @@ const DEFAULT_RENDER_VISUAL_EFFECTS: RenderVisualEffects = {
   flash: TRANSPARENT_RENDER_COLOR,
   flashExpiry: 0,
   flashStartedAt: 0,
+  cooldown: TRANSPARENT_RENDER_COLOR,
+  cooldownExpiry: 0,
 }
 
 // --- DOM setup ---
@@ -839,6 +843,29 @@ function drawFlashOverlay(
   fgCtx.restore()
 }
 
+// Draw a steady cooldown overlay and clear it locally once its timer ends.
+function drawCooldownOverlay(
+  x: number,
+  y: number,
+  radius: number,
+  fx: RenderVisualEffects,
+  now: number,
+): void {
+  if (fx.cooldownExpiry == 0) return
+
+  if (now >= fx.cooldownExpiry) {
+    fx.cooldown = TRANSPARENT_RENDER_COLOR
+    fx.cooldownExpiry = 0
+    return
+  }
+
+  if (radius <= 0 || isTransparent(fx.cooldown)) return
+
+  fgCtx.save()
+  drawFilledCircleOnContext(fgCtx, x, y, radius, fx.cooldown)
+  fgCtx.restore()
+}
+
 // Draw one entity and all of its client-side visual effects.
 function drawEntity(
   x: number,
@@ -851,6 +878,7 @@ function drawEntity(
   drawRangeCircle(x, y, fx)
   drawEntitySprite(x, y, radius, app)
   drawSelectionOutline(x, y, radius, fx)
+  drawCooldownOverlay(x, y, radius, fx, now)
   drawFlashOverlay(x, y, radius, fx, now)
 }
 
@@ -890,6 +918,8 @@ function visualEffectsToRender(
     flashStartedAt: flashExpiry > 0
       ? (keepExistingFlashPhase ? prevFx.flashStartedAt : now)
       : 0,
+    cooldown: packedRgbaToRenderColor(fx.cooldown),
+    cooldownExpiry: fx.cooldownExpiryMs <= 0 ? 0 : now + fx.cooldownExpiryMs,
   }
 }
 
@@ -1637,7 +1667,9 @@ function isEntityVisualEffects(value: unknown): value is EntityVisualEffects {
     typeof (value as Record<string, unknown>).rangeRadius === 'number' &&
     typeof (value as Record<string, unknown>).range === 'number' &&
     typeof (value as Record<string, unknown>).flash === 'number' &&
-    typeof (value as Record<string, unknown>).flashExpiryMs === 'number'
+    typeof (value as Record<string, unknown>).flashExpiryMs === 'number' &&
+    typeof (value as Record<string, unknown>).cooldown === 'number' &&
+    typeof (value as Record<string, unknown>).cooldownExpiryMs === 'number'
   )
 }
 

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -1007,13 +1007,13 @@ function drawCooldownOverlay(
     ? Math.max(0, Math.min(1, (fx.cooldownExpiry - now) / fx.cooldownDuration))
     : 1
   const startAngle = -Math.PI / 2
-  const endAngle = startAngle + fractionRemaining * 2 * Math.PI
+  const endAngle = startAngle - fractionRemaining * 2 * Math.PI
 
   fgCtx.save()
   fgCtx.fillStyle = fx.cooldown.css
   fgCtx.beginPath()
   fgCtx.moveTo(x, y)
-  fgCtx.arc(x, y, radius, startAngle, endAngle, false)
+  fgCtx.arc(x, y, radius, startAngle, endAngle, true)
   fgCtx.closePath()
   fgCtx.fill()
   fgCtx.restore()

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -1187,13 +1187,19 @@ function appearanceToRender(app: EntityAppearance): RenderAppearance {
 
 // Convert wire-format visual effects into client render state, preserving flash
 // phase across repeated delta updates when appropriate.
+function tickExpiryToWallMs(expiryTick: number, currentTick: number, now: number): number {
+  if (expiryTick <= 0) return 0
+  return now + Math.max(0, expiryTick - currentTick) * 50
+}
+
 function visualEffectsToRender(
   fx: EntityVisualEffects,
   now: number,
+  currentTick: number,
   prevFx?: RenderVisualEffects,
 ): RenderVisualEffects {
   const flash = packedRgbaToRenderColor(fx.flash)
-  const flashExpiry = fx.flashExpiryMs <= 0 ? 0 : now + fx.flashExpiryMs
+  const flashExpiry = tickExpiryToWallMs(fx.flashExpiryTick, currentTick, now)
   const keepExistingFlashPhase =
     prevFx !== undefined &&
     prevFx.flashExpiry > now &&
@@ -1211,19 +1217,20 @@ function visualEffectsToRender(
       ? (keepExistingFlashPhase ? prevFx.flashStartedAt : now)
       : 0,
     cooldown: packedRgbaToRenderColor(fx.cooldown),
-    cooldownExpiry: fx.cooldownExpiryMs <= 0 ? 0 : now + fx.cooldownExpiryMs,
-    cooldownDuration: fx.cooldownDurationMs,
+    cooldownExpiry: tickExpiryToWallMs(fx.cooldownExpiryTick, currentTick, now),
+    cooldownDuration: Math.max(0, fx.cooldownDurationTick - currentTick) * 50,
   }
 }
 
 function explosionToRender(
   transient: TransientExplosion,
   now: number,
+  currentTick: number,
 ): RenderTransientExplosion {
   return {
     x: transient.x,
     y: transient.y,
-    expiry: transient.expiryMs <= 0 ? 0 : now + transient.expiryMs,
+    expiry: tickExpiryToWallMs(transient.expiryTick, currentTick, now),
     primary: packedRgbaToRenderColor(transient.primaryColor),
     secondary: packedRgbaToRenderColor(transient.secondaryColor),
     radius: transient.radius,
@@ -1234,11 +1241,12 @@ function explosionToRender(
 function beamToRender(
   transient: TransientBeam,
   now: number,
+  currentTick: number,
 ): RenderTransientBeam {
   return {
     x: transient.x,
     y: transient.y,
-    expiry: transient.expiryMs <= 0 ? 0 : now + transient.expiryMs,
+    expiry: tickExpiryToWallMs(transient.expiryTick, currentTick, now),
     primary: packedRgbaToRenderColor(transient.primaryColor),
     secondary: packedRgbaToRenderColor(transient.secondaryColor),
     targetX: transient.targetX,
@@ -1260,6 +1268,7 @@ function healthToFraction(health: EntityHealth): number {
 function upsertToRenderEntity(
   upsert: EntityUpsert,
   now: number,
+  currentTick: number,
   prevApp?: RenderAppearance,
   prevFx?: RenderVisualEffects,
   prevHealthFraction?: number,
@@ -1268,7 +1277,7 @@ function upsertToRenderEntity(
     pos: upsert.pos,
     app: upsert.app ? appearanceToRender(upsert.app) : (prevApp ?? DEFAULT_RENDER_APPEARANCE),
     fx: upsert.vfx
-      ? visualEffectsToRender(upsert.vfx, now, prevFx)
+      ? visualEffectsToRender(upsert.vfx, now, currentTick, prevFx)
       : (prevFx ?? DEFAULT_RENDER_VISUAL_EFFECTS),
     healthFraction: upsert.health
       ? healthToFraction(upsert.health)
@@ -2163,9 +2172,9 @@ function isEntityVisualEffects(value: unknown): value is EntityVisualEffects {
     typeof (value as Record<string, unknown>).rangeRadius === 'number' &&
     typeof (value as Record<string, unknown>).range === 'number' &&
     typeof (value as Record<string, unknown>).flash === 'number' &&
-    typeof (value as Record<string, unknown>).flashExpiryMs === 'number' &&
+    typeof (value as Record<string, unknown>).flashExpiryTick === 'number' &&
     typeof (value as Record<string, unknown>).cooldown === 'number' &&
-    typeof (value as Record<string, unknown>).cooldownExpiryMs === 'number'
+    typeof (value as Record<string, unknown>).cooldownExpiryTick === 'number'
   )
 }
 
@@ -2188,7 +2197,7 @@ function isTransientExplosion(value: unknown): value is TransientExplosion {
     value !== null &&
     typeof (value as Record<string, unknown>).x === 'number' &&
     typeof (value as Record<string, unknown>).y === 'number' &&
-    typeof (value as Record<string, unknown>).expiryMs === 'number' &&
+    typeof (value as Record<string, unknown>).expiryTick === 'number' &&
     typeof (value as Record<string, unknown>).primaryColor === 'number' &&
     typeof (value as Record<string, unknown>).secondaryColor === 'number' &&
     typeof (value as Record<string, unknown>).radius === 'number'
@@ -2201,7 +2210,7 @@ function isTransientBeam(value: unknown): value is TransientBeam {
     value !== null &&
     typeof (value as Record<string, unknown>).x === 'number' &&
     typeof (value as Record<string, unknown>).y === 'number' &&
-    typeof (value as Record<string, unknown>).expiryMs === 'number' &&
+    typeof (value as Record<string, unknown>).expiryTick === 'number' &&
     typeof (value as Record<string, unknown>).primaryColor === 'number' &&
     typeof (value as Record<string, unknown>).secondaryColor === 'number' &&
     typeof (value as Record<string, unknown>).targetX === 'number' &&
@@ -2361,7 +2370,7 @@ function applyWorldDelta(delta: WorldDelta): void {
   for (const entity of delta.upserts) {
     const prevEntity = currEntitiesById.get(entity.pos.id)
     const nextEntity =
-      upsertToRenderEntity(entity, now, prevEntity?.app, prevEntity?.fx, prevEntity?.healthFraction)
+      upsertToRenderEntity(entity, now, delta.tick, prevEntity?.app, prevEntity?.fx, prevEntity?.healthFraction)
     if (prevEntity) prevRenderStateById.set(entity.pos.id, prevEntity)
     currEntitiesById.set(entity.pos.id, nextEntity)
   }
@@ -2370,11 +2379,11 @@ function applyWorldDelta(delta: WorldDelta): void {
     prevRenderStateById.delete(entityId)
   }
   for (const transient of delta.transientExplosions) {
-    const rendered = explosionToRender(transient, now)
+    const rendered = explosionToRender(transient, now, delta.tick)
     transientExplosionsByPos.set(transientDisplayKey(transient.x, transient.y), rendered)
   }
   for (const transient of delta.transientBeams) {
-    const rendered = beamToRender(transient, now)
+    const rendered = beamToRender(transient, now, delta.tick)
     transientBeamsByPos.set(transientDisplayKey(transient.x, transient.y), rendered)
   }
 

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -372,6 +372,7 @@ let currSnapshotTime = 0
 let snapshotIntervalMs = 50
 let lives = 0
 let resources = 0
+let currentWave = 0
 let latestTick: number | null = null
 let measuredTickRate = 0
 let averageFrameBytes = 0
@@ -968,7 +969,20 @@ function drawFps(ctx: CanvasRenderingContext2D): void {
   ctx.restore()
 }
 
-// Draw the top HUD bar that displays lives and resources.
+// Return the wave-status text for the center of the HUD based on phase.
+// `currentWave` is 0-based; wave numbers shown to the player are 1-based.
+function getWaveStatusText(): string {
+  const waveNum = currentWave + 1
+  switch (currentPhase) {
+    case 'build':    return `Prepare for Wave ${waveNum}`
+    case 'wave':     return `Wave ${waveNum}`
+    case 'game_over': return 'Game Over'
+    case 'victory':  return 'Invaders Thwarted!'
+    default:         return ''
+  }
+}
+
+// Draw the top HUD bar that displays lives, resources, and wave status.
 function drawHud(ctx: CanvasRenderingContext2D): void {
   ctx.save()
   ctx.font = '20px monospace'
@@ -983,7 +997,15 @@ function drawHud(ctx: CanvasRenderingContext2D): void {
   ctx.fillRect(0, 0, hudCanvas.width, barHeight)
 
   ctx.fillStyle = 'white'
+  ctx.textAlign = 'left'
   ctx.fillText(`${livesLabel}   ${resourcesLabel}`, pad, pad)
+
+  const centerText = getWaveStatusText()
+  if (centerText) {
+    ctx.textAlign = 'center'
+    ctx.fillText(centerText, hudCanvas.width / 2, pad)
+  }
+
   ctx.restore()
 }
 
@@ -1819,6 +1841,7 @@ function resetClientWorldState(): void {
   snapshotIntervalMs = 50
   lives = 0
   resources = 0
+  currentWave = 0
   latestTick = null
   measuredTickRate = 0
   averageFrameBytes = 0
@@ -1877,6 +1900,7 @@ function applyWorldDelta(delta: WorldDelta): void {
   finishSnapshotUpdate()
   latestTick = delta.tick
   updateMeasuredTickRate(now, delta.tick)
+  currentWave = delta.currentWave
   lives = delta.lives
   resources = delta.resources
   applyUiState(delta.uiState)
@@ -1894,6 +1918,7 @@ function isWorldDelta(value: unknown): value is WorldDelta {
 
   return (
     typeof v.tick === 'number' &&
+    typeof v.currentWave === 'number' &&
     Array.isArray(v.upserts) &&
     Array.isArray(v.erased) &&
     typeof v.lives === 'number' &&

--- a/corvid/sim/web/src/main.ts
+++ b/corvid/sim/web/src/main.ts
@@ -62,6 +62,7 @@ interface RenderVisualEffects {
   flashStartedAt: number
   cooldown: RenderColor
   cooldownExpiry: number
+  cooldownDuration: number
 }
 
 // Fully materialized render snapshot for one entity id, derived from
@@ -155,6 +156,7 @@ const DEFAULT_RENDER_VISUAL_EFFECTS: RenderVisualEffects = {
   flashStartedAt: 0,
   cooldown: TRANSPARENT_RENDER_COLOR,
   cooldownExpiry: 0,
+  cooldownDuration: 0,
 }
 
 // --- DOM setup ---
@@ -971,8 +973,19 @@ function drawCooldownOverlay(
 
   if (radius <= 0 || isTransparent(fx.cooldown)) return
 
+  const fractionRemaining = fx.cooldownDuration > 0
+    ? Math.max(0, Math.min(1, (fx.cooldownExpiry - now) / fx.cooldownDuration))
+    : 1
+  const startAngle = -Math.PI / 2
+  const endAngle = startAngle + fractionRemaining * 2 * Math.PI
+
   fgCtx.save()
-  drawFilledCircleOnContext(fgCtx, x, y, radius, fx.cooldown)
+  fgCtx.fillStyle = fx.cooldown.css
+  fgCtx.beginPath()
+  fgCtx.moveTo(x, y)
+  fgCtx.arc(x, y, radius, startAngle, endAngle, true)
+  fgCtx.closePath()
+  fgCtx.fill()
   fgCtx.restore()
 }
 
@@ -1085,6 +1098,7 @@ function visualEffectsToRender(
       : 0,
     cooldown: packedRgbaToRenderColor(fx.cooldown),
     cooldownExpiry: fx.cooldownExpiryMs <= 0 ? 0 : now + fx.cooldownExpiryMs,
+    cooldownDuration: fx.cooldownDurationMs,
   }
 }
 

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -46,6 +46,20 @@ interface PathPoint {
   y: number
 }
 
+interface MapDesign {
+  backgroundSprite: string
+  foregroundSprite: string
+  paths: PathPoint[]
+}
+
+export interface DefenderMenuItem {
+  entityName: string
+  displayName: string
+  flavorText: string
+  resourceCost: number
+  appearance: EntityAppearance
+}
+
 export interface EntityUpsert {
   pos: EntityPosition
   app?: EntityAppearance
@@ -87,7 +101,8 @@ export interface WorldDelta {
 
 export interface WorldSnapshot {
   type: 'world_snapshot'
-  paths: PathPoint[]
+  mapDesign: MapDesign
+  defenderMenu: DefenderMenuItem[]
   delta: WorldDelta
 }
 

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -50,6 +50,7 @@ interface PathPoint {
 interface MapDesign {
   backgroundSprite: string
   foregroundSprite: string
+  pathWidth: number
   paths: PathPoint[]
 }
 

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -31,6 +31,7 @@ export interface EntityAppearance {
   radius: number
   fg: number
   bg: number
+  attackRadius: number
 }
 
 export interface EntityVisualEffects {
@@ -80,6 +81,8 @@ export interface UiCanvasMsg {
   ctrl: boolean
   alt: boolean
   meta: boolean
+  command?: string
+  parameters?: string[]
 }
 
 export interface UiActionMsg {

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -62,6 +62,13 @@ export interface DefenderMenuItem {
   appearance: EntityAppearance
 }
 
+export interface UiState {
+  placementAllowed?: boolean
+  spawnAllowed?: boolean
+  defenderSelected: boolean
+  defenderSummary?: DefenderMenuItem
+}
+
 export interface EntityUpsert {
   pos: EntityPosition
   app?: EntityAppearance
@@ -93,15 +100,6 @@ export interface UiActionMsg {
   fields?: Record<string, string>
 }
 
-export interface UiResponseMsg {
-  type: 'ui_response'
-  seq: number
-  ok: boolean
-  response: string
-  reason?: string
-  fields?: Record<string, string>
-}
-
 export interface WorldDelta {
   type: 'world_delta'
   tick: number
@@ -110,6 +108,7 @@ export interface WorldDelta {
   lives: number
   resources: number
   phase: string
+  uiState: UiState
 }
 
 export interface WorldSnapshot {
@@ -119,5 +118,5 @@ export interface WorldSnapshot {
   delta: WorldDelta
 }
 
-export type ServerMsg = HelloAckMsg | UiResponseMsg | WorldDelta | WorldSnapshot;
+export type ServerMsg = HelloAckMsg | WorldDelta | WorldSnapshot;
 export type ClientMsg = HelloMsg | UiCanvasMsg | UiActionMsg;

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -20,6 +20,11 @@ export type UiCanvasEvent =
 
 export type UiButton = 'left' | 'middle' | 'right' | 'other'
 
+export interface Position {
+  x: number
+  y: number
+}
+
 export interface EntityPosition {
   id: number
   x: number
@@ -65,7 +70,7 @@ export interface DefenderMenuItem {
 export interface UiState {
   placementAllowed?: boolean
   spawnAllowed?: boolean
-  defenderSelected: boolean
+  selectedDefender?: Position
   defenderSummary?: DefenderMenuItem
 }
 

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -92,6 +92,15 @@ export interface UiActionMsg {
   fields?: Record<string, string>
 }
 
+export interface UiResponseMsg {
+  type: 'ui_response'
+  seq: number
+  ok: boolean
+  response: string
+  reason?: string
+  fields?: Record<string, string>
+}
+
 export interface WorldDelta {
   type: 'world_delta'
   tick: number
@@ -109,5 +118,5 @@ export interface WorldSnapshot {
   delta: WorldDelta
 }
 
-export type ServerMsg = HelloAckMsg | WorldDelta | WorldSnapshot;
+export type ServerMsg = HelloAckMsg | UiResponseMsg | WorldDelta | WorldSnapshot;
 export type ClientMsg = HelloMsg | UiCanvasMsg | UiActionMsg;

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -45,6 +45,8 @@ export interface EntityVisualEffects {
   range: number
   flash: number
   flashExpiryMs: number
+  cooldown: number
+  cooldownExpiryMs: number
 }
 
 interface PathPoint {

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -40,6 +40,11 @@ export interface EntityAppearance {
   trailColor?: number
 }
 
+export interface EntityHealth {
+  current: number
+  max: number
+}
+
 export interface EntityVisualEffects {
   selection: number
   rangeRadius: number
@@ -104,6 +109,7 @@ export interface EntityUpsert {
   pos: EntityPosition
   app?: EntityAppearance
   vfx?: EntityVisualEffects
+  health?: EntityHealth
 }
 
 export interface UiCanvasMsg {

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -37,6 +37,7 @@ export interface EntityAppearance {
   fg: number
   bg: number
   attackRadius: number
+  trailColor?: number
 }
 
 export interface EntityVisualEffects {

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -114,6 +114,7 @@ export interface WorldDelta {
   tick: number
   upserts: EntityUpsert[]
   erased: number[]
+  currentWave: number
   lives: number
   resources: number
   phase: string

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -65,6 +65,8 @@ export interface DefenderMenuItem {
   flavorText: string
   resourceCost: number
   appearance: EntityAppearance
+  totalDamageDealt?: number  // Only present on selected-defender summaries.
+  totalKills?: number
 }
 
 export interface UiState {

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -50,16 +50,16 @@ export interface EntityVisualEffects {
   rangeRadius: number
   range: number
   flash: number
-  flashExpiryMs: number
+  flashExpiryTick: number
   cooldown: number
-  cooldownExpiryMs: number
-  cooldownDurationMs: number
+  cooldownExpiryTick: number
+  cooldownDurationTick: number
 }
 
 export interface TransientExplosion {
   x: number
   y: number
-  expiryMs: number
+  expiryTick: number
   primaryColor: number
   secondaryColor: number
   radius: number
@@ -68,7 +68,7 @@ export interface TransientExplosion {
 export interface TransientBeam {
   x: number
   y: number
-  expiryMs: number
+  expiryTick: number
   primaryColor: number
   secondaryColor: number
   targetX: number

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -75,6 +75,8 @@ export interface TransientBeam {
   targetY: number
   startDistance: number
   lineWidth: number
+  halfAngleDeg: number
+  coneRadius: number
 }
 
 interface PathPoint {
@@ -89,9 +91,17 @@ interface MapDesign {
   paths: PathPoint[]
 }
 
+export interface CategoryItem {
+  name: string
+  displayName: string
+  flavorText: string
+  appearance: EntityAppearance
+}
+
 export interface DefenderMenuItem {
   entityName: string
   displayName: string
+  category: string
   flavorText: string
   resourceCost: number
   appearance: EntityAppearance
@@ -156,6 +166,7 @@ export interface WorldSnapshot {
   type: 'world_snapshot'
   mapDesign: MapDesign
   defenderMenu: DefenderMenuItem[]
+  categories: CategoryItem[]
   delta: WorldDelta
 }
 

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -53,6 +53,7 @@ export interface EntityVisualEffects {
   flashExpiryMs: number
   cooldown: number
   cooldownExpiryMs: number
+  cooldownDurationMs: number
 }
 
 export interface TransientExplosion {

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -25,6 +25,10 @@ export interface Position {
   y: number
 }
 
+export interface Circle extends Position {
+  radius: number
+}
+
 export interface EntityPosition {
   id: number
   x: number
@@ -57,23 +61,18 @@ export interface EntityVisualEffects {
 }
 
 export interface TransientExplosion {
-  x: number
-  y: number
+  circle: Circle
   expiryTick: number
   primaryColor: number
   secondaryColor: number
-  radius: number
 }
 
 export interface TransientBeam {
-  x: number
-  y: number
+  circle: Circle
   expiryTick: number
   primaryColor: number
   secondaryColor: number
-  targetX: number
-  targetY: number
-  startDistance: number
+  targetPos: Position
   lineWidth: number
   halfAngleDeg: number
   coneRadius: number

--- a/corvid/sim/web/src/types.ts
+++ b/corvid/sim/web/src/types.ts
@@ -49,6 +49,27 @@ export interface EntityVisualEffects {
   cooldownExpiryMs: number
 }
 
+export interface TransientExplosion {
+  x: number
+  y: number
+  expiryMs: number
+  primaryColor: number
+  secondaryColor: number
+  radius: number
+}
+
+export interface TransientBeam {
+  x: number
+  y: number
+  expiryMs: number
+  primaryColor: number
+  secondaryColor: number
+  targetX: number
+  targetY: number
+  startDistance: number
+  lineWidth: number
+}
+
 interface PathPoint {
   x: number
   y: number
@@ -114,6 +135,8 @@ export interface WorldDelta {
   tick: number
   upserts: EntityUpsert[]
   erased: number[]
+  transientExplosions: TransientExplosion[]
+  transientBeams: TransientBeam[]
   currentWave: number
   lives: number
   resources: number

--- a/tests/ecs_test.cpp
+++ b/tests/ecs_test.cpp
@@ -3772,6 +3772,78 @@ using two_storage_scene_t =
 using three_storage_scene_t =
     archetype_scene<scene_reg_t, arch_pv_t, arch_pvh_t, arch_h_t>;
 
+// Compile-time checks for `tuple_union_t`, `tuple_index_v`, and
+// `wrap_optionals_t` from `ecs_meta.h`.
+void EcsMeta_TupleUnion() {
+  // Deduplication: overlapping types appear only once, in first-seen order.
+  if (true) {
+    using u = tuple_union_t<std::tuple<Position, Velocity>,
+        std::tuple<Velocity, Health>>;
+    static_assert(std::is_same_v<u, std::tuple<Position, Velocity, Health>>);
+    static_assert(std::tuple_size_v<u> == 3);
+  }
+
+  // Fully overlapping tuples collapse to a single copy of each type.
+  if (true) {
+    using u = tuple_union_t<std::tuple<Position, Velocity>,
+        std::tuple<Position, Velocity>>;
+    static_assert(std::is_same_v<u, std::tuple<Position, Velocity>>);
+    static_assert(std::tuple_size_v<u> == 2);
+  }
+
+  // A single input tuple is passed through unchanged.
+  if (true) {
+    using u = tuple_union_t<std::tuple<Health>>;
+    static_assert(std::is_same_v<u, std::tuple<Health>>);
+  }
+
+  // An empty pack produces an empty tuple.
+  if (true) {
+    using u = tuple_union_t<>;
+    static_assert(std::is_same_v<u, std::tuple<>>);
+  }
+
+  // Three-way union: types from all three tuples, no duplicates.
+  if (true) {
+    using u = tuple_union_t<std::tuple<Position>, std::tuple<Velocity>,
+        std::tuple<Health>>;
+    static_assert(std::is_same_v<u, std::tuple<Position, Velocity, Health>>);
+  }
+}
+
+void EcsMeta_TupleIndex() {
+  // `tuple_index_v` returns the 0-based position of each type in a tuple.
+  if (true) {
+    using t = std::tuple<Position, Velocity, Health>;
+    static_assert(tuple_index_v<Position, t> == 0);
+    static_assert(tuple_index_v<Velocity, t> == 1);
+    static_assert(tuple_index_v<Health, t> == 2);
+  }
+
+  // Works correctly for a single-element tuple.
+  if (true) { static_assert(tuple_index_v<Health, std::tuple<Health>> == 0); }
+}
+
+void EcsMeta_WrapOptionals() {
+  // `wrap_optionals_t` transforms each element type to `std::optional<T>`.
+  if (true) {
+    using wrapped = wrap_optionals_t<std::tuple<Position, Velocity, Health>>;
+    static_assert(std::is_same_v<std::tuple_element_t<0, wrapped>,
+        std::optional<Position>>);
+    static_assert(std::is_same_v<std::tuple_element_t<1, wrapped>,
+        std::optional<Velocity>>);
+    static_assert(std::is_same_v<std::tuple_element_t<2, wrapped>,
+        std::optional<Health>>);
+    static_assert(std::tuple_size_v<wrapped> == 3);
+  }
+
+  // An empty tuple wraps to an empty tuple of optionals.
+  if (true) {
+    using wrapped = wrap_optionals_t<std::tuple<>>;
+    static_assert(std::is_same_v<wrapped, std::tuple<>>);
+  }
+}
+
 // Basic construction, type queries, storage access.
 void ArchetypeScene_Basic() {
   // Default construction: empty, zero size.
@@ -6513,6 +6585,134 @@ void ArchetypeScene_TryGetComponents() {
   }
 }
 
+void ArchetypeScene_MegaTuple() {
+  // `component_union_t` is the deduplicated union of all archetype component
+  // types. For `two_storage_scene_t` (arch_pv_t: {Position, Velocity} and
+  // arch_pvh_t: {Position, Velocity, Health}), the union is
+  // {Position, Velocity, Health}.
+  if (true) {
+    using cu = two_storage_scene_t::component_union_t;
+    static_assert(std::is_same_v<cu, std::tuple<Position, Velocity, Health>>);
+    static_assert(std::tuple_size_v<cu> == 3);
+  }
+
+  // `megatuple_t` wraps each component in `std::optional`.
+  if (true) {
+    using mt = two_storage_scene_t::megatuple_t;
+    static_assert(
+        std::is_same_v<std::tuple_element_t<0, mt>, std::optional<Position>>);
+    static_assert(
+        std::is_same_v<std::tuple_element_t<1, mt>, std::optional<Velocity>>);
+    static_assert(
+        std::is_same_v<std::tuple_element_t<2, mt>, std::optional<Health>>);
+    static_assert(std::tuple_size_v<mt> == 3);
+  }
+
+  // `bitmap_t` is `uint64_t`.
+  if (true) {
+    static_assert(std::is_same_v<two_storage_scene_t::bitmap_t, uint64_t>);
+  }
+
+  // Setting Position and Velocity optionals routes to arch_pv_t (SID 1).
+  if (true) {
+    two_storage_scene_t s;
+    two_storage_scene_t::megatuple_t tpl{};
+    std::get<std::optional<Position>>(tpl) = Position{1.f, 2.f};
+    std::get<std::optional<Velocity>>(tpl) = Velocity{3.f, 4.f};
+    auto h = s.store_new_entity_from_mega({}, tpl);
+    EXPECT_TRUE(h);
+    EXPECT_TRUE(s.storage<scene_sid_t{1}>().contains(h.id()));
+    EXPECT_FALSE(s.storage<scene_sid_t{2}>().contains(h.id()));
+    auto* pos = s.try_get_component<Position>(h.id());
+    ASSERT_TRUE(pos != nullptr);
+    EXPECT_EQ(pos->x, 1.f);
+    EXPECT_EQ(pos->y, 2.f);
+    auto* vel = s.try_get_component<Velocity>(h.id());
+    ASSERT_TRUE(vel != nullptr);
+    EXPECT_EQ(vel->vx, 3.f);
+    EXPECT_EQ(vel->vy, 4.f);
+    // Health is not in arch_pv_t; try_get_component returns null.
+    EXPECT_TRUE(s.try_get_component<Health>(h.id()) == nullptr);
+  }
+
+  // Setting all three optionals routes to arch_pvh_t (SID 2).
+  if (true) {
+    two_storage_scene_t s;
+    two_storage_scene_t::megatuple_t tpl{};
+    std::get<std::optional<Position>>(tpl) = Position{5.f, 6.f};
+    std::get<std::optional<Velocity>>(tpl) = Velocity{7.f, 8.f};
+    std::get<std::optional<Health>>(tpl) = Health{42};
+    auto h = s.store_new_entity_from_mega({}, tpl);
+    EXPECT_TRUE(h);
+    EXPECT_FALSE(s.storage<scene_sid_t{1}>().contains(h.id()));
+    EXPECT_TRUE(s.storage<scene_sid_t{2}>().contains(h.id()));
+    auto* hp = s.try_get_component<Health>(h.id());
+    ASSERT_TRUE(hp != nullptr);
+    EXPECT_EQ(hp->hp, 42);
+    auto* pos = s.try_get_component<Position>(h.id());
+    ASSERT_TRUE(pos != nullptr);
+    EXPECT_EQ(pos->x, 5.f);
+  }
+
+  // No optionals set: bitmap matches no archetype; returns invalid handle and
+  // leaves the registry and storages empty.
+  if (true) {
+    two_storage_scene_t s;
+    two_storage_scene_t::megatuple_t tpl{};
+    auto h = s.store_new_entity_from_mega({}, tpl);
+    EXPECT_FALSE(h);
+    EXPECT_EQ(s.size(), 0U);
+    EXPECT_EQ(s.registry().size(), 0U);
+  }
+
+  // Partial bitmap with no match (Health-only is not an archetype in
+  // `two_storage_scene_t`); returns invalid handle.
+  if (true) {
+    two_storage_scene_t s;
+    two_storage_scene_t::megatuple_t tpl{};
+    std::get<std::optional<Health>>(tpl) = Health{99};
+    auto h = s.store_new_entity_from_mega({}, tpl);
+    EXPECT_FALSE(h);
+    EXPECT_EQ(s.size(), 0U);
+  }
+
+  // `three_storage_scene_t` adds arch_h_t (Health-only). Setting only Health
+  // routes to arch_h_t (SID 3).
+  if (true) {
+    three_storage_scene_t s;
+    three_storage_scene_t::megatuple_t tpl{};
+    std::get<std::optional<Health>>(tpl) = Health{55};
+    auto h = s.store_new_entity_from_mega({}, tpl);
+    EXPECT_TRUE(h);
+    EXPECT_FALSE(s.storage<scene_sid_t{1}>().contains(h.id()));
+    EXPECT_FALSE(s.storage<scene_sid_t{2}>().contains(h.id()));
+    EXPECT_TRUE(s.storage<scene_sid_t{3}>().contains(h.id()));
+    auto* hp = s.try_get_component<Health>(h.id());
+    ASSERT_TRUE(hp != nullptr);
+    EXPECT_EQ(hp->hp, 55);
+  }
+
+  // Multiple entities from different mega-tuples coexist in their respective
+  // storages.
+  if (true) {
+    two_storage_scene_t s;
+    two_storage_scene_t::megatuple_t pv_tpl{};
+    std::get<std::optional<Position>>(pv_tpl) = Position{};
+    std::get<std::optional<Velocity>>(pv_tpl) = Velocity{};
+    two_storage_scene_t::megatuple_t pvh_tpl{};
+    std::get<std::optional<Position>>(pvh_tpl) = Position{};
+    std::get<std::optional<Velocity>>(pvh_tpl) = Velocity{};
+    std::get<std::optional<Health>>(pvh_tpl) = Health{};
+    auto h1 = s.store_new_entity_from_mega({}, pv_tpl);
+    auto h2 = s.store_new_entity_from_mega({}, pvh_tpl);
+    EXPECT_TRUE(h1);
+    EXPECT_TRUE(h2);
+    EXPECT_EQ(s.size(), 2U);
+    EXPECT_EQ(s.storage<scene_sid_t{1}>().size(), 1U);
+    EXPECT_EQ(s.storage<scene_sid_t{2}>().size(), 1U);
+  }
+}
+
 void ComponentScene_StageNewEntity() {
   // stage_new_entity() creates a staged entity and returns its handle.
   if (true) {
@@ -7711,8 +7911,9 @@ void ComponentStorage_At() {
   }
 }
 
-MAKE_TEST_LIST(ArchetypeStorage_Basic, ArchetypeStorage_Registry,
-    ArchetypeStorage_Add, ArchetypeStorage_Remove, ArchetypeStorage_Erase,
+MAKE_TEST_LIST(EcsMeta_TupleUnion, EcsMeta_TupleIndex, EcsMeta_WrapOptionals,
+    ArchetypeStorage_Basic, ArchetypeStorage_Registry, ArchetypeStorage_Add,
+    ArchetypeStorage_Remove, ArchetypeStorage_Erase,
     ArchetypeStorage_RowAccess, ArchetypeStorage_ComponentAccess,
     ArchetypeStorage_Limit, ArchetypeStorage_SwapAndMove,
     ArchetypeStorage_Iterator, ArchetypeStorage_EraseIf, ArchetypeStorage_At,
@@ -7738,10 +7939,10 @@ MAKE_TEST_LIST(ArchetypeStorage_Basic, ArchetypeStorage_Registry,
     ArchetypeScene_AddNewRuntime, ArchetypeScene_StoreEntity,
     ArchetypeScene_EntityLifecycle, ArchetypeScene_MigrateEdgeCases,
     ArchetypeScene_ForEach, ArchetypeScene_TryGetComponent,
-    ArchetypeScene_TryGetComponents, ComponentIndex_Flat,
-    ComponentIndex_Sorted, ComponentIndex_Paged, ComponentStorage_Basic,
-    ComponentStorage_MultiStore, ComponentStorage_Remove,
-    ComponentStorage_Erase, ComponentStorage_EraseIf,
+    ArchetypeScene_TryGetComponents, ArchetypeScene_MegaTuple,
+    ComponentIndex_Flat, ComponentIndex_Sorted, ComponentIndex_Paged,
+    ComponentStorage_Basic, ComponentStorage_MultiStore,
+    ComponentStorage_Remove, ComponentStorage_Erase, ComponentStorage_EraseIf,
     ComponentStorage_Iterator, ComponentStorage_IndexVariants,
     ComponentStorage_AddNew, ComponentStorage_SwapMoveReserve,
     ComponentStorage_At, ComponentScene_Basic, ComponentScene_StoreEntity,

--- a/tests/ecs_test.cpp
+++ b/tests/ecs_test.cpp
@@ -6713,6 +6713,86 @@ void ArchetypeScene_MegaTuple() {
   }
 }
 
+void ArchetypeScene_TryGetSomeComponents() {
+  // All requested components present: all pointers non-null with correct
+  // values.
+  if (true) {
+    two_storage_scene_t s;
+    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{1.f, 2.f},
+        Velocity{3.f, 4.f}, Health{77});
+    auto [pos, vel, hp] =
+        s.try_get_some_components<Position, Velocity, Health>(h.id());
+    ASSERT_TRUE(pos != nullptr);
+    ASSERT_TRUE(vel != nullptr);
+    ASSERT_TRUE(hp != nullptr);
+    EXPECT_EQ(pos->x, 1.f);
+    EXPECT_EQ(vel->vx, 3.f);
+    EXPECT_EQ(hp->hp, 77);
+  }
+
+  // Entity in arch_pv_t: Position and Velocity are non-null, Health is null.
+  if (true) {
+    two_storage_scene_t s;
+    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{5.f, 6.f},
+        Velocity{7.f, 8.f});
+    auto [pos, vel, hp] =
+        s.try_get_some_components<Position, Velocity, Health>(h.id());
+    ASSERT_TRUE(pos != nullptr);
+    ASSERT_TRUE(vel != nullptr);
+    EXPECT_TRUE(hp == nullptr);
+    EXPECT_EQ(pos->x, 5.f);
+    EXPECT_EQ(vel->vx, 7.f);
+  }
+
+  // Invalid entity ID: all pointers null.
+  if (true) {
+    two_storage_scene_t s;
+    auto [pos, vel, hp] =
+        s.try_get_some_components<Position, Velocity, Health>(
+            scene_reg_t::id_t::invalid);
+    EXPECT_TRUE(pos == nullptr);
+    EXPECT_TRUE(vel == nullptr);
+    EXPECT_TRUE(hp == nullptr);
+  }
+
+  // Staged entity: all pointers null.
+  if (true) {
+    two_storage_scene_t s;
+    auto id = s.stage_new_entity().id();
+    auto [pos, vel] = s.try_get_some_components<Position, Velocity>(id);
+    EXPECT_TRUE(pos == nullptr);
+    EXPECT_TRUE(vel == nullptr);
+  }
+
+  // Mutation through returned pointers updates stored data.
+  if (true) {
+    two_storage_scene_t s;
+    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{}, Velocity{},
+        Health{10});
+    auto [pos, hp] = s.try_get_some_components<Position, Health>(h.id());
+    ASSERT_TRUE(pos != nullptr);
+    ASSERT_TRUE(hp != nullptr);
+    pos->x = 99.f;
+    hp->hp = 42;
+    EXPECT_EQ(s.storage<scene_sid_t{2}>()[h.id()].component<Position>().x,
+        99.f);
+    EXPECT_EQ(s.storage<scene_sid_t{2}>()[h.id()].component<Health>().hp, 42);
+  }
+
+  // On a const scene, returned pointers are const-qualified.
+  if (true) {
+    two_storage_scene_t s;
+    auto h =
+        s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 0.f}, Velocity{});
+    const auto& cs = s;
+    auto [pos, vel] = cs.try_get_some_components<Position, Velocity>(h.id());
+    static_assert(std::is_same_v<decltype(pos), const Position*>);
+    static_assert(std::is_same_v<decltype(vel), const Velocity*>);
+    ASSERT_TRUE(pos != nullptr);
+    EXPECT_EQ(pos->x, 1.f);
+  }
+}
+
 void ComponentScene_StageNewEntity() {
   // stage_new_entity() creates a staged entity and returns its handle.
   if (true) {
@@ -7939,9 +8019,9 @@ MAKE_TEST_LIST(EcsMeta_TupleUnion, EcsMeta_TupleIndex, EcsMeta_WrapOptionals,
     ArchetypeScene_AddNewRuntime, ArchetypeScene_StoreEntity,
     ArchetypeScene_EntityLifecycle, ArchetypeScene_MigrateEdgeCases,
     ArchetypeScene_ForEach, ArchetypeScene_TryGetComponent,
-    ArchetypeScene_TryGetComponents, ArchetypeScene_MegaTuple,
-    ComponentIndex_Flat, ComponentIndex_Sorted, ComponentIndex_Paged,
-    ComponentStorage_Basic, ComponentStorage_MultiStore,
+    ArchetypeScene_TryGetComponents, ArchetypeScene_TryGetSomeComponents,
+    ArchetypeScene_MegaTuple, ComponentIndex_Flat, ComponentIndex_Sorted,
+    ComponentIndex_Paged, ComponentStorage_Basic, ComponentStorage_MultiStore,
     ComponentStorage_Remove, ComponentStorage_Erase, ComponentStorage_EraseIf,
     ComponentStorage_Iterator, ComponentStorage_IndexVariants,
     ComponentStorage_AddNew, ComponentStorage_SwapMoveReserve,

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -612,13 +612,15 @@ void SimGame_HandleUiCanvasSpawnsTowerButKeepsBuildPhase() {
   const auto before = extractGameDelta(game);
 
   game.handleUiCanvas(UiCanvasInput{.seq = 1,
-      .event = UiCanvasEvent::dblclick,
+      .event = UiCanvasEvent::click,
       .button = UiMouseButton::left,
       .buttons = 1,
       .x = 10.F,
       .y = 20.F,
       .canvasX = 100.F,
-      .canvasY = 200.F});
+      .canvasY = 200.F,
+      .command = "spawn",
+      .parameters = {"DefenderAoeBasic"}});
 
   const auto after = extractGameDelta(game);
   EXPECT_EQ(before.phase, std::string_view{"build"});
@@ -781,13 +783,15 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
   SimGame game;
   game.loadMap();
   game.handleUiCanvas(UiCanvasInput{.seq = 1,
-      .event = UiCanvasEvent::dblclick,
+      .event = UiCanvasEvent::click,
       .button = UiMouseButton::left,
       .buttons = 1,
       .x = 10.F,
       .y = 20.F,
       .canvasX = 100.F,
-      .canvasY = 200.F});
+      .canvasY = 200.F,
+      .command = "spawn",
+      .parameters = {"DefenderAoeBasic"}});
   (void)game.next();
 
   SimGameStateJson state;
@@ -848,13 +852,15 @@ void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
   SimGame game;
   game.loadMap();
   game.handleUiCanvas(UiCanvasInput{.seq = 1,
-      .event = UiCanvasEvent::dblclick,
+      .event = UiCanvasEvent::click,
       .button = UiMouseButton::left,
       .buttons = 1,
       .x = 10.F,
       .y = 20.F,
       .canvasX = 100.F,
-      .canvasY = 200.F});
+      .canvasY = 200.F,
+      .command = "spawn",
+      .parameters = {"DefenderAoeBasic"}});
 
   SimGameStateJson initial_state;
   (void)buildSimGameStateJson(initial_state, game);
@@ -867,7 +873,9 @@ void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
       .x = 10.F,
       .y = 20.F,
       .canvasX = 100.F,
-      .canvasY = 200.F});
+      .canvasY = 200.F,
+      .command{},
+      .parameters{}});
 
   SimGameStateJson state;
   (void)buildSimGameStateJson(state, game);

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -681,6 +681,39 @@ void SimGame_HandleUiCanvasRightClickSpawnPlacesDefender() {
   EXPECT_TRUE(after.erased.empty());
 }
 
+void SimGame_HandleUiCanvasSpawnsShooterDefender() {
+  SimGame game;
+  (void)game.loadMap();
+  const auto before = extractGameDelta(game);
+
+  (void)game.handleUiCanvas(UiCanvasInput{.seq = 1,
+      .event = UiCanvasEvent::click,
+      .button = UiMouseButton::right,
+      .buttons = 2,
+      .x = 300.F,
+      .y = 100.F,
+      .canvasX = 100.F,
+      .canvasY = 200.F,
+      .command = "spawn",
+      .parameters = {"DefenderShooterBasic"}});
+
+  const auto pending = extractGameDelta(game);
+  EXPECT_TRUE(pending.upserts.empty());
+  EXPECT_FALSE(pending.spawnAllowed.has_value());
+
+  (void)game.next();
+
+  const auto after = extractGameDelta(game);
+  EXPECT_EQ(before.phase, std::string_view{"build"});
+  EXPECT_EQ(after.phase, std::string_view{"build"});
+  ASSERT_TRUE(after.spawnAllowed.has_value());
+  EXPECT_TRUE(*after.spawnAllowed);
+  ASSERT_EQ(after.upserts.size(), 1U);
+  EXPECT_NEAR(after.upserts[0].second.x, 300.0, 1e-6);
+  EXPECT_NEAR(after.upserts[0].second.y, 100.0, 1e-6);
+  EXPECT_TRUE(after.erased.empty());
+}
+
 void SimGame_HandleUiCanvasPlacingIntentRejectsPathOverlapOnNextTick() {
   SimGame game;
   (void)game.loadMap();
@@ -1091,6 +1124,7 @@ MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_NextMovesInvaderAlpha,
     SimGame_HandleUiActionStartWaveTransitionsToWavePhase,
     SimGame_HandleUiCanvasSpawnsDefenderButKeepsBuildPhase,
     SimGame_HandleUiCanvasRightClickSpawnPlacesDefender,
+    SimGame_HandleUiCanvasSpawnsShooterDefender,
     SimGame_HandleUiCanvasPlacingIntentRejectsPathOverlapOnNextTick,
     SimGame_HandleUiCanvasRejectsBlockedDefenderSpawnOnNextTick,
     SimGame_StartWaveSpawnsFirstEnemyOnFirstStep,

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -972,7 +972,8 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
   EXPECT_TRUE(state.body.contains(R"("flashExpiryMs":250)"));
   EXPECT_TRUE(state.body.contains(R"("uiState")"));
   EXPECT_TRUE(state.body.contains(R"("spawnAllowed":true)"));
-  EXPECT_TRUE(state.body.contains(R"("selectedDefender":{"x":300.0,"y":100.0})"));
+  EXPECT_FALSE(state.body.contains(R"("selectedDefender")"));
+  EXPECT_FALSE(state.body.contains(R"("defenderSummary")"));
   EXPECT_FALSE(state.body.contains(R"("modified")"));
   EXPECT_FALSE(state.body.contains(R"("flash_expiry")"));
   EXPECT_FALSE(state.body.contains(R"("glow")"));
@@ -1042,8 +1043,8 @@ void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
 
   (void)game.handleUiCanvas(UiCanvasInput{.seq = 2,
       .event = UiCanvasEvent::click,
-      .button = UiMouseButton::right,
-      .buttons = 2,
+      .button = UiMouseButton::left,
+      .buttons = 1,
       .x = 300.F,
       .y = 100.F,
       .canvasX = 100.F,
@@ -1078,8 +1079,8 @@ void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
     const auto flash_expiry_ms = vfx.get_number<uint32_t>("flashExpiryMs");
     ASSERT_TRUE(flash.has_value());
     ASSERT_TRUE(flash_expiry_ms.has_value());
-    EXPECT_EQ(*flash, 0xFF7F7FAFU);
-    EXPECT_EQ(*flash_expiry_ms, 250U);
+    EXPECT_EQ(*flash, 0xFF7F7FFFU);
+    EXPECT_EQ(*flash_expiry_ms, 200U);
     ++count;
   }
   EXPECT_EQ(count, 1U);

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -163,6 +163,64 @@ findPosition(const auto& entries, SimWorld::EntityId id) {
     return &it->second;
 }
 
+// Test helpers that register the entity type on demand (idempotent) and spawn
+// with placement applied, matching the old `spawnInvaderAlpha` /
+// `spawnDefenderAoe` behavior.
+[[nodiscard]] SimWorld::Handle
+spawnInvaderAlpha(SimWorld& w, PathId pid, float progress = 0.F) {
+  WorldScene::megatuple_t tpl{};
+  std::get<std::optional<Position>>(tpl) = Position{};
+  std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'\u03B1',
+      .radius = 30.F,
+      .fgColor = 0xFFFFFFFF,
+      .bgColor = 0x000000FF};
+  std::get<std::optional<VisualEffects>>(tpl) = VisualEffects{};
+  std::get<std::optional<Pathing>>(tpl) =
+      Pathing{.path_id = PathId::invalid, .progress = 0.F, .speed = 50.F};
+  std::get<std::optional<Invader>>(tpl) =
+      Invader{.invaderType = 1, .hitCircleRadius = 30.F, .bounty = 10};
+  std::get<std::optional<Health>>(tpl) =
+      Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 10.F};
+  w.registerEntity("InvaderAlphaBasic", tpl);
+  auto h = w.spawnEntity("InvaderAlphaBasic");
+  if (!h) return h;
+  if (auto* pat = w.try_get_component<Pathing>(h.id())) {
+    pat->path_id = pid;
+    pat->progress = progress;
+    if (auto* pos = w.try_get_component<Position>(h.id()))
+      if (const auto* path = w.getPath(pid))
+        *pos = path->calculatePositionFromProgress(progress, progress);
+  }
+  return h;
+}
+
+[[nodiscard]] SimWorld::Handle
+spawnDefenderAoe(SimWorld& w, Position spawn_pos) {
+  WorldScene::megatuple_t tpl{};
+  std::get<std::optional<Position>>(tpl) = Position{};
+  std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'A',
+      .radius = 30.F,
+      .fgColor = 0xFFFFFFFF,
+      .bgColor = 0x7F7FFFFF};
+  std::get<std::optional<VisualEffects>>(tpl) = VisualEffects{};
+  std::get<std::optional<Defender>>(tpl) = Defender{.defenderType = 1,
+      .hitCircleRadius = 30.F,
+      .attackRadius = 100.F,
+      .rangeColor = 0xFFFF0000,
+      .attackDamage = 5.F,
+      .cooldown = WorldTick{20},
+      .nextAttack = WorldTick{0}};
+  std::get<std::optional<DefenderStats>>(tpl) = DefenderStats{};
+  std::get<std::optional<Health>>(tpl) =
+      Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 0.F};
+  std::get<std::optional<DefenderAoe>>(tpl) = DefenderAoe{.damageType = 1};
+  w.registerEntity("DefenderAoeBasic", tpl);
+  auto h = w.spawnEntity("DefenderAoeBasic");
+  if (!h) return h;
+  if (auto* pos = w.try_get_component<Position>(h.id())) *pos = spawn_pos;
+  return h;
+}
+
 } // namespace
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
@@ -175,8 +233,8 @@ void SimWorld_SpawnAndSnapshot() {
   p.joints = {{{0.F, 0.F}}, {{200.F, 0.F}}};
   const auto pid = w.addPath(p);
 
-  const auto invader = w.spawnInvaderAlpha(pid);
-  const auto defender = w.spawnDefenderAoe(Position{30.F, 40.F});
+  const auto invader = spawnInvaderAlpha(w, pid);
+  const auto defender = spawnDefenderAoe(w, Position{30.F, 40.F});
 
   EXPECT_EQ(w.size(), 2U);
 
@@ -197,7 +255,7 @@ void SimWorld_NextMovesInvaderAlpha() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{200.F, 0.F}}};
   const auto pid = w.addPath(p);
-  const auto invader = w.spawnInvaderAlpha(pid);
+  const auto invader = spawnInvaderAlpha(w, pid);
 
   (void)w.next();
 
@@ -214,7 +272,7 @@ void SimWorld_ExtractUpdatedEntitiesReportsMovedInvaderOncePerExtraction() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{300.F, 0.F}}};
   const auto pid = w.addPath(p);
-  const auto invader = w.spawnInvaderAlpha(pid);
+  const auto invader = spawnInvaderAlpha(w, pid);
 
   (void)w.next();
   (void)w.tick();
@@ -238,8 +296,8 @@ void SimWorld_TowerInRangeFlashesItselfAndInvader() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{500.F, 0.F}}};
   const auto pid = w.addPath(p);
-  const auto tower = w.spawnDefenderAoe({0.F, 0.F});
-  const auto invader = w.spawnInvaderAlpha(pid);
+  const auto tower = spawnDefenderAoe(w, {0.F, 0.F});
+  const auto invader = spawnInvaderAlpha(w, pid);
 
   (void)extractWorldDelta(w);
   (void)w.tick();
@@ -269,8 +327,8 @@ void SimWorld_SnapshotSinceTracksChanges() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{500.F, 0.F}}};
   const auto pid = w.addPath(p);
-  const auto invader = w.spawnInvaderAlpha(pid);
-  (void)w.spawnDefenderAoe(Position{500.F, 500.F});
+  const auto invader = spawnInvaderAlpha(w, pid);
+  (void)spawnDefenderAoe(w, Position{500.F, 500.F});
 
   // Drain the spawn-time dirty list; both entities visible at tick_=0.
   const auto initial = extractWorldDelta(w);
@@ -299,7 +357,7 @@ void SimWorld_SnapshotSinceTracksChanges() {
 
 void SimWorld_DefenderDoesNotAppearAsChangedAfterTick() {
   SimWorld w;
-  const auto defender = w.spawnDefenderAoe(Position{50.F, 60.F});
+  const auto defender = spawnDefenderAoe(w, Position{50.F, 60.F});
 
   const auto initial = extractWorldDelta(w);
   ASSERT_EQ(initial.upserts.size(), 1U);
@@ -396,7 +454,7 @@ void SimWorld_EnemyAdvancesOnTick() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{100.F, 0.F}}};
   const auto pid = w.addPath(p);
-  const auto enemy = w.spawnInvaderAlpha(pid);
+  const auto enemy = spawnInvaderAlpha(w, pid);
 
   EXPECT_TRUE(static_cast<bool>(enemy));
   EXPECT_EQ(w.size(), 1U);
@@ -416,7 +474,7 @@ void SimWorld_ResolveEscapeesVisitsEscapedEnemy() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
   const auto pid = w.addPath(p);
-  const auto enemy = w.spawnInvaderAlpha(pid, 8.F);
+  const auto enemy = spawnInvaderAlpha(w, pid, 8.F);
 
   (void)w.next();
   EXPECT_EQ(w.size(), 1U);
@@ -451,7 +509,7 @@ void SimWorld_ResolveEscapeesCanLeaveEnemyAlive() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
   const auto pid = w.addPath(p);
-  const auto enemy = w.spawnInvaderAlpha(pid, 8.F);
+  const auto enemy = spawnInvaderAlpha(w, pid, 8.F);
 
   (void)w.next();
 

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -598,7 +598,7 @@ void SimGame_HandleUiActionStartWaveTransitionsToWavePhase() {
   SimGame game;
   game.loadMap();
 
-  game.handleUiAction(
+  (void)game.handleUiAction(
       UiActionInput{.seq = 1, .action = "start_wave", .fields = {}});
 
   const auto delta = extractGameDelta(game);
@@ -611,12 +611,12 @@ void SimGame_HandleUiCanvasSpawnsTowerButKeepsBuildPhase() {
   game.loadMap();
   const auto before = extractGameDelta(game);
 
-  game.handleUiCanvas(UiCanvasInput{.seq = 1,
+  (void)game.handleUiCanvas(UiCanvasInput{.seq = 1,
       .event = UiCanvasEvent::click,
       .button = UiMouseButton::left,
       .buttons = 1,
-      .x = 10.F,
-      .y = 20.F,
+      .x = 200.F,
+      .y = 0.F,
       .canvasX = 100.F,
       .canvasY = 200.F,
       .command = "spawn",
@@ -626,8 +626,8 @@ void SimGame_HandleUiCanvasSpawnsTowerButKeepsBuildPhase() {
   EXPECT_EQ(before.phase, std::string_view{"build"});
   EXPECT_EQ(after.phase, std::string_view{"build"});
   ASSERT_EQ(after.upserts.size(), 1U);
-  EXPECT_NEAR(after.upserts[0].second.x, 10.0, 1e-6);
-  EXPECT_NEAR(after.upserts[0].second.y, 20.0, 1e-6);
+  EXPECT_NEAR(after.upserts[0].second.x, 200.0, 1e-6);
+  EXPECT_NEAR(after.upserts[0].second.y, 0.0, 1e-6);
   EXPECT_TRUE(after.erased.empty());
 }
 
@@ -635,12 +635,12 @@ void SimGame_HandleUiCanvasRightClickSpawnPlacesTower() {
   SimGame game;
   game.loadMap();
 
-  game.handleUiCanvas(UiCanvasInput{.seq = 1,
+  (void)game.handleUiCanvas(UiCanvasInput{.seq = 1,
       .event = UiCanvasEvent::click,
       .button = UiMouseButton::right,
       .buttons = 2,
-      .x = 15.F,
-      .y = 25.F,
+      .x = 200.F,
+      .y = 0.F,
       .canvasX = 120.F,
       .canvasY = 210.F,
       .command = "spawn",
@@ -649,9 +649,56 @@ void SimGame_HandleUiCanvasRightClickSpawnPlacesTower() {
   const auto after = extractGameDelta(game);
   EXPECT_EQ(after.phase, std::string_view{"build"});
   ASSERT_EQ(after.upserts.size(), 1U);
-  EXPECT_NEAR(after.upserts[0].second.x, 15.0, 1e-6);
-  EXPECT_NEAR(after.upserts[0].second.y, 25.0, 1e-6);
+  EXPECT_NEAR(after.upserts[0].second.x, 200.0, 1e-6);
+  EXPECT_NEAR(after.upserts[0].second.y, 0.0, 1e-6);
   EXPECT_TRUE(after.erased.empty());
+}
+
+void SimGame_HandleUiCanvasPlacingResponseRejectsPathOverlap() {
+  SimGame game;
+  game.loadMap();
+
+  const auto response = game.handleUiCanvas(UiCanvasInput{.seq = 7,
+      .event = UiCanvasEvent::dragmove,
+      .button = UiMouseButton::left,
+      .buttons = 1,
+      .x = 10.F,
+      .y = 20.F,
+      .canvasX = 100.F,
+      .canvasY = 200.F,
+      .command = "placing",
+      .parameters = {"DefenderAoeBasic"}});
+
+  ASSERT_TRUE(response.has_value());
+  EXPECT_EQ(response->seq, 7U);
+  EXPECT_EQ(response->response, std::string_view{"placement"});
+  EXPECT_FALSE(response->ok);
+  EXPECT_EQ(response->reason, std::string_view{"blocked"});
+  ASSERT_EQ(response->fields.size(), 1U);
+  EXPECT_EQ(response->fields[0].key, std::string_view{"valid"});
+  EXPECT_EQ(response->fields[0].value, std::string_view{"false"});
+}
+
+void SimGame_HandleUiCanvasRejectsBlockedTowerSpawn() {
+  SimGame game;
+  game.loadMap();
+
+  const auto response = game.handleUiCanvas(UiCanvasInput{.seq = 1,
+      .event = UiCanvasEvent::click,
+      .button = UiMouseButton::right,
+      .buttons = 2,
+      .x = 10.F,
+      .y = 20.F,
+      .canvasX = 100.F,
+      .canvasY = 200.F,
+      .command = "spawn",
+      .parameters = {"DefenderAoeBasic"}});
+
+  const auto delta = extractGameDelta(game);
+  EXPECT_TRUE(delta.upserts.empty());
+  ASSERT_TRUE(response.has_value());
+  EXPECT_EQ(response->response, std::string_view{"placement"});
+  EXPECT_FALSE(response->ok);
 }
 
 void SimGame_StartWaveSpawnsFirstEnemyOnFirstStep() {
@@ -805,12 +852,12 @@ void SimJson_BuildHelloAckJson() {
 void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
   SimGame game;
   game.loadMap();
-  game.handleUiCanvas(UiCanvasInput{.seq = 1,
+  (void)game.handleUiCanvas(UiCanvasInput{.seq = 1,
       .event = UiCanvasEvent::click,
       .button = UiMouseButton::left,
       .buttons = 1,
-      .x = 10.F,
-      .y = 20.F,
+      .x = 200.F,
+      .y = 0.F,
       .canvasX = 100.F,
       .canvasY = 200.F,
       .command = "spawn",
@@ -819,7 +866,7 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
 
   SimGameStateJson state;
   (void)buildSimGameStateJson(state, game);
-  EXPECT_TRUE(state.body.contains(R"("x":10.0)"));
+  EXPECT_TRUE(state.body.contains(R"("x":200.0)"));
   EXPECT_TRUE(state.body.contains(R"("radius":30.000)"));
   EXPECT_TRUE(state.body.contains(R"("vfx")"));
   EXPECT_TRUE(state.body.contains(R"("flashExpiryMs":250)"));
@@ -851,7 +898,7 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
     ASSERT_TRUE(pos);
     const auto x = pos.get_number<float>("x");
     ASSERT_TRUE(x.has_value());
-    EXPECT_NEAR(*x, 10.0, 1e-6);
+    EXPECT_NEAR(*x, 200.0, 1e-6);
 
     const auto app = entry.get_object("app");
     ASSERT_TRUE(app);
@@ -874,12 +921,12 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
 void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
   SimGame game;
   game.loadMap();
-  game.handleUiCanvas(UiCanvasInput{.seq = 1,
+  (void)game.handleUiCanvas(UiCanvasInput{.seq = 1,
       .event = UiCanvasEvent::click,
       .button = UiMouseButton::left,
       .buttons = 1,
-      .x = 10.F,
-      .y = 20.F,
+      .x = 200.F,
+      .y = 0.F,
       .canvasX = 100.F,
       .canvasY = 200.F,
       .command = "spawn",
@@ -889,12 +936,12 @@ void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
   (void)buildSimGameStateJson(initial_state, game);
   (void)game.tick();
 
-  game.handleUiCanvas(UiCanvasInput{.seq = 2,
+  (void)game.handleUiCanvas(UiCanvasInput{.seq = 2,
       .event = UiCanvasEvent::click,
       .button = UiMouseButton::right,
       .buttons = 2,
-      .x = 10.F,
-      .y = 20.F,
+      .x = 200.F,
+      .y = 0.F,
       .canvasX = 100.F,
       .canvasY = 200.F,
       .command{},
@@ -918,7 +965,7 @@ void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
     ASSERT_TRUE(pos);
     const auto x = pos.get_number<float>("x");
     ASSERT_TRUE(x.has_value());
-    EXPECT_NEAR(*x, 10.0, 1e-6);
+    EXPECT_NEAR(*x, 200.0, 1e-6);
 
     const auto vfx = entry.get_object("vfx");
     ASSERT_TRUE(vfx);
@@ -1009,6 +1056,8 @@ MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_NextMovesInvaderAlpha,
     SimGame_HandleUiActionStartWaveTransitionsToWavePhase,
     SimGame_HandleUiCanvasSpawnsTowerButKeepsBuildPhase,
     SimGame_HandleUiCanvasRightClickSpawnPlacesTower,
+    SimGame_HandleUiCanvasPlacingResponseRejectsPathOverlap,
+    SimGame_HandleUiCanvasRejectsBlockedTowerSpawn,
     SimGame_StartWaveSpawnsFirstEnemyOnFirstStep,
     SimGame_ExtractDeltaConsumesWorldUpdatesButNotState,
     SimGame_ExtractFullIncludesPathsAndState, SimJson_ParseUiCanvasMessage,

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -33,7 +33,14 @@ using namespace corvid::sim;
 namespace {
 
 struct WorldDelta {
-  std::vector<std::pair<SimWorld::EntityId, Position>> upserts;
+  struct Upsert {
+    SimWorld::EntityId id;
+    Position pos;
+    Appearance app;
+    VisualEffects fx;
+  };
+
+  std::vector<Upsert> upserts;
   std::vector<SimWorld::EntityId> erased;
 };
 
@@ -74,18 +81,6 @@ struct GameSnapshot {
 }
 
 [[nodiscard]] std::vector<EntitySnapshot>
-snapshot(SimWorld& world, const std::vector<SimWorld::EntityId>& ids) {
-  const auto all = snapshot(world);
-  std::vector<EntitySnapshot> filtered;
-  filtered.reserve(ids.size());
-  std::ranges::copy_if(all, std::back_inserter(filtered),
-      [&ids](const EntitySnapshot& snap) {
-        return std::ranges::find(ids, snap.id) != ids.end();
-      });
-  return filtered;
-}
-
-[[nodiscard]] std::vector<EntitySnapshot>
 filterSnapshot(const std::vector<EntitySnapshot>& all,
     const std::vector<SimWorld::EntityId>& ids) {
   std::vector<EntitySnapshot> filtered;
@@ -101,7 +96,9 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
   WorldDelta delta;
   (void)world.extractUpdatedEntities(
       [&delta](SimWorld::EntityId id, const Position& pos, const Appearance&,
-          const VisualEffects&) { delta.upserts.emplace_back(id, pos); },
+          const VisualEffects& fx) {
+        delta.upserts.push_back({id, pos, {}, fx});
+      },
       [&delta](SimWorld::EntityId id) { delta.erased.push_back(id); });
   return delta;
 }
@@ -144,16 +141,26 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
 
 [[nodiscard]] bool containsId(const auto& entries, SimWorld::EntityId id) {
   return std::ranges::any_of(entries, [id](const auto& entry) {
-    return entry.first == id;
+    if constexpr (requires { entry.id; })
+      return entry.id == id;
+    else
+      return entry.first == id;
   });
 }
 
 [[nodiscard]] const Position*
 findPosition(const auto& entries, SimWorld::EntityId id) {
   const auto it = std::ranges::find_if(entries, [id](const auto& entry) {
-    return entry.first == id;
+    if constexpr (requires { entry.id; })
+      return entry.id == id;
+    else
+      return entry.first == id;
   });
-  return it == entries.end() ? nullptr : &it->second;
+  if (it == entries.end()) return nullptr;
+  if constexpr (requires { it->pos; })
+    return &it->pos;
+  else
+    return &it->second;
 }
 
 } // namespace
@@ -164,96 +171,106 @@ void SimWorld_SpawnAndSnapshot() {
   SimWorld w;
   EXPECT_EQ(w.size(), 0U);
 
-  const auto mover = w.spawnMover(Position{10.F, 20.F}, Velocity{1.F, 2.F});
-  const auto background = w.spawnBackground(Position{30.F, 40.F});
+  PathJoints p;
+  p.joints = {{{0.F, 0.F}}, {{200.F, 0.F}}};
+  const auto pid = w.addPath(p);
+
+  const auto invader = w.spawnInvaderAlpha(pid);
+  const auto defender = w.spawnDefenderAoe(Position{30.F, 40.F});
 
   EXPECT_EQ(w.size(), 2U);
 
   const auto all = snapshot(w);
   ASSERT_EQ(all.size(), 2U);
   EXPECT_EQ(
-      filterSnapshot(all, std::vector<SimWorld::EntityId>{mover.id()}).size(),
+      filterSnapshot(all, std::vector<SimWorld::EntityId>{invader.id()}).size(),
       1U);
   EXPECT_EQ(
       filterSnapshot(all,
-          std::vector<SimWorld::EntityId>{mover.id(), background.id()})
+          std::vector<SimWorld::EntityId>{invader.id(), defender.id()})
           .size(),
       2U);
 }
 
-void SimWorld_TickMovesMover() {
+void SimWorld_NextMovesInvaderAlpha() {
   SimWorld w;
-  const auto mover = w.spawnMover(Position{100.F, 200.F}, Velocity{3.F, -5.F});
+  PathJoints p;
+  p.joints = {{{0.F, 0.F}}, {{200.F, 0.F}}};
+  const auto pid = w.addPath(p);
+  const auto invader = w.spawnInvaderAlpha(pid);
 
   (void)w.next();
 
   const auto snaps = snapshot(w);
   EXPECT_EQ(*w.tick(), 1U);
   ASSERT_EQ(snaps.size(), 1U);
-  EXPECT_EQ(snaps[0].id, mover.id());
-  EXPECT_NEAR(snaps[0].pos.x, 103.0, 1e-6);
-  EXPECT_NEAR(snaps[0].pos.y, 195.0, 1e-6);
+  EXPECT_EQ(snaps[0].id, invader.id());
+  EXPECT_NEAR(snaps[0].pos.x, 100.0, 1e-6);
+  EXPECT_NEAR(snaps[0].pos.y, 0.0, 1e-6);
 }
 
-void SimWorld_ExtractUpdatedEntitiesReportsMovedMoverOncePerExtraction() {
+void SimWorld_ExtractUpdatedEntitiesReportsMovedInvaderOncePerExtraction() {
   SimWorld w;
-  const auto mover = w.spawnMover(Position{0.F, 0.F}, Velocity{2.F, 3.F});
+  PathJoints p;
+  p.joints = {{{0.F, 0.F}}, {{300.F, 0.F}}};
+  const auto pid = w.addPath(p);
+  const auto invader = w.spawnInvaderAlpha(pid);
 
   (void)w.next();
   (void)w.tick();
   const auto delta = extractWorldDelta(w);
 
-  EXPECT_TRUE(containsId(delta.upserts, mover.id()));
+  EXPECT_TRUE(containsId(delta.upserts, invader.id()));
   EXPECT_TRUE(delta.erased.empty());
 
-  const auto* pos = findPosition(delta.upserts, mover.id());
+  const auto* pos = findPosition(delta.upserts, invader.id());
   ASSERT_TRUE(pos != nullptr);
-  EXPECT_NEAR(pos->x, 2.0, 1e-6);
-  EXPECT_NEAR(pos->y, 3.0, 1e-6);
+  EXPECT_NEAR(pos->x, 100.0, 1e-6);
+  EXPECT_NEAR(pos->y, 0.0, 1e-6);
 
   const auto empty_delta = extractWorldDelta(w);
   EXPECT_TRUE(empty_delta.upserts.empty());
   EXPECT_TRUE(empty_delta.erased.empty());
 }
 
-void SimWorld_BounceMinEdge() {
+void SimWorld_TowerInRangeFlashesItselfAndInvader() {
   SimWorld w;
-  const float half_w = SimWorld::widthOfWorld * 0.5F;
-  const float half_h = SimWorld::heightOfWorld * 0.5F;
-  const auto mover = w.spawnMover(Position{-half_w + 0.5F, -half_h + 0.5F},
-      Velocity{-2.F, -2.F});
+  PathJoints p;
+  p.joints = {{{0.F, 0.F}}, {{500.F, 0.F}}};
+  const auto pid = w.addPath(p);
+  const auto tower = w.spawnDefenderAoe({0.F, 0.F});
+  const auto invader = w.spawnInvaderAlpha(pid);
 
+  (void)extractWorldDelta(w);
+  (void)w.tick();
   (void)w.next();
 
-  const auto snaps = snapshot(w, std::vector<SimWorld::EntityId>{mover.id()});
-  (void)w.tick();
-  ASSERT_EQ(snaps.size(), 1U);
-  EXPECT_EQ(snaps[0].id, mover.id());
-  EXPECT_GE(snaps[0].pos.x, -half_w);
-  EXPECT_GE(snaps[0].pos.y, -half_h);
-}
+  const auto delta = extractWorldDelta(w);
+  ASSERT_EQ(delta.upserts.size(), 2U);
+  EXPECT_TRUE(containsId(delta.upserts, tower.id()));
+  EXPECT_TRUE(containsId(delta.upserts, invader.id()));
 
-void SimWorld_BounceMaxEdge() {
-  SimWorld w;
-  const float half_w = SimWorld::widthOfWorld * 0.5F;
-  const float half_h = SimWorld::heightOfWorld * 0.5F;
-  const auto mover =
-      w.spawnMover(Position{half_w - 0.5F, half_h - 0.5F}, Velocity{2.F, 2.F});
+  const auto tower_it = std::ranges::find(delta.upserts, tower.id(),
+      &WorldDelta::Upsert::id);
+  ASSERT_TRUE(tower_it != delta.upserts.end());
+  EXPECT_EQ(tower_it->fx.flash_color, 0xFFFFFFFFU);
+  EXPECT_EQ(tower_it->fx.flash_expiry, WorldTick{6});
 
-  (void)w.next();
-
-  const auto snaps = snapshot(w, std::vector<SimWorld::EntityId>{mover.id()});
-  (void)w.tick();
-  ASSERT_EQ(snaps.size(), 1U);
-  EXPECT_EQ(snaps[0].id, mover.id());
-  EXPECT_LE(snaps[0].pos.x, half_w);
-  EXPECT_LE(snaps[0].pos.y, half_h);
+  const auto invader_it = std::ranges::find(delta.upserts, invader.id(),
+      &WorldDelta::Upsert::id);
+  ASSERT_TRUE(invader_it != delta.upserts.end());
+  EXPECT_EQ(invader_it->fx.flash_color, 0xFF7F7FFFU);
+  EXPECT_EQ(invader_it->fx.flash_expiry, WorldTick{6});
+  EXPECT_NEAR(invader_it->pos.x, 100.0, 1e-6);
 }
 
 void SimWorld_SnapshotSinceTracksChanges() {
   SimWorld w;
-  (void)w.spawnMover(Position{10.F, 10.F}, Velocity{1.F, 0.F});
-  (void)w.spawnBackground(Position{20.F, 20.F});
+  PathJoints p;
+  p.joints = {{{0.F, 0.F}}, {{500.F, 0.F}}};
+  const auto pid = w.addPath(p);
+  const auto invader = w.spawnInvaderAlpha(pid);
+  (void)w.spawnDefenderAoe(Position{500.F, 500.F});
 
   // Drain the spawn-time dirty list; both entities visible at tick_=0.
   const auto initial = extractWorldDelta(w);
@@ -271,6 +288,7 @@ void SimWorld_SnapshotSinceTracksChanges() {
   const auto moved = extractWorldDelta(w);
   EXPECT_EQ(moved.upserts.size(), 1U);
   EXPECT_TRUE(moved.erased.empty());
+  EXPECT_TRUE(containsId(moved.upserts, invader.id()));
 
   (void)w.tick();
 
@@ -279,14 +297,18 @@ void SimWorld_SnapshotSinceTracksChanges() {
   EXPECT_TRUE(stable.erased.empty());
 }
 
-void SimWorld_BackgroundDoesNotAppearAsChangedAfterTick() {
+void SimWorld_DefenderDoesNotAppearAsChangedAfterTick() {
   SimWorld w;
-  (void)w.spawnBackground(Position{50.F, 60.F});
+  const auto defender = w.spawnDefenderAoe(Position{50.F, 60.F});
 
+  const auto initial = extractWorldDelta(w);
+  ASSERT_EQ(initial.upserts.size(), 1U);
+  EXPECT_TRUE(containsId(initial.upserts, defender.id()));
+
+  (void)w.tick();
   (void)w.next();
 
   const auto snaps = snapshot(w);
-  (void)w.tick();
   ASSERT_EQ(snaps.size(), 1U);
   EXPECT_NEAR(snaps[0].pos.x, 50.0, 1e-6);
   EXPECT_NEAR(snaps[0].pos.y, 60.0, 1e-6);
@@ -374,7 +396,7 @@ void SimWorld_EnemyAdvancesOnTick() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{100.F, 0.F}}};
   const auto pid = w.addPath(p);
-  const auto enemy = w.spawnEnemy(pid, 10.F);
+  const auto enemy = w.spawnInvaderAlpha(pid);
 
   EXPECT_TRUE(static_cast<bool>(enemy));
   EXPECT_EQ(w.size(), 1U);
@@ -385,8 +407,8 @@ void SimWorld_EnemyAdvancesOnTick() {
   const auto delta = extractWorldDelta(w);
   EXPECT_TRUE(containsId(delta.upserts, enemy.id()));
   ASSERT_EQ(delta.upserts.size(), 1U);
-  EXPECT_NEAR(delta.upserts[0].second.x, 10.0, 1e-5);
-  EXPECT_NEAR(delta.upserts[0].second.y, 0.0, 1e-5);
+  EXPECT_NEAR(delta.upserts[0].pos.x, 0.0, 1e-5);
+  EXPECT_NEAR(delta.upserts[0].pos.y, 0.0, 1e-5);
 }
 
 void SimWorld_ResolveEscapeesVisitsEscapedEnemy() {
@@ -394,20 +416,20 @@ void SimWorld_ResolveEscapeesVisitsEscapedEnemy() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
   const auto pid = w.addPath(p);
-  const auto enemy = w.spawnEnemy(pid, 5.F, 8.F);
+  const auto enemy = w.spawnInvaderAlpha(pid, 8.F);
 
   (void)w.next();
   EXPECT_EQ(w.size(), 1U);
 
   size_t resolved = 0;
   (void)w.resolveEscapees(
-      [&](SimWorld::EntityId id, const Position& pos, const PathFollower& pf) {
+      [&](SimWorld::EntityId id, const Position& pos, const Pathing& pf) {
         ++resolved;
         EXPECT_EQ(id, enemy.id());
         EXPECT_NEAR(pos.x, 8.0, 1e-6);
         EXPECT_NEAR(pos.y, 0.0, 1e-6);
-        EXPECT_NEAR(pf.progress, 13.0, 1e-6);
-        EXPECT_NEAR(pf.speed, 5.0, 1e-6);
+        EXPECT_NEAR(pf.progress, 108.0, 1e-6);
+        EXPECT_NEAR(pf.speed, 100.0, 1e-6);
         return true;
       });
 
@@ -429,13 +451,13 @@ void SimWorld_ResolveEscapeesCanLeaveEnemyAlive() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
   const auto pid = w.addPath(p);
-  const auto enemy = w.spawnEnemy(pid, 5.F, 8.F);
+  const auto enemy = w.spawnInvaderAlpha(pid, 8.F);
 
   (void)w.next();
 
   size_t resolved = 0;
   (void)w.resolveEscapees(
-      [&](SimWorld::EntityId id, const Position&, const PathFollower&) {
+      [&](SimWorld::EntityId id, const Position&, const Pathing&) {
         ++resolved;
         EXPECT_EQ(id, enemy.id());
         return false;
@@ -681,10 +703,15 @@ void SimJson_ParseUiActionMessageFields() {
   EXPECT_EQ(input->seq, 7U);
   EXPECT_EQ(input->action, "start_wave");
   ASSERT_EQ(input->fields.size(), 2U);
-  EXPECT_EQ(input->fields[0].key, "tower/kind");
-  EXPECT_EQ(input->fields[0].value, "ice");
-  EXPECT_EQ(input->fields[1].key, "note");
-  EXPECT_EQ(input->fields[1].value, std::string("line\nbreak"));
+  const auto tower_kind = std::ranges::find(input->fields, "tower/kind",
+      &UiActionField::key);
+  ASSERT_TRUE(tower_kind != input->fields.end());
+  EXPECT_EQ(tower_kind->value, "ice");
+
+  const auto note =
+      std::ranges::find(input->fields, "note", &UiActionField::key);
+  ASSERT_TRUE(note != input->fields.end());
+  EXPECT_EQ(note->value, std::string("line\nbreak"));
 }
 
 void SimJson_BuildHelloAckJson() {
@@ -708,9 +735,9 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
   sim_game_state_json state;
   (void)build_sim_game_state_json(state, game);
   EXPECT_TRUE(state.body.contains(R"("x":10.0)"));
-  EXPECT_TRUE(state.body.contains(R"("radius":20.000)"));
-  EXPECT_FALSE(state.body.contains(R"("vfx")"));
-  EXPECT_FALSE(state.body.contains(R"("flashExpiryMs")"));
+  EXPECT_TRUE(state.body.contains(R"("radius":30.000)"));
+  EXPECT_TRUE(state.body.contains(R"("vfx")"));
+  EXPECT_TRUE(state.body.contains(R"("flashExpiryMs":250)"));
   EXPECT_FALSE(state.body.contains(R"("modified")"));
   EXPECT_FALSE(state.body.contains(R"("flash_expiry")"));
   EXPECT_FALSE(state.body.contains(R"("glow")"));
@@ -748,7 +775,12 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
     ASSERT_TRUE(!app.get_number<uint32_t>("modified").has_value());
 
     const auto vfx = entry.get_object("vfx");
-    EXPECT_TRUE(!vfx);
+    ASSERT_TRUE(vfx);
+    ASSERT_TRUE(vfx.get_number<uint32_t>("selection").has_value());
+    ASSERT_TRUE(vfx.get_number<float>("rangeRadius").has_value());
+    ASSERT_TRUE(vfx.get_number<uint32_t>("range").has_value());
+    ASSERT_TRUE(vfx.get_number<uint32_t>("flash").has_value());
+    ASSERT_TRUE(vfx.get_number<uint32_t>("flashExpiryMs").has_value());
     ++count;
   }
   EXPECT_EQ(count, 1U);
@@ -871,15 +903,18 @@ void SimJson_BuildWorldSnapshotJsonShape() {
 
 // NOLINTEND(readability-function-cognitive-complexity)
 
-MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_TickMovesMover,
-    SimWorld_ExtractUpdatedEntitiesReportsMovedMoverOncePerExtraction,
-    SimWorld_BounceMinEdge, SimWorld_BounceMaxEdge,
+MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_NextMovesInvaderAlpha,
+    SimWorld_ExtractUpdatedEntitiesReportsMovedInvaderOncePerExtraction,
+    SimWorld_TowerInRangeFlashesItselfAndInvader,
     SimWorld_SnapshotSinceTracksChanges,
-    SimWorld_BackgroundDoesNotAppearAsChangedAfterTick, BakePath_TwoJoints,
+    SimWorld_DefenderDoesNotAppearAsChangedAfterTick, BakePath_TwoJoints,
     BakePath_ThreeJoints, BakePath_Degenerate, PathPosition_Endpoints,
-    PathPosition_Midpoint, SimWorld_EnemyAdvancesOnTick,
+    PathPosition_Midpoint, PathPosition_CrossingSegmentBoundaryEmitsJoint,
+    SimWorld_EnemyAdvancesOnTick,
     SimWorld_ResolveEscapeesVisitsEscapedEnemy,
     SimWorld_ResolveEscapeesCanLeaveEnemyAlive, SimWorld_GetPathOutOfRange,
+    SimWorld_ObtainPathIncludesTerminalJoint,
+    SimWorld_FromJointsThrowsWhenJointIsOutOfBounds,
     SimGame_LoadMapInitialSnapshotAndState,
     SimGame_HandleUiActionStartWaveTransitionsToWavePhase,
     SimGame_HandleUiCanvasSpawnsTowerButKeepsBuildPhase,

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -182,8 +182,8 @@ void SimWorld_SpawnAndSnapshot() {
 
   const auto all = snapshot(w);
   ASSERT_EQ(all.size(), 2U);
-  EXPECT_EQ(
-      filterSnapshot(all, std::vector<SimWorld::EntityId>{invader.id()}).size(),
+  EXPECT_EQ(filterSnapshot(all, std::vector<SimWorld::EntityId>{invader.id()})
+                .size(),
       1U);
   EXPECT_EQ(
       filterSnapshot(all,
@@ -250,17 +250,17 @@ void SimWorld_TowerInRangeFlashesItselfAndInvader() {
   EXPECT_TRUE(containsId(delta.upserts, tower.id()));
   EXPECT_TRUE(containsId(delta.upserts, invader.id()));
 
-  const auto tower_it = std::ranges::find(delta.upserts, tower.id(),
-      &WorldDelta::Upsert::id);
+  const auto tower_it =
+      std::ranges::find(delta.upserts, tower.id(), &WorldDelta::Upsert::id);
   ASSERT_TRUE(tower_it != delta.upserts.end());
-  EXPECT_EQ(tower_it->fx.flash_color, 0xFFFFFFFFU);
-  EXPECT_EQ(tower_it->fx.flash_expiry, WorldTick{6});
+  EXPECT_EQ(tower_it->fx.flashColor, 0xFFFFFFFFU);
+  EXPECT_EQ(tower_it->fx.flashExpiry, WorldTick{6});
 
-  const auto invader_it = std::ranges::find(delta.upserts, invader.id(),
-      &WorldDelta::Upsert::id);
+  const auto invader_it =
+      std::ranges::find(delta.upserts, invader.id(), &WorldDelta::Upsert::id);
   ASSERT_TRUE(invader_it != delta.upserts.end());
-  EXPECT_EQ(invader_it->fx.flash_color, 0xFF7F7FFFU);
-  EXPECT_EQ(invader_it->fx.flash_expiry, WorldTick{6});
+  EXPECT_EQ(invader_it->fx.flashColor, 0xFF7F7FFFU);
+  EXPECT_EQ(invader_it->fx.flashExpiry, WorldTick{6});
   EXPECT_NEAR(invader_it->pos.x, 100.0, 1e-6);
 }
 
@@ -540,7 +540,7 @@ void SimGame_HandleUiActionStartWaveTransitionsToWavePhase() {
   SimGame game;
   game.loadMap();
 
-  game.handle_UiAction(
+  game.handleUiAction(
       UiActionInput{.seq = 1, .action = "start_wave", .fields = {}});
 
   const auto delta = extractGameDelta(game);
@@ -703,8 +703,8 @@ void SimJson_ParseUiActionMessageFields() {
   EXPECT_EQ(input->seq, 7U);
   EXPECT_EQ(input->action, "start_wave");
   ASSERT_EQ(input->fields.size(), 2U);
-  const auto tower_kind = std::ranges::find(input->fields, "tower/kind",
-      &UiActionField::key);
+  const auto tower_kind =
+      std::ranges::find(input->fields, "tower/kind", &UiActionField::key);
   ASSERT_TRUE(tower_kind != input->fields.end());
   EXPECT_EQ(tower_kind->value, "ice");
 
@@ -715,7 +715,7 @@ void SimJson_ParseUiActionMessageFields() {
 }
 
 void SimJson_BuildHelloAckJson() {
-  EXPECT_EQ(build_sim_hello_ack_json(),
+  EXPECT_EQ(buildSimHelloAckJson(),
       std::string(R"({"type":"hello_ack","message":"connected"})"));
 }
 
@@ -732,8 +732,8 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
       .canvasY = 200.F});
   (void)game.next();
 
-  sim_game_state_json state;
-  (void)build_sim_game_state_json(state, game);
+  SimGameStateJson state;
+  (void)buildSimGameStateJson(state, game);
   EXPECT_TRUE(state.body.contains(R"("x":10.0)"));
   EXPECT_TRUE(state.body.contains(R"("radius":30.000)"));
   EXPECT_TRUE(state.body.contains(R"("vfx")"));
@@ -798,8 +798,8 @@ void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
       .canvasX = 100.F,
       .canvasY = 200.F});
 
-  sim_game_state_json initial_state;
-  (void)build_sim_game_state_json(initial_state, game);
+  SimGameStateJson initial_state;
+  (void)buildSimGameStateJson(initial_state, game);
   (void)game.tick();
 
   game.handleUiCanvas(UiCanvasInput{.seq = 2,
@@ -811,8 +811,8 @@ void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
       .canvasX = 100.F,
       .canvasY = 200.F});
 
-  sim_game_state_json state;
-  (void)build_sim_game_state_json(state, game);
+  SimGameStateJson state;
+  (void)buildSimGameStateJson(state, game);
 
   json_value_view root;
   ASSERT_TRUE(parse_json(state.body, root));
@@ -847,27 +847,27 @@ void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
 void SimJson_FlashExpiryDelayMsUsesCurrentTickRelativeTiming() {
   VisualEffects fx{
       .modified = WorldTick{12},
-      .selection_color = 0,
-      .range_radius = 0.F,
-      .range_color = 0,
-      .flash_color = 0xFF0000FF,
-      .flash_expiry = WorldTick{15},
+      .selectionColor = 0,
+      .rangeRadius = 0.F,
+      .rangeColor = 0,
+      .flashColor = 0xFF0000FF,
+      .flashExpiry = WorldTick{15},
   };
 
-  EXPECT_EQ(flash_expiry_delay_ms(fx, WorldTick{10}), 250U);
-  EXPECT_EQ(flash_expiry_delay_ms(fx, WorldTick{15}), 0U);
-  EXPECT_EQ(flash_expiry_delay_ms(fx, WorldTick{16}), 0U);
+  EXPECT_EQ(flashExpiryDelayMs(fx, WorldTick{10}), 250U);
+  EXPECT_EQ(flashExpiryDelayMs(fx, WorldTick{15}), 0U);
+  EXPECT_EQ(flashExpiryDelayMs(fx, WorldTick{16}), 0U);
 
-  fx.flash_color = 0;
-  EXPECT_EQ(flash_expiry_delay_ms(fx, WorldTick{10}), 0U);
+  fx.flashColor = 0;
+  EXPECT_EQ(flashExpiryDelayMs(fx, WorldTick{10}), 0U);
 }
 
 void SimJson_BuildWorldSnapshotJsonShape() {
   SimGame game;
   game.loadMap();
 
-  sim_game_state_json state;
-  (void)build_sim_game_state_json(state, game, update_strategy::full);
+  SimGameStateJson state;
+  (void)buildSimGameStateJson(state, game, update_strategy::full);
   EXPECT_TRUE(state.body.contains(R"("type":"world_snapshot")"));
   EXPECT_TRUE(state.body.contains(R"("x":0.0)"));
 
@@ -910,8 +910,7 @@ MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_NextMovesInvaderAlpha,
     SimWorld_DefenderDoesNotAppearAsChangedAfterTick, BakePath_TwoJoints,
     BakePath_ThreeJoints, BakePath_Degenerate, PathPosition_Endpoints,
     PathPosition_Midpoint, PathPosition_CrossingSegmentBoundaryEmitsJoint,
-    SimWorld_EnemyAdvancesOnTick,
-    SimWorld_ResolveEscapeesVisitsEscapedEnemy,
+    SimWorld_EnemyAdvancesOnTick, SimWorld_ResolveEscapeesVisitsEscapedEnemy,
     SimWorld_ResolveEscapeesCanLeaveEnemyAlive, SimWorld_GetPathOutOfRange,
     SimWorld_ObtainPathIncludesTerminalJoint,
     SimWorld_FromJointsThrowsWhenJointIsOutOfBounds,

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -937,7 +937,9 @@ void SimJson_BuildWorldSnapshotJsonShape() {
   ASSERT_TRUE(root_type.has_value());
   EXPECT_EQ(*root_type, std::string_view{"world_snapshot"});
 
-  const auto paths = obj.get_array("paths");
+  const auto map_design = obj.get_object("mapDesign");
+  ASSERT_TRUE(map_design);
+  const auto paths = map_design.get_array("paths");
   ASSERT_TRUE(paths);
   size_t path_points = 0;
   for (const auto point : paths) {

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -176,7 +176,7 @@ spawnInvaderAlpha(SimWorld& w, PathId pid, float progress = 0.F) {
       .bgColor = 0x000000FF};
   std::get<std::optional<VisualEffects>>(tpl) = VisualEffects{};
   std::get<std::optional<Pathing>>(tpl) =
-      Pathing{.path_id = PathId::invalid, .progress = 0.F, .speed = 50.F};
+      Pathing{.pathId = PathId::invalid, .progress = 0.F, .speed = 50.F};
   std::get<std::optional<Invader>>(tpl) =
       Invader{.invaderType = 1, .hitCircleRadius = 30.F, .bounty = 10};
   std::get<std::optional<Health>>(tpl) =
@@ -185,7 +185,7 @@ spawnInvaderAlpha(SimWorld& w, PathId pid, float progress = 0.F) {
   auto h = w.spawnEntity("InvaderAlphaBasic");
   if (!h) return h;
   if (auto* pat = w.try_get_component<Pathing>(h.id())) {
-    pat->path_id = pid;
+    pat->pathId = pid;
     pat->progress = progress;
     if (auto* pos = w.try_get_component<Position>(h.id()))
       if (const auto* path = w.getPath(pid))

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -54,7 +54,7 @@ struct GameDelta {
   std::string_view phase;
   std::optional<bool> placementAllowed;
   std::optional<bool> spawnAllowed;
-  bool defenderSelected{};
+  std::optional<Position> selectedDefender;
   std::optional<DefenderSummary> defenderSummary;
 };
 
@@ -141,7 +141,7 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
         delta.phase = phase;
         delta.placementAllowed = uiState.placementAllowed;
         delta.spawnAllowed = uiState.spawnAllowed;
-        delta.defenderSelected = uiState.defenderSelected;
+        delta.selectedDefender = uiState.selectedDefender;
         delta.defenderSummary = uiState.defenderSummary;
       });
   return delta;
@@ -681,6 +681,42 @@ void SimGame_HandleUiCanvasRightClickSpawnPlacesDefender() {
   EXPECT_TRUE(after.erased.empty());
 }
 
+void SimGame_HandleUiCanvasSelectingDefenderReportsSelectedPosition() {
+  SimGame game;
+  (void)game.loadMap();
+
+  (void)game.handleUiCanvas(UiCanvasInput{.seq = 1,
+      .event = UiCanvasEvent::click,
+      .button = UiMouseButton::right,
+      .buttons = 2,
+      .x = 300.F,
+      .y = 100.F,
+      .canvasX = 120.F,
+      .canvasY = 210.F,
+      .command = "spawn",
+      .parameters = {"DefenderAoeBasic"}});
+  (void)game.next();
+  (void)extractGameDelta(game);
+
+  (void)game.handleUiCanvas(UiCanvasInput{.seq = 2,
+      .event = UiCanvasEvent::click,
+      .button = UiMouseButton::left,
+      .buttons = 1,
+      .x = 300.F,
+      .y = 100.F,
+      .canvasX = 120.F,
+      .canvasY = 210.F,
+      .command{},
+      .parameters{}});
+  (void)game.next();
+
+  const auto delta = extractGameDelta(game);
+  ASSERT_TRUE(delta.selectedDefender.has_value());
+  EXPECT_NEAR(delta.selectedDefender->x, 300.0, 1e-6);
+  EXPECT_NEAR(delta.selectedDefender->y, 100.0, 1e-6);
+  ASSERT_TRUE(delta.defenderSummary.has_value());
+}
+
 void SimGame_HandleUiCanvasSpawnsShooterDefender() {
   SimGame game;
   (void)game.loadMap();
@@ -850,7 +886,7 @@ void SimGame_ExtractFullIncludesPathsAndState() {
   EXPECT_EQ(lives, 20);
   EXPECT_EQ(resources, 100);
   EXPECT_EQ(phase, std::string_view{"build"});
-  EXPECT_FALSE(uiState.defenderSelected);
+  EXPECT_FALSE(uiState.selectedDefender.has_value());
 }
 
 void SimJson_ParseUiCanvasMessage() {
@@ -936,6 +972,7 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
   EXPECT_TRUE(state.body.contains(R"("flashExpiryMs":250)"));
   EXPECT_TRUE(state.body.contains(R"("uiState")"));
   EXPECT_TRUE(state.body.contains(R"("spawnAllowed":true)"));
+  EXPECT_TRUE(state.body.contains(R"("selectedDefender":{"x":300.0,"y":100.0})"));
   EXPECT_FALSE(state.body.contains(R"("modified")"));
   EXPECT_FALSE(state.body.contains(R"("flash_expiry")"));
   EXPECT_FALSE(state.body.contains(R"("glow")"));

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -52,6 +52,10 @@ struct GameDelta {
   int lives{};
   int resources{};
   std::string_view phase;
+  std::optional<bool> placementAllowed;
+  std::optional<bool> spawnAllowed;
+  bool defenderSelected{};
+  std::optional<DefenderSummary> defenderSummary;
 };
 
 struct EntitySnapshot {
@@ -116,7 +120,7 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
       [&snap](SimWorld::EntityId id, const Position& pos, const Appearance&,
           const VisualEffects&) { snap.entities.push_back({id, pos}); },
       [](SimWorld::EntityId) {},
-      [](size_t, WaveTick, int, int, std::string_view) {});
+      [](size_t, WaveTick, int, int, std::string_view, const UiState&) {});
 
   snap.path_points = std::move(pathsById);
   return snap;
@@ -129,12 +133,16 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
           const VisualEffects&) { delta.upserts.emplace_back(id, pos); },
       [&delta](SimWorld::EntityId id) { delta.erased.push_back(id); },
       [&delta](size_t currentWave, WaveTick waveTick, int lives, int resources,
-          std::string_view phase) {
+          std::string_view phase, const UiState& uiState) {
         delta.currentWave = currentWave;
         delta.waveTick = waveTick;
         delta.lives = lives;
         delta.resources = resources;
         delta.phase = phase;
+        delta.placementAllowed = uiState.placementAllowed;
+        delta.spawnAllowed = uiState.spawnAllowed;
+        delta.defenderSelected = uiState.defenderSelected;
+        delta.defenderSummary = uiState.defenderSummary;
       });
   return delta;
 }
@@ -178,10 +186,10 @@ spawnInvaderAlpha(SimWorld& w, PathId pid, float progress = 0.F) {
   std::get<std::optional<Pathing>>(tpl) =
       Pathing{.pathId = PathId::invalid, .progress = 0.F, .speed = 50.F};
   std::get<std::optional<Invader>>(tpl) =
-      Invader{.invaderType = 1, .hitCircleRadius = 30.F, .bounty = 10};
+      Invader{.hitCircleRadius = 30.F, .bounty = 10};
   std::get<std::optional<Health>>(tpl) =
       Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 10.F};
-  w.registerEntity("InvaderAlphaBasic", tpl);
+  (void)w.registerEntity("InvaderAlphaBasic", tpl);
   auto h = w.spawnEntity("InvaderAlphaBasic");
   if (!h) return h;
   if (auto* pat = w.try_get_component<Pathing>(h.id())) {
@@ -203,8 +211,7 @@ spawnDefenderAoe(SimWorld& w, Position spawn_pos) {
       .fgColor = 0xFFFFFFFF,
       .bgColor = 0x7F7FFFFF};
   std::get<std::optional<VisualEffects>>(tpl) = VisualEffects{};
-  std::get<std::optional<Defender>>(tpl) = Defender{.defenderType = 1,
-      .hitCircleRadius = 30.F,
+  std::get<std::optional<Defender>>(tpl) = Defender{.hitCircleRadius = 30.F,
       .attackRadius = 100.F,
       .rangeColor = 0xFFFF0000,
       .attackDamage = 5.F,
@@ -214,7 +221,7 @@ spawnDefenderAoe(SimWorld& w, Position spawn_pos) {
   std::get<std::optional<Health>>(tpl) =
       Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 0.F};
   std::get<std::optional<DefenderAoe>>(tpl) = DefenderAoe{.damageType = 1};
-  w.registerEntity("DefenderAoeBasic", tpl);
+  (void)w.registerEntity("DefenderAoeBasic", tpl);
   auto h = w.spawnEntity("DefenderAoeBasic");
   if (!h) return h;
   if (auto* pos = w.try_get_component<Position>(h.id())) *pos = spawn_pos;
@@ -575,13 +582,13 @@ void SimWorld_FromJointsThrowsWhenJointIsOutOfBounds() {
 
 void SimGame_LoadMapInitialSnapshotAndState() {
   SimGame game;
-  game.loadMap();
+  (void)game.loadMap();
 
   const auto snap = snapshot(game);
   ASSERT_EQ(snap.entities.size(), 0U);
   ASSERT_EQ(snap.path_points.size(), 1U);
-  EXPECT_EQ(snap.path_points[0].joints.front().p.x, 0.F);
-  EXPECT_EQ(snap.path_points[0].joints.front().p.y, 0.F);
+  EXPECT_EQ(snap.path_points[0].joints.front().pos.x, 0.F);
+  EXPECT_EQ(snap.path_points[0].joints.front().pos.y, 0.F);
   EXPECT_GT(snap.path_points[0].joints.size(), 2U);
 
   const auto delta = extractGameDelta(game);
@@ -596,69 +603,89 @@ void SimGame_LoadMapInitialSnapshotAndState() {
 
 void SimGame_HandleUiActionStartWaveTransitionsToWavePhase() {
   SimGame game;
-  game.loadMap();
+  (void)game.loadMap();
 
   (void)game.handleUiAction(
       UiActionInput{.seq = 1, .action = "start_wave", .fields = {}});
 
+  const auto before = extractGameDelta(game);
+  EXPECT_EQ(before.phase, std::string_view{"build"});
+
+  (void)game.next();
+
   const auto delta = extractGameDelta(game);
   EXPECT_EQ(delta.phase, std::string_view{"wave"});
-  EXPECT_EQ(delta.waveTick, WaveTick{0});
+  EXPECT_EQ(delta.waveTick, WaveTick{1});
 }
 
 void SimGame_HandleUiCanvasSpawnsDefenderButKeepsBuildPhase() {
   SimGame game;
-  game.loadMap();
+  (void)game.loadMap();
   const auto before = extractGameDelta(game);
 
   (void)game.handleUiCanvas(UiCanvasInput{.seq = 1,
       .event = UiCanvasEvent::click,
       .button = UiMouseButton::left,
       .buttons = 1,
-      .x = 200.F,
-      .y = 0.F,
+      .x = 300.F,
+      .y = 100.F,
       .canvasX = 100.F,
       .canvasY = 200.F,
       .command = "spawn",
       .parameters = {"DefenderAoeBasic"}});
 
+  const auto pending = extractGameDelta(game);
+  EXPECT_TRUE(pending.upserts.empty());
+  EXPECT_FALSE(pending.spawnAllowed.has_value());
+
+  (void)game.next();
+
   const auto after = extractGameDelta(game);
   EXPECT_EQ(before.phase, std::string_view{"build"});
   EXPECT_EQ(after.phase, std::string_view{"build"});
+  ASSERT_TRUE(after.spawnAllowed.has_value());
+  EXPECT_TRUE(*after.spawnAllowed);
   ASSERT_EQ(after.upserts.size(), 1U);
-  EXPECT_NEAR(after.upserts[0].second.x, 200.0, 1e-6);
-  EXPECT_NEAR(after.upserts[0].second.y, 0.0, 1e-6);
+  EXPECT_NEAR(after.upserts[0].second.x, 300.0, 1e-6);
+  EXPECT_NEAR(after.upserts[0].second.y, 100.0, 1e-6);
   EXPECT_TRUE(after.erased.empty());
 }
 
 void SimGame_HandleUiCanvasRightClickSpawnPlacesDefender() {
   SimGame game;
-  game.loadMap();
+  (void)game.loadMap();
 
   (void)game.handleUiCanvas(UiCanvasInput{.seq = 1,
       .event = UiCanvasEvent::click,
       .button = UiMouseButton::right,
       .buttons = 2,
-      .x = 200.F,
-      .y = 0.F,
+      .x = 300.F,
+      .y = 100.F,
       .canvasX = 120.F,
       .canvasY = 210.F,
       .command = "spawn",
       .parameters = {"DefenderAoeBasic"}});
 
+  const auto pending = extractGameDelta(game);
+  EXPECT_TRUE(pending.upserts.empty());
+
+  (void)game.next();
+
   const auto after = extractGameDelta(game);
   EXPECT_EQ(after.phase, std::string_view{"build"});
+  ASSERT_TRUE(after.spawnAllowed.has_value());
+  EXPECT_TRUE(*after.spawnAllowed);
   ASSERT_EQ(after.upserts.size(), 1U);
-  EXPECT_NEAR(after.upserts[0].second.x, 200.0, 1e-6);
-  EXPECT_NEAR(after.upserts[0].second.y, 0.0, 1e-6);
+  EXPECT_NEAR(after.upserts[0].second.x, 300.0, 1e-6);
+  EXPECT_NEAR(after.upserts[0].second.y, 100.0, 1e-6);
   EXPECT_TRUE(after.erased.empty());
 }
 
-void SimGame_HandleUiCanvasPlacingResponseRejectsPathOverlap() {
+void SimGame_HandleUiCanvasPlacingIntentRejectsPathOverlapOnNextTick() {
   SimGame game;
-  game.loadMap();
+  (void)game.loadMap();
 
-  const auto response = game.handleUiCanvas(UiCanvasInput{.seq = 7,
+  (void)game.handleUiCanvas(UiCanvasInput{.seq = 7,
       .event = UiCanvasEvent::dragmove,
       .button = UiMouseButton::left,
       .buttons = 1,
@@ -669,21 +696,21 @@ void SimGame_HandleUiCanvasPlacingResponseRejectsPathOverlap() {
       .command = "placing",
       .parameters = {"DefenderAoeBasic"}});
 
-  ASSERT_TRUE(response.has_value());
-  EXPECT_EQ(response->seq, 7U);
-  EXPECT_EQ(response->response, std::string_view{"placement"});
-  EXPECT_FALSE(response->ok);
-  EXPECT_EQ(response->reason, std::string_view{"blocked"});
-  ASSERT_EQ(response->fields.size(), 1U);
-  EXPECT_EQ(response->fields[0].key, std::string_view{"valid"});
-  EXPECT_EQ(response->fields[0].value, std::string_view{"false"});
+  const auto pending = extractGameDelta(game);
+  EXPECT_FALSE(pending.placementAllowed.has_value());
+
+  (void)game.next();
+
+  const auto delta = extractGameDelta(game);
+  ASSERT_TRUE(delta.placementAllowed.has_value());
+  EXPECT_FALSE(*delta.placementAllowed);
 }
 
-void SimGame_HandleUiCanvasRejectsBlockedDefenderSpawn() {
+void SimGame_HandleUiCanvasRejectsBlockedDefenderSpawnOnNextTick() {
   SimGame game;
-  game.loadMap();
+  (void)game.loadMap();
 
-  const auto response = game.handleUiCanvas(UiCanvasInput{.seq = 1,
+  (void)game.handleUiCanvas(UiCanvasInput{.seq = 1,
       .event = UiCanvasEvent::click,
       .button = UiMouseButton::right,
       .buttons = 2,
@@ -694,17 +721,18 @@ void SimGame_HandleUiCanvasRejectsBlockedDefenderSpawn() {
       .command = "spawn",
       .parameters = {"DefenderAoeBasic"}});
 
+  (void)game.next();
+
   const auto delta = extractGameDelta(game);
   EXPECT_TRUE(delta.upserts.empty());
-  ASSERT_TRUE(response.has_value());
-  EXPECT_EQ(response->response, std::string_view{"placement"});
-  EXPECT_FALSE(response->ok);
+  ASSERT_TRUE(delta.spawnAllowed.has_value());
+  EXPECT_FALSE(*delta.spawnAllowed);
 }
 
 void SimGame_StartWaveSpawnsFirstEnemyOnFirstStep() {
   SimGame game;
-  game.loadMap();
-  game.start_wave();
+  (void)game.loadMap();
+  (void)game.start_wave();
 
   (void)game.next();
 
@@ -726,8 +754,8 @@ void SimGame_StartWaveSpawnsFirstEnemyOnFirstStep() {
 
 void SimGame_ExtractDeltaConsumesWorldUpdatesButNotState() {
   SimGame game;
-  game.loadMap();
-  game.start_wave();
+  (void)game.loadMap();
+  (void)game.start_wave();
 
   (void)game.next();
   (void)game.tick();
@@ -753,7 +781,7 @@ void SimGame_ExtractDeltaConsumesWorldUpdatesButNotState() {
 
 void SimGame_ExtractFullIncludesPathsAndState() {
   SimGame game;
-  game.loadMap();
+  (void)game.loadMap();
 
   size_t path_points = 0;
   size_t upserts = 0;
@@ -763,20 +791,22 @@ void SimGame_ExtractFullIncludesPathsAndState() {
   int lives = -1;
   int resources = -1;
   std::string_view phase = "unknown";
+  UiState uiState;
 
   (void)game.extractFull(
       [&path_points](PathId, const Position&) { ++path_points; },
       [&upserts](SimWorld::EntityId, const Position&, const Appearance&,
           const VisualEffects&) { ++upserts; },
       [&erased](SimWorld::EntityId) { ++erased; },
-      [&currentWave, &waveTick, &lives, &resources, &phase](size_t wave,
-          WaveTick tick, int newLives, int newResources,
-          std::string_view newPhase) {
+      [&currentWave, &waveTick, &lives, &resources, &phase,
+          &uiState](size_t wave, WaveTick tick, int newLives, int newResources,
+          std::string_view newPhase, const UiState& newUiState) {
         currentWave = wave;
         waveTick = tick;
         lives = newLives;
         resources = newResources;
         phase = newPhase;
+        uiState = newUiState;
       });
 
   EXPECT_GT(path_points, 0U);
@@ -787,6 +817,7 @@ void SimGame_ExtractFullIncludesPathsAndState() {
   EXPECT_EQ(lives, 20);
   EXPECT_EQ(resources, 100);
   EXPECT_EQ(phase, std::string_view{"build"});
+  EXPECT_FALSE(uiState.defenderSelected);
 }
 
 void SimJson_ParseUiCanvasMessage() {
@@ -851,13 +882,13 @@ void SimJson_BuildHelloAckJson() {
 
 void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
   SimGame game;
-  game.loadMap();
+  (void)game.loadMap();
   (void)game.handleUiCanvas(UiCanvasInput{.seq = 1,
       .event = UiCanvasEvent::click,
       .button = UiMouseButton::left,
       .buttons = 1,
-      .x = 200.F,
-      .y = 0.F,
+      .x = 300.F,
+      .y = 100.F,
       .canvasX = 100.F,
       .canvasY = 200.F,
       .command = "spawn",
@@ -866,10 +897,12 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
 
   SimGameStateJson state;
   (void)buildSimGameStateJson(state, game);
-  EXPECT_TRUE(state.body.contains(R"("x":200.0)"));
+  EXPECT_TRUE(state.body.contains(R"("x":300.0)"));
   EXPECT_TRUE(state.body.contains(R"("radius":30.000)"));
   EXPECT_TRUE(state.body.contains(R"("vfx")"));
   EXPECT_TRUE(state.body.contains(R"("flashExpiryMs":250)"));
+  EXPECT_TRUE(state.body.contains(R"("uiState")"));
+  EXPECT_TRUE(state.body.contains(R"("spawnAllowed":true)"));
   EXPECT_FALSE(state.body.contains(R"("modified")"));
   EXPECT_FALSE(state.body.contains(R"("flash_expiry")"));
   EXPECT_FALSE(state.body.contains(R"("glow")"));
@@ -898,7 +931,7 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
     ASSERT_TRUE(pos);
     const auto x = pos.get_number<float>("x");
     ASSERT_TRUE(x.has_value());
-    EXPECT_NEAR(*x, 200.0, 1e-6);
+    EXPECT_NEAR(*x, 300.0, 1e-6);
 
     const auto app = entry.get_object("app");
     ASSERT_TRUE(app);
@@ -920,17 +953,18 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
 
 void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
   SimGame game;
-  game.loadMap();
+  (void)game.loadMap();
   (void)game.handleUiCanvas(UiCanvasInput{.seq = 1,
       .event = UiCanvasEvent::click,
       .button = UiMouseButton::left,
       .buttons = 1,
-      .x = 200.F,
-      .y = 0.F,
+      .x = 300.F,
+      .y = 100.F,
       .canvasX = 100.F,
       .canvasY = 200.F,
       .command = "spawn",
       .parameters = {"DefenderAoeBasic"}});
+  (void)game.next();
 
   SimGameStateJson initial_state;
   (void)buildSimGameStateJson(initial_state, game);
@@ -940,12 +974,13 @@ void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
       .event = UiCanvasEvent::click,
       .button = UiMouseButton::right,
       .buttons = 2,
-      .x = 200.F,
-      .y = 0.F,
+      .x = 300.F,
+      .y = 100.F,
       .canvasX = 100.F,
       .canvasY = 200.F,
       .command{},
       .parameters{}});
+  (void)game.next();
 
   SimGameStateJson state;
   (void)buildSimGameStateJson(state, game);
@@ -965,7 +1000,7 @@ void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
     ASSERT_TRUE(pos);
     const auto x = pos.get_number<float>("x");
     ASSERT_TRUE(x.has_value());
-    EXPECT_NEAR(*x, 200.0, 1e-6);
+    EXPECT_NEAR(*x, 300.0, 1e-6);
 
     const auto vfx = entry.get_object("vfx");
     ASSERT_TRUE(vfx);
@@ -1000,7 +1035,7 @@ void SimJson_FlashExpiryDelayMsUsesCurrentTickRelativeTiming() {
 
 void SimJson_BuildWorldSnapshotJsonShape() {
   SimGame game;
-  game.loadMap();
+  (void)game.loadMap();
 
   SimGameStateJson state;
   (void)buildSimGameStateJson(state, game, update_strategy::full);
@@ -1056,8 +1091,8 @@ MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_NextMovesInvaderAlpha,
     SimGame_HandleUiActionStartWaveTransitionsToWavePhase,
     SimGame_HandleUiCanvasSpawnsDefenderButKeepsBuildPhase,
     SimGame_HandleUiCanvasRightClickSpawnPlacesDefender,
-    SimGame_HandleUiCanvasPlacingResponseRejectsPathOverlap,
-    SimGame_HandleUiCanvasRejectsBlockedDefenderSpawn,
+    SimGame_HandleUiCanvasPlacingIntentRejectsPathOverlapOnNextTick,
+    SimGame_HandleUiCanvasRejectsBlockedDefenderSpawnOnNextTick,
     SimGame_StartWaveSpawnsFirstEnemyOnFirstStep,
     SimGame_ExtractDeltaConsumesWorldUpdatesButNotState,
     SimGame_ExtractFullIncludesPathsAndState, SimJson_ParseUiCanvasMessage,

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -291,7 +291,7 @@ void SimWorld_ExtractUpdatedEntitiesReportsMovedInvaderOncePerExtraction() {
   EXPECT_TRUE(empty_delta.erased.empty());
 }
 
-void SimWorld_TowerInRangeFlashesItselfAndInvader() {
+void SimWorld_DefenderInRangeFlashesItselfAndInvader() {
   SimWorld w;
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{500.F, 0.F}}};
@@ -606,7 +606,7 @@ void SimGame_HandleUiActionStartWaveTransitionsToWavePhase() {
   EXPECT_EQ(delta.waveTick, WaveTick{0});
 }
 
-void SimGame_HandleUiCanvasSpawnsTowerButKeepsBuildPhase() {
+void SimGame_HandleUiCanvasSpawnsDefenderButKeepsBuildPhase() {
   SimGame game;
   game.loadMap();
   const auto before = extractGameDelta(game);
@@ -631,7 +631,7 @@ void SimGame_HandleUiCanvasSpawnsTowerButKeepsBuildPhase() {
   EXPECT_TRUE(after.erased.empty());
 }
 
-void SimGame_HandleUiCanvasRightClickSpawnPlacesTower() {
+void SimGame_HandleUiCanvasRightClickSpawnPlacesDefender() {
   SimGame game;
   game.loadMap();
 
@@ -679,7 +679,7 @@ void SimGame_HandleUiCanvasPlacingResponseRejectsPathOverlap() {
   EXPECT_EQ(response->fields[0].value, std::string_view{"false"});
 }
 
-void SimGame_HandleUiCanvasRejectsBlockedTowerSpawn() {
+void SimGame_HandleUiCanvasRejectsBlockedDefenderSpawn() {
   SimGame game;
   game.loadMap();
 
@@ -1043,7 +1043,7 @@ void SimJson_BuildWorldSnapshotJsonShape() {
 
 MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_NextMovesInvaderAlpha,
     SimWorld_ExtractUpdatedEntitiesReportsMovedInvaderOncePerExtraction,
-    SimWorld_TowerInRangeFlashesItselfAndInvader,
+    SimWorld_DefenderInRangeFlashesItselfAndInvader,
     SimWorld_SnapshotSinceTracksChanges,
     SimWorld_DefenderDoesNotAppearAsChangedAfterTick, BakePath_TwoJoints,
     BakePath_ThreeJoints, BakePath_Degenerate, PathPosition_Endpoints,
@@ -1054,10 +1054,10 @@ MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_NextMovesInvaderAlpha,
     SimWorld_FromJointsThrowsWhenJointIsOutOfBounds,
     SimGame_LoadMapInitialSnapshotAndState,
     SimGame_HandleUiActionStartWaveTransitionsToWavePhase,
-    SimGame_HandleUiCanvasSpawnsTowerButKeepsBuildPhase,
-    SimGame_HandleUiCanvasRightClickSpawnPlacesTower,
+    SimGame_HandleUiCanvasSpawnsDefenderButKeepsBuildPhase,
+    SimGame_HandleUiCanvasRightClickSpawnPlacesDefender,
     SimGame_HandleUiCanvasPlacingResponseRejectsPathOverlap,
-    SimGame_HandleUiCanvasRejectsBlockedTowerSpawn,
+    SimGame_HandleUiCanvasRejectsBlockedDefenderSpawn,
     SimGame_StartWaveSpawnsFirstEnemyOnFirstStep,
     SimGame_ExtractDeltaConsumesWorldUpdatesButNotState,
     SimGame_ExtractFullIncludesPathsAndState, SimJson_ParseUiCanvasMessage,

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -296,7 +296,7 @@ void SimWorld_TowerInRangeFlashesItselfAndInvader() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{500.F, 0.F}}};
   const auto pid = w.addPath(p);
-  const auto tower = spawnDefenderAoe(w, {0.F, 0.F});
+  const auto defender = spawnDefenderAoe(w, {0.F, 0.F});
   const auto invader = spawnInvaderAlpha(w, pid);
 
   (void)extractWorldDelta(w);
@@ -305,14 +305,14 @@ void SimWorld_TowerInRangeFlashesItselfAndInvader() {
 
   const auto delta = extractWorldDelta(w);
   ASSERT_EQ(delta.upserts.size(), 2U);
-  EXPECT_TRUE(containsId(delta.upserts, tower.id()));
+  EXPECT_TRUE(containsId(delta.upserts, defender.id()));
   EXPECT_TRUE(containsId(delta.upserts, invader.id()));
 
-  const auto tower_it =
-      std::ranges::find(delta.upserts, tower.id(), &WorldDelta::Upsert::id);
-  ASSERT_TRUE(tower_it != delta.upserts.end());
-  EXPECT_EQ(tower_it->fx.flashColor, 0xFFFFFFFFU);
-  EXPECT_EQ(tower_it->fx.flashExpiry, WorldTick{6});
+  const auto defender_it =
+      std::ranges::find(delta.upserts, defender.id(), &WorldDelta::Upsert::id);
+  ASSERT_TRUE(defender_it != delta.upserts.end());
+  EXPECT_EQ(defender_it->fx.flashColor, 0xFFFFFFFFU);
+  EXPECT_EQ(defender_it->fx.flashExpiry, WorldTick{6});
 
   const auto invader_it =
       std::ranges::find(delta.upserts, invader.id(), &WorldDelta::Upsert::id);
@@ -827,16 +827,16 @@ void SimJson_ParseUiCanvasMessage() {
 
 void SimJson_ParseUiActionMessageFields() {
   const auto input = parseUiActionMessage(
-      R"({"type":"ui_action","seq":7,"action":"start_wave","fields":{"tower\/kind":"ice","note":"line\nbreak"}})");
+      R"({"type":"ui_action","seq":7,"action":"start_wave","fields":{"defender/kind":"ice","note":"line\nbreak"}})");
 
   ASSERT_TRUE(input.has_value());
   EXPECT_EQ(input->seq, 7U);
   EXPECT_EQ(input->action, "start_wave");
   ASSERT_EQ(input->fields.size(), 2U);
-  const auto tower_kind =
-      std::ranges::find(input->fields, "tower/kind", &UiActionField::key);
-  ASSERT_TRUE(tower_kind != input->fields.end());
-  EXPECT_EQ(tower_kind->value, "ice");
+  const auto defender_kind =
+      std::ranges::find(input->fields, "defender/kind", &UiActionField::key);
+  ASSERT_TRUE(defender_kind != input->fields.end());
+  EXPECT_EQ(defender_kind->value, "ice");
 
   const auto note =
       std::ranges::find(input->fields, "note", &UiActionField::key);

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -205,7 +205,7 @@ void SimWorld_NextMovesInvaderAlpha() {
   EXPECT_EQ(*w.tick(), 1U);
   ASSERT_EQ(snaps.size(), 1U);
   EXPECT_EQ(snaps[0].id, invader.id());
-  EXPECT_NEAR(snaps[0].pos.x, 100.0, 1e-6);
+  EXPECT_NEAR(snaps[0].pos.x, 50.0, 1e-6);
   EXPECT_NEAR(snaps[0].pos.y, 0.0, 1e-6);
 }
 
@@ -225,7 +225,7 @@ void SimWorld_ExtractUpdatedEntitiesReportsMovedInvaderOncePerExtraction() {
 
   const auto* pos = findPosition(delta.upserts, invader.id());
   ASSERT_TRUE(pos != nullptr);
-  EXPECT_NEAR(pos->x, 100.0, 1e-6);
+  EXPECT_NEAR(pos->x, 50.0, 1e-6);
   EXPECT_NEAR(pos->y, 0.0, 1e-6);
 
   const auto empty_delta = extractWorldDelta(w);
@@ -261,7 +261,7 @@ void SimWorld_TowerInRangeFlashesItselfAndInvader() {
   ASSERT_TRUE(invader_it != delta.upserts.end());
   EXPECT_EQ(invader_it->fx.flashColor, 0xFF7F7FFFU);
   EXPECT_EQ(invader_it->fx.flashExpiry, WorldTick{6});
-  EXPECT_NEAR(invader_it->pos.x, 100.0, 1e-6);
+  EXPECT_NEAR(invader_it->pos.x, 50.0, 1e-6);
 }
 
 void SimWorld_SnapshotSinceTracksChanges() {
@@ -407,7 +407,7 @@ void SimWorld_EnemyAdvancesOnTick() {
   const auto delta = extractWorldDelta(w);
   EXPECT_TRUE(containsId(delta.upserts, enemy.id()));
   ASSERT_EQ(delta.upserts.size(), 1U);
-  EXPECT_NEAR(delta.upserts[0].pos.x, 0.0, 1e-5);
+  EXPECT_NEAR(delta.upserts[0].pos.x, 50.0, 1e-5);
   EXPECT_NEAR(delta.upserts[0].pos.y, 0.0, 1e-5);
 }
 
@@ -428,8 +428,8 @@ void SimWorld_ResolveEscapeesVisitsEscapedEnemy() {
         EXPECT_EQ(id, enemy.id());
         EXPECT_NEAR(pos.x, 8.0, 1e-6);
         EXPECT_NEAR(pos.y, 0.0, 1e-6);
-        EXPECT_NEAR(pf.progress, 108.0, 1e-6);
-        EXPECT_NEAR(pf.speed, 100.0, 1e-6);
+        EXPECT_NEAR(pf.progress, 58.0, 1e-6);
+        EXPECT_NEAR(pf.speed, 50.0, 1e-6);
         return true;
       });
 

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -631,6 +631,29 @@ void SimGame_HandleUiCanvasSpawnsTowerButKeepsBuildPhase() {
   EXPECT_TRUE(after.erased.empty());
 }
 
+void SimGame_HandleUiCanvasRightClickSpawnPlacesTower() {
+  SimGame game;
+  game.loadMap();
+
+  game.handleUiCanvas(UiCanvasInput{.seq = 1,
+      .event = UiCanvasEvent::click,
+      .button = UiMouseButton::right,
+      .buttons = 2,
+      .x = 15.F,
+      .y = 25.F,
+      .canvasX = 120.F,
+      .canvasY = 210.F,
+      .command = "spawn",
+      .parameters = {"DefenderAoeBasic"}});
+
+  const auto after = extractGameDelta(game);
+  EXPECT_EQ(after.phase, std::string_view{"build"});
+  ASSERT_EQ(after.upserts.size(), 1U);
+  EXPECT_NEAR(after.upserts[0].second.x, 15.0, 1e-6);
+  EXPECT_NEAR(after.upserts[0].second.y, 25.0, 1e-6);
+  EXPECT_TRUE(after.erased.empty());
+}
+
 void SimGame_StartWaveSpawnsFirstEnemyOnFirstStep() {
   SimGame game;
   game.loadMap();
@@ -985,6 +1008,7 @@ MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_NextMovesInvaderAlpha,
     SimGame_LoadMapInitialSnapshotAndState,
     SimGame_HandleUiActionStartWaveTransitionsToWavePhase,
     SimGame_HandleUiCanvasSpawnsTowerButKeepsBuildPhase,
+    SimGame_HandleUiCanvasRightClickSpawnPlacesTower,
     SimGame_StartWaveSpawnsFirstEnemyOnFirstStep,
     SimGame_ExtractDeltaConsumesWorldUpdatesButNotState,
     SimGame_ExtractFullIncludesPathsAndState, SimJson_ParseUiCanvasMessage,

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <cstdlib>
 #include <cstddef>
 #include <string>
 #include <string_view>
@@ -31,6 +32,12 @@ using namespace corvid;
 using namespace corvid::sim;
 
 namespace {
+
+// NOLINTBEGIN(bugprone-throwing-static-initialization)
+const bool kSuppressMapEntityCsv = [] {
+  return setenv("CORVID_SUPPRESS_MAP_ENTITY_CSV", "1", 1) == 0;
+}();
+// NOLINTEND(bugprone-throwing-static-initialization)
 
 struct WorldDelta {
   struct Upsert {
@@ -938,7 +945,7 @@ void SimGame_HandleUiCanvasSpawnsShooterDefender() {
       .canvasX = 100.F,
       .canvasY = 200.F,
       .command = "spawn",
-      .parameters = {"DefenderShooterBasic"}});
+      .parameters = {"DefenderShooterPistol"}});
 
   const auto pending = extractGameDelta(game);
   EXPECT_TRUE(pending.upserts.empty());

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -284,14 +284,13 @@ spawnDefenderShooter(SimWorld& w, Position spawn_pos) {
     std::get<std::optional<DefenderStats>>(tpl) = DefenderStats{};
     std::get<std::optional<Health>>(tpl) =
         Health{.currentHealth = 80.F, .maxHealth = 80.F, .regen = 0.F};
-    std::get<std::optional<DefenderShooter>>(tpl) =
-        DefenderShooter{.bulletTemplate = DefenderBullet{.expiry =
-                WorldTick{60},
+    std::get<std::optional<DefenderShooter>>(tpl) = DefenderShooter{
+        .bulletTemplate = DefenderBullet{.expiry = WorldTick{60},
             .hitCircleRadius = 8.F,
             .speed = 200.F,
             .directDamage = 15.F,
             .projectileType = 1},
-            .fireRate = 0.033F};
+        .fireRate = 0.033F};
     (void)w.registerEntity("DefenderShooterBasic", tpl);
   }
   auto h = w.spawnEntity("DefenderShooterBasic");

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -1239,7 +1239,7 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
   EXPECT_TRUE(state.body.contains(R"("x":300.0)"));
   EXPECT_TRUE(state.body.contains(R"("radius":30.000)"));
   EXPECT_TRUE(state.body.contains(R"("vfx")"));
-  EXPECT_TRUE(state.body.contains(R"("flashExpiryMs":250)"));
+  EXPECT_TRUE(state.body.contains(R"("flashExpiryTick":5)"));
   EXPECT_TRUE(state.body.contains(R"("uiState")"));
   EXPECT_TRUE(state.body.contains(R"("spawnAllowed":true)"));
   EXPECT_FALSE(state.body.contains(R"("selectedDefender")"));
@@ -1286,7 +1286,7 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
     ASSERT_TRUE(vfx.get_number<float>("rangeRadius").has_value());
     ASSERT_TRUE(vfx.get_number<uint32_t>("range").has_value());
     ASSERT_TRUE(vfx.get_number<uint32_t>("flash").has_value());
-    ASSERT_TRUE(vfx.get_number<uint32_t>("flashExpiryMs").has_value());
+    ASSERT_TRUE(vfx.get_number<uint32_t>("flashExpiryTick").has_value());
     ++count;
   }
   EXPECT_EQ(count, 1U);
@@ -1346,17 +1346,17 @@ void SimJson_BuildWorldDeltaIncludesFlashVisualEffects() {
     const auto vfx = entry.get_object("vfx");
     ASSERT_TRUE(vfx);
     const auto flash = vfx.get_number<uint32_t>("flash");
-    const auto flash_expiry_ms = vfx.get_number<uint32_t>("flashExpiryMs");
+    const auto flash_expiry_tick = vfx.get_number<uint32_t>("flashExpiryTick");
     ASSERT_TRUE(flash.has_value());
-    ASSERT_TRUE(flash_expiry_ms.has_value());
+    ASSERT_TRUE(flash_expiry_tick.has_value());
     EXPECT_EQ(*flash, 0xFF7F7FFFU);
-    EXPECT_EQ(*flash_expiry_ms, 200U);
+    EXPECT_EQ(*flash_expiry_tick, 5U);
     ++count;
   }
   EXPECT_EQ(count, 1U);
 }
 
-void SimJson_FlashExpiryDelayMsUsesCurrentTickRelativeTiming() {
+void SimJson_FlashExpiryTickReturnsAbsoluteTick() {
   VisualEffects fx{
       .modified = WorldTick{12},
       .selectionColor = 0,
@@ -1366,12 +1366,10 @@ void SimJson_FlashExpiryDelayMsUsesCurrentTickRelativeTiming() {
       .flashExpiry = WorldTick{15},
   };
 
-  EXPECT_EQ(flashExpiryDelayMs(fx, WorldTick{10}), 250U);
-  EXPECT_EQ(flashExpiryDelayMs(fx, WorldTick{15}), 0U);
-  EXPECT_EQ(flashExpiryDelayMs(fx, WorldTick{16}), 0U);
+  EXPECT_EQ(flashExpiryTick(fx), 15U);
 
   fx.flashColor = 0;
-  EXPECT_EQ(flashExpiryDelayMs(fx, WorldTick{10}), 0U);
+  EXPECT_EQ(flashExpiryTick(fx), 0U);
 }
 
 void SimJson_BuildWorldSnapshotJsonShape() {
@@ -1463,6 +1461,6 @@ MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_NextMovesInvaderAlpha,
     SimJson_ParseUiActionMessageFields, SimJson_BuildHelloAckJson,
     SimJson_BuildWorldDeltaJsonShapeAndFormatting,
     SimJson_BuildWorldDeltaIncludesFlashVisualEffects,
-    SimJson_FlashExpiryDelayMsUsesCurrentTickRelativeTiming,
+    SimJson_FlashExpiryTickReturnsAbsoluteTick,
     SimJson_BuildWorldSnapshotJsonShape,
     SimGame_BuildCurrentMapEntityCsvReport)

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -51,8 +51,8 @@ struct GameDelta {
   std::vector<TransientBeam> transientBeams;
   size_t currentWave{};
   WaveTick waveTick{};
-  int lives{};
-  int resources{};
+  uint16_t lives{};
+  uint16_t resources{};
   std::string_view phase;
   std::optional<bool> placementAllowed;
   std::optional<bool> spawnAllowed;
@@ -109,6 +109,16 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
   return delta;
 }
 
+[[nodiscard]] std::vector<TransientExplosion> extractTransientExplosions(
+    SimWorld& world) {
+  std::vector<TransientExplosion> explosions;
+  (void)world.extractTransientExplosions(
+      [&explosions](const TransientExplosion& transient) {
+        explosions.push_back(transient);
+      });
+  return explosions;
+}
+
 [[nodiscard]] GameSnapshot snapshot(SimGame& game) {
   GameSnapshot snap;
   std::vector<PathJoints> pathsById;
@@ -121,8 +131,7 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
       },
       [&snap](SimWorld::EntityId id, const Position& pos, const Appearance&,
           const VisualEffects&) { snap.entities.push_back({id, pos}); },
-      [](SimWorld::EntityId) {},
-      [](const TransientExplosion&) {},
+      [](SimWorld::EntityId) {}, [](const TransientExplosion&) {},
       [](const TransientBeam&) {},
       [](size_t, WaveTick, int, int, std::string_view, const UiState&) {});
 
@@ -337,6 +346,33 @@ void SimWorld_DefenderInRangeFlashesItselfAndInvader() {
   EXPECT_EQ(invader_it->fx.flashColor, 0xFF7F7FFFU);
   EXPECT_EQ(invader_it->fx.flashExpiry, WorldTick{6});
   EXPECT_NEAR(invader_it->pos.x, 50.0, 1e-6);
+}
+
+void SimWorld_DefenderAoeAttackEmitsPulseExplosion() {
+  SimWorld w;
+  PathJoints p;
+  p.joints = {{{0.F, 0.F}}, {{500.F, 0.F}}};
+  const auto pid = w.addPath(p);
+  const auto defender = spawnDefenderAoe(w, {0.F, 0.F});
+  (void)spawnInvaderAlpha(w, pid);
+
+  (void)extractWorldDelta(w);
+  (void)w.tick();
+  (void)w.next();
+
+  const auto explosions = extractTransientExplosions(w);
+  ASSERT_EQ(explosions.size(), 1U);
+  EXPECT_NEAR(explosions[0].x, 0.0, 1e-6);
+  EXPECT_NEAR(explosions[0].y, 0.0, 1e-6);
+  EXPECT_EQ(explosions[0].expiry, WorldTick{2});
+  EXPECT_EQ(explosions[0].primaryColor, 0xFFFF0030U);
+  EXPECT_EQ(explosions[0].secondaryColor, 0xFFFF0010U);
+  EXPECT_NEAR(explosions[0].radius, 100.0, 1e-6);
+
+  const auto drained = extractTransientExplosions(w);
+  EXPECT_TRUE(drained.empty());
+
+  EXPECT_TRUE(w.try_get_component<Position>(defender.id()) != nullptr);
 }
 
 void SimWorld_SnapshotSinceTracksChanges() {
@@ -860,8 +896,7 @@ void SimGame_ExtractFullIncludesPathsAndState() {
       [&upserts](SimWorld::EntityId, const Position&, const Appearance&,
           const VisualEffects&) { ++upserts; },
       [&erased](SimWorld::EntityId) { ++erased; },
-      [](const TransientExplosion&) {},
-      [](const TransientBeam&) {},
+      [](const TransientExplosion&) {}, [](const TransientBeam&) {},
       [&currentWave, &waveTick, &lives, &resources, &phase,
           &uiState](size_t wave, WaveTick tick, int newLives, int newResources,
           std::string_view newPhase, const UiState& newUiState) {
@@ -1145,6 +1180,7 @@ void SimJson_BuildWorldSnapshotJsonShape() {
 MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_NextMovesInvaderAlpha,
     SimWorld_ExtractUpdatedEntitiesReportsMovedInvaderOncePerExtraction,
     SimWorld_DefenderInRangeFlashesItselfAndInvader,
+    SimWorld_DefenderAoeAttackEmitsPulseExplosion,
     SimWorld_SnapshotSinceTracksChanges,
     SimWorld_DefenderDoesNotAppearAsChangedAfterTick, BakePath_TwoJoints,
     BakePath_ThreeJoints, PathPosition_Endpoints, PathPosition_Midpoint,

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -162,8 +162,8 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
       [&delta](const TransientBeam& transient) {
         delta.transientBeams.push_back(transient);
       },
-      [&delta](size_t currentWave, WaveTick waveTick, int lives, int resources,
-          std::string_view phase, const UiState& uiState) {
+      [&delta](size_t currentWave, WaveTick waveTick, uint16_t lives,
+          uint16_t resources, std::string_view phase, const UiState& uiState) {
         delta.currentWave = currentWave;
         delta.waveTick = waveTick;
         delta.lives = lives;
@@ -1068,7 +1068,7 @@ void SimGame_ReachesGameOverAsSoonAsLivesAreExhausted() {
   (void)game.start_wave();
 
   bool sawZeroLives = false;
-  for (int i = 0; i < 2000; ++i) {
+  for (uint16_t i = 0; i < 2000; ++i) {
     (void)game.next();
     const auto delta = extractGameDelta(game);
     if (delta.lives <= 0) {
@@ -1126,8 +1126,8 @@ void SimGame_ExtractFullIncludesPathsAndState() {
   size_t erased = 0;
   size_t currentWave = 99;
   WaveTick waveTick{99};
-  int lives = -1;
-  int resources = -1;
+  uint16_t lives = -1;
+  uint16_t resources = -1;
   std::string_view phase = "unknown";
   UiState uiState;
 
@@ -1137,8 +1137,8 @@ void SimGame_ExtractFullIncludesPathsAndState() {
           const VisualEffects&, const Health&) { ++upserts; },
       [&erased](SimWorld::EntityId) { ++erased; },
       [](const TransientExplosion&) {}, [](const TransientBeam&) {},
-      [&currentWave, &waveTick, &lives, &resources, &phase,
-          &uiState](size_t wave, WaveTick tick, int newLives, int newResources,
+      [&currentWave, &waveTick, &lives, &resources, &phase, &uiState](
+          size_t wave, WaveTick tick, uint16_t newLives, uint16_t newResources,
           std::string_view newPhase, const UiState& newUiState) {
         currentWave = wave;
         waveTick = tick;

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -409,16 +409,6 @@ void BakePath_ThreeJoints() {
   EXPECT_NEAR(bp.totalLength, 10.0, 1e-6);
 }
 
-void BakePath_Degenerate() {
-  PathJoints p;
-  p.joints = {{{0.F, 0.F}}};
-
-  const auto bp = SegmentedPath::fromJoints(p);
-
-  EXPECT_TRUE(bp.segments.empty());
-  EXPECT_NEAR(bp.totalLength, 0.0, 1e-6);
-}
-
 void PathPosition_Endpoints() {
   PathJoints p;
   p.joints = {{{0.F, 0.F}}, {{10.F, 0.F}}};
@@ -573,13 +563,6 @@ void SimWorld_ObtainPathIncludesTerminalJoint() {
   EXPECT_NEAR(points[2].y, 5.0, 1e-6);
 }
 
-void SimWorld_FromJointsThrowsWhenJointIsOutOfBounds() {
-  PathJoints p;
-  p.joints = {{{0.F, 0.F}}, {{(SimWorld::widthOfWorld / 2.F) + 1.F, 0.F}}};
-
-  EXPECT_THROW(SegmentedPath::fromJoints(p), std::runtime_error);
-}
-
 void SimGame_LoadMapInitialSnapshotAndState() {
   SimGame game;
   (void)game.loadMap();
@@ -595,7 +578,7 @@ void SimGame_LoadMapInitialSnapshotAndState() {
   EXPECT_EQ(delta.currentWave, 0U);
   EXPECT_EQ(delta.waveTick, WaveTick{});
   EXPECT_EQ(delta.lives, 20);
-  EXPECT_EQ(delta.resources, 100);
+  EXPECT_EQ(delta.resources, 1000);
   EXPECT_EQ(delta.phase, std::string_view{"build"});
   EXPECT_TRUE(delta.upserts.empty());
   EXPECT_TRUE(delta.erased.empty());
@@ -815,7 +798,7 @@ void SimGame_StartWaveSpawnsFirstEnemyOnFirstStep() {
   EXPECT_EQ(delta.currentWave, 0U);
   EXPECT_EQ(delta.waveTick, WaveTick{1});
   EXPECT_EQ(delta.lives, 20);
-  EXPECT_EQ(delta.resources, 100);
+  EXPECT_EQ(delta.resources, 1000);
   EXPECT_EQ(delta.phase, std::string_view{"wave"});
   EXPECT_TRUE(delta.upserts.empty());
   EXPECT_TRUE(delta.erased.empty());
@@ -884,7 +867,7 @@ void SimGame_ExtractFullIncludesPathsAndState() {
   EXPECT_EQ(currentWave, 0U);
   EXPECT_EQ(waveTick, WaveTick{0});
   EXPECT_EQ(lives, 20);
-  EXPECT_EQ(resources, 100);
+  EXPECT_EQ(resources, 1000);
   EXPECT_EQ(phase, std::string_view{"build"});
   EXPECT_FALSE(uiState.selectedDefender.has_value());
 }
@@ -1152,12 +1135,11 @@ MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_NextMovesInvaderAlpha,
     SimWorld_DefenderInRangeFlashesItselfAndInvader,
     SimWorld_SnapshotSinceTracksChanges,
     SimWorld_DefenderDoesNotAppearAsChangedAfterTick, BakePath_TwoJoints,
-    BakePath_ThreeJoints, BakePath_Degenerate, PathPosition_Endpoints,
-    PathPosition_Midpoint, PathPosition_CrossingSegmentBoundaryEmitsJoint,
+    BakePath_ThreeJoints, PathPosition_Endpoints, PathPosition_Midpoint,
+    PathPosition_CrossingSegmentBoundaryEmitsJoint,
     SimWorld_EnemyAdvancesOnTick, SimWorld_ResolveEscapeesVisitsEscapedEnemy,
     SimWorld_ResolveEscapeesCanLeaveEnemyAlive, SimWorld_GetPathOutOfRange,
     SimWorld_ObtainPathIncludesTerminalJoint,
-    SimWorld_FromJointsThrowsWhenJointIsOutOfBounds,
     SimGame_LoadMapInitialSnapshotAndState,
     SimGame_HandleUiActionStartWaveTransitionsToWavePhase,
     SimGame_HandleUiCanvasSpawnsDefenderButKeepsBuildPhase,

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -1055,6 +1055,61 @@ void SimGame_ExtractDeltaConsumesWorldUpdatesButNotState() {
   EXPECT_EQ(empty_world_delta.phase, std::string_view{"wave"});
 }
 
+void SimGame_ReachesGameOverAsSoonAsLivesAreExhausted() {
+  SimGame game;
+  (void)game.loadMap();
+  (void)game.start_wave();
+
+  bool sawZeroLives = false;
+  for (int i = 0; i < 2000; ++i) {
+    (void)game.next();
+    const auto delta = extractGameDelta(game);
+    if (delta.lives <= 0) {
+      sawZeroLives = true;
+      EXPECT_EQ(delta.phase, std::string_view{"game_over"});
+      break;
+    }
+    (void)game.tick();
+  }
+
+  EXPECT_TRUE(sawZeroLives);
+}
+
+void SimGame_GameOverFreezesRemainingInvaders() {
+  SimGame game;
+  (void)game.loadMap();
+  (void)game.start_wave();
+
+  GameDelta terminalDelta;
+  GameSnapshot terminalSnapshot;
+  bool reachedGameOver = false;
+  for (int i = 0; i < 2000; ++i) {
+    (void)game.next();
+    terminalDelta = extractGameDelta(game);
+    if (terminalDelta.phase == std::string_view{"game_over"}) {
+      terminalSnapshot = snapshot(game);
+      reachedGameOver = true;
+      break;
+    }
+    (void)game.tick();
+  }
+
+  ASSERT_TRUE(reachedGameOver);
+
+  (void)game.tick();
+  (void)game.next();
+
+  const auto afterSnapshot = snapshot(game);
+  ASSERT_EQ(afterSnapshot.entities.size(), terminalSnapshot.entities.size());
+  for (size_t i = 0; i < terminalSnapshot.entities.size(); ++i) {
+    EXPECT_EQ(afterSnapshot.entities[i].id, terminalSnapshot.entities[i].id);
+    EXPECT_NEAR(afterSnapshot.entities[i].pos.x,
+        terminalSnapshot.entities[i].pos.x, 1e-6);
+    EXPECT_NEAR(afterSnapshot.entities[i].pos.y,
+        terminalSnapshot.entities[i].pos.y, 1e-6);
+  }
+}
+
 void SimGame_ExtractFullIncludesPathsAndState() {
   SimGame game;
   (void)game.loadMap();
@@ -1379,6 +1434,8 @@ MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_NextMovesInvaderAlpha,
     SimGame_HandleUiCanvasRejectsBlockedDefenderSpawnOnNextTick,
     SimGame_StartWaveSpawnsFirstEnemyOnFirstStep,
     SimGame_ExtractDeltaConsumesWorldUpdatesButNotState,
+    SimGame_ReachesGameOverAsSoonAsLivesAreExhausted,
+    SimGame_GameOverFreezesRemainingInvaders,
     SimGame_ExtractFullIncludesPathsAndState, SimJson_ParseUiCanvasMessage,
     SimJson_ParseUiActionMessageFields, SimJson_BuildHelloAckJson,
     SimJson_BuildWorldDeltaJsonShapeAndFormatting,

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -47,6 +47,8 @@ struct WorldDelta {
 struct GameDelta {
   std::vector<std::pair<SimWorld::EntityId, Position>> upserts;
   std::vector<SimWorld::EntityId> erased;
+  std::vector<TransientExplosion> transientExplosions;
+  std::vector<TransientBeam> transientBeams;
   size_t currentWave{};
   WaveTick waveTick{};
   int lives{};
@@ -120,6 +122,8 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
       [&snap](SimWorld::EntityId id, const Position& pos, const Appearance&,
           const VisualEffects&) { snap.entities.push_back({id, pos}); },
       [](SimWorld::EntityId) {},
+      [](const TransientExplosion&) {},
+      [](const TransientBeam&) {},
       [](size_t, WaveTick, int, int, std::string_view, const UiState&) {});
 
   snap.path_points = std::move(pathsById);
@@ -132,6 +136,12 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
       [&delta](SimWorld::EntityId id, const Position& pos, const Appearance&,
           const VisualEffects&) { delta.upserts.emplace_back(id, pos); },
       [&delta](SimWorld::EntityId id) { delta.erased.push_back(id); },
+      [&delta](const TransientExplosion& transient) {
+        delta.transientExplosions.push_back(transient);
+      },
+      [&delta](const TransientBeam& transient) {
+        delta.transientBeams.push_back(transient);
+      },
       [&delta](size_t currentWave, WaveTick waveTick, int lives, int resources,
           std::string_view phase, const UiState& uiState) {
         delta.currentWave = currentWave;
@@ -850,6 +860,8 @@ void SimGame_ExtractFullIncludesPathsAndState() {
       [&upserts](SimWorld::EntityId, const Position&, const Appearance&,
           const VisualEffects&) { ++upserts; },
       [&erased](SimWorld::EntityId) { ++erased; },
+      [](const TransientExplosion&) {},
+      [](const TransientBeam&) {},
       [&currentWave, &waveTick, &lives, &resources, &phase,
           &uiState](size_t wave, WaveTick tick, int newLives, int newResources,
           std::string_view newPhase, const UiState& newUiState) {

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -101,9 +101,9 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
 [[nodiscard]] WorldDelta extractWorldDelta(SimWorld& world) {
   WorldDelta delta;
   (void)world.extractUpdatedEntities(
-      [&delta](SimWorld::EntityId id, const Position& pos, const Appearance&,
-          const VisualEffects& fx) {
-        delta.upserts.push_back({id, pos, {}, fx});
+      [&delta](SimWorld::EntityId id, const Position& pos,
+          const Appearance& app, const VisualEffects& fx) {
+        delta.upserts.push_back({id, pos, app, fx});
       },
       [&delta](SimWorld::EntityId id) { delta.erased.push_back(id); });
   return delta;
@@ -170,8 +170,10 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
   return std::ranges::any_of(entries, [id](const auto& entry) {
     if constexpr (requires { entry.id; })
       return entry.id == id;
-    else
+    else if constexpr (requires { entry.first; })
       return entry.first == id;
+    else
+      return entry == id;
   });
 }
 
@@ -195,20 +197,22 @@ findPosition(const auto& entries, SimWorld::EntityId id) {
 // `spawnDefenderAoe` behavior.
 [[nodiscard]] SimWorld::Handle
 spawnInvaderAlpha(SimWorld& w, PathId pid, float progress = 0.F) {
-  WorldScene::megatuple_t tpl{};
-  std::get<std::optional<Position>>(tpl) = Position{};
-  std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'\u03B1',
-      .radius = 30.F,
-      .fgColor = 0xFFFFFFFF,
-      .bgColor = 0x000000FF};
-  std::get<std::optional<VisualEffects>>(tpl) = VisualEffects{};
-  std::get<std::optional<Pathing>>(tpl) =
-      Pathing{.pathId = PathId::invalid, .progress = 0.F, .speed = 50.F};
-  std::get<std::optional<Invader>>(tpl) =
-      Invader{.hitCircleRadius = 30.F, .bounty = 10};
-  std::get<std::optional<Health>>(tpl) =
-      Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 10.F};
-  (void)w.registerEntity("InvaderAlphaBasic", tpl);
+  if (!w.findEntityTemplate("InvaderAlphaBasic")) {
+    WorldScene::megatuple_t tpl{};
+    std::get<std::optional<Position>>(tpl) = Position{};
+    std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'\u03B1',
+        .radius = 30.F,
+        .fgColor = 0xFFFFFFFF,
+        .bgColor = 0x000000FF};
+    std::get<std::optional<VisualEffects>>(tpl) = VisualEffects{};
+    std::get<std::optional<Pathing>>(tpl) =
+        Pathing{.pathId = PathId::invalid, .progress = 0.F, .speed = 50.F};
+    std::get<std::optional<Invader>>(tpl) =
+        Invader{.hitCircleRadius = 30.F, .bounty = 10};
+    std::get<std::optional<Health>>(tpl) =
+        Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 10.F};
+    (void)w.registerEntity("InvaderAlphaBasic", tpl);
+  }
   auto h = w.spawnEntity("InvaderAlphaBasic");
   if (!h) return h;
   if (auto* pat = w.try_get_component<Pathing>(h.id())) {
@@ -223,25 +227,62 @@ spawnInvaderAlpha(SimWorld& w, PathId pid, float progress = 0.F) {
 
 [[nodiscard]] SimWorld::Handle
 spawnDefenderAoe(SimWorld& w, Position spawn_pos) {
-  WorldScene::megatuple_t tpl{};
-  std::get<std::optional<Position>>(tpl) = Position{};
-  std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'A',
-      .radius = 30.F,
-      .fgColor = 0xFFFFFFFF,
-      .bgColor = 0x7F7FFFFF};
-  std::get<std::optional<VisualEffects>>(tpl) = VisualEffects{};
-  std::get<std::optional<Defender>>(tpl) = Defender{.hitCircleRadius = 30.F,
-      .attackRadius = 100.F,
-      .rangeColor = 0xFFFF0000,
-      .attackDamage = 5.F,
-      .cooldown = WorldTick{20},
-      .nextAttack = WorldTick{0}};
-  std::get<std::optional<DefenderStats>>(tpl) = DefenderStats{};
-  std::get<std::optional<Health>>(tpl) =
-      Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 0.F};
-  std::get<std::optional<DefenderAoe>>(tpl) = DefenderAoe{.damageType = 1};
-  (void)w.registerEntity("DefenderAoeBasic", tpl);
+  if (!w.findEntityTemplate("DefenderAoeBasic")) {
+    WorldScene::megatuple_t tpl{};
+    std::get<std::optional<Position>>(tpl) = Position{};
+    std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'A',
+        .radius = 30.F,
+        .fgColor = 0xFFFFFFFF,
+        .bgColor = 0x7F7FFFFF};
+    std::get<std::optional<VisualEffects>>(tpl) = VisualEffects{};
+    std::get<std::optional<Defender>>(tpl) = Defender{.hitCircleRadius = 30.F,
+        .attackRadius = 100.F,
+        .rangeColor = 0xFFFF0000,
+        .attackDamage = 5.F,
+        .cooldown = WorldTick{20},
+        .nextAttack = WorldTick{0}};
+    std::get<std::optional<DefenderStats>>(tpl) = DefenderStats{};
+    std::get<std::optional<Health>>(tpl) =
+        Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 0.F};
+    std::get<std::optional<DefenderAoe>>(tpl) = DefenderAoe{.damageType = 1};
+    (void)w.registerEntity("DefenderAoeBasic", tpl);
+  }
   auto h = w.spawnEntity("DefenderAoeBasic");
+  if (!h) return h;
+  if (auto* pos = w.try_get_component<Position>(h.id())) *pos = spawn_pos;
+  return h;
+}
+
+[[nodiscard]] SimWorld::Handle
+spawnDefenderShooter(SimWorld& w, Position spawn_pos) {
+  if (!w.findEntityTemplate("DefenderShooterBasic")) {
+    WorldScene::megatuple_t tpl{};
+    std::get<std::optional<Position>>(tpl) = Position{};
+    std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'S',
+        .radius = 25.F,
+        .fgColor = 0xFFFFFFFF,
+        .bgColor = 0x7FFF7F3F,
+        .attackRadius = 150.F};
+    std::get<std::optional<VisualEffects>>(tpl) = VisualEffects{};
+    std::get<std::optional<Defender>>(tpl) = Defender{.hitCircleRadius = 25.F,
+        .attackRadius = 150.F,
+        .rangeColor = 0xFF00FF00,
+        .attackDamage = 15.F,
+        .cooldown = WorldTick{30},
+        .nextAttack = WorldTick{0}};
+    std::get<std::optional<DefenderStats>>(tpl) = DefenderStats{};
+    std::get<std::optional<Health>>(tpl) =
+        Health{.currentHealth = 80.F, .maxHealth = 80.F, .regen = 0.F};
+    std::get<std::optional<DefenderShooter>>(tpl) = DefenderShooter{
+        .bulletTemplate = DefenderBullet{.hitCircleRadius = 8.F,
+            .speed = 200.F,
+            .directDamage = 15.F,
+            .projectileType = 1,
+            .expiry = WorldTick{60}},
+        .fireRate = 0.033F};
+    (void)w.registerEntity("DefenderShooterBasic", tpl);
+  }
+  auto h = w.spawnEntity("DefenderShooterBasic");
   if (!h) return h;
   if (auto* pos = w.try_get_component<Position>(h.id())) *pos = spawn_pos;
   return h;
@@ -373,6 +414,139 @@ void SimWorld_DefenderAoeAttackEmitsPulseExplosion() {
   EXPECT_TRUE(drained.empty());
 
   EXPECT_TRUE(w.try_get_component<Position>(defender.id()) != nullptr);
+}
+
+void SimWorld_DefenderShooterSpawnsVisibleBullet() {
+  SimWorld w;
+  PathJoints p;
+  p.joints = {{{0.F, 0.F}}, {{500.F, 0.F}}};
+  const auto pid = w.addPath(p);
+  const auto defender = spawnDefenderShooter(w, {0.F, 0.F});
+  (void)spawnInvaderAlpha(w, pid);
+
+  (void)extractWorldDelta(w);
+  (void)w.next();
+
+  const auto delta = extractWorldDelta(w);
+  ASSERT_EQ(delta.upserts.size(), 1U);
+  const auto bulletIt = std::ranges::find_if(delta.upserts,
+      [&](const WorldDelta::Upsert& upsert) {
+        return upsert.id != defender.id() && upsert.app.glyph == U'*';
+      });
+  ASSERT_TRUE(bulletIt != delta.upserts.end());
+  EXPECT_TRUE(bulletIt->app.glyph == U'*');
+  EXPECT_NEAR(bulletIt->app.radius, 8.0, 1e-6);
+  EXPECT_NEAR(bulletIt->pos.x, 0.0, 1e-6);
+  EXPECT_NEAR(bulletIt->pos.y, 0.0, 1e-6);
+}
+
+void SimWorld_DefenderShooterBulletHitsInvaderOnNextStep() {
+  SimWorld w;
+  PathJoints p;
+  p.joints = {{{0.F, 0.F}}, {{500.F, 0.F}}};
+  const auto pid = w.addPath(p);
+  const auto defender = spawnDefenderShooter(w, {0.F, 0.F});
+  const auto invader = spawnInvaderAlpha(w, pid);
+
+  (void)extractWorldDelta(w);
+  (void)w.next();
+  const auto bulletSpawnDelta = extractWorldDelta(w);
+  const auto bulletIt = std::ranges::find_if(bulletSpawnDelta.upserts,
+      [&](const WorldDelta::Upsert& upsert) {
+        return upsert.id != defender.id() && upsert.id != invader.id();
+      });
+  ASSERT_TRUE(bulletIt != bulletSpawnDelta.upserts.end());
+  const auto bulletId = bulletIt->id;
+  (void)w.tick();
+
+  (void)w.next();
+
+  const auto delta = extractWorldDelta(w);
+  EXPECT_TRUE(containsId(delta.upserts, invader.id()));
+  EXPECT_TRUE(containsId(delta.erased, bulletId));
+
+  const auto* hp = w.try_get_component<Health>(invader.id());
+  ASSERT_TRUE(hp != nullptr);
+  EXPECT_NEAR(hp->currentHealth, 85.0, 1e-6);
+
+  const auto* stats = w.try_get_component<DefenderStats>(defender.id());
+  ASSERT_TRUE(stats != nullptr);
+  EXPECT_NEAR(stats->totalDamageDealt, 15.0, 1e-6);
+
+  const auto explosions = extractTransientExplosions(w);
+  ASSERT_EQ(explosions.size(), 1U);
+  EXPECT_NEAR(explosions[0].x, 100.0, 1e-6);
+  EXPECT_NEAR(explosions[0].y, 0.0, 1e-6);
+}
+
+void SimWorld_DefenderShooterBulletHitsFirstInvaderAlongPath() {
+  SimWorld w;
+  PathJoints p;
+  p.joints = {{{0.F, 0.F}}, {{500.F, 0.F}}};
+  const auto pid = w.addPath(p);
+  const auto defender = spawnDefenderShooter(w, {0.F, 0.F});
+  const auto nearInvader = spawnInvaderAlpha(w, pid, 0.F);
+  const auto farInvader = spawnInvaderAlpha(w, pid, 100.F);
+
+  (void)extractWorldDelta(w);
+  (void)w.next();
+  (void)extractWorldDelta(w);
+  (void)w.tick();
+
+  (void)w.next();
+
+  const auto* nearHp = w.try_get_component<Health>(nearInvader.id());
+  const auto* farHp = w.try_get_component<Health>(farInvader.id());
+  ASSERT_TRUE(nearHp != nullptr);
+  ASSERT_TRUE(farHp != nullptr);
+  EXPECT_NEAR(nearHp->currentHealth, 85.0, 1e-6);
+  EXPECT_NEAR(farHp->currentHealth, 100.0, 1e-6);
+
+  const auto* stats = w.try_get_component<DefenderStats>(defender.id());
+  ASSERT_TRUE(stats != nullptr);
+  EXPECT_NEAR(stats->totalDamageDealt, 15.0, 1e-6);
+}
+
+void SimWorld_ExplosiveBulletDetonatesOnExpiry() {
+  SimWorld w;
+  PathJoints p;
+  p.joints = {{{0.F, 0.F}}, {{500.F, 0.F}}};
+  const auto pid = w.addPath(p);
+  const auto defender = spawnDefenderShooter(w, {0.F, 0.F});
+  const auto invader = spawnInvaderAlpha(w, pid, 50.F);
+  auto* shooter = w.try_get_component<DefenderShooter>(defender.id());
+  ASSERT_TRUE(shooter != nullptr);
+  shooter->bulletTemplate.splashRadius = 250.F;
+  shooter->bulletTemplate.expiry = WorldTick{1};
+
+  (void)extractWorldDelta(w);
+  (void)w.next();
+  const auto bulletSpawnDelta = extractWorldDelta(w);
+  const auto bulletIt = std::ranges::find_if(bulletSpawnDelta.upserts,
+      [&](const WorldDelta::Upsert& upsert) {
+        return upsert.id != defender.id() && upsert.id != invader.id();
+      });
+  ASSERT_TRUE(bulletIt != bulletSpawnDelta.upserts.end());
+  const auto bulletId = bulletIt->id;
+  (void)w.tick();
+  (void)w.next();
+
+  const auto delta = extractWorldDelta(w);
+  EXPECT_TRUE(containsId(delta.erased, bulletId));
+
+  const auto* hp = w.try_get_component<Health>(invader.id());
+  ASSERT_TRUE(hp != nullptr);
+  EXPECT_NEAR(hp->currentHealth, 85.0, 1e-6);
+
+  const auto* stats = w.try_get_component<DefenderStats>(defender.id());
+  ASSERT_TRUE(stats != nullptr);
+  EXPECT_NEAR(stats->totalDamageDealt, 15.0, 1e-6);
+
+  const auto explosions = extractTransientExplosions(w);
+  ASSERT_EQ(explosions.size(), 1U);
+  EXPECT_NEAR(explosions[0].x, 200.0, 1e-6);
+  EXPECT_NEAR(explosions[0].y, 0.0, 1e-6);
+  EXPECT_NEAR(explosions[0].radius, 250.0, 1e-6);
 }
 
 void SimWorld_SnapshotSinceTracksChanges() {
@@ -1181,6 +1355,10 @@ MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_NextMovesInvaderAlpha,
     SimWorld_ExtractUpdatedEntitiesReportsMovedInvaderOncePerExtraction,
     SimWorld_DefenderInRangeFlashesItselfAndInvader,
     SimWorld_DefenderAoeAttackEmitsPulseExplosion,
+    SimWorld_DefenderShooterSpawnsVisibleBullet,
+    SimWorld_DefenderShooterBulletHitsInvaderOnNextStep,
+    SimWorld_DefenderShooterBulletHitsFirstInvaderAlongPath,
+    SimWorld_ExplosiveBulletDetonatesOnExpiry,
     SimWorld_SnapshotSinceTracksChanges,
     SimWorld_DefenderDoesNotAppearAsChangedAfterTick, BakePath_TwoJoints,
     BakePath_ThreeJoints, PathPosition_Endpoints, PathPosition_Midpoint,

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -130,7 +130,9 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
         pathsById[ndx].joints.push_back({pos});
       },
       [&snap](SimWorld::EntityId id, const Position& pos, const Appearance&,
-          const VisualEffects&, const Health&) { snap.entities.push_back({id, pos}); },
+          const VisualEffects&, const Health&) {
+        snap.entities.push_back({id, pos});
+      },
       [](SimWorld::EntityId) {}, [](const TransientExplosion&) {},
       [](const TransientBeam&) {},
       [](size_t, WaveTick, int, int, std::string_view, const UiState&) {});
@@ -143,7 +145,9 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
   GameDelta delta;
   (void)game.extractDelta(
       [&delta](SimWorld::EntityId id, const Position& pos, const Appearance&,
-          const VisualEffects&, const Health&) { delta.upserts.emplace_back(id, pos); },
+          const VisualEffects&, const Health&) {
+        delta.upserts.emplace_back(id, pos);
+      },
       [&delta](SimWorld::EntityId id) { delta.erased.push_back(id); },
       [&delta](const TransientExplosion& transient) {
         delta.transientExplosions.push_back(transient);

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -75,7 +75,7 @@ struct GameSnapshot {
   (void)world.markAllDirty();
   (void)world.extractUpdatedEntities(
       [&snaps](SimWorld::EntityId id, const Position& pos, const Appearance&,
-          const VisualEffects&) {
+          const VisualEffects&, const Health&) {
         const auto it = std::ranges::find(snaps, id, &EntitySnapshot::id);
         if (it == snaps.end())
           snaps.push_back({id, pos});
@@ -102,7 +102,7 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
   WorldDelta delta;
   (void)world.extractUpdatedEntities(
       [&delta](SimWorld::EntityId id, const Position& pos,
-          const Appearance& app, const VisualEffects& fx) {
+          const Appearance& app, const VisualEffects& fx, const Health&) {
         delta.upserts.push_back({id, pos, app, fx});
       },
       [&delta](SimWorld::EntityId id) { delta.erased.push_back(id); });
@@ -130,7 +130,7 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
         pathsById[ndx].joints.push_back({pos});
       },
       [&snap](SimWorld::EntityId id, const Position& pos, const Appearance&,
-          const VisualEffects&) { snap.entities.push_back({id, pos}); },
+          const VisualEffects&, const Health&) { snap.entities.push_back({id, pos}); },
       [](SimWorld::EntityId) {}, [](const TransientExplosion&) {},
       [](const TransientBeam&) {},
       [](size_t, WaveTick, int, int, std::string_view, const UiState&) {});
@@ -143,7 +143,7 @@ filterSnapshot(const std::vector<EntitySnapshot>& all,
   GameDelta delta;
   (void)game.extractDelta(
       [&delta](SimWorld::EntityId id, const Position& pos, const Appearance&,
-          const VisualEffects&) { delta.upserts.emplace_back(id, pos); },
+          const VisualEffects&, const Health&) { delta.upserts.emplace_back(id, pos); },
       [&delta](SimWorld::EntityId id) { delta.erased.push_back(id); },
       [&delta](const TransientExplosion& transient) {
         delta.transientExplosions.push_back(transient);
@@ -1068,7 +1068,7 @@ void SimGame_ExtractFullIncludesPathsAndState() {
   (void)game.extractFull(
       [&path_points](PathId, const Position&) { ++path_points; },
       [&upserts](SimWorld::EntityId, const Position&, const Appearance&,
-          const VisualEffects&) { ++upserts; },
+          const VisualEffects&, const Health&) { ++upserts; },
       [&erased](SimWorld::EntityId) { ++erased; },
       [](const TransientExplosion&) {}, [](const TransientBeam&) {},
       [&currentWave, &waveTick, &lives, &resources, &phase,

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -284,13 +284,14 @@ spawnDefenderShooter(SimWorld& w, Position spawn_pos) {
     std::get<std::optional<DefenderStats>>(tpl) = DefenderStats{};
     std::get<std::optional<Health>>(tpl) =
         Health{.currentHealth = 80.F, .maxHealth = 80.F, .regen = 0.F};
-    std::get<std::optional<DefenderShooter>>(tpl) = DefenderShooter{
-        .bulletTemplate = DefenderBullet{.hitCircleRadius = 8.F,
+    std::get<std::optional<DefenderShooter>>(tpl) =
+        DefenderShooter{.bulletTemplate = DefenderBullet{.expiry =
+                WorldTick{60},
+            .hitCircleRadius = 8.F,
             .speed = 200.F,
             .directDamage = 15.F,
-            .projectileType = 1,
-            .expiry = WorldTick{60}},
-        .fireRate = 0.033F};
+            .projectileType = 1},
+            .fireRate = 0.033F};
     (void)w.registerEntity("DefenderShooterBasic", tpl);
   }
   auto h = w.spawnEntity("DefenderShooterBasic");
@@ -414,12 +415,12 @@ void SimWorld_DefenderAoeAttackEmitsPulseExplosion() {
 
   const auto explosions = extractTransientExplosions(w);
   ASSERT_EQ(explosions.size(), 1U);
-  EXPECT_NEAR(explosions[0].x, 0.0, 1e-6);
-  EXPECT_NEAR(explosions[0].y, 0.0, 1e-6);
+  EXPECT_NEAR(explosions[0].circle.x, 0.0, 1e-6);
+  EXPECT_NEAR(explosions[0].circle.y, 0.0, 1e-6);
   EXPECT_EQ(explosions[0].expiry, WorldTick{2});
   EXPECT_EQ(explosions[0].primaryColor, 0xFFFF0030U);
   EXPECT_EQ(explosions[0].secondaryColor, 0xFFFF0010U);
-  EXPECT_NEAR(explosions[0].radius, 100.0, 1e-6);
+  EXPECT_NEAR(explosions[0].circle.radius, 100.0, 1e-6);
 
   const auto drained = extractTransientExplosions(w);
   EXPECT_TRUE(drained.empty());
@@ -486,8 +487,8 @@ void SimWorld_DefenderShooterBulletHitsInvaderOnNextStep() {
 
   const auto explosions = extractTransientExplosions(w);
   ASSERT_EQ(explosions.size(), 1U);
-  EXPECT_NEAR(explosions[0].x, 100.0, 1e-6);
-  EXPECT_NEAR(explosions[0].y, 0.0, 1e-6);
+  EXPECT_NEAR(explosions[0].circle.x, 100.0, 1e-6);
+  EXPECT_NEAR(explosions[0].circle.y, 0.0, 1e-6);
 }
 
 void SimWorld_DefenderShooterBulletHitsFirstInvaderAlongPath() {
@@ -555,9 +556,9 @@ void SimWorld_ExplosiveBulletDetonatesOnExpiry() {
 
   const auto explosions = extractTransientExplosions(w);
   ASSERT_EQ(explosions.size(), 1U);
-  EXPECT_NEAR(explosions[0].x, 200.0, 1e-6);
-  EXPECT_NEAR(explosions[0].y, 0.0, 1e-6);
-  EXPECT_NEAR(explosions[0].radius, 250.0, 1e-6);
+  EXPECT_NEAR(explosions[0].circle.x, 200.0, 1e-6);
+  EXPECT_NEAR(explosions[0].circle.y, 0.0, 1e-6);
+  EXPECT_NEAR(explosions[0].circle.radius, 250.0, 1e-6);
 }
 
 void SimWorld_SnapshotSinceTracksChanges() {

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -34,7 +34,7 @@ using namespace corvid::sim;
 namespace {
 
 // NOLINTBEGIN(bugprone-throwing-static-initialization)
-const bool kSuppressMapEntityCsv = [] {
+[[maybe_unused]] const bool kSuppressMapEntityCsv = [] {
   return setenv("CORVID_SUPPRESS_MAP_ENTITY_CSV", "1", 1) == 0;
 }();
 // NOLINTEND(bugprone-throwing-static-initialization)

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -203,12 +203,19 @@ findPosition(const auto& entries, SimWorld::EntityId id) {
     return &it->second;
 }
 
+// Shared template store for all test helpers. Populated lazily, once per
+// label, across all test cases.
+EntityTemplateStore testStore;
+
+// Set the world's template store and ensure the world points at `testStore`.
+void ensureTestStore(SimWorld& w) { w.setEntityTemplateStore(&testStore); }
+
 // Test helpers that register the entity type on demand (idempotent) and spawn
-// with placement applied, matching the old `spawnInvaderAlpha` /
-// `spawnDefenderAoe` behavior.
+// with placement applied.
 [[nodiscard]] SimWorld::Handle
 spawnInvaderAlpha(SimWorld& w, PathId pid, float progress = 0.F) {
-  if (!w.findEntityTemplate("InvaderAlphaBasic")) {
+  ensureTestStore(w);
+  if (!testStore.templates.contains("InvaderAlphaBasic")) {
     WorldScene::megatuple_t tpl{};
     std::get<std::optional<Position>>(tpl) = Position{};
     std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'\u03B1',
@@ -222,7 +229,7 @@ spawnInvaderAlpha(SimWorld& w, PathId pid, float progress = 0.F) {
         Invader{.hitCircleRadius = 30.F, .bounty = 10};
     std::get<std::optional<Health>>(tpl) =
         Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 10.F};
-    (void)w.registerEntity("InvaderAlphaBasic", tpl);
+    (void)testStore.registerEntity("InvaderAlphaBasic", tpl);
   }
   auto h = w.spawnEntity("InvaderAlphaBasic");
   if (!h) return h;
@@ -238,7 +245,8 @@ spawnInvaderAlpha(SimWorld& w, PathId pid, float progress = 0.F) {
 
 [[nodiscard]] SimWorld::Handle
 spawnDefenderAoe(SimWorld& w, Position spawn_pos) {
-  if (!w.findEntityTemplate("DefenderAoeBasic")) {
+  ensureTestStore(w);
+  if (!testStore.templates.contains("DefenderAoeBasic")) {
     WorldScene::megatuple_t tpl{};
     std::get<std::optional<Position>>(tpl) = Position{};
     std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'A',
@@ -256,7 +264,7 @@ spawnDefenderAoe(SimWorld& w, Position spawn_pos) {
     std::get<std::optional<Health>>(tpl) =
         Health{.currentHealth = 100.F, .maxHealth = 100.F, .regen = 0.F};
     std::get<std::optional<DefenderAoe>>(tpl) = DefenderAoe{.damageType = 1};
-    (void)w.registerEntity("DefenderAoeBasic", tpl);
+    (void)testStore.registerEntity("DefenderAoeBasic", tpl);
   }
   auto h = w.spawnEntity("DefenderAoeBasic");
   if (!h) return h;
@@ -266,7 +274,8 @@ spawnDefenderAoe(SimWorld& w, Position spawn_pos) {
 
 [[nodiscard]] SimWorld::Handle
 spawnDefenderShooter(SimWorld& w, Position spawn_pos) {
-  if (!w.findEntityTemplate("DefenderShooterBasic")) {
+  ensureTestStore(w);
+  if (!testStore.templates.contains("DefenderShooterBasic")) {
     WorldScene::megatuple_t tpl{};
     std::get<std::optional<Position>>(tpl) = Position{};
     std::get<std::optional<Appearance>>(tpl) = Appearance{.glyph = U'S',
@@ -291,7 +300,7 @@ spawnDefenderShooter(SimWorld& w, Position spawn_pos) {
             .directDamage = 15.F,
             .projectileType = 1},
         .fireRate = 0.033F};
-    (void)w.registerEntity("DefenderShooterBasic", tpl);
+    (void)testStore.registerEntity("DefenderShooterBasic", tpl);
   }
   auto h = w.spawnEntity("DefenderShooterBasic");
   if (!h) return h;
@@ -1253,13 +1262,10 @@ void SimJson_BuildWorldDeltaJsonShapeAndFormatting() {
   const auto obj = root.as_object();
   ASSERT_TRUE(obj);
   const auto tick_value = obj.get_number<uint32_t>("tick");
-  const auto wave_tick_value = obj.get_number<uint32_t>("waveTick");
   const auto phase_value = obj.get_string_view_if_plain("phase");
   ASSERT_TRUE(tick_value.has_value());
-  ASSERT_TRUE(wave_tick_value.has_value());
   ASSERT_TRUE(phase_value.has_value());
   EXPECT_EQ(*tick_value, 0U);
-  EXPECT_EQ(*wave_tick_value, 0U);
   EXPECT_EQ(*phase_value, std::string_view{"build"});
 
   const auto upserts = obj.get_array("upserts");

--- a/tests/sim_world_test.cpp
+++ b/tests/sim_world_test.cpp
@@ -1408,6 +1408,22 @@ void SimJson_BuildWorldSnapshotJsonShape() {
   EXPECT_EQ(*delta_phase, std::string_view{"build"});
 }
 
+void SimGame_BuildCurrentMapEntityCsvReport() {
+  SimGame game;
+  ASSERT_TRUE(game.loadMap());
+
+  const auto csv = game.buildCurrentMapEntityCsvReport();
+  EXPECT_TRUE(
+      csv.contains("entityName,Radius,Speed,Radius,Health,Regen,Bounty\n"));
+  EXPECT_TRUE(csv.contains("InvaderAlphaBasic,30,50,30,50,10,10\n"));
+  EXPECT_TRUE(csv.contains("InvaderBetaBasic,40,30,40,120,12,25\n"));
+  EXPECT_TRUE(csv.contains(
+      "\nentityName,resourceCost,radius,attackRadius,"
+      "attackDamage,cooldown\n"));
+  EXPECT_TRUE(csv.contains("DefenderAoeBasic,50,30,100,6,20\n"));
+  EXPECT_TRUE(csv.contains("DefenderHitscanBasic,100,25,200,30,25\n"));
+}
+
 // NOLINTEND(readability-function-cognitive-complexity)
 
 MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_NextMovesInvaderAlpha,
@@ -1441,4 +1457,5 @@ MAKE_TEST_LIST(SimWorld_SpawnAndSnapshot, SimWorld_NextMovesInvaderAlpha,
     SimJson_BuildWorldDeltaJsonShapeAndFormatting,
     SimJson_BuildWorldDeltaIncludesFlashVisualEffects,
     SimJson_FlashExpiryDelayMsUsesCurrentTickRelativeTiming,
-    SimJson_BuildWorldSnapshotJsonShape)
+    SimJson_BuildWorldSnapshotJsonShape,
+    SimGame_BuildCurrentMapEntityCsvReport)


### PR DESCRIPTION
## Summary

This PR significantly advances the CorvidSim tower-defense prototype across the
full stack: server-side world logic, the game/UI layer, the JSON wire protocol,
the TypeScript client, and ECS infrastructure.

### World simulation (`sim_world.h`)

- Added `TargetMode` enum (`first`, `last`, `closest`, `strongest`, `weakest`)
  with a registered sequence-enum spec for serialization.
- Introduced `SimWorldBounds` -- a shared base struct that centralizes the fixed
  world extents (1920x1080, centered at the origin), bounds checks, and the
  `bounceFromBoundary` helper.
- `SegmentedPath` now inherits `SimWorldBounds` and stores a pre-computed
  `angle` per segment; extracted `segmentAtProgress` helper and added
  `angleAtProgress` to expose facing direction to callers.
- Added ECS components: `Pathing`, `Health`, `TransientExplosion`,
  `TransientBeam`, `Defender`, `DefenderStats`, `DefenderAoe`,
  `DefenderHitscan`, `DefenderBullet`, `DefenderShooter`, `Invader`.
- `SimWorld` now inherits `SimWorldBounds` and hosts the new components, a
  targeting system, fire-and-forget transient queues (beams and explosions),
  and a pending-kills list.
- Renamed terminology from "enemy/tower" to "invader/defender" throughout.

### Game and UI layer (`sim_game.h`)

- Added `CategoryDefinition`, `EntityDefinition`, `DefenderSummary`,
  `MapDesign`, and `UiState` structs to represent design-time data, runtime
  selection state, and UI interaction intent.
- `SimGame` now loads maps from disk, drives wave spawning, handles
  placement/relocation/selection intents from the client, streams delta and
  full-snapshot callbacks (positions, appearances, health, VFX, transients,
  game-state metadata), and builds a CSV dump of the current map's entity
  definitions for debugging.
- Added `UiMouseButton` enum with registered spec.

### Wire protocol (`sim_json_wire.h`, `sim_json_parse.h`)

- Expanded `WorldDelta` / `WorldSnapshot` JSON to include `EntityHealth`,
  `TransientExplosion`, `TransientBeam`, and a `SimGameStateJson` struct
  carrying wave number, lives, resources, phase, and `UiState`.
- Client messages now carry an optional `command` string and `parameters`
  array to support cheat/debug commands from the browser console.
- `EntityAppearance` wire struct gained `attackRadius` and optional
  `trailColor`; `EntityVisualEffects` gained cooldown fields.

### Map data (`maps/map1.json`)

- Added the first complete map definition: categories, entity definitions for
  two invader types and four defender types, two wave definitions, and a
  multi-segment path.

### TypeScript client (`web/src/main.ts`, `types.ts`)

- Added `Position`, `EntityHealth`, `TransientExplosion`, `TransientBeam` to
  the shared type definitions; extended `EntityAppearance` and
  `EntityVisualEffects` with the new fields.
- Full rendering pipeline rewrite:
  - Multi-canvas compositing (background path layer, world layer, HUD, FPS
    overlay) with independent redraw cadences.
  - Snapshot interpolation between the previous and current server tick to
    smooth entity motion.
  - Sprite memoization (offscreen bitmaps keyed by appearance) cleared on
    resize.
  - Placement ghost with drag-to-position and live validity feedback.
  - Slide-in overlay panel with pinning logic for the placement/selection UI,
    adapting to which screen edge the mouse is near.
  - Defender summary panel (cost, range, damage, targeting mode) populated
    from server-streamed data.
  - Transient rendering: timed explosions and beam/cone effects drawn per
    frame with expiry-based alpha decay.
  - Viewport scaling that maintains the 1920x1080 aspect ratio inside the
    available browser area, with fullscreen support.

### ECS infrastructure (`ecs_meta.h`, `archetype_scene.h`, `archetype_storage.h`)

- Added compile-time TMP utilities: `tuple_union_t` (deduplicated union of
  component-type tuples), `tuple_index_v` (index of a type in a tuple),
  `wrap_optionals_t` (wraps each element in `std::optional`).
- `ArchetypeScene` now exposes `megatuple_t` (one `optional<C>` per unique
  component type across all archetypes), `bitmap_t`, and a compile-time
  `bitmap_table_v`; `store_new_entity_from_mega` allows runtime archetype
  dispatch by matching the set of present optionals to a stored bitmap.
- Extended `archetype_storage` with `add_new_from_mega`.
- Expanded performance documentation on `try_get_component` and
  `try_get_components`.

### Tests (`sim_world_test.cpp`, `ecs_test.cpp`)

- `sim_world_test.cpp`: substantially extended to cover wave lifecycle,
  invader/defender spawning via `SimGame`, JSON delta/snapshot streaming,
  VFX fields, CSV dump format, placement validation, selection, and
  game-over detection.
- `ecs_test.cpp`: new tests for `megatuple_t`, `bitmap_t`, and
  `store_new_entity_from_mega`.

### Minor fixes and polish

- `timing_wheel.h`: minor corrections.
- `bitmask_enum.h`, `bool_enums.h`, `sequence_enum.h`: small fixes.
- `http_server.h`, `json_parser.h`: minor improvements.
- `corvid_sim_main.h`, `sim_ws_handler.h`: wired up new game-state streaming.
- Renamed `PathJoints::Joint::p` to `pos` for clarity.
- Marked `Position::fromPolar` `[[nodiscard]]`.

## Test plan

- [x] `./cleanbuild.sh sim_world_test.cpp` passes
- [x] `./cleanbuild.sh ecs_test.cpp` passes
- [x] Full `./cleanbuild.sh` passes
- [x] Start the sim server and open `index.html` in a browser; verify map
      loads, invaders walk the path, defenders can be placed and attack, and
      the overlay panel shows defender details

🤖 Generated with [Claude Code](https://claude.com/claude-code)