### PR TITLE
Reusable std::formatter bases + full enum spec parsing, with a pragma-region organization pass

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -133,6 +133,9 @@
     "lldb.dereferencePointers": true,
     "lldb.consoleMode": "commands",
     "cmake.ignoreCMakeListsMissing": true,
+    "files.exclude": {
+        "**/tests/.local/**": true
+    },
     "files.watcherExclude": {
         "**/.git/**": true,
         "**/build/**": true,
@@ -145,6 +148,7 @@
     },
     "search.exclude": {
         "**/build/**": true,
-        "**/out/**": true
+        "**/out/**": true,
+        "**/tests/.local/**": true
     }
 }

--- a/cleanbuild.sh
+++ b/cleanbuild.sh
@@ -9,17 +9,20 @@ set -e
 # tied to this checkout. IDE clangd won't resolve those headers correctly
 # until this script (or a bare `cmake -S tests -B tests/build`) has run once.
 
-# Choose which standard library to use. Optionally pass a test source filename
-# first to build and run a matching unit test, then pass "libstdcpp" or
-# "libcxx" to override the default. Add "tidy" to run clang-tidy during the
+# Choose the compiler and standard library. Optionally pass a test source
+# filename first to build and run a matching unit test, then pass "clang"
+# (default) or "gcc" to pick the compiler. The standard library defaults to
+# match the compiler (clang -> libc++, gcc -> libstdc++); pass "libstdcpp" or
+# "libcxx" to override, except gcc + libc++ is rejected because the libc++ path
+# is clang-only. Add "tidy" to run clang-tidy during the
 # build. Add a sanitizer mode ("asan" [which includes ubsan], "tsan", "ubsan",
 # or "msan") to instrument the build with the corresponding LLVM sanitizer.
 # Add "coverage" to build with source-based coverage instrumentation and run
 # llvm-profdata/llvm-cov after tests pass; mutually exclusive with sanitizers
 # and tidy. Add "scan" to skip the build and run the Clang Static Analyzer
 # (`analyze-build`) against the compile_commands.json instead; mutually
-# exclusive with everything else. The default is `libcxx`, no tidy, no
-# sanitizer, no coverage, no scan.
+# exclusive with everything else. The default is clang with `libcxx`, no tidy,
+# no sanitizer, no coverage, no scan.
 #
 # This script builds and runs one configuration at a time. To exercise every
 # configuration (plain, asan, tsan, msan, tidy) in sequence, pass "all":
@@ -31,6 +34,7 @@ set -e
 # the run exits non-zero if any config fails configure, build, or test.
 
 choice=""
+compiler=""
 use_tidy=false
 sanitizer=""
 use_coverage=false
@@ -38,7 +42,7 @@ use_scan=false
 test_name=""
 target_name=""
 
-usage="Usage: $0 [all | [testname.cpp] [libstdcpp|libcxx] [tidy] [asan|tsan|ubsan|msan] [coverage] [scan]]"
+usage="Usage: $0 [all | [testname.cpp] [clang|gcc] [libstdcpp|libcxx] [tidy] [asan|tsan|ubsan|msan] [coverage] [scan]]"
 
 # Enforce the core/utils band layering before any build (fast, static, and
 # build-independent). See corvid/deps.md.
@@ -76,6 +80,7 @@ if [[ "${1:-}" == "all" ]]; then
 fi
 
 if [[ $# -gt 0 && "$1" != "libstdcpp" && "$1" != "libcxx" \
+      && "$1" != "clang" && "$1" != "gcc" \
       && "$1" != "tidy" && "$1" != "--tidy" \
       && "$1" != "asan" && "$1" != "tsan" && "$1" != "ubsan" \
       && "$1" != "msan" && "$1" != "coverage" && "$1" != "scan" ]]; then
@@ -93,6 +98,9 @@ for arg in "$@"; do
   case "$arg" in
     libstdcpp|libcxx)
       choice="$arg"
+      ;;
+    clang|gcc)
+      compiler="$arg"
       ;;
     tidy|--tidy)
       use_tidy=true
@@ -138,17 +146,41 @@ if $use_scan; then
   fi
 fi
 
+# Default the compiler to clang; gcc is opt-in.
+if [[ -z "$compiler" ]]; then
+  compiler="clang"
+fi
+
+# The standard library defaults to match the compiler: clang pairs with
+# libc++, gcc with libstdc++. An explicit libstdcpp/libcxx arg overrides this.
 if [[ -z "$choice" ]]; then
-  choice="libcxx"
+  if [[ "$compiler" == "gcc" ]]; then
+    choice="libstdcpp"
+  else
+    choice="libcxx"
+  fi
+fi
+
+# The libc++ path below is clang-only (it hardcodes -nostdinc++, the libc++
+# include prefix, compiler-rt, and lld), so gcc + libc++ cannot work here.
+if [[ "$compiler" == "gcc" && "$choice" == "libcxx" ]]; then
+  echo "$0: gcc cannot build against libc++; use 'gcc libstdcpp'" >&2
+  exit 1
 fi
 
 if [[ "$choice" == "libstdcpp" ]]; then
-  echo "Using libstdc++"
-  export CC="$(command -v clang)"
-  export CXX="$(command -v clang++)"
   LIBSTD_OPTION="-DUSE_LIBSTDCPP=ON"
+  if [[ "$compiler" == "gcc" ]]; then
+    echo "Using gcc with libstdc++"
+    export CC="$(command -v gcc)"
+    export CXX="$(command -v g++)"
+  else
+    echo "Using clang with libstdc++"
+    export CC="$(command -v clang)"
+    export CXX="$(command -v clang++)"
+  fi
 else
-  echo "Using libc++"
+  echo "Using clang with libc++"
   export CC="/usr/bin/clang-22"
   export CXX="/usr/bin/clang++-22"
   LIBSTD_OPTION="-DUSE_LIBSTDCPP=OFF"
@@ -206,7 +238,7 @@ fi
 rm -rf "$buildRoot"
 mkdir -p "$buildRoot" "$buildDir"
 
-# Run cmake to configure the project with Ninja (or MinGW Makefiles) and clang
+# Run cmake to configure the project with Ninja and the selected compiler
 cmake -S tests -B "$buildRoot" -G "Ninja" $LIBSTD_OPTION $TIDY_OPTION $TEST_NAME_OPTION $SAN_OPTION $COV_OPTION
 
 # Scan mode: hand the compile database to the Clang Static Analyzer and

--- a/corvid/concurrency/jthread_stoppable_sleep.h
+++ b/corvid/concurrency/jthread_stoppable_sleep.h
@@ -27,6 +27,8 @@
 
 namespace corvid { inline namespace concurrency {
 
+#pragma region jthread_stoppable_sleep
+
 // Interruptible deadline sleep for use with `std::jthread`.
 //
 // Wraps the workaround needed because libc++ does not yet implement the
@@ -49,6 +51,8 @@ namespace corvid { inline namespace concurrency {
 //
 class jthread_stoppable_sleep {
 public:
+#pragma region Operations
+
   // Sleep until `deadline`. Returns true if a stop was requested before the
   // deadline, false if the deadline elapsed normally.
   template<typename Clock, typename Duration>
@@ -71,8 +75,14 @@ public:
     (void)::pthread_setname_np(::pthread_self(), label.c_str());
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   std::mutex mutex_;
   std::condition_variable cv_;
+
+#pragma endregion
 };
+
+#pragma endregion
 }} // namespace corvid::concurrency

--- a/corvid/concurrency/notifiable.h
+++ b/corvid/concurrency/notifiable.h
@@ -29,6 +29,8 @@
 namespace corvid { inline namespace concurrency {
 inline namespace notifiable_ns {
 
+#pragma region details
+
 namespace details {
 // Detects a `relaxed_atomic<U>`, or any type that opts in by defining
 // `is_relaxed_atomic = std::true_type` and `value_type`. Does not require
@@ -64,6 +66,9 @@ template<typename T>
 concept atomic_like =
     is_specialization_of_v<T, std::atomic> || relaxed_atomic_like<T>;
 } // namespace details
+
+#pragma endregion
+#pragma region notifiable
 
 // A value of type `T` guarded by a mutex and condition variable.
 //
@@ -113,6 +118,8 @@ concept atomic_like =
 template<typename T>
 class notifiable {
 public:
+#pragma region Construction
+
   // Return type of `wait_until` / `wait_until_changed` / `wait_for` /
   // `wait_for_changed`, and parameter type of `notify` / `notify_one`.
   // For non-atomic `T` this is `T` itself; for `std::atomic<U>` it is `U`,
@@ -128,6 +135,9 @@ public:
 
   notifiable(const notifiable&) = delete;
   notifiable& operator=(const notifiable&) = delete;
+
+#pragma endregion
+#pragma region Notification
 
   // Set value to `val` under lock, then wake all waiters.
   //
@@ -174,6 +184,9 @@ public:
     modify_value(value_);
   }
 
+#pragma endregion
+#pragma region Reading
+
   // Return a snapshot of the current value under lock.
   [[nodiscard]] T get() const
   requires(!details::atomic_like<T>)
@@ -194,6 +207,9 @@ public:
     else
       return value_->load(order);
   }
+
+#pragma endregion
+#pragma region Waiting
 
   // Block until `pred(value)` returns true; return the value at that point.
   template<std::predicate<const T&> Pred>
@@ -240,6 +256,9 @@ public:
     cv_.wait(lock, [&] { return do_load() != expected_old; });
     return do_load();
   }
+
+#pragma endregion
+#pragma region Timed waiting
 
   // Block until `pred(value)` returns true or `timeout` elapses.
   //
@@ -296,6 +315,9 @@ public:
     return std::nullopt;
   }
 
+#pragma endregion
+#pragma region Helpers
+
   // Read a `T` as a `value_t`. For `std::atomic<U>` or `relaxed_atomic<U>`,
   // uses a `relaxed` load rather than the implicit conversion operator (which
   // would be `seq_cst` for `std::atomic`). This is correct when called inside
@@ -310,9 +332,15 @@ public:
 private:
   [[nodiscard]] value_t do_load() const { return load_value(value_); }
 
+#pragma endregion
+#pragma region Data members
+
   mutable std::mutex mutex_;
   mutable std::condition_variable cv_;
   T value_;
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::concurrency::notifiable_ns

--- a/corvid/concurrency/sync_lock.h
+++ b/corvid/concurrency/sync_lock.h
@@ -21,6 +21,8 @@
 
 namespace corvid { inline namespace concurrency { inline namespace sync_lock {
 
+#pragma region synchronizer
+
 // Synchronization object for use with containers.
 //
 // Not copyable or moveable.
@@ -32,6 +34,9 @@ public:
 private:
   mutable std::mutex mutex_;
 };
+
+#pragma endregion
+#pragma region breakable_synchronizer
 
 // Breakable synchronization object. Once the guarded resource is frozen, you
 // call `disable` and the conversion to `synchronizer` returns `nullptr`, so
@@ -51,12 +56,17 @@ private:
   mutable std::atomic<const synchronizer*> sync_ = &actual_sync_;
 };
 
+#pragma endregion
+#pragma region reverse_lock
+
 // Reversed lock. Unlocks on construction, relocks on destruction.
 //
 // This class is largely internal. The normal way to use it is to call
 // `reverse` on a `lock`.
 class [[nodiscard]] reverse_lock final {
 public:
+#pragma region Construction
+
   explicit reverse_lock(const synchronizer* sync) : sync_{sync} {
     if (sync_) sync_->unlock();
   }
@@ -70,6 +80,9 @@ public:
     if (sync_) sync_->lock();
   }
 
+#pragma endregion
+#pragma region Operations
+
   [[nodiscard]] const synchronizer* release() const noexcept {
     const auto old = sync_;
     sync_ = nullptr;
@@ -78,9 +91,16 @@ public:
 
   [[nodiscard]] operator bool() const noexcept { return sync_; }
 
+#pragma endregion
+#pragma region Data members
 private:
   mutable const synchronizer* sync_{};
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region lock
 
 // Attestation of a lock on a sync object.
 //
@@ -129,6 +149,8 @@ private:
 // even construct it on the instance's `sync` member.
 class [[nodiscard]] lock final {
 public:
+#pragma region Construction
+
   constexpr lock() noexcept = default;
 
   explicit lock(const synchronizer& sync) : sync_{&sync} { sync_->lock(); }
@@ -150,6 +172,9 @@ public:
   ~lock() {
     if (sync_) sync_->unlock();
   }
+
+#pragma endregion
+#pragma region Operations
 
   // Whether a `synchronizer` is associated.
   [[nodiscard]] explicit operator bool() const noexcept { return sync_; }
@@ -179,8 +204,13 @@ public:
     return reverse_lock{sync_};
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   mutable const synchronizer* sync_{};
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::concurrency::sync_lock

--- a/corvid/concurrency/timer_fuse.h
+++ b/corvid/concurrency/timer_fuse.h
@@ -25,6 +25,8 @@
 
 namespace corvid { inline namespace concurrency {
 
+#pragma region timer_fuse
+
 // Copyable liveness token for a per-operation timeout on a shared resource.
 //
 // `T` is the resource type (e.g., a connection class), which must be managed
@@ -62,13 +64,21 @@ namespace corvid { inline namespace concurrency {
 template<typename T>
 class timer_fuse {
 public:
+#pragma region Types
+
   using resource_t = T;
   using resource_ptr_t = std::shared_ptr<T>;
   using resource_weak_ptr_t = std::weak_ptr<T>;
 
+#pragma endregion
+#pragma region Construction
+
   // Default-constructed fuse is permanently unarmed: `get_if_armed` always
   // returns `nullptr`. It exists only to be copied over.
   timer_fuse() = default;
+
+#pragma endregion
+#pragma region Operations
 
   // Return the live resource if the fuse is still armed, `nullptr` otherwise.
   //
@@ -112,6 +122,8 @@ public:
   // Stale any pending callback on `seq` without scheduling a new one.
   static void disarm(std::atomic_uint64_t& seq) { ++seq; }
 
+#pragma endregion
+#pragma region Implementation
 private:
   // Due to global treaties against war crimes, only `set_timeout` may
   // construct an armed fuse.
@@ -119,9 +131,15 @@ private:
       uint64_t target) noexcept
       : resource_{std::move(resource)}, seq_{&seq}, target_{target} {}
 
+#pragma endregion
+#pragma region Data members
+
   resource_weak_ptr_t resource_;
   std::atomic_uint64_t* seq_{};
   uint64_t target_{};
+
+#pragma endregion
 };
 
+#pragma endregion
 }} // namespace corvid::concurrency

--- a/corvid/concurrency/timers.h
+++ b/corvid/concurrency/timers.h
@@ -29,9 +29,9 @@
 
 namespace corvid { inline namespace concurrency {
 
-//
 // Thread-safe timers.
-//
+
+#pragma region Aliases
 
 // Time point and duration using steady clock.
 using time_point_t = std::chrono::steady_clock::time_point;
@@ -44,6 +44,9 @@ class timer_event;
 // Timers and events can only be constructed as shared.
 using timers_ptr = std::shared_ptr<timers>;
 using timer_event_ptr = std::shared_ptr<timer_event>;
+
+#pragma endregion
+#pragma region timer_invocation
 
 // Parameter passed to the timer callback. Besides the event itself, and access
 // to the `timers` object, it also includes various timestamps and counts
@@ -74,6 +77,9 @@ struct timer_invocation {
   time_point_t now;
 };
 
+#pragma endregion
+#pragma region Callbacks
+
 // Callback invoked when a timer fires.
 //
 // See below for notes on synchronization and thread safety.
@@ -102,6 +108,9 @@ using timer_callback_t = std::function<time_point_t(const timer_invocation&)>;
 // be safe to call from any thread. Value should increase monotonically.
 using clock_callback_t = std::function<time_point_t()>;
 
+#pragma endregion
+#pragma region timer_event
+
 // Timer event.
 //
 // Contains full state of the event. All contents are either immutable or
@@ -109,6 +118,8 @@ using clock_callback_t = std::function<time_point_t()>;
 //
 // Set `canceled` to true to prevent the event from firing again.
 class timer_event final {
+#pragma region Construction
+
   enum class allow : bool { ctor };
 
 public:
@@ -145,6 +156,9 @@ public:
   timer_event(timer_event&&) = delete;
   timer_event& operator=(const timer_event&) = delete;
   timer_event& operator=(timer_event&&) = delete;
+
+#pragma endregion
+#pragma region Data members
 
   // When the timer was created.
   const time_point_t created_at;
@@ -192,7 +206,12 @@ public:
 
   // Synchronize access to data bound into the callback, if needed.
   synchronizer sync;
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region timers
 
 // Priority queue of timers.
 //
@@ -200,6 +219,8 @@ public:
 // is called. All methods are thread-safe and may be safely invoked even from
 // inside a callback without deadlock.
 class timers final: public std::enable_shared_from_this<timers> {
+#pragma region Types
+
   // Lightweight internal class to reference an upcoming event. If there's no
   // `scheduled_event` for an `event` in the priority queue, it's not
   // scheduled. Note that the `event` is kept alive by its presence in a
@@ -216,6 +237,9 @@ class timers final: public std::enable_shared_from_this<timers> {
   using scheduled_queue_t = std::priority_queue<scheduled_event>;
   enum class allow : bool { ctor };
 
+#pragma endregion
+#pragma region Construction
+
 public:
   // Effectively private: can only be constructed through `make` factory
   // method.
@@ -231,6 +255,9 @@ public:
   [[nodiscard]] static timers_ptr make(std::string name) {
     return std::make_shared<timers>(allow::ctor, std::move(name));
   }
+
+#pragma endregion
+#pragma region Operations
 
   // Get current time according to the registered clock callback.
   [[nodiscard]] auto get_now(const lock& attestation = {}) const {
@@ -382,6 +409,9 @@ public:
     clock_callback_ = callback;
   }
 
+#pragma endregion
+#pragma region Data members
+
   // Name, for logging.
   const std::string name;
 
@@ -397,6 +427,9 @@ private:
   // For each event that is scheduled, there should be exactly one entry in
   // `scheduled_events_` at any time.
   scheduled_queue_t scheduled_events_;
+
+#pragma endregion
 };
 
+#pragma endregion
 }} // namespace corvid::concurrency

--- a/corvid/concurrency/timing_wheel.h
+++ b/corvid/concurrency/timing_wheel.h
@@ -35,6 +35,8 @@ namespace corvid { inline namespace concurrency {
 
 using namespace std::chrono_literals;
 
+#pragma region timing_wheel
+
 // Single-level timing wheel with configurable precision (100ms by default).
 //
 // Schedules `std::function<void()>` callbacks and fires them at the
@@ -82,6 +84,8 @@ using namespace std::chrono_literals;
 //
 class timing_wheel {
 public:
+#pragma region Types
+
   using time_point_t = std::chrono::steady_clock::time_point;
   using duration_t = std::chrono::milliseconds;
 
@@ -94,11 +98,17 @@ public:
   // All slots in the wheel, indexed by the tick position.
   using slots_t = std::vector<slot_t>;
 
+#pragma endregion
+#pragma region Constants
+
   // Default slot count covers ~60s at 100ms per slot.
   static constexpr size_t default_slot_count{600};
 
   // Default resolution: one 100ms slot per tick.
   static constexpr duration_t default_tick_interval{100ms};
+
+#pragma endregion
+#pragma region Construction
 
   // Construct a timing wheel with `slot_count` slots and `tick_interval`
   // precision, starting from `start_time`. `slot_count` must be at least 2.
@@ -123,6 +133,9 @@ public:
   timing_wheel(timing_wheel&&) = delete;
   timing_wheel& operator=(const timing_wheel&) = delete;
   timing_wheel& operator=(timing_wheel&&) = delete;
+
+#pragma endregion
+#pragma region Operations
 
   // Return the maximum delay this wheel can schedule. Attempts to schedule a
   // delay beyond this value will fail; they will not be capped.
@@ -216,6 +229,8 @@ public:
     return last_tick_ + tick_interval_;
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   mutable std::mutex mutex_;
 
@@ -227,7 +242,12 @@ private:
   size_t current_slot_{0};
   time_point_t last_tick_;
   tombstone stopped_;
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region timing_wheel_runner
 
 // Runs a `timing_wheel` in its own background thread.
 //
@@ -239,6 +259,8 @@ private:
 // is destroyed.
 class [[nodiscard]] timing_wheel_runner {
 public:
+#pragma region Construction
+
   explicit timing_wheel_runner(
       size_t slot_count = timing_wheel::default_slot_count,
       timing_wheel::duration_t tick_interval =
@@ -263,6 +285,9 @@ public:
   timing_wheel_runner& operator=(const timing_wheel_runner&) = delete;
   timing_wheel_runner& operator=(timing_wheel_runner&&) = delete;
 
+#pragma endregion
+#pragma region Operations
+
   // Signal the wheel thread to exit. Pending callbacks are discarded.
   // Idempotent and thread-safe. Also called implicitly by the destructor.
   [[nodiscard]] bool stop() { return thread_.request_stop(); }
@@ -274,6 +299,8 @@ public:
   }
   [[nodiscard]] operator timing_wheel&() noexcept { return *wheel_; }
 
+#pragma endregion
+#pragma region Implementation
 private:
   void run(const std::stop_token& st) {
     jthread_stoppable_sleep::set_thread_name("wheel");
@@ -286,8 +313,14 @@ private:
       wheel_->tick(std::chrono::steady_clock::now());
   }
 
+#pragma endregion
+#pragma region Data members
+
   std::shared_ptr<timing_wheel> wheel_;
   std::jthread thread_;
+
+#pragma endregion
 };
 
+#pragma endregion
 }} // namespace corvid::concurrency

--- a/corvid/concurrency/tombstone.h
+++ b/corvid/concurrency/tombstone.h
@@ -20,6 +20,8 @@
 
 namespace corvid { inline namespace concurrency {
 
+#pragma region tombstone_of
+
 // A tombstone is a thread-safe, atomic value that can be set to a final value
 // which indicates that it is dead.
 //
@@ -37,6 +39,8 @@ namespace corvid { inline namespace concurrency {
 template<typename T = bool, T FV = true, T IV = {}>
 class tombstone_of {
 public:
+#pragma region Types
+
   using value_type = T;
   using atomic_type = std::atomic<value_type>;
   static constexpr value_type final_v = FV;
@@ -47,6 +51,9 @@ public:
   static_assert(initial_v != final_v,
       "Initial value must not be the same as final value.");
 
+#pragma endregion
+#pragma region Construction
+
   tombstone_of() = default;
 
   tombstone_of(const tombstone_of&) = delete;
@@ -55,6 +62,9 @@ public:
   tombstone_of& operator=(tombstone_of&&) = delete;
 
   explicit tombstone_of(value_type v) noexcept : value_{v} {}
+
+#pragma endregion
+#pragma region Operations
 
   // Kill the tombstone, returning true if this call killed it and false if it
   // was already dead.
@@ -117,10 +127,18 @@ public:
     return *this;
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   atomic_type value_{initial_v};
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region tombstone
 
 using tombstone = tombstone_of<bool, true, false>;
 
+#pragma endregion
 }} // namespace corvid::concurrency

--- a/corvid/containers/core/arena_allocator.h
+++ b/corvid/containers/core/arena_allocator.h
@@ -130,6 +130,12 @@ public:
   }
 
   // Sets thread-local scope for arena.
+  //
+  // gcc's -Wdangling-pointer misfires here: `arena` is a reference parameter,
+  // so `&arena.head_` points into the caller's arena (which outlives the
+  // guard), not a local. Silence it on gcc; clang does not warn.
+  PRAGMA_GCC_DIAG(push)
+  PRAGMA_GCC_IGNORED("-Wdangling-pointer")
   class [[nodiscard]] scope {
   public:
     explicit scope(extensible_arena& arena) noexcept : old_head{&arena.head_} {
@@ -141,6 +147,7 @@ public:
   private:
     pointer* old_head;
   };
+  PRAGMA_GCC_DIAG(pop)
 };
 
 // Allocator that uses the `extensible_arena` that is currently in scope.

--- a/corvid/containers/core/arena_allocator.h
+++ b/corvid/containers/core/arena_allocator.h
@@ -19,6 +19,8 @@
 
 namespace corvid { inline namespace container { namespace arena {
 
+#pragma region extensible_arena
+
 // Arena implemented as a singly linked list of blocks.
 //
 // To use:
@@ -47,6 +49,8 @@ namespace corvid { inline namespace container { namespace arena {
 // The expectation is that the arena is much larger than any single value, so
 // the waste from the last unfilled bit is minimal.
 class extensible_arena final {
+#pragma region Implementation
+
   struct list_node;
   struct list_node_deleter {
     void operator()(list_node* node) const noexcept {
@@ -114,9 +118,15 @@ class extensible_arena final {
 
   pointer head_;
 
+#pragma endregion
+#pragma region Construction
+
 public:
   explicit extensible_arena(size_t capacity) noexcept
       : head_{list_node::make(capacity)} {}
+
+#pragma endregion
+#pragma region Operations
 
   [[nodiscard]] static void* allocate(size_t n, size_t align) {
     return allocate(get_head(), n, align);
@@ -128,6 +138,9 @@ public:
 
     return false;
   }
+
+#pragma endregion
+#pragma region scope
 
   // Sets thread-local scope for arena.
   //
@@ -148,11 +161,18 @@ public:
     pointer* old_head;
   };
   PRAGMA_GCC_DIAG(pop)
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region arena_allocator
 
 // Allocator that uses the `extensible_arena` that is currently in scope.
 template<typename T>
 class arena_allocator {
+#pragma region Types
+
   static_assert(std::is_same_v<T, std::remove_cv_t<T>>);
 
 public:
@@ -161,10 +181,16 @@ public:
   using difference_type = std::ptrdiff_t;
   using propagate_on_container_move_assignment = std::true_type;
 
+#pragma endregion
+#pragma region Construction
+
   constexpr arena_allocator() noexcept = default;
   constexpr arena_allocator(const arena_allocator&) noexcept = default;
   template<class U>
   constexpr arena_allocator(const arena_allocator<U>&) noexcept {}
+
+#pragma endregion
+#pragma region Operations
 
   // NOLINTBEGIN(bugprone-sizeof-expression)
 
@@ -178,7 +204,12 @@ public:
   // NOLINTEND(bugprone-sizeof-expression)
 
   constexpr void deallocate(T*, std::size_t) {}
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region Collections
 
 // Arena-specialized collections. Can be reinterpreted as their standard forms
 // because they are designed to be the same size and memory layout.
@@ -207,7 +238,8 @@ static_assert(
     sizeof(arena_allocator_traits<int>) ==
     sizeof(std::allocator_traits<std::allocator<int>>));
 
-// Helpers:
+#pragma endregion
+#pragma region Helpers
 
 // Allocate a new object of type `T` using the scoped `extensible_arena`.
 // Designed to allocate an arena-specialized container whose contents use the
@@ -235,4 +267,5 @@ decltype(auto) arena_scope(extensible_arena& arena, F&& f) {
   return std::forward<F>(f)();
 }
 
+#pragma endregion
 }}} // namespace corvid::container::arena

--- a/corvid/containers/core/custom_handle.h
+++ b/corvid/containers/core/custom_handle.h
@@ -126,11 +126,11 @@ public:
 #pragma endregion
 #pragma region Access
 
-  [[nodiscard]] reference_type operator*() const {
+  [[nodiscard]] decltype(auto) operator*() const {
     if constexpr (std::is_pointer_v<resource_id_type>)
       return *reinterpret_cast<element_type*>(resource_);
     else
-      return reinterpret_cast<reference_type>(resource_);
+      return static_cast<element_type>(resource_);
   }
 
   [[nodiscard]] constexpr element_type* operator->() const noexcept {

--- a/corvid/containers/core/custom_handle.h
+++ b/corvid/containers/core/custom_handle.h
@@ -19,6 +19,7 @@
 #include <format>
 
 #include "containers_shared.h"
+#include "../../meta/formatting.h"
 
 // NOTE:
 // This was originally intended to work with `std::unique_ptr` but that's not
@@ -171,29 +172,8 @@ public:
 
 }} // namespace corvid::custhandle
 
-// Formatter for `custom_handle`, narrow or wide.
-//
-// Forwards to the `element_type` formatter, dereferencing the handle and
-// honoring the element's full spec grammar (so `{:?}` debugs the element when
-// it supports it). A null handle (one comparing equal to `null_v`) instead
-// renders the unquoted marker `(null)`. As with `optional_ptr`, the marker is
-// not padded: fill, align, and width apply only to a live handle.
 template<typename TAG, typename T, typename TPtr, TPtr N,
     corvid::CharType CharT>
 requires std::formattable<T, CharT>
 struct std::formatter<corvid::custhandle::custom_handle<TAG, T, TPtr, N>,
-    CharT>: std::formatter<T, CharT> {
-  using base = std::formatter<T, CharT>;
-
-  template<typename FormatContext>
-  auto format(const corvid::custhandle::custom_handle<TAG, T, TPtr, N>& h,
-      FormatContext& ctx) const {
-    if (h) return base::format(*h, ctx);
-
-    static constexpr CharT marker[]{CharT('('), CharT('n'), CharT('u'),
-        CharT('l'), CharT('l'), CharT(')')};
-    auto out = ctx.out();
-    for (const CharT c : std::basic_string_view<CharT>{marker, 6}) *out++ = c;
-    return out;
-  }
-};
+    CharT>: corvid::nullable_formatter<T, CharT> {};

--- a/corvid/containers/core/enum_variant.h
+++ b/corvid/containers/core/enum_variant.h
@@ -121,6 +121,11 @@ struct overloaded_callbacks: Lambdas... {
   }
 };
 
+// Deduction guide. Needed for gcc, which does not perform aggregate CTAD for
+// this base-class aggregate the way clang does.
+template<typename... Lambdas>
+overloaded_callbacks(Lambdas...) -> overloaded_callbacks<Lambdas...>;
+
 // Indexed callbacks.
 //
 // Like the `overloaded` helper documented for `std::visit`, except that it's

--- a/corvid/containers/core/fixed_bitset.h
+++ b/corvid/containers/core/fixed_bitset.h
@@ -31,6 +31,8 @@
 namespace corvid { inline namespace container {
 inline namespace fixed_bitsets {
 
+#pragma region fixed_bitset
+
 // Fixed-size bitset backed by `std::array<word_t, word_count_v>`.
 //
 // This is a maximalist version of `std::bitset`.
@@ -72,6 +74,8 @@ template<size_t N_BITS = 64, typename POS = size_t, typename TAG = void,
     size_t FORCED_WORD = 0>
 class fixed_bitset {
 public:
+#pragma region Types
+
   static constexpr size_t bit_count_v = N_BITS;
   static constexpr size_t forced_word_v = FORCED_WORD;
 
@@ -109,6 +113,9 @@ public:
   // Number of words needed to hold all `bit_count_v` bits (ceiling division).
   static constexpr size_t word_count_v =
       (bit_count_v + bits_per_word_v - 1) / bits_per_word_v;
+
+#pragma endregion
+#pragma region iterator
 
   // Read-only iterator over bit positions that are set.
   //
@@ -181,6 +188,9 @@ public:
 
   using const_iterator = iterator;
 
+#pragma endregion
+#pragma region reference
+
   // Akin to `std::bitset<N>::reference`.
   // This is a proxy object that behaves like a reference to a single bit,
   // allowing read and write access. It is returned by the mutable
@@ -229,7 +239,8 @@ public:
     friend class fixed_bitset;
   };
 
-  // Construction.
+#pragma endregion
+#pragma region Construction
 
   constexpr fixed_bitset() = default;
   constexpr fixed_bitset(const fixed_bitset&) = default;
@@ -247,7 +258,8 @@ public:
   // TODO: Consider implementing `to_string`, `to_ulong`, `to_ullong`, and
   // constructors that initialize from numbers and strings.
 
-  // Comparison.
+#pragma endregion
+#pragma region Comparison
 
   // Equality comparison.
   [[nodiscard]] constexpr bool operator==(
@@ -259,7 +271,8 @@ public:
   [[nodiscard]] constexpr auto operator<=>(
       const fixed_bitset&) const noexcept = default;
 
-  // Element access.
+#pragma endregion
+#pragma region Element access
 
   // Read-only bit access. Does not throw. Fastest path.
   [[nodiscard]] constexpr bool operator[](pos_t pos) const noexcept {
@@ -305,12 +318,15 @@ public:
     return cnt;
   }
 
-  // Capacity.
+#pragma endregion
+#pragma region Capacity
 
   // Number of bit positions (`N_BITS`).
   [[nodiscard]] constexpr size_t size() const noexcept { return bit_count_v; }
 
-  // Modifiers.
+#pragma endregion
+#pragma region Modifiers
+#pragma region Bitwise
 
   // AND each word with `rhs` in place.
   constexpr fixed_bitset& operator&=(const fixed_bitset& rhs) noexcept {
@@ -357,6 +373,9 @@ public:
   operator^(fixed_bitset lhs, const fixed_bitset& rhs) noexcept {
     return lhs ^= rhs;
   }
+
+#pragma endregion
+#pragma region Shifts
 
   // Left shift.
   [[nodiscard]] friend constexpr fixed_bitset
@@ -427,6 +446,9 @@ public:
     for (size_t ndx = limit; ndx < word_count_v; ++ndx) words_[ndx] = 0;
     return *this;
   }
+
+#pragma endregion
+#pragma region Rotations
 
   // Rotate bits left by shift positions.
   constexpr fixed_bitset& rotl(size_t shift) noexcept {
@@ -518,6 +540,9 @@ public:
     return lhs.rotr(shift);
   }
 
+#pragma endregion
+#pragma region Set, reset, flip
+
   // Set all bits.
   constexpr auto& set() noexcept {
     words_.fill(all_ones_v);
@@ -555,7 +580,9 @@ public:
     return flip_unchecked(checked_index(pos));
   }
 
-  // Extended queries.
+#pragma endregion
+#pragma endregion
+#pragma region Extended queries
 
   // Number of consecutive zero bits starting at bit 0.
   [[nodiscard]] constexpr pos_t countr_zero() const noexcept {
@@ -668,7 +695,8 @@ public:
     return as_pos(bit_count_v - static_cast<size_t>(countl_zero()));
   }
 
-  // Iteration. All const.
+#pragma endregion
+#pragma region Iteration
 
   // Iterator to the first set bit, or `end` if none are set.
   [[nodiscard]] constexpr iterator begin() const noexcept {
@@ -688,8 +716,13 @@ public:
     return (self.words_);
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   std::array<word_t, word_count_v> words_{};
+
+#pragma endregion
+#pragma region Implementation
 
   // Valid bits in the topmost word. Less than `bits_per_word_v` only when
   // `FORCED_WORD` causes `N_BITS` to not be a multiple of `bits_per_word_v`.
@@ -765,9 +798,14 @@ private:
       throw std::out_of_range{"fixed_bitset: pos out of range"};
     return ndx;
   }
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::container::fixed_bitsets
+
+#pragma region format_kind
 
 // `fixed_bitset` iterates the positions of its set bits, so without this the
 // std range formatter would print those positions (`[1, 3]`, like in the
@@ -777,6 +815,9 @@ template<std::size_t N, typename POS, typename TAG, std::size_t FW>
 constexpr std::range_format
     std::format_kind<corvid::container::fixed_bitset<N, POS, TAG, FW>> =
         std::range_format::disabled;
+
+#pragma endregion
+#pragma region formatter
 
 // Formatter for `fixed_bitset`. Three mutually exclusive representations, all
 // streamed straight to the output so nothing the size of the bit count is
@@ -851,3 +892,5 @@ private:
   enum class mode : std::uint8_t { binary, index, hex };
   mode mode_{mode::binary};
 };
+
+#pragma endregion

--- a/corvid/containers/core/hash_combiner.h
+++ b/corvid/containers/core/hash_combiner.h
@@ -23,6 +23,8 @@
 
 namespace corvid { inline namespace hash_combiners {
 
+#pragma region hash_combiner
+
 // Incrementally combine hashes for compound keys.
 //
 // The mixer matches the common boost-style combine formula and is suitable for
@@ -38,14 +40,22 @@ namespace corvid { inline namespace hash_combiners {
 //   }
 class hash_combiner {
 public:
+#pragma region Construction
+
   constexpr hash_combiner() noexcept = default;
   constexpr explicit hash_combiner(size_t seed) noexcept : seed_(seed) {}
+
+#pragma endregion
+#pragma region Accessors
 
   // Return the current accumulated hash value.
   [[nodiscard]] constexpr size_t value() const noexcept { return seed_; }
   [[nodiscard]] constexpr explicit operator size_t() const noexcept {
     return seed_;
   }
+
+#pragma endregion
+#pragma region Operations
 
   // Mix an already-computed hash value into the accumulator.
   constexpr void combine_hash(size_t hash) noexcept {
@@ -66,9 +76,16 @@ public:
     (combine(values), ...);
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   size_t seed_ = 0;
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region combined_hash
 
 // Hash several values as an ordered tuple-like sequence.
 //
@@ -83,4 +100,5 @@ template<typename... Ts>
   return combiner.value();
 }
 
+#pragma endregion
 }} // namespace corvid::hash_combiners

--- a/corvid/containers/core/indirect_key.h
+++ b/corvid/containers/core/indirect_key.h
@@ -4,6 +4,8 @@
 #include <functional>
 #include <cstddef>
 
+#include "../../meta/formatting.h"
+
 namespace corvid { inline namespace container { inline namespace indirect_key {
 
 // Indirect keys are similar to `std::reference_wrapper`, but are designed to
@@ -128,27 +130,12 @@ template<typename T, typename C>
 struct std::less<corvid::indirect_map_key<T, C>>
     : corvid::indirect_map_key<T, C>::compare {};
 
-// Formatters for the indirect keys, narrow or wide. Each acts like its
-// referenced key, so it forwards to the key's formatter, honoring its full
-// spec grammar.
 template<typename T, typename H, typename E, typename CharT>
 requires std::formattable<T, CharT>
 struct std::formatter<corvid::indirect_hash_key<T, H, E>, CharT>
-    : std::formatter<T, CharT> {
-  template<typename FormatContext>
-  auto format(const corvid::indirect_hash_key<T, H, E>& k,
-      FormatContext& ctx) const {
-    return std::formatter<T, CharT>::format(k.key, ctx);
-  }
-};
+    : corvid::forwarding_formatter<T, CharT> {};
 
 template<typename T, typename C, typename CharT>
 requires std::formattable<T, CharT>
 struct std::formatter<corvid::indirect_map_key<T, C>, CharT>
-    : std::formatter<T, CharT> {
-  template<typename FormatContext>
-  auto
-  format(const corvid::indirect_map_key<T, C>& k, FormatContext& ctx) const {
-    return std::formatter<T, CharT>::format(k.key, ctx);
-  }
-};
+    : corvid::forwarding_formatter<T, CharT> {};

--- a/corvid/containers/core/opt_find.h
+++ b/corvid/containers/core/opt_find.h
@@ -21,10 +21,12 @@
 
 namespace corvid { inline namespace opt_find {
 
-// Search container for key `k`, returning `optional_ptr` to element. When a
-// search fails to find anything, the `has_value` of the return is false.
+#pragma region find_opt
+
+// Search container for key `k`, returning `optional_ptr` to element, allowing
+// `std::optional` semantics instead of comparison with `end`.
 //
-// Uses `find` method on `T::key_type` if available, `std::find` otherwise.
+// Uses `find` method on `T::key_type` when available, `std::find` otherwise.
 // Note that this means it only uses the find method on associative containers,
 // not strings.
 //
@@ -35,7 +37,7 @@ namespace corvid { inline namespace opt_find {
 //
 // For `std::string` and `std::string_view`, searches for a single character
 // using `std::find`. Even works for arrays, but not arrays decayed into
-// pointers (because we can't determine the size, then).
+// pointers (because then we can't determine the size).
 template<auto field = extract_field::value>
 [[nodiscard]] constexpr auto find_opt(KeyFindable auto&& c, const auto& k) {
   return internal::optional_ptr{it_to_ptr<field>(c, c.find(k))};
@@ -49,9 +51,13 @@ find_opt(RangeWithoutFind auto&& c, const auto& k) {
       it_to_ptr<field>(c, std::find(begin(c), end(c), k))};
 }
 
+#pragma endregion
+#pragma region contains
+
 // Determine whether the container has the key.
 [[nodiscard]] constexpr bool contains(auto&& c, const auto& k) {
   return find_opt(c, k).has_value();
 }
 
+#pragma endregion
 }} // namespace corvid::opt_find

--- a/corvid/containers/core/optional_ptr.h
+++ b/corvid/containers/core/optional_ptr.h
@@ -19,6 +19,7 @@
 #include <format>
 
 #include "containers_shared.h"
+#include "../../meta/formatting.h"
 
 // This is internal, like it says, so don't import it.
 namespace corvid::internal {
@@ -199,27 +200,7 @@ private:
 
 } // namespace corvid::internal
 
-// Formatter for `optional_ptr`, narrow or wide.
-//
-// Forwards to the pointee's formatter, honoring its full spec grammar (so
-// `{:?}` debugs the pointee when the pointee type supports it). A null
-// `optional_ptr` instead renders the unquoted marker `(null)`. The marker is
-// not padded: fill, align, and width apply only to a present pointee.
 template<corvid::PointerLike Ptr, corvid::CharType CharT>
 requires std::formattable<corvid::pointer_element_t<Ptr>, CharT>
 struct std::formatter<corvid::internal::optional_ptr<Ptr>, CharT>
-    : std::formatter<corvid::pointer_element_t<Ptr>, CharT> {
-  using base = std::formatter<corvid::pointer_element_t<Ptr>, CharT>;
-
-  template<typename FormatContext>
-  auto format(const corvid::internal::optional_ptr<Ptr>& op,
-      FormatContext& ctx) const {
-    if (op.has_value()) return base::format(op.value(), ctx);
-
-    static constexpr CharT marker[]{CharT('('), CharT('n'), CharT('u'),
-        CharT('l'), CharT('l'), CharT(')')};
-    auto out = ctx.out();
-    for (const CharT c : std::basic_string_view<CharT>{marker, 6}) *out++ = c;
-    return out;
-  }
-};
+    : corvid::nullable_formatter<corvid::pointer_element_t<Ptr>, CharT> {};

--- a/corvid/containers/core/scoped_value.h
+++ b/corvid/containers/core/scoped_value.h
@@ -24,6 +24,8 @@
 namespace corvid { inline namespace container {
 inline namespace value_scoping {
 
+#pragma region scoped_value
+
 // RAII helper for temporarily changing a value and restoring it on scope exit.
 //
 // Example:
@@ -38,6 +40,8 @@ inline namespace value_scoping {
 template<typename T>
 class [[nodiscard]] scoped_value {
 public:
+#pragma region Construction
+
   static_assert(!std::is_reference_v<T>,
       "scoped_value cannot store a reference type");
   static_assert(std::is_move_constructible_v<T>,
@@ -76,13 +80,21 @@ public:
     return *this;
   }
 
+#pragma endregion
+#pragma region Operations
+
   // Disarm the `scoped_value`, leaving the current value in place and
   // preventing any future restore.
   void release() noexcept { target_ = nullptr; }
 
+#pragma endregion
+#pragma region Data members
 private:
   T* target_{};
   T old_value_;
+
+#pragma endregion
+#pragma region Implementation
 
   void do_swap() noexcept(std::is_nothrow_swappable_v<T>) {
     using std::swap;
@@ -92,6 +104,9 @@ private:
   void restore() noexcept(std::is_nothrow_swappable_v<T>) {
     if (target_) do_swap();
   }
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::container::value_scoping

--- a/corvid/containers/core/strong_type.h
+++ b/corvid/containers/core/strong_type.h
@@ -18,6 +18,7 @@
 #include <format>
 
 #include "containers_shared.h"
+#include "../../meta/formatting.h"
 
 namespace corvid { inline namespace strongtypes {
 
@@ -771,27 +772,10 @@ struct hash<corvid::strongtypes::strong_type<T, TAG>>
 };
 } // namespace std
 
-// `strong_type` conditionally forwards `begin`/`end`, so when the underlying
-// `T` is a range it would otherwise be claimed by the std range formatter and
-// enumerated element by element. Disabling its range format leaves the
-// forwarding formatter below as the only match; for a non-range `T` this is a
-// harmless no-op, since `format_kind` is consulted only for ranges.
 template<typename T, typename TAG>
 constexpr std::range_format std::format_kind<corvid::strong_type<T, TAG>> =
     std::range_format::disabled;
-
-// Formatter for `strong_type`, narrow or wide.
-//
-// Formats the wrapper exactly as its underlying value would, honoring that
-// type's full spec grammar, including `?` debug. Available only when the
-// underlying type is itself formattable for `CharT`.
 template<typename T, typename TAG, corvid::CharType CharT>
 requires std::formattable<T, CharT>
 struct std::formatter<corvid::strong_type<T, TAG>, CharT>
-    : std::formatter<T, CharT> {
-  template<typename FormatContext>
-  auto
-  format(const corvid::strong_type<T, TAG>& obj, FormatContext& ctx) const {
-    return std::formatter<T, CharT>::format(obj.value(), ctx);
-  }
-};
+    : corvid::forwarding_formatter<T, CharT> {};

--- a/corvid/containers/core/transparent.h
+++ b/corvid/containers/core/transparent.h
@@ -31,6 +31,9 @@ namespace corvid { inline namespace containers {
 // `hash` and `equal`.
 //
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0919r3.html
+
+#pragma region transparent less
+
 struct transparent_less_stringlike {
   using is_transparent = void;
 
@@ -39,6 +42,9 @@ struct transparent_less_stringlike {
     return std::string_view{l} < std::string_view{r};
   }
 };
+
+#pragma endregion
+#pragma region transparent hash
 
 struct transparent_hash_equal_stringlike {
   using is_transparent = void;
@@ -54,6 +60,9 @@ struct transparent_hash_equal_stringlike {
            static_cast<std::string_view>(r);
   }
 };
+
+#pragma endregion
+#pragma region Aliases
 
 // Map keyed by `std::string`, with transparent search.
 template<typename V = std::string,
@@ -79,4 +88,5 @@ using string_unordered_set_alloc = std::unordered_set<std::string,
 
 using string_unordered_set = string_unordered_set_alloc<>;
 
+#pragma endregion
 }} // namespace corvid::containers

--- a/corvid/containers/utils/enum_vector.h
+++ b/corvid/containers/utils/enum_vector.h
@@ -23,6 +23,8 @@
 
 namespace corvid { inline namespace container { inline namespace enum_vectors {
 
+#pragma region enum_vector
+
 // Wrapper for vector where the index is a class enum.
 //
 // Provides full access to underlying type, but avoids casting.
@@ -30,6 +32,8 @@ template<typename T, sequence::SequentialEnum E,
     class Allocator = std::allocator<T>>
 class enum_vector {
 public:
+#pragma region Types
+
   using value_type = T;
   using allocator_type = Allocator;
   using size_type = std::underlying_type_t<E>;
@@ -42,6 +46,9 @@ public:
   using const_iterator = std::vector<T, Allocator>::const_iterator;
   using enum_t = E;
 
+#pragma endregion
+#pragma region Construction
+
   enum_vector() = default;
   explicit enum_vector(size_type count, const T& value = T(),
       const Allocator& alloc = Allocator())
@@ -50,6 +57,9 @@ public:
   enum_vector(std::initializer_list<T> init,
       const Allocator& alloc = Allocator())
       : data_(init, alloc) {}
+
+#pragma endregion
+#pragma region Capacity
 
   [[nodiscard]] size_type size() const noexcept { return data_.size(); }
   [[nodiscard]] bool empty() const noexcept { return data_.empty(); }
@@ -61,6 +71,9 @@ public:
   void resize(size_type count, const T& value) { data_.resize(count, value); }
   void clear() noexcept { data_.clear(); }
   void shrink_to_fit() { data_.shrink_to_fit(); }
+
+#pragma endregion
+#pragma region Element access
 
   [[nodiscard]] decltype(auto)
   operator[](this auto& self, enum_t ndx) noexcept {
@@ -81,6 +94,9 @@ public:
     return self.data_.data();
   }
 
+#pragma endregion
+#pragma region Iterators
+
   [[nodiscard]] decltype(auto) begin(this auto& self) noexcept {
     return self.data_.begin();
   }
@@ -92,6 +108,9 @@ public:
   }
   [[nodiscard]] const_iterator cend() const noexcept { return data_.cend(); }
 
+#pragma endregion
+#pragma region Modifiers
+
   void push_back(const T& value) { data_.push_back(value); }
   void push_back(T&& value) { data_.push_back(std::move(value)); }
   template<class... Args>
@@ -100,7 +119,8 @@ public:
   }
   void pop_back() { data_.pop_back(); }
 
-  // Additional methods.
+#pragma endregion
+#pragma region Additional methods
 
   [[nodiscard]] enum_t size_as_enum() const noexcept {
     return enum_t{static_cast<size_type>(data_.size())};
@@ -115,8 +135,13 @@ public:
     return data_.get_allocator();
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   std::vector<T, Allocator> data_{};
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::container::enum_vectors

--- a/corvid/containers/utils/interval.h
+++ b/corvid/containers/utils/interval.h
@@ -18,6 +18,7 @@
 #define NOMINMAX
 
 #include <cassert>
+#include <cstdint>
 #include <format>
 #include <iterator>
 #include <limits>

--- a/corvid/containers/utils/interval.h
+++ b/corvid/containers/utils/interval.h
@@ -31,9 +31,7 @@
 
 namespace corvid { inline namespace intervals {
 
-//
-// interval
-//
+#pragma region interval
 
 // Represent a closed interval of integers.
 //
@@ -71,6 +69,8 @@ template<typename V = int64_t, typename U = as_underlying_t<V>>
 requires Integer<V> || StdEnum<V>
 class interval {
 public:
+#pragma region interval_iterator
+
   class interval_iterator {
     // A note on iterator size:
     //
@@ -138,11 +138,10 @@ public:
     U u_;
   };
 
-public:
-  //
-  // Types
-  //
+#pragma endregion
+#pragma region Types
 
+public:
   using raw_pair = std::pair<U, U>;
   using value_type = V;
   using representation_type = U;
@@ -155,9 +154,8 @@ public:
   using reverse_iterator = std::reverse_iterator<iterator>;
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-  //
-  // Construction
-  //
+#pragma endregion
+#pragma region Construction
 
   constexpr interval() noexcept : pair_{U{}, U{}} {}
   constexpr interval(const interval&) noexcept = default;
@@ -182,9 +180,8 @@ public:
   // Convert to a copy of the underlying half-open [begin, end) pair.
   [[nodiscard]] constexpr operator raw_pair() const noexcept { return pair_; }
 
-  //
-  // Iterators
-  //
+#pragma endregion
+#pragma region Iterators
 
   // Note: When `invalid`, so are the iterators, but `empty` is fine.
 
@@ -208,9 +205,8 @@ public:
   [[nodiscard]] constexpr auto rbegin() const noexcept { return crbegin(); }
   [[nodiscard]] constexpr auto rend() const noexcept { return crend(); }
 
-  //
-  // Size
-  //
+#pragma endregion
+#pragma region Size
 
   // Note: When `invalid`, then `size` underflows by going negative. Therefore,
   // while an invalid instance counts as empty, its size is undefined.
@@ -308,9 +304,8 @@ public:
     b() += as_u(len);
   }
 
-  //
-  // Min/max
-  //
+#pragma endregion
+#pragma region Min/max
 
   // The `min` and `max` methods provide lower-level access to the interval
   // values, both because they return U instead of V, and also because they
@@ -330,6 +325,8 @@ public:
     return *this;
   }
 
+#pragma endregion
+#pragma region Implementation
 private:
   [[nodiscard]] constexpr bool ok() const noexcept {
     assert(!invalid());
@@ -349,8 +346,16 @@ private:
   [[nodiscard]] static constexpr U as_u(V v) { return static_cast<U>(v); }
   [[nodiscard]] static constexpr V as_v(U u) { return static_cast<V>(u); }
 
+#pragma endregion
+#pragma region Data members
+
   raw_pair pair_{};
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region make_interval
 
 // Make interval for full range of sequence enum, for use with ranged-for.
 //
@@ -376,11 +381,17 @@ template<bitmask::BitmaskEnum E, typename U = as_underlying_t<E>>
   return interval<E, U>{E{}, max_value<E>()};
 }
 
+#pragma endregion
+#pragma region Interval
+
 // `T` must be an an `interval`.
 template<typename T>
 concept Interval = is_specialization_of_v<T, interval>;
 
+#pragma endregion
 }} // namespace corvid::intervals
+
+#pragma region format_kind
 
 // `interval` is iterable, so without this the std range formatter would
 // enumerate every value instead of showing the bounds. Disabling its range
@@ -388,6 +399,9 @@ concept Interval = is_specialization_of_v<T, interval>;
 template<typename V, typename U>
 constexpr std::range_format std::format_kind<corvid::interval<V, U>> =
     std::range_format::disabled;
+
+#pragma endregion
+#pragma region formatter
 
 // Formatter for `interval`, narrow only: a numeric or enum range is a narrow
 // concern, and going wide would mean parameterizing the brackets too.
@@ -429,3 +443,5 @@ struct std::formatter<corvid::interval<V, U>, char> {
 private:
   bool debug_{false};
 };
+
+#pragma endregion

--- a/corvid/controllers/pid_controller.h
+++ b/corvid/controllers/pid_controller.h
@@ -23,6 +23,8 @@
 
 namespace corvid { inline namespace lang { namespace controllers {
 
+#pragma region pid_controller
+
 // PID controller class.
 //
 // The Proportional-Integral-Derivative (PID) controller is a common control
@@ -108,10 +110,15 @@ namespace corvid { inline namespace lang { namespace controllers {
 // change in the measured value instead of the error.
 class pid_controller {
 public:
+#pragma region Constants
+
   static constexpr double pos_infinity =
       std::numeric_limits<double>::infinity();
   static constexpr double neg_infinity =
       -std::numeric_limits<double>::infinity();
+
+#pragma endregion
+#pragma region Construction
 
   pid_controller(double kp, double ki, double kd, double alpha = 0.0,
       double min_value = neg_infinity,
@@ -126,6 +133,9 @@ public:
 
   pid_controller(const pid_controller&) = default;
   pid_controller& operator=(const pid_controller&) = delete;
+
+#pragma endregion
+#pragma region Operations
 
   // Update the controller, returning the new input value.
   [[nodiscard]] double
@@ -203,7 +213,9 @@ public:
     d_term_last_ = 0.0;
   }
 
-  // Accessors.
+#pragma endregion
+#pragma region Accessors
+
   [[nodiscard]] double kp() const noexcept { return kp_; }
   [[nodiscard]] double ki() const noexcept { return ki_; }
   [[nodiscard]] double kd() const noexcept { return kd_; }
@@ -218,6 +230,8 @@ public:
     return cumulative_error_;
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   const double kp_{0.0};
   const double ki_{0.0};
@@ -231,6 +245,9 @@ private:
   double error_last_{0.0};
   double cumulative_error_{0.0};
   double d_term_last_{0.0};
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::lang::controllers

--- a/corvid/controllers/sopdt_plant.h
+++ b/corvid/controllers/sopdt_plant.h
@@ -22,6 +22,8 @@
 
 namespace corvid { inline namespace lang { namespace controllers {
 
+#pragma region soptd_plant
+
 // Simulation of SOPTD (Second-Order Plus Dead Time) plant for testing
 // purposes.
 //
@@ -36,6 +38,8 @@ namespace corvid { inline namespace lang { namespace controllers {
 // intended for testing, not production use.
 class soptd_plant {
 public:
+#pragma region Construction
+
   soptd_plant(double K, double tau1, double tau2, double L, double dt)
       : K_{K}, tau1_{tau1}, tau2_{tau2}, L_{L}, dt_{dt} {
     // Compute number of samples corresponding to dead time L.
@@ -48,6 +52,9 @@ public:
 
   soptd_plant(const soptd_plant&) = default;
   soptd_plant& operator=(const soptd_plant&) = delete;
+
+#pragma endregion
+#pragma region Operations
 
   [[nodiscard]] double update(double u) {
     // Apply dead time via delay buffer.
@@ -67,12 +74,17 @@ public:
     std::ranges::fill(delay_buffer_, 0.0);
   }
 
+#pragma endregion
+#pragma region Accessors
+
   [[nodiscard]] double get_gain() const { return K_; }
   [[nodiscard]] double get_tau1() const { return tau1_; }
   [[nodiscard]] double get_tau2() const { return tau2_; }
   [[nodiscard]] double get_dead_time() const { return L_; }
   [[nodiscard]] double get_dt() const { return dt_; }
 
+#pragma endregion
+#pragma region Data members
 private:
   const double K_;
   const double tau1_;
@@ -82,6 +94,9 @@ private:
   double x1_ = 0.0;
   double x2_ = 0.0;
   std::vector<double> delay_buffer_;
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::lang::controllers

--- a/corvid/ecs/archetype_scene.h
+++ b/corvid/ecs/archetype_scene.h
@@ -644,13 +644,8 @@ public:
               using storage_t = std::remove_cvref_t<decltype(storage)>;
               auto row = storage[id];
               found = result_t{
-                  [&]() -> std::conditional_t<std::is_const_v<self_t>,
-                            const Cs*, Cs*> {
-                    if constexpr (has_all_components_v<storage_t, Cs>)
-                      return &row.template component<Cs>();
-                    else
-                      return nullptr;
-                  }()...};
+                  some_component_ptr<std::is_const_v<self_t>, storage_t, Cs>(
+                      row)...};
             }
           }(std::get<Is>(self.storages_)),
           ...);
@@ -687,6 +682,20 @@ public:
   }
 
 private:
+  // Pointer to component `C` in `row`, or null when the row's storage lacks
+  // `C`. `IsConst` pins the pointer constness to the scene's, independent of
+  // whether `C` is present, so the absent case still yields a matching `const
+  // C*` / `C*`. Factored out of `try_get_some_components` because gcc cannot
+  // pack-expand a lambda that names an unexpanded parameter pack.
+  template<bool IsConst, typename StorageT, typename C, typename Row>
+  [[nodiscard]] static constexpr std::conditional_t<IsConst, const C*, C*>
+  some_component_ptr(Row& row) noexcept {
+    if constexpr (has_all_components_v<StorageT, C>)
+      return &row.template component<C>();
+    else
+      return nullptr;
+  }
+
   // Bit index of component type C in `component_union_t` / `megatuple_t`.
   template<typename C>
   static constexpr size_t component_bit_v =

--- a/corvid/ecs/archetype_scene.h
+++ b/corvid/ecs/archetype_scene.h
@@ -18,6 +18,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <tuple>
 #include <type_traits>

--- a/corvid/ecs/archetype_scene.h
+++ b/corvid/ecs/archetype_scene.h
@@ -31,6 +31,8 @@
 
 namespace corvid { inline namespace ecs { inline namespace archetype_scenes {
 
+#pragma region archetype_scene_base
+
 // Non-templated base for `archetype_scene<>`. Befriended by `storage_base` so
 // that the protected `storage_drop_all` thunk can reach the otherwise-private
 // `do_drop_all` on any storage, without making that method public.
@@ -43,6 +45,9 @@ protected:
     return s.do_drop_all();
   }
 };
+
+#pragma endregion
+#pragma region archetype_scene
 
 // Aggregates an `entity_registry` with a fixed, heterogeneous tuple of entity
 // data storages (`archetype_storage` or `chunked_archetype_storage` or
@@ -82,6 +87,8 @@ protected:
 template<typename REG, typename... STORES>
 class archetype_scene: public archetype_scene_base {
 public:
+#pragma region Types
+
   using registry_t = REG;
   using storage_ts = std::tuple<STORES...>;
   using storage_tuple_t = std::tuple<std::monostate, STORES...>;
@@ -128,6 +135,9 @@ public:
   template<store_id_t SID>
   using storage_t = std::tuple_element_t<*SID, storage_tuple_t>;
 
+#pragma endregion
+#pragma region Construction
+
   // Construct with unlimited, unbound storages. Each storage is bound to
   // this scene's registry and assigned `store_id_t{N}` for 1-based index N.
   // An optional allocator propagates to the registry; all storage allocations
@@ -144,6 +154,9 @@ public:
   ~archetype_scene() {
     try_or_terminate([&] { return clear() || true; });
   }
+
+#pragma endregion
+#pragma region Accessors
 
   // Registry access.
   [[nodiscard]] decltype(auto) registry(this auto& self) noexcept {
@@ -164,6 +177,9 @@ public:
     using storage_type = std::remove_cvref_t<STORAGE>;
     return (std::get<storage_type>(self.storages_));
   }
+
+#pragma endregion
+#pragma region Create
 
   // Create a new entity in staging. Returns its handle, or an invalid handle
   // on failure (e.g., registry at ID limit).
@@ -241,6 +257,9 @@ public:
     return handle_t{};
   }
 
+#pragma endregion
+#pragma region Store
+
   // Insert an already-staged entity into a storage selected at runtime by
   // `store_id`. Returns false if `store_id` does not match a storage, the
   // entity is not in staging, or insertion fails (e.g., storage at limit).
@@ -309,6 +328,9 @@ public:
     return store_entity(handle.id(), std::forward<T>(obj));
   }
 
+#pragma endregion
+#pragma region Erase and remove
+
   // Erase entity from whatever storage it occupies (or from staging if it
   // has not been placed in any storage). Invalidates `id`. ID must be valid.
   [[nodiscard]] bool erase_entity(id_t& id) {
@@ -366,6 +388,9 @@ public:
     if (!registry_.is_valid(handle)) return false;
     return remove_entity(handle.id());
   }
+
+#pragma endregion
+#pragma region Migrate
 
   // Migrate entity to storage `to` using a caller-supplied `build` function
   // that maps the source row to the target components. Both the source storage
@@ -483,6 +508,9 @@ public:
     if (!registry_.is_valid(handle)) return false;
     return migrate_entity(handle.id(), to);
   }
+
+#pragma endregion
+#pragma region Queries
 
   // Return the total number of entities across all storages. Does not include
   // staged entities.
@@ -653,6 +681,9 @@ public:
     return found;
   }
 
+#pragma endregion
+#pragma region Clear
+
   // Erase all entities in all storages and in staging. After this call the
   // registry and all storages are empty. When `policy` is release, uses the
   // fast path that drops storage vectors and resets the registry wholesale,
@@ -681,6 +712,8 @@ public:
     return true;
   }
 
+#pragma endregion
+#pragma region Implementation
 private:
   // Pointer to component `C` in `row`, or null when the row's storage lacks
   // `C`. `IsConst` pins the pointer constness to the scene's, independent of
@@ -788,11 +821,16 @@ private:
     return result;
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   // `registry_` must be declared before `storages_` because each storage
   // holds a pointer to it (initialized in `make_storages`).
   registry_t registry_;
   storage_tuple_t storages_;
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::ecs::archetype_scenes

--- a/corvid/ecs/archetype_storage.h
+++ b/corvid/ecs/archetype_storage.h
@@ -32,6 +32,8 @@
 
 namespace corvid { inline namespace ecs { inline namespace archetype_storages {
 
+#pragma region archetype_storage
+
 // Packed archetype components storage with O(1) lookup through
 // `entity_registry`.
 //
@@ -69,6 +71,8 @@ class archetype_storage<REG, std::tuple<Cs...>, TAG> final
     : public archetype_storage_base<
           archetype_storage<REG, std::tuple<Cs...>, TAG>, REG,
           std::tuple<Cs...>> {
+#pragma region Types
+
   using base_t = archetype_storage_base<
       archetype_storage<REG, std::tuple<Cs...>, TAG>, REG, std::tuple<Cs...>>;
 
@@ -101,7 +105,8 @@ public:
   template<typename T>
   using component_vector_t = std::vector<T, component_allocator_t<T>>;
 
-  // Constructors.
+#pragma endregion
+#pragma region Construction
 
   // Default-constructed storage has no registry binding. Assign from a
   // fully constructed instance before calling any mutation methods.
@@ -130,7 +135,9 @@ public:
   archetype_storage& operator=(const archetype_storage&) = delete;
   archetype_storage& operator=(archetype_storage&&) noexcept = default;
 
-  // Swap.
+#pragma endregion
+#pragma region Swap
+
   void swap(archetype_storage& other) noexcept {
     base_t::do_swap_base(other);
     components_.swap(other.components_);
@@ -140,6 +147,9 @@ public:
       noexcept(lhs.swap(rhs))) {
     lhs.swap(rhs);
   }
+
+#pragma endregion
+#pragma region Capacity
 
   // Shrink all component vectors and IDs to fit their size.
   void shrink_to_fit() {
@@ -166,6 +176,9 @@ public:
     return static_cast<size_type>(min_cap);
   }
 
+#pragma endregion
+#pragma region Insertion
+
   // Create a new entity by extracting this archetype's components from `mega`,
   // a `megatuple_t` (tuple of optionals). Each `optional<C>` for a component
   // `C` in this archetype must have a value; the caller is responsible for
@@ -178,6 +191,8 @@ public:
   }
   // NOLINTEND(bugprone-unchecked-optional-access)
 
+#pragma endregion
+#pragma region Implementation
 private:
   using base_t::registry_;
   using base_t::store_id_;
@@ -273,9 +288,14 @@ private:
         component_vector_t<Cs>{component_allocator_t<Cs>{alloc}}...};
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   // SoA storage: a tuple of vectors, one per component type.
   std::tuple<component_vector_t<Cs>...> components_{};
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::ecs::archetype_storages

--- a/corvid/ecs/archetype_storage_base.h
+++ b/corvid/ecs/archetype_storage_base.h
@@ -36,6 +36,8 @@ class archetype_scene_base;
 namespace corvid { inline namespace ecs {
 inline namespace archetype_storage_bases {
 
+#pragma region archetype_storage_base
+
 // CRTP base class for `archetype_storage`, `chunked_archetype_storage`, and
 // `mono_archetype_storage`. Provides the registry-interaction plumbing common
 // to all packed archetype storages (entity ID tracking, `entity_registry`
@@ -75,6 +77,8 @@ class archetype_storage_base;
 template<typename CHILD, typename REG, typename... Cs>
 class archetype_storage_base<CHILD, REG, std::tuple<Cs...>> {
 public:
+#pragma region Types
+
   using derived_t = CHILD;
   using registry_t = REG;
   using id_t = registry_t::id_t;
@@ -90,6 +94,9 @@ public:
   using tuple_t = std::tuple<Cs...>;
 
   static_assert(sizeof...(Cs) > 0);
+
+#pragma endregion
+#pragma region Queries
 
   // Check whether an entity is in this storage, by ID.
   [[nodiscard]] bool contains(id_t id) const {
@@ -124,6 +131,9 @@ public:
     limit_ = new_limit;
     return true;
   }
+
+#pragma endregion
+#pragma region Removal
 
   // Remove entity by ID, moving it back to staging. Returns success flag.
   bool remove(id_t id) { return do_remove_erase(id, store_id_t{}); }
@@ -160,6 +170,9 @@ public:
     return true;
   }
 
+#pragma endregion
+#pragma region add_guard
+
   // RAII guard for `add`: captures `size` on construction. If `disarm` is not
   // called before destruction, rolls `ids_` and derived storage back to the
   // saved size, providing strong exception safety.
@@ -188,6 +201,9 @@ public:
     derived_t* owner_{};
     size_type saved_size_{};
   };
+
+#pragma endregion
+#pragma region row_wrapper
 
   // Lightweight, non-owning handle to a single entity's row. When
   // `ACCESS=access::as_mutable`, `row_lens` (mutable);
@@ -262,6 +278,9 @@ public:
   // Mutable row lens.
   using row_lens = row_wrapper<access::as_mutable>;
 
+#pragma endregion
+#pragma region row_iterator
+
   // Bidirectional iterator. Dereferencing yields a `row_lens` or `row_view`,
   // depending on constness. Invalidated by any structural mutation
   // (add/remove/erase).
@@ -328,6 +347,9 @@ public:
   using iterator = row_iterator<access::as_mutable>;
   using const_iterator = row_iterator<access::as_const>;
 
+#pragma endregion
+#pragma region Insertion
+
   // Atomically create an entity in the registry and insert it into this
   // storage. Returns the new entity's handle on success, or an invalid handle
   // if the registry refused creation or the storage limit would be exceeded.
@@ -376,6 +398,9 @@ public:
     if (!registry_->is_valid(handle)) return false;
     return add(handle.id(), std::forward<Args>(args)...);
   }
+
+#pragma endregion
+#pragma region Conditional removal
 
   // Erase entities for which `pred(comp, id)` returns true, where `comp` is a
   // const reference to the entity's `C` component and `id` is its ID. Uses
@@ -433,6 +458,9 @@ public:
     return do_remove_erase_if(std::move(pred), store_id_t{});
   }
 
+#pragma endregion
+#pragma region Element access
+
   // Access the row for entity `id` as a `row_lens` (mutable) or `row_view`
   // (const). Entity must be valid and in this storage; asserts in debug.
   [[nodiscard]] row_lens operator[](id_t id) noexcept {
@@ -471,6 +499,9 @@ public:
     return (*this)[handle.id()];
   }
 
+#pragma endregion
+#pragma region Iteration
+
   // Bidirectional iteration over all entities in storage-sequential order.
   [[nodiscard]] iterator begin() noexcept { return iterator{*this, 0}; }
   [[nodiscard]] iterator end() noexcept { return iterator{*this, size()}; }
@@ -486,6 +517,9 @@ public:
   [[nodiscard]] const_iterator cend() const noexcept {
     return const_iterator{*this, size()};
   }
+
+#pragma endregion
+#pragma region Construction
 
   // Public deleted/defined special members.
   archetype_storage_base(const archetype_storage_base&) = delete;
@@ -531,6 +565,9 @@ protected:
     return *this;
   }
 
+#pragma endregion
+#pragma region Helpers
+
   // CRTP helpers.
   [[nodiscard]] derived_t& derived() noexcept {
     return static_cast<derived_t&>(*this);
@@ -550,6 +587,9 @@ protected:
     return true;
   }
 
+#pragma endregion
+#pragma region Data members
+
   // Data members shared by all derived classes.
   registry_t* registry_{nullptr};
   store_id_t store_id_{store_id_t::invalid};
@@ -560,6 +600,8 @@ protected:
   // to `do_drop_all`.
   friend class ::corvid::ecs::archetype_scene_base;
 
+#pragma endregion
+#pragma region Implementation
 private:
   // Fast bulk-drop: clear component and ID vectors without touching the
   // registry. Only safe when the registry will be reset wholesale immediately
@@ -631,6 +673,9 @@ private:
     }
     return cnt;
   }
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::ecs::archetype_storage_bases

--- a/corvid/ecs/chunked_archetype_storage.h
+++ b/corvid/ecs/chunked_archetype_storage.h
@@ -32,6 +32,8 @@
 namespace corvid { inline namespace ecs {
 inline namespace chunked_archetype_storages {
 
+#pragma region chunked_archetype_storage
+
 // AoSoA archetype component storage with O(1) lookup through
 // `entity_registry`.
 //
@@ -67,6 +69,8 @@ class chunked_archetype_storage<REG, std::tuple<Cs...>, CHUNKSZ, TAG> final
     : public archetype_storage_base<
           chunked_archetype_storage<REG, std::tuple<Cs...>, CHUNKSZ, TAG>, REG,
           std::tuple<Cs...>> {
+#pragma region Types
+
   using base_t = archetype_storage_base<
       chunked_archetype_storage<REG, std::tuple<Cs...>, CHUNKSZ, TAG>, REG,
       std::tuple<Cs...>>;
@@ -110,7 +114,8 @@ public:
 
   using chunk_vector_t = std::vector<chunk_tuple_t, chunk_allocator_t>;
 
-  // Constructors.
+#pragma endregion
+#pragma region Construction
 
   // Default-constructed storage has no registry binding. Assign from a
   // fully constructed instance before calling any mutation methods.
@@ -141,7 +146,9 @@ public:
   chunked_archetype_storage& operator=(
       chunked_archetype_storage&&) noexcept = default;
 
-  // Swap.
+#pragma endregion
+#pragma region Swap
+
   void swap(chunked_archetype_storage& other) noexcept {
     base_t::do_swap_base(other);
     chunks_.swap(other.chunks_);
@@ -151,6 +158,9 @@ public:
       chunked_archetype_storage& rhs) noexcept(noexcept(lhs.swap(rhs))) {
     lhs.swap(rhs);
   }
+
+#pragma endregion
+#pragma region Capacity
 
   // Shrink the chunk vector and IDs to fit their current sizes.
   void shrink_to_fit() {
@@ -173,6 +183,8 @@ public:
     return static_cast<size_type>(ids_.capacity());
   }
 
+#pragma endregion
+#pragma region Implementation
 private:
   using base_t::registry_;
   using base_t::store_id_;
@@ -281,9 +293,14 @@ private:
     // NOLINTEND(clang-analyzer-core.NullDereference)
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   // AoSoA storage: one chunk per K entities, each chunk a tuple of arrays.
   chunk_vector_t chunks_{};
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::ecs::chunked_archetype_storages

--- a/corvid/ecs/component_index_policies.h
+++ b/corvid/ecs/component_index_policies.h
@@ -58,6 +58,8 @@ namespace corvid { inline namespace ecs { inline namespace component_indexes {
 //   SIZE_T - Type used to store packed-array indices. Defaults to the
 //             underlying type of `ID_T`.
 
+#pragma region flat_sparse_index
+
 // Flat sparse reverse index.
 //
 // A plain `std::vector<size_type>`, indexed by `*id`. The vector grows to
@@ -71,8 +73,13 @@ template<sequence::SequentialEnum ID_T,
     typename SIZE_T = std::underlying_type_t<ID_T>>
 class flat_sparse_index {
 public:
+#pragma region Types
+
   using id_t = ID_T;
   using size_type = SIZE_T;
+
+#pragma endregion
+#pragma region Operations
 
   // Insert or overwrite the ndx for `id`. Grows the vector if needed.
   void insert(id_t id, size_type ndx) {
@@ -99,9 +106,16 @@ public:
   // Clear all state.
   void clear() noexcept { data_.clear(); }
 
+#pragma endregion
+#pragma region Data members
 private:
   std::vector<size_type> data_;
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region sorted_pair_index
 
 // Sorted-pair reverse index.
 //
@@ -113,11 +127,16 @@ private:
 template<sequence::SequentialEnum ID_T,
     typename SIZE_T = std::underlying_type_t<ID_T>>
 class sorted_pair_index {
+#pragma region Types
+
   using id_t = ID_T;
   using size_type = SIZE_T;
   using pair_t = std::pair<id_t, size_type>;
   using iter_t = std::vector<pair_t>::iterator;
   using citer_t = std::vector<pair_t>::const_iterator;
+
+#pragma endregion
+#pragma region Helpers
 
   [[nodiscard]] iter_t find_it(id_t id) {
     return std::lower_bound(data_.begin(), data_.end(), id,
@@ -128,6 +147,9 @@ class sorted_pair_index {
     return std::lower_bound(data_.cbegin(), data_.cend(), id,
         [](const pair_t& p, id_t v) { return p.first < v; });
   }
+
+#pragma endregion
+#pragma region Operations
 
 public:
   // Insert ndx for `id`. If a stale entry already exists (from a prior failed
@@ -165,9 +187,16 @@ public:
   // Clear all state.
   void clear() { data_.clear(); }
 
+#pragma endregion
+#pragma region Data members
 private:
   std::vector<pair_t> data_;
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region paged_sparse_index
 
 // Paged sparse reverse index.
 //
@@ -185,11 +214,16 @@ private:
 template<sequence::SequentialEnum ID_T,
     typename SIZE_T = std::underlying_type_t<ID_T>, size_t PAGE_SIZE = 256>
 class paged_sparse_index {
+#pragma region Types
+
   using id_t = ID_T;
   using size_type = SIZE_T;
   static constexpr size_t page_size_v = PAGE_SIZE;
   static_assert((page_size_v & (page_size_v - 1)) == 0,
       "PAGE_SIZE must be a power of two");
+
+#pragma endregion
+#pragma region Helpers
 
   static constexpr size_t page_of(size_t raw) noexcept {
     return raw / page_size_v;
@@ -206,6 +240,9 @@ class paged_sparse_index {
     }
     return page_dir_[pg];
   }
+
+#pragma endregion
+#pragma region Operations
 
 public:
   // Insert or overwrite the ndx for `id`.
@@ -240,6 +277,8 @@ public:
     alloc_.clear();
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   // Outer directory: page index -> raw pointer into the page's array.
   // `nullptr` means the page has not been allocated yet.
@@ -247,6 +286,9 @@ private:
 
   // Owning storage for each allocated page. Freed all at once by `clear`.
   std::vector<std::unique_ptr<size_type[]>> alloc_;
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::ecs::component_indexes

--- a/corvid/ecs/component_scene.h
+++ b/corvid/ecs/component_scene.h
@@ -29,6 +29,8 @@
 
 namespace corvid { inline namespace ecs { inline namespace component_scenes {
 
+#pragma region component_scene_base
+
 // Non-templated base for `component_scene<>`. Befriended by
 // `component_storage_base` so that the protected `storage_drop_all` thunk can
 // reach the otherwise-private `do_drop_all` on any storage, without making
@@ -42,6 +44,9 @@ protected:
     s.do_drop_all();
   }
 };
+
+#pragma endregion
+#pragma region component_scene
 
 // Aggregates a component-mode `entity_registry` with a fixed, heterogeneous
 // tuple of `component_storage_base`-derived storages and exposes a unified
@@ -75,6 +80,8 @@ protected:
 template<typename REG, typename... STORES>
 class component_scene: public component_scene_base {
 public:
+#pragma region Types
+
   using registry_t = REG;
   using storage_ts = std::tuple<STORES...>;
   using storage_tuple_t = std::tuple<std::monostate, STORES...>;
@@ -110,6 +117,9 @@ public:
   template<store_id_t SID>
   using storage_t = std::tuple_element_t<*SID, storage_tuple_t>;
 
+#pragma endregion
+#pragma region Construction
+
   // Construct with unlimited, unbound storages. Each storage is bound to this
   // scene's registry and assigned `store_id_t{N}` for 1-based index `N`. An
   // optional allocator propagates to the registry.
@@ -125,6 +135,9 @@ public:
   ~component_scene() {
     try_or_terminate([&] { return clear() || true; });
   }
+
+#pragma endregion
+#pragma region Accessors
 
   // Registry access.
   [[nodiscard]] decltype(auto) registry(this auto& self) noexcept {
@@ -145,11 +158,17 @@ public:
     return (std::get<storage_type>(self.storages_));
   }
 
+#pragma endregion
+#pragma region Create
+
   // Create a new entity in staging. Returns its handle, or an invalid handle
   // on failure (e.g., registry at ID limit).
   [[nodiscard]] handle_t stage_new_entity(const metadata_t& metadata = {}) {
     return registry_.create_handle({}, metadata);
   }
+
+#pragma endregion
+#pragma region Store
 
   // Insert an existing entity into storage `SID`. The entity must be valid
   // and not already present in that storage. Trailing components may be
@@ -170,6 +189,9 @@ public:
     if (!registry_.is_valid(handle)) return false;
     return store_entity<SID>(handle.id(), std::forward<Args>(args)...);
   }
+
+#pragma endregion
+#pragma region Remove and restage
 
   // Remove entity from storage `SID` only. The entity remains alive in the
   // registry and any other storages it occupies. If this is its last storage,
@@ -209,6 +231,9 @@ public:
     return restage_entity(handle.id());
   }
 
+#pragma endregion
+#pragma region Erase
+
   // Erase entity: remove from all storages it currently occupies, then
   // destroy it in the registry. Sets `id` to `id_t::invalid`. Returns false
   // if the entity is already invalid.
@@ -245,6 +270,9 @@ public:
       return rec.location.contains(store_id_t{});
     });
   }
+
+#pragma endregion
+#pragma region Queries
 
   // Return the total number of living entities (including those in staging).
   [[nodiscard]] size_type size() const noexcept { return registry_.size(); }
@@ -344,6 +372,9 @@ public:
     return failures;
   }
 
+#pragma endregion
+#pragma region Clear
+
   // Erase all entities in all storages and in staging.
   //
   // Release path (default): drops storage vectors without per-entity registry
@@ -367,6 +398,8 @@ public:
     return true;
   }
 
+#pragma endregion
+#pragma region Implementation
 private:
   // Return a mutable or const reference to the component held by the storage
   // matched by selector `C` for entity `id`, propagating the scene's
@@ -493,10 +526,16 @@ private:
         STORES{registry_, store_id_t{Is + 1}}...);
   }
 
+#pragma endregion
+#pragma region Data members
+
   // `registry_` must be declared before `storages_` because each storage
   // holds a pointer to it (initialized in `make_storages`).
   registry_t registry_;
   storage_tuple_t storages_;
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::ecs::component_scenes

--- a/corvid/ecs/component_storage.h
+++ b/corvid/ecs/component_storage.h
@@ -29,6 +29,8 @@
 
 namespace corvid { inline namespace ecs { inline namespace component_storages {
 
+#pragma region component_storage
+
 // Packed single-component storage for the component model.
 //
 // Maps entity IDs to densely packed component records using swap-and-pop for
@@ -58,6 +60,8 @@ template<typename REG, typename C, typename TAG = void,
 class component_storage final
     : public component_storage_base<component_storage<REG, C, TAG, IDX>, REG,
           IDX> {
+#pragma region Types
+
   using base_t =
       component_storage_base<component_storage<REG, C, TAG, IDX>, REG, IDX>;
 
@@ -85,7 +89,8 @@ public:
   static_assert(std::is_trivially_copyable_v<component_t>,
       "Component type must be trivially copyable");
 
-  // Constructors.
+#pragma endregion
+#pragma region Construction
 
   // Default-constructed instances can only be assigned to.
   component_storage() noexcept = default;
@@ -115,6 +120,9 @@ public:
     return *this;
   }
 
+#pragma endregion
+#pragma region Swap
+
   // Swap with another storage of the same type.
   void swap(component_storage& other) noexcept {
     base_t::do_swap_base(other);
@@ -124,6 +132,9 @@ public:
   friend void swap(component_storage& lhs, component_storage& rhs) noexcept {
     lhs.swap(rhs);
   }
+
+#pragma endregion
+#pragma region Capacity
 
   // Reduce memory usage to fit current size.
   void shrink_to_fit() {
@@ -137,6 +148,9 @@ public:
     ids_.reserve(new_cap);
   }
 
+#pragma endregion
+#pragma region Insertion
+
   // Add a component for a new entity. Component-first convenience overload.
   [[nodiscard]] handle_t
   add_new(const component_t& component, const metadata_t& metadata = {}) {
@@ -149,6 +163,9 @@ public:
       const component_t& component = component_t{}) {
     return base_t::add_new(metadata, component);
   }
+
+#pragma endregion
+#pragma region Conditional removal
 
   // Erase entities for which `pred(component, id)` returns true. Removed
   // entities are erased from the registry if this is their last storage.
@@ -165,6 +182,9 @@ public:
   size_type remove_if(auto pred) {
     return do_bulk_op(std::move(pred), removal_mode::preserve);
   }
+
+#pragma endregion
+#pragma region row_view
 
   // Read-only view of a single entity's row. Provides a `component<T>`
   // accessor uniform with archetype storages (only valid for `T ==
@@ -187,6 +207,9 @@ public:
 
     [[nodiscard]] id_t id() const noexcept { return entity_id; }
   };
+
+#pragma endregion
+#pragma region Element access
 
   // Mutable access: returns `component_t&` directly.
   [[nodiscard]] component_t& operator[](id_t id) noexcept {
@@ -228,6 +251,9 @@ public:
           "invalid handle or entity not in this storage");
     return (*this)[handle.id()];
   }
+
+#pragma endregion
+#pragma region iterator_t
 
   // Contiguous iterator over components. Dereferencing yields a `component_t`
   // reference; `id` returns the entity ID at the current position.
@@ -328,6 +354,9 @@ public:
   using iterator = iterator_t<access::as_mutable>;
   using const_iterator = iterator_t<access::as_const>;
 
+#pragma endregion
+#pragma region Iteration
+
   [[nodiscard]] iterator begin() noexcept { return {this, 0}; }
   [[nodiscard]] iterator end() noexcept { return {this, size()}; }
   [[nodiscard]] const_iterator begin() const noexcept { return {this, 0}; }
@@ -335,6 +364,8 @@ public:
   [[nodiscard]] const_iterator cbegin() const noexcept { return begin(); }
   [[nodiscard]] const_iterator cend() const noexcept { return end(); }
 
+#pragma endregion
+#pragma region Implementation
 private:
   using base_t::registry_;
   using base_t::store_id_;
@@ -406,8 +437,13 @@ private:
     return cnt;
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   std::vector<C, component_allocator_type> components_;
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::ecs::component_storages

--- a/corvid/ecs/component_storage_base.h
+++ b/corvid/ecs/component_storage_base.h
@@ -35,6 +35,8 @@ class component_scene_base;
 namespace corvid { inline namespace ecs {
 inline namespace component_storage_bases {
 
+#pragma region component_storage_base
+
 // CRTP base class for component-model entity storages.
 //
 // Mirrors `archetype_storage_base` structurally but uses a policy-based
@@ -68,6 +70,8 @@ inline namespace component_storage_bases {
 template<typename CHILD, typename REG, typename IDX>
 class component_storage_base {
 public:
+#pragma region Types
+
   static_assert(REG::is_component_v,
       "component_storage_base requires a component-mode registry "
       "(OWN_COUNT must be >= 2)");
@@ -84,6 +88,9 @@ public:
       std::allocator_traits<allocator_type>::template rebind_alloc<id_t>;
   using id_vector_t = std::vector<id_t, id_allocator_t>;
   using index_t = IDX;
+
+#pragma endregion
+#pragma region Queries
 
   // Check whether entity `id` is currently in this storage (via bitmap).
   [[nodiscard]] bool contains(id_t id) const {
@@ -124,6 +131,9 @@ public:
     return true;
   }
 
+#pragma endregion
+#pragma region Removal
+
   // Remove entity from this storage. Entity remains alive: moved to staging
   // if this was its only storage, otherwise remains in its other storages.
   // Returns false if entity is invalid or not in this storage.
@@ -153,6 +163,9 @@ public:
   // Remove all entities from this storage. Entities with no remaining
   // storages are destroyed in the registry.
   bool clear() { return do_remove_erase_all(removal_mode::remove) || true; }
+
+#pragma endregion
+#pragma region Insertion
 
   // Insert component data for an entity. Entity must be valid and not already
   // in this storage. May be in other storages (component model allows this).
@@ -193,6 +206,9 @@ public:
     return owner.release();
   }
 
+#pragma endregion
+#pragma region add_guard
+
   // RAII guard for `add`: captures `size` on construction. If `disarm` is not
   // called before destruction, rolls `ids_` and the derived storage back to
   // the saved size, providing strong exception safety. The `reverse_index_` is
@@ -223,6 +239,9 @@ public:
     derived_t* owner_{};
     size_type saved_size_{};
   };
+
+#pragma endregion
+#pragma region Construction
 
   component_storage_base(const component_storage_base&) = delete;
   component_storage_base& operator=(const component_storage_base&) = delete;
@@ -263,6 +282,9 @@ protected:
     return *this;
   }
 
+#pragma endregion
+#pragma region Helpers
+
   // CRTP helpers.
   [[nodiscard]] derived_t& derived() noexcept {
     return static_cast<derived_t&>(*this);
@@ -282,6 +304,9 @@ protected:
     return true;
   }
 
+#pragma endregion
+#pragma region Data members
+
   // Data members.
   registry_t* registry_{nullptr};
   store_id_t store_id_{store_id_t::invalid};
@@ -293,6 +318,8 @@ protected:
   // to `do_drop_all`.
   friend class ::corvid::ecs::component_scene_base;
 
+#pragma endregion
+#pragma region Implementation
 private:
   // Fast bulk-drop: clear component and ID vectors without touching the
   // registry. Only safe when the registry will be reset wholesale immediately
@@ -329,6 +356,9 @@ private:
     derived().do_clear_storage();
     return true;
   }
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::ecs::component_storage_bases

--- a/corvid/ecs/ecs_meta.h
+++ b/corvid/ecs/ecs_meta.h
@@ -23,6 +23,8 @@
 
 namespace corvid { inline namespace ecs { inline namespace ecs_metas {
 
+#pragma region Tuple membership
+
 // True if `T` appears at least once in `Tuple`.
 template<typename T, typename Tuple>
 struct tuple_contains;
@@ -39,10 +41,16 @@ inline constexpr bool has_all_components_v =
     (tuple_contains_v<Cs, typename Storage::tuple_t> && ...);
 // NOLINTEND(readability-redundant-typename)
 
+#pragma endregion
+#pragma region dependent_false_v
+
 // Always-false helper for `static_assert` in templates, avoiding reliance on
 // `sizeof(C) == 0` which requires `C` to be a complete type.
 template<typename>
 inline constexpr bool dependent_false_v = false;
+
+#pragma endregion
+#pragma region Storage selection
 
 // 0-based index into `Storages...` of the first storage whose
 // `component_t == C`. Fails to compile if no storage matches.
@@ -133,6 +141,9 @@ template<typename C, typename... Storages>
 inline constexpr size_t storage_index_for_v =
     storage_index_for_impl<C, Storages...>();
 
+#pragma endregion
+#pragma region Migration
+
 // Returns a copy of component `C` from `row` if `SrcTuple` contains `C`,
 // otherwise returns a value-initialized `C{}`.
 //
@@ -145,6 +156,9 @@ template<typename C, typename SrcTuple>
   else
     return C{};
 }
+
+#pragma endregion
+#pragma region Tuple operations
 
 // Helper: append T to Tuple only if T is not already present.
 template<typename T, typename Tuple>
@@ -204,4 +218,5 @@ struct wrap_optionals<std::tuple<Cs...>> {
 template<typename Tuple>
 using wrap_optionals_t = wrap_optionals<Tuple>::type;
 
+#pragma endregion
 }}} // namespace corvid::ecs::ecs_metas

--- a/corvid/ecs/entity_ids.h
+++ b/corvid/ecs/entity_ids.h
@@ -31,10 +31,16 @@ namespace id_enums {
 // These have to be declared up front so that we can place `enum_spec_v` in the
 // global namespace. Note that "sys/types.h" also defines a type named `id_t`
 // and rudely injects it into the global namespace.
+
+#pragma region id_t
+
 enum class id_t : size_t { invalid = std::numeric_limits<size_t>::max() };
 consteval auto corvid_enum_spec(id_t*) {
   return corvid::enums::sequence::make_sequence_enum_spec<id_t, "">();
 }
+
+#pragma endregion
+#pragma region entity_id_t
 
 enum class entity_id_t : size_t {
   invalid = std::numeric_limits<size_t>::max()
@@ -42,6 +48,9 @@ enum class entity_id_t : size_t {
 consteval auto corvid_enum_spec(entity_id_t*) {
   return corvid::enums::sequence::make_sequence_enum_spec<entity_id_t, "">();
 }
+
+#pragma endregion
+#pragma region component_id_t
 
 enum class component_id_t : size_t {
   invalid = std::numeric_limits<size_t>::max()
@@ -51,6 +60,9 @@ consteval auto corvid_enum_spec(component_id_t*) {
       "">();
 }
 
+#pragma endregion
+#pragma region archetype_id_t
+
 enum class archetype_id_t : size_t {
   invalid = std::numeric_limits<size_t>::max()
 };
@@ -59,6 +71,9 @@ consteval auto corvid_enum_spec(archetype_id_t*) {
       "">();
 }
 
+#pragma endregion
+#pragma region store_id_t
+
 enum class store_id_t : size_t {
   invalid = std::numeric_limits<size_t>::max()
 };
@@ -66,5 +81,6 @@ consteval auto corvid_enum_spec(store_id_t*) {
   return corvid::enums::sequence::make_sequence_enum_spec<store_id_t, "">();
 }
 
+#pragma endregion
 } // namespace id_enums
 }} // namespace corvid::ecs

--- a/corvid/ecs/entity_registry.h
+++ b/corvid/ecs/entity_registry.h
@@ -309,7 +309,7 @@ public:
     friend class entity_registry<T, EID, SID, GEN, OWN_COUNT, REUSE, A>;
   };
 
-  static constexpr location_record invalid_location;
+  static constexpr location_record invalid_location{};
 
   // Entity record. The entity ID is implied by its location in `records_`.
   //

--- a/corvid/ecs/entity_registry.h
+++ b/corvid/ecs/entity_registry.h
@@ -34,6 +34,8 @@
 
 namespace corvid { inline namespace ecs { inline namespace entity_registries {
 
+#pragma region entity_registry
+
 // Entity Component System: Entity Registry
 //
 // The entity registry owns IDs for entities of a particular entity type in the
@@ -94,6 +96,8 @@ template<typename T = void,
     sequence_order REUSE = sequence_order::fifo, class A = std::allocator<T>>
 class entity_registry {
 public:
+#pragma region Types
+
   static constexpr bool is_versioned_v = (GEN == generation_scheme::versioned);
   static constexpr bool is_archetype_v = (OWN_COUNT == 1);
   static constexpr bool is_component_v = !is_archetype_v;
@@ -142,6 +146,9 @@ public:
 
   static_assert(OWN_COUNT >= 1,
       "OWN_COUNT must be 1 (archetype mode) or >= 2 (component mode)");
+
+#pragma endregion
+#pragma region handle_t
 
   // A handle to an entity. Contains ID and optionally generation data to
   // detect reuse. No ownership: does nothing on destruction.
@@ -195,6 +202,9 @@ public:
     friend class entity_registry<T, EID, SID, GEN, OWN_COUNT, REUSE, A>;
   };
 
+#pragma endregion
+#pragma region location_t
+
   // Single location type.
   //
   // This is the type used for parameters.
@@ -205,6 +215,9 @@ public:
     store_id_t store_id{store_id_t::invalid};
     size_type ndx{*id_t::invalid};
   };
+
+#pragma endregion
+#pragma region location_record
 
   // Record of external storage location(s) for entity.
   //
@@ -311,6 +324,9 @@ public:
 
   static constexpr location_record invalid_location{};
 
+#pragma endregion
+#pragma region record_t
+
   // Entity record. The entity ID is implied by its location in `records_`.
   //
   // When specializing `entity_registry` class, the user must do the math to
@@ -335,6 +351,9 @@ public:
   using record_allocator_type =
       std::allocator_traits<A>::template rebind_alloc<record_t>;
 
+#pragma endregion
+#pragma region Construction
+
 public:
   entity_registry() = default;
   explicit entity_registry(const allocator_type& alloc)
@@ -348,6 +367,9 @@ public:
   [[nodiscard]] allocator_type get_allocator() const noexcept {
     return allocator_type{records_.get_allocator()};
   }
+
+#pragma endregion
+#pragma region Limit
 
   // Maximum allowed ID value.
   //
@@ -377,6 +399,9 @@ public:
 
     return records_.set_id_limit(new_limit);
   }
+
+#pragma endregion
+#pragma region Creation
 
   // Create a new entity record, returning its ID, or `id_t::invalid` on
   // failure.
@@ -417,6 +442,9 @@ public:
       return handle_t{id, 0};
   }
 
+#pragma endregion
+#pragma region Validity
+
   // Check whether the ID is valid. Cannot detect ID reuse, since it's not a
   // handle.
   //
@@ -440,6 +468,9 @@ public:
     if (!is_valid(handle)) return id_t::invalid;
     return handle.id();
   }
+
+#pragma endregion
+#pragma region Location
 
   // Get location for ID. Must be valid.
   //
@@ -531,6 +562,9 @@ public:
     return records_[id].location.store_ids_[sid];
   }
 
+#pragma endregion
+#pragma region Erase
+
   // Erase by ID. Fails if ID is invalid (but cannot detect ID reuse). Returns
   // success.
   //
@@ -547,6 +581,9 @@ public:
     if (!is_valid(handle)) return false;
     return do_erase(handle.id_);
   }
+
+#pragma endregion
+#pragma region Metadata access
 
   // Access metadata by ID. Must be valid.
   [[nodiscard]]
@@ -568,6 +605,9 @@ public:
     if (!self.is_valid(handle)) throw std::invalid_argument("invalid handle");
     return std::forward<decltype(self)>(self).at(handle.id_);
   }
+
+#pragma endregion
+#pragma region Iteration
 
   // Erase all records matching predicate called as `pred(id, rec)`, where
   // `id` is the entity ID and `rec` is the `record_t&`. Returns count erased.
@@ -604,6 +644,9 @@ public:
     return cnt;
   }
 
+#pragma endregion
+#pragma region Queries
+
   // Return current size, which is the count of living entities.
   //
   // This is not necessarily the size of the underlying vector, which may be
@@ -618,6 +661,9 @@ public:
   [[nodiscard]] id_t max_id() const noexcept {
     return id_t{records_.size() - 1};
   }
+
+#pragma endregion
+#pragma region Capacity
 
   // Clear all records.
   //
@@ -666,6 +712,9 @@ public:
       for (size_type i = old_size; i < new_cap; ++i) push_free(id_t{i});
     }
   }
+
+#pragma endregion
+#pragma region handle_owner
 
   // RAII owner for an entity ID handle. Erases the entity on destruction
   // unless ownership is released first.
@@ -766,6 +815,8 @@ public:
     return handle_owner{*this, metadata};
   }
 
+#pragma endregion
+#pragma region Implementation
 private:
   // True if the record at `id` represents a living entity.
   //
@@ -875,6 +926,8 @@ private:
     return true;
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   using id_container_t = id_container<record_t, id_t, record_allocator_type>;
 
@@ -892,5 +945,9 @@ private:
   // giving stack (most-recently freed-first) reuse order.
   id_t free_head_{id_t::invalid};
   [[no_unique_address]] maybe_t<id_t, is_fifo_v> free_tail_{id_t::invalid};
+
+#pragma endregion
 };
+
+#pragma endregion
 }}} // namespace corvid::ecs::entity_registries

--- a/corvid/ecs/id_container.h
+++ b/corvid/ecs/id_container.h
@@ -27,6 +27,8 @@
 
 namespace corvid { inline namespace ecs { inline namespace id_containers {
 
+#pragma region id_container
+
 // ECS ID-keyed flat vector.
 //
 // Wraps `enum_vector<T, ID, A>` plus an `ID limit_`, using composition instead
@@ -50,6 +52,8 @@ namespace corvid { inline namespace ecs { inline namespace id_containers {
 template<typename T, sequence::SequentialEnum ID, class A = std::allocator<T>>
 class id_container {
 public:
+#pragma region Types
+
   using id_t = ID;
   using size_type = std::underlying_type_t<id_t>;
   using value_type = T;
@@ -62,7 +66,8 @@ public:
   static_assert(std::is_unsigned_v<size_type>,
       "id_container: ID underlying type must be unsigned");
 
-  // Construction.
+#pragma endregion
+#pragma region Construction
 
   id_container() = default;
 
@@ -79,7 +84,8 @@ public:
     return data_.get_allocator();
   }
 
-  // ID limit.
+#pragma endregion
+#pragma region ID limit
 
   // Exclusive upper bound on valid IDs. Defaults to `id_t::invalid`.
   [[nodiscard]] id_t id_limit() const noexcept { return limit_; }
@@ -95,7 +101,8 @@ public:
     return true;
   }
 
-  // Capacity and size.
+#pragma endregion
+#pragma region Capacity and size
 
   [[nodiscard]] size_type size() const noexcept {
     return static_cast<size_type>(data_.size());
@@ -111,7 +118,8 @@ public:
 
   [[nodiscard]] bool empty() const noexcept { return data_.empty(); }
 
-  // Memory management.
+#pragma endregion
+#pragma region Memory management
 
   void reserve(size_type new_cap) { data_.reserve(new_cap); }
 
@@ -126,7 +134,8 @@ public:
 
   void shrink_to_fit() { data_.shrink_to_fit(); }
 
-  // Element access.
+#pragma endregion
+#pragma region Element access
 
   // Access slot by ID. No bounds check.
   [[nodiscard]] decltype(auto) operator[](this auto& self, id_t id) noexcept {
@@ -151,7 +160,8 @@ public:
     return self.data_.data();
   }
 
-  // Modifiers.
+#pragma endregion
+#pragma region Modifiers
 
   [[nodiscard]] bool push_back(const value_type& value) {
     if (size_as_enum() >= limit_) return false;
@@ -173,7 +183,8 @@ public:
 
   void pop_back() { data_.pop_back(); }
 
-  // Iteration over all allocated slots (slot 0 through size()-1).
+#pragma endregion
+#pragma region Iteration
 
   [[nodiscard]] decltype(auto) begin(this auto& self) noexcept {
     return self.data_.begin();
@@ -191,9 +202,14 @@ public:
     return self.data_.underlying();
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   enum_vector<value_type, id_t, allocator_type> data_;
   id_t limit_{id_t::invalid};
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::ecs::id_containers

--- a/corvid/ecs/mono_archetype_storage.h
+++ b/corvid/ecs/mono_archetype_storage.h
@@ -30,6 +30,8 @@
 namespace corvid { inline namespace ecs {
 inline namespace mono_archetype_storages {
 
+#pragma region mono_archetype_storage
+
 // Packed single-component storage with O(1) lookup through `entity_registry`.
 //
 // Maps entity IDs to densely packed component records using swap-and-pop for
@@ -53,6 +55,8 @@ template<typename REG, typename C, typename TAG = void>
 class mono_archetype_storage final
     : public archetype_storage_base<mono_archetype_storage<REG, C, TAG>, REG,
           std::tuple<C>> {
+#pragma region Types
+
   using base_t = archetype_storage_base<mono_archetype_storage<REG, C, TAG>,
       REG, std::tuple<C>>;
 
@@ -81,7 +85,8 @@ public:
   static_assert(std::is_trivially_copyable_v<component_t>,
       "Component type must be trivially copyable");
 
-  // Constructors.
+#pragma endregion
+#pragma region Construction
 
   // Default-constructed instances can only be assigned to.
   mono_archetype_storage() noexcept = default;
@@ -111,6 +116,9 @@ public:
     return *this;
   }
 
+#pragma endregion
+#pragma region Swap
+
   // Swap with another storage.
   void swap(mono_archetype_storage& other) noexcept {
     base_t::do_swap_base(other);
@@ -121,6 +129,9 @@ public:
   swap(mono_archetype_storage& lhs, mono_archetype_storage& rhs) noexcept {
     lhs.swap(rhs);
   }
+
+#pragma endregion
+#pragma region Capacity
 
   // Reduce memory usage to fit current size.
   void shrink_to_fit() {
@@ -133,6 +144,9 @@ public:
     components_.reserve(new_cap);
     ids_.reserve(new_cap);
   }
+
+#pragma endregion
+#pragma region Insertion
 
   // Add a component for a new entity, returning its handle or an invalid
   // handle on failure.
@@ -173,6 +187,9 @@ public:
     return add(handle.id(), component);
   }
 
+#pragma endregion
+#pragma region Conditional removal
+
   // Erase components for which `pred(component, id)` returns true. Returns
   // count erased.
   // Predicate shape: `(const component_t& comp, id_t id) -> bool`.
@@ -189,6 +206,9 @@ public:
     }
     return cnt;
   }
+
+#pragma endregion
+#pragma region row_view
 
   // Read-only view of a single entity's row. Provides a `component<T>`
   // accessor uniform with archetype storages (only valid for `T ==
@@ -212,6 +232,9 @@ public:
 
     [[nodiscard]] id_t id() const noexcept { return entity_id; }
   };
+
+#pragma endregion
+#pragma region Element access
 
   // Mutable access: returns `component_t&` directly.
   [[nodiscard]] component_t& operator[](id_t id) noexcept {
@@ -253,6 +276,9 @@ public:
           "invalid handle or entity not in this storage");
     return (*this)[handle.id()];
   }
+
+#pragma endregion
+#pragma region iterator_t
 
   // Contiguous iterator over components. Dereferencing yields a `component_t`
   // reference; `id` returns the entity ID at the current position.
@@ -355,6 +381,9 @@ public:
   using iterator = iterator_t<access::as_mutable>;
   using const_iterator = iterator_t<access::as_const>;
 
+#pragma endregion
+#pragma region Iteration
+
   [[nodiscard]] iterator begin() noexcept { return {this, 0}; }
   [[nodiscard]] iterator end() noexcept { return {this, size()}; }
   [[nodiscard]] const_iterator begin() const noexcept { return {this, 0}; }
@@ -362,6 +391,8 @@ public:
   [[nodiscard]] const_iterator cbegin() const noexcept { return begin(); }
   [[nodiscard]] const_iterator cend() const noexcept { return end(); }
 
+#pragma endregion
+#pragma region Implementation
 private:
   using base_t::registry_;
   using base_t::store_id_;
@@ -437,8 +468,13 @@ private:
     return true;
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   std::vector<C, component_allocator_type> components_;
+
+#pragma endregion
 };
 
+#pragma endregion
 }}} // namespace corvid::ecs::mono_archetype_storages

--- a/corvid/ecs/stable_ids.h
+++ b/corvid/ecs/stable_ids.h
@@ -32,6 +32,8 @@
 
 namespace corvid { inline namespace ecs { inline namespace stable_id_vector {
 
+#pragma region stable_ids
+
 // An indexed vector to store elements by stable ID, suitable for Entity
 // Component Systems, where it functions as the basis for a sparse set.
 //
@@ -86,6 +88,8 @@ template<typename T, sequence::SequentialEnum ID = id_enums::id_t,
     typename ALLOCATOR = std::allocator<T>>
 class stable_ids {
 public:
+#pragma region Types
+
   using id_t = ID;
   using size_type = std::underlying_type_t<id_t>;
   using allocator_type = ALLOCATOR;
@@ -105,6 +109,9 @@ public:
       "its underlying type");
   static_assert(std::is_unsigned_v<std::underlying_type_t<id_t>>,
       "ID type for stable_ids must use an unsigned underlying type");
+
+#pragma endregion
+#pragma region handle_t
 
   // An opaque handle that refers to an element. When GEN is enabled, it
   // captures a generation snapshot that allows `is_valid(handle_t)` to detect
@@ -147,6 +154,8 @@ public:
     friend class stable_ids<T, ID, GEN, REUSE_ORDER, ALLOCATOR>;
   };
 
+#pragma endregion
+#pragma region slot_t
 private:
   // Internal slot stored in `reverse_`. Contains the handle and, when FIFO is
   // enabled, a next-pointer for the intrusive free list.
@@ -162,8 +171,10 @@ private:
   static_assert(sizeof(handle_t) <= 16);
   static_assert(std::is_trivially_copyable_v<slot_t>);
 
+#pragma endregion
+#pragma region Construction
+
 public:
-  // Construction.
   stable_ids() = default;
   explicit stable_ids(const allocator_type& alloc)
       : data_{alloc}, indexes_{index_allocator_type{alloc}},
@@ -196,6 +207,9 @@ public:
       swap(lhs.fifo_tail_, rhs.fifo_tail_);
     }
   }
+
+#pragma endregion
+#pragma region Limit
 
   // Maximum allowed ID value. Insertion fails when this limit is reached.
   // Defaults to `id_t::invalid` (the maximum representable value).
@@ -240,6 +254,9 @@ public:
     return true;
   }
 
+#pragma endregion
+#pragma region Failure policy
+
   // Control whether insertion throws on ID overflow (by default) or returns
   // `id_t::invalid`, requiring the caller to check.
   [[nodiscard]] on_failure throw_on_insert_failure() const noexcept {
@@ -248,6 +265,9 @@ public:
   void throw_on_insert_failure(on_failure policy) noexcept {
     throw_on_insert_failure_ = policy;
   }
+
+#pragma endregion
+#pragma region Insertion
 
   // Push a new element, returning its assigned ID.
   [[nodiscard]] id_t push_back(const T& value) {
@@ -281,6 +301,9 @@ public:
     return get_handle(emplace_back(std::forward<Args>(args)...));
   }
 
+#pragma endregion
+#pragma region Validity
+
   // Get handle for ID.
   [[nodiscard]] handle_t get_handle(id_t id) const {
     if (!is_valid(id)) return handle_t{id_t::invalid};
@@ -308,6 +331,9 @@ public:
     if constexpr (is_versioned_v) return live.gen_ == handle.gen_;
     return true;
   }
+
+#pragma endregion
+#pragma region Erase
 
   // Erase element by ID. Returns true if erased, false if ID was invalid.
   //
@@ -338,6 +364,9 @@ public:
     }
     return cnt;
   }
+
+#pragma endregion
+#pragma region Capacity
 
   // Clear all elements. If `policy` is release, also free all memory.
   // It's faster to clear with release than to clear and then `shrink_to_fit`.
@@ -413,6 +442,9 @@ public:
     if (prefill == allocation_policy::eager) do_prefill(new_cap);
   }
 
+#pragma endregion
+#pragma region Queries
+
   // Return current size. This is the count of elements actually present,
   // regardless of their IDs.
   [[nodiscard]] size_type size() const noexcept {
@@ -458,6 +490,9 @@ public:
   // Return whether container is empty.
   [[nodiscard]] bool empty() const noexcept { return data_.empty(); }
 
+#pragma endregion
+#pragma region Element access
+
   // Access element by ID. Must be valid.
   [[nodiscard]] decltype(auto) operator[](this auto& self, id_t id) noexcept {
     assert(self.is_valid(id));
@@ -488,6 +523,9 @@ public:
     return std::span{self.data_};
   }
 
+#pragma endregion
+#pragma region Iteration
+
   // Iterators.
   [[nodiscard]] auto begin(this auto& self) noexcept {
     return std::forward<decltype(self)>(self).data_.begin();
@@ -498,6 +536,8 @@ public:
   [[nodiscard]] auto cbegin() const noexcept { return data_.cbegin(); }
   [[nodiscard]] auto cend() const noexcept { return data_.cend(); }
 
+#pragma endregion
+#pragma region Implementation
 private:
   // Allocate a new ID, either by reusing a freed one or creating a new one.
   // When `REUSE_ORDER` is FIFO, pops the oldest freed ID and swaps it into the
@@ -636,6 +676,8 @@ private:
     if constexpr (is_fifo_v) rebuild_fifo_list();
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   // Actual data.
   std::vector<T, data_allocator_type> data_;
@@ -685,5 +727,9 @@ private:
   // reactivate it (LIFO or FIFO as above). Otherwise we expand and prefill
   // `indexes_` and `reverse_` with a new ID. Either way, the caller pushes
   // the new value to the back of `data_`.
+
+#pragma endregion
 };
+
+#pragma endregion
 }}} // namespace corvid::ecs::stable_id_vector

--- a/corvid/enums/bool_enums.h
+++ b/corvid/enums/bool_enums.h
@@ -26,6 +26,8 @@ namespace corvid { inline namespace enums { namespace bool_enums {
 // For naming, these typically have suffixes like "_scheme", "_mode",
 // "_behavior", or "_policy", or they have prefixes like "on_".
 
+#pragma region Boolean enums
+
 // Whether to access values as const or as mutable.
 enum class access : bool { as_const = false, as_mutable = true };
 
@@ -89,4 +91,5 @@ enum class shot_type : bool { single = false, multi = true };
 // Whether the data is generated in advance or on demand.
 enum class production_policy : bool { complete = false, streaming = true };
 
+#pragma endregion
 }}} // namespace corvid::enums::bool_enums

--- a/corvid/enums/enum_formatter.h
+++ b/corvid/enums/enum_formatter.h
@@ -24,6 +24,8 @@
 #include "bitmask_enum.h"
 #include "../strings/debug_escaping.h"
 
+#pragma region formatter
+
 // Formatter for registered Corvid enums (sequence or bitmask), narrow or wide.
 //
 // Deliberately constrained to enums that opt into the registry rather than to
@@ -54,6 +56,8 @@ template<typename E, corvid::CharType CharT>
 requires(corvid::enums::sequence::SequentialEnum<E> ||
          corvid::enums::bitmask::BitmaskEnum<E>)
 struct std::formatter<E, CharT> {
+#pragma region Parse
+
   constexpr void set_debug_format() { debug_ = true; }
 
   constexpr auto parse(auto& ctx) {
@@ -66,6 +70,9 @@ struct std::formatter<E, CharT> {
       throw std::format_error("enum format spec accepts only '?'");
     return it;
   }
+
+#pragma endregion
+#pragma region Format
 
   template<typename FormatContext>
   auto format(E e, FormatContext& ctx) const {
@@ -85,6 +92,12 @@ struct std::formatter<E, CharT> {
     return out;
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   bool debug_{false};
+
+#pragma endregion
 };
+
+#pragma endregion

--- a/corvid/enums/enum_formatter.h
+++ b/corvid/enums/enum_formatter.h
@@ -16,15 +16,19 @@
 // limitations under the License.
 #pragma once
 #include <format>
+#include <optional>
+#include <string>
+#include <string_view>
 
 #include "../meta/concepts.h"
+#include "../meta/formatting.h"
 #include "../strings/targeting.h"
 #include "enum_conversion.h"
 #include "sequence_enum.h"
 #include "bitmask_enum.h"
 #include "../strings/debug_escaping.h"
 
-#pragma region formatter
+#pragma region enum formatter
 
 // Formatter for registered Corvid enums (sequence or bitmask), narrow or wide.
 //
@@ -36,39 +40,54 @@
 // library's enum formatter. Unregistered scoped enums therefore have no
 // formatter.
 //
-// Writes the value straight into the format context's output iterator through
-// Corvid's enum string conversion, with no intermediate string: a sequence
-// enum prints by name and a bitmask enum prints as its "a + b + c"
-// combination.
+// Writes the value into the format context's output iterator through Corvid's
+// enum string conversion. A sequence enum prints its name, or its decimal
+// underlying value when the value is unnamed; a bitmask enum prints its named
+// bits as "a + b + c", with any leftover bits in hex. This numeric fallback is
+// the plain default rendering of the number: the spec here cannot give it an
+// alternate base, a sign, or zero padding. To format the number that way,
+// format the underlying value via `operator*`, e.g. `{:#06x}` on `*e`.
 //
 // Enum names are stored as char; for a wide CharT the per-unit widening
 // happens in the output target (see
 // corvid::strings::output_iterator_appendable). Corvid names are 7-bit ASCII,
 // so the widening is a direct per-unit conversion.
 //
-// Supports the empty spec (the plain rendering above) and the `?` debug spec,
-// which quotes and escapes the rendering with the standard's debug rules so an
-// enum composes with the std range and map formatters: `{::?}` quotes each
-// element, and `set_debug_format` lets a `map<int, E>` print `{1: "red"}`.
-// There is no fill, align, width, or precision; those would need a
-// materialized string to pad.
+// Supports the parts of the standard spec grammar that apply to a name: fill
+// and align, width, precision, and the `?` debug spec. Debug quotes and
+// escapes the rendering with the standard's debug rules so an enum composes
+// with the std range and map formatters: `{::?}` quotes each element, and
+// `set_debug_format` lets a `map<int, E>` print `{1: "red"}`. With neither
+// width nor precision, the rendering streams straight through with no
+// intermediate string. Width or precision needs the rendered length, so a
+// named sequence value pads its stored view in place while a bitmask
+// combination, an unnamed value's numeric form, or the escaped debug spec
+// renders into a string first. Sign, `#`, zero-pad, locale, and any non-`?`
+// type do not apply to a name and are rejected.
 template<typename E, corvid::CharType CharT>
 requires(corvid::enums::sequence::SequentialEnum<E> ||
          corvid::enums::bitmask::BitmaskEnum<E>)
 struct std::formatter<E, CharT> {
 #pragma region Parse
 
-  constexpr void set_debug_format() { debug_ = true; }
+  constexpr void set_debug_format() { spec_.debug = true; }
 
-  constexpr auto parse(auto& ctx) {
-    auto it = ctx.begin();
-    if (it != ctx.end() && *it == '?') {
-      debug_ = true;
-      ++it;
-    }
-    if (it != ctx.end() && *it != '}')
-      throw std::format_error("enum format spec accepts only '?'");
-    return it;
+  constexpr auto parse(std::basic_format_parse_context<CharT>& ctx) {
+    const auto begin = ctx.begin();
+    const auto spec_text = std::basic_string_view<CharT>{begin,
+        static_cast<std::size_t>(ctx.end() - begin)};
+    const auto consumed = spec_.parse(spec_text);
+    validate_spec();
+
+    // An automatic `{}` width or precision has no id in the spec string, so
+    // claim one from the parse context now.
+    if (spec_.width_arg.is_automatic())
+      spec_.width_arg.value = ctx.next_arg_id();
+    if (spec_.precision_arg.is_automatic())
+      spec_.precision_arg.value = ctx.next_arg_id();
+
+    // Stop at the spec-terminating `}`.
+    return begin + consumed;
   }
 
 #pragma endregion
@@ -76,26 +95,78 @@ struct std::formatter<E, CharT> {
 
   template<typename FormatContext>
   auto format(E e, FormatContext& ctx) const {
+    std::size_t width = spec_.width;
+    if (spec_.width_arg.is_dynamic()) width = spec_.width_arg.get_dynamic(ctx);
+    std::optional<std::size_t> prec = spec_.precision;
+    if (spec_.precision_arg.is_dynamic())
+      prec = spec_.precision_arg.get_dynamic(ctx);
+
+    // Fast path: with neither width nor precision, there is nothing to measure
+    // the rendering against, so stream it straight into the output with no
+    // intermediate string.
+    if (!width && !prec) return render<CharT>(e, ctx.out());
+
+    // A named sequence value is already stored as a view, so trim and pad it
+    // in place with no buffer.
+    if constexpr (corvid::enums::sequence::SequentialEnum<E>) {
+      if (!spec_.debug) {
+        const std::string_view name = corvid::enums::sequence::enum_as_view(e);
+        if (!name.empty()) return write_field(ctx.out(), name, prec, width);
+      }
+    }
+
+    // A bitmask combination, an unnamed value's numeric form, and the escaped
+    // debug spec are produced on the fly, so render into a narrow ASCII buffer
+    // (names and debug escapes are 7-bit) before trimming and padding.
+    std::string buffer;
+    render<char>(e, std::back_inserter(buffer));
+    return write_field(ctx.out(), buffer, prec, width);
+  }
+
+#pragma endregion
+#pragma region Helpers
+private:
+  // Render `e` into `out`: the plain name, or the quoted and escaped name for
+  // the debug spec. Each char is widened to `RenderCharT`.
+  template<corvid::CharType RenderCharT, typename OutIt>
+  OutIt render(E e, OutIt out) const {
     using namespace corvid::strings;
-    using It = FormatContext::iterator;
-    if (!debug_) {
-      output_iterator_appendable<It, char, CharT> target{ctx.out()};
+    if (!spec_.debug) {
+      output_iterator_appendable<OutIt, char, RenderCharT> target{out};
       append_enum(target, e);
       return target.out;
     }
-    auto out = ctx.out();
-    *out++ = CharT('"');
-    debug_escaping_appendable<It, CharT> target{out};
+    *out++ = RenderCharT('"');
+    debug_escaping_appendable<OutIt, RenderCharT> target{out};
     append_enum(target, e);
     out = target.out;
-    *out++ = CharT('"');
+    *out++ = RenderCharT('"');
     return out;
+  }
+
+  // Trim `content` to precision and pad it to width, widening to `CharT`.
+  template<typename OutIt>
+  OutIt write_field(OutIt out, std::string_view content,
+      std::optional<std::size_t> prec, std::size_t width) const {
+    if (prec) content = content.substr(0, *prec);
+    return spec_.write_padded(out, content, width);
+  }
+
+  // Reject spec fields that do not apply to a name: sign, `#`, zero-pad,
+  // locale, and any type other than the `?` debug spec.
+  constexpr void validate_spec() const {
+    if (spec_.sign != '-' || spec_.alternate || spec_.zero_pad ||
+        spec_.has_locale ||
+        (spec_.type != CharT(0) && spec_.type != CharT('?')))
+      throw std::format_error(
+          "enum format spec accepts only fill and align, "
+          "width, precision, and '?'");
   }
 
 #pragma endregion
 #pragma region Data members
-private:
-  bool debug_{false};
+
+  corvid::spec_parser<CharT> spec_;
 
 #pragma endregion
 };

--- a/corvid/enums/enums_shared.h
+++ b/corvid/enums/enums_shared.h
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <charconv>
 #include <concepts>
+#include <cstdint>
 #include <limits>
 #include <ranges>
 #include <vector>

--- a/corvid/enums/sequence_enum.h
+++ b/corvid/enums/sequence_enum.h
@@ -664,7 +664,7 @@ template<strings::fixed_string names, std::integral U, size_t NameCount,
     const size_t comma = whole.find(',', pos);
     if (comma > seg_end) throw std::invalid_argument("invalid structure");
     const auto maybe_start =
-        strings::parse_int<U>(whole.substr(pos, comma - pos));
+        strings::parse_num<U>(whole.substr(pos, comma - pos));
     if (!maybe_start) throw std::invalid_argument("invalid segment start");
 
     const U start = *maybe_start;

--- a/corvid/filesys/epoll.h
+++ b/corvid/filesys/epoll.h
@@ -21,15 +21,22 @@
 
 namespace corvid { inline namespace filesys {
 
+#pragma region epoll
+
 // RAII wrapper around Linux `epoll`.
 //
 // `epoll` owns a single epoll instance, inherits the general fd helpers from
 // `os_file`, and adds named helpers for `epoll_ctl` and `epoll_wait`.
 class [[nodiscard]] epoll: public os_file {
 public:
+#pragma region Types
+
   using handle_t = os_file::file_handle_t;
   static constexpr handle_t invalid_handle = os_file::invalid_file_handle;
   static constexpr int default_flags = EPOLL_CLOEXEC;
+
+#pragma endregion
+#pragma region Construction
 
   epoll() noexcept = default;
   explicit epoll(int flags) noexcept : os_file(::epoll_create1(flags)) {}
@@ -45,6 +52,9 @@ public:
   [[nodiscard]] static epoll create(int flags = default_flags) noexcept {
     return epoll{flags};
   }
+
+#pragma endregion
+#pragma region Control
 
   // Invoke `epoll_ctl` on this epoll instance.
   [[nodiscard]] bool
@@ -72,6 +82,9 @@ public:
     return control(EPOLL_CTL_DEL, fd);
   }
 
+#pragma endregion
+#pragma region Wait
+
   // Wait for up to `maxevents` ready entries, optionally timing out.
   // A `timeout_ms` of -1 means to wait indefinitely (which is probably
   // unwise), while 0 means to return immediately. Returns the number of ready
@@ -92,6 +105,9 @@ public:
   wait(epoll_event (&events)[N], int timeout_ms) const noexcept {
     return wait(events, static_cast<int>(N), timeout_ms);
   }
+
+#pragma endregion
 };
 
+#pragma endregion
 }} // namespace corvid::filesys

--- a/corvid/filesys/event_fd.h
+++ b/corvid/filesys/event_fd.h
@@ -26,16 +26,23 @@
 namespace corvid { inline namespace filesys {
 using namespace bool_enums;
 
+#pragma region event_fd
+
 // RAII wrapper around Linux `eventfd`.
 //
 // `event_fd` owns a single eventfd handle, inherits the general fd helpers
 // from `os_file`, and adds typed counter-based read/write operations.
 class [[nodiscard]] event_fd: public os_file {
 public:
+#pragma region Types
+
   using handle_t = os_file::file_handle_t;
   using counter_t = eventfd_t;
   static constexpr handle_t invalid_handle = os_file::invalid_file_handle;
   static constexpr int default_flags = EFD_CLOEXEC | EFD_NONBLOCK;
+
+#pragma endregion
+#pragma region Construction
 
   event_fd() noexcept = default;
   explicit event_fd(counter_t initial_value,
@@ -49,8 +56,6 @@ public:
   event_fd& operator=(event_fd&&) noexcept = default;
   event_fd& operator=(const event_fd&) = delete;
 
-  ~event_fd() = default;
-
   // Create an `event_fd` with `initial_value`. Defaults to non-blocking
   // counter mode (`EFD_CLOEXEC | EFD_NONBLOCK`); pass `event_mode::semaphore`
   // to add `EFD_SEMAPHORE`, or `execution::blocking` to omit `EFD_NONBLOCK`.
@@ -62,6 +67,9 @@ public:
     if (exec == execution::nonblocking) flags |= EFD_NONBLOCK;
     return event_fd{initial_value, flags};
   }
+
+#pragma endregion
+#pragma region Operations
 
   // Add `value` to the counter. Returns true on success.
   [[nodiscard]] bool notify(counter_t value = 1) const noexcept {
@@ -83,6 +91,9 @@ public:
   [[nodiscard]] bool read(counter_t& value) const noexcept {
     return ::eventfd_read(handle(), &value) == 0;
   }
+
+#pragma endregion
 };
 
+#pragma endregion
 }} // namespace corvid::filesys

--- a/corvid/filesys/net_socket.h
+++ b/corvid/filesys/net_socket.h
@@ -37,6 +37,7 @@ using namespace std::chrono_literals;
 using namespace bool_enums;
 
 #pragma region Enums
+#pragma region socket_type
 
 // `SOCK_*` wrapper for socket types and flags.
 enum class socket_type : int {
@@ -59,6 +60,9 @@ consteval auto corvid_enum_spec(socket_type*) {
       "stream,datagram,raw,rdm,seqpacket,dccp,,,,packet", wrapclip{},
       socket_type{1}>();
 }
+
+#pragma endregion
+#pragma region address_family
 
 // `AF_*` wrapper for address family domains.
 // NOLINTNEXTLINE(performance-enum-size)
@@ -124,6 +128,9 @@ consteval auto corvid_enum_spec(address_family*) {
       "mctp">();
 }
 
+#pragma endregion
+#pragma region protocol_type
+
 // `IPPROTO_*` wrapper for protocol types.
 // NOLINTNEXTLINE(performance-enum-size)
 enum class protocol_type : int {
@@ -170,6 +177,9 @@ consteval auto corvid_enum_spec(protocol_type*) {
       "mtp,,beetph|98,encap|103,pim|108,comp|115,l2tp|132,sctp|135,mh,udplite,"
       "mpls|143,ethernet|255,raw">();
 }
+
+#pragma endregion
+#pragma region socket_option
 
 // `SO_*` wrapper for socket options.
 // NOLINTNEXTLINE(performance-enum-size)
@@ -276,6 +286,9 @@ consteval auto corvid_enum_spec(socket_option*) {
       wrapclip{}, socket_option{1}>();
 }
 
+#pragma endregion
+#pragma region tcp_option
+
 // "TCP_* wrapper for TCP-level socket options".
 // NOLINTNEXTLINE(performance-enum-size)
 enum class tcp_option : int {
@@ -329,6 +342,7 @@ consteval auto corvid_enum_spec(tcp_option*) {
       wrapclip{}, tcp_option{1}>();
 }
 
+#pragma endregion
 #pragma endregion
 #pragma region net_socket
 
@@ -800,6 +814,8 @@ public:
     return std::pair{net_socket{os_file{fd}}, addr};
   }
 
+#pragma endregion
+#pragma region Implementation
 private:
   [[nodiscard]] static net_socket do_create(address_family domain,
       execution exec, message_style style) noexcept {
@@ -812,6 +828,8 @@ private:
       type = socket_type{*type | *socket_type::nonblock};
     return net_socket{domain, type, protocol_type{0}};
   }
+
+#pragma endregion
 };
 
 #pragma endregion

--- a/corvid/filesys/os_file.h
+++ b/corvid/filesys/os_file.h
@@ -37,6 +37,8 @@ namespace corvid { inline namespace filesys {
 
 using namespace corvid::strings::no_zero_funcs;
 
+#pragma region msg_flags
+
 // `MSG_*` wrapper.
 enum class msg_flags : int {
   none = 0,                    // 0x0000'0000
@@ -69,6 +71,9 @@ consteval auto corvid_enum_spec(msg_flags*) {
       "dontroute,peek,oob">();
 }
 
+#pragma endregion
+#pragma region fcntl_ops
+
 // `F_*` wrapper for `fcntl` operations.
 // NOLINTNEXTLINE(performance-enum-size)
 enum class fcntl_ops : int {
@@ -96,6 +101,9 @@ consteval auto corvid_enum_spec(fcntl_ops*) {
       "dupfd,getfd,setfd,getfl,setfl,getlk,setlk,setlkw,setown,getown,setsig,"
       "getsig,getlk64,setlk64,setlkw64,setownex,getownex">();
 }
+
+#pragma endregion
+#pragma region errno_code
 
 // `E_*` wrapper for `errno` values.
 //
@@ -266,6 +274,9 @@ using EC = errno_code;
 inline errno_code e_code() { return errno_code{errno}; };
 inline bool e_code_is(errno_code code) { return e_code() == code; }
 
+#pragma endregion
+#pragma region o_flags
+
 // `O_*` wrapper for `open` flags.
 enum class o_flags : int {
   rdonly = O_RDONLY,                     // 0x0000'0000 sequence value
@@ -301,8 +312,12 @@ consteval auto corvid_enum_spec(o_flags*) {
       ",,rdwr,wronly">();
 }
 
+#pragma endregion
+
 // TODO: Move out into "mmap.h", which also wraps `::map` and `::madvise` and
 // defines a RAII `mmap` wrapper class.
+
+#pragma region mmap_prot
 
 // `PROT_*` wrapper.
 enum class mmap_prot : uint32_t {
@@ -318,6 +333,9 @@ consteval auto corvid_enum_spec(mmap_prot*) {
   return corvid::enums::bitmask::make_bitmask_enum_spec<mmap_prot,
       "exec,write,read">();
 }
+
+#pragma endregion
+#pragma region mmap_mask
 
 // `MAP_*` wrapper.
 enum class mmap_mask : uint32_t {
@@ -347,6 +365,9 @@ consteval auto corvid_enum_spec(mmap_mask*) {
       "fixed_noreplace,sync,hugetlb,stack,nonblock,populate,noreserve,locked,"
       "executable,denywrite,,,growsdown,,,anonymous,fixed,,,private,shared">();
 }
+
+#pragma endregion
+#pragma region mmap_advice
 
 // `MADV_*` wrapper.
 // NOLINTNEXTLINE(performance-enum-size)
@@ -383,11 +404,18 @@ consteval auto corvid_enum_spec(mmap_advice*) {
       "wipeonfork,keeponfork,cold,pageout,populate_read,populate_write,"
       "dontneed_locked,collapse">();
 }
+
+#pragma endregion
+#pragma region details
+
 namespace details {
 // Platform file handle type and invalid-handle sentinel.
 using file_handle_t = int;
 constexpr file_handle_t invalid_file_handle = -1;
 } // namespace details
+
+#pragma endregion
+#pragma region os_file
 
 // RAII wrapper around an OS file descriptor or handle.
 //
@@ -399,9 +427,14 @@ constexpr file_handle_t invalid_file_handle = -1;
 // Platform-specific code is isolated in a guarded section.
 class [[nodiscard]] os_file {
 public:
+#pragma region Types
+
   using file_handle_t = details::file_handle_t;
   static constexpr file_handle_t invalid_file_handle =
       details::invalid_file_handle;
+
+#pragma endregion
+#pragma region Construction
 
   // Adopt an existing handle. Defaults to an invalid (closed) file.
   explicit os_file(file_handle_t h = invalid_file_handle) noexcept
@@ -422,6 +455,9 @@ public:
 
   ~os_file() { close(); }
 
+#pragma endregion
+#pragma region Accessors
+
   // True if the handle is valid (i.e., the file is open).
   [[nodiscard]] bool is_open() const noexcept {
     return handle_ != invalid_file_handle;
@@ -433,6 +469,9 @@ public:
   // Return the raw platform handle.
   [[nodiscard]] file_handle_t handle() const noexcept { return handle_; }
   [[nodiscard]] file_handle_t operator*() const noexcept { return handle_; }
+
+#pragma endregion
+#pragma region Formatting
 
   // Render as `fd=<handle>` for an open file, or `fd=closed`. As a
   // `self_rendering_formatter` target, it applies the spec's width, fill, and
@@ -452,6 +491,9 @@ public:
     return spec.write_padded(out, view, spec.width);
   }
 
+#pragma endregion
+#pragma region Close and release
+
   // Close the file. Idempotent. Returns true when the file was open and is
   // now closed, false if it could not be closed (likely because it already
   // was). Note that, on failure, the file is left in a closed state to avoid
@@ -469,6 +511,9 @@ public:
     handle_ = invalid_file_handle;
     return h;
   }
+
+#pragma endregion
+#pragma region I/O
 
   // Write as much of `data` as possible to the file. On success, removes the
   // written prefix from `data` and returns true. On failure, leaves `data`
@@ -552,6 +597,9 @@ public:
     return true;
   }
 
+#pragma endregion
+#pragma region Control
+
   // Invoke `fcntl(cmd, args...)` on the handle. Returns -1 on failure.
   template<typename... Args>
   [[nodiscard]] int control(fcntl_ops cmd, Args&&... args) const noexcept {
@@ -580,6 +628,9 @@ public:
     return set_flags(new_flags);
   }
 
+#pragma endregion
+#pragma region Errors
+
   // Check whether the last error was a hard error (true) or a soft error
   // (false). A soft error represents flow control conditions that are expected
   // to occur in normal operation and can be retried, while a hard error is an
@@ -592,13 +643,23 @@ public:
     return (err != EC::again && err != EC::wouldblock && err != EC::intr);
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   file_handle_t handle_{invalid_file_handle};
+
+#pragma endregion
 };
+
+#pragma endregion
 }} // namespace corvid::filesys
+
+#pragma region formatter
 
 // Format an `os_file` by self-rendering as `fd=<handle>` (or `fd=closed`),
 // applying the spec's width/fill/align and precision via `format_to_spec`.
 template<corvid::CharType CharT>
 struct std::formatter<corvid::filesys::os_file, CharT>
     : corvid::self_rendering_formatter<CharT> {};
+
+#pragma endregion

--- a/corvid/filesys/os_file.h
+++ b/corvid/filesys/os_file.h
@@ -28,6 +28,7 @@
 #include <sys/socket.h>
 #include <sys/uio.h>
 
+#include "../meta/formatting.h"
 #include "../strings/no_zero.h"
 #include "../enums/bitmask_enum.h"
 #include "../enums/sequence_enum.h"
@@ -433,6 +434,24 @@ public:
   [[nodiscard]] file_handle_t handle() const noexcept { return handle_; }
   [[nodiscard]] file_handle_t operator*() const noexcept { return handle_; }
 
+  // Render as `fd=<handle>` for an open file, or `fd=closed`. As a
+  // `self_rendering_formatter` target, it applies the spec's width, fill, and
+  // align, plus precision (truncating the rendered text), itself, since it
+  // knows its own length. Any dynamic width/precision arrives already
+  // resolved.
+  template<corvid::CharType CharT, typename OutIt>
+  OutIt
+  format_to_spec(const corvid::parsed_spec<CharT>& spec, OutIt out) const {
+    std::string content{"fd=closed"};
+    if (!is_open()) {
+      content.resize(3);
+      strings::append_num(content, handle_);
+    }
+    std::string_view view{content};
+    if (spec.precision) view = view.substr(0, *spec.precision);
+    return spec.write_padded(out, view, spec.width);
+  }
+
   // Close the file. Idempotent. Returns true when the file was open and is
   // now closed, false if it could not be closed (likely because it already
   // was). Note that, on failure, the file is left in a closed state to avoid
@@ -577,3 +596,9 @@ private:
   file_handle_t handle_{invalid_file_handle};
 };
 }} // namespace corvid::filesys
+
+// Format an `os_file` by self-rendering as `fd=<handle>` (or `fd=closed`),
+// applying the spec's width/fill/align and precision via `format_to_spec`.
+template<corvid::CharType CharT>
+struct std::formatter<corvid::filesys::os_file, CharT>
+    : corvid::self_rendering_formatter<CharT> {};

--- a/corvid/filesys/os_file.h
+++ b/corvid/filesys/os_file.h
@@ -442,13 +442,13 @@ public:
   template<corvid::CharType CharT, typename OutIt>
   OutIt
   format_to_spec(const corvid::parsed_spec<CharT>& spec, OutIt out) const {
-    std::string content{"fd=closed"};
-    if (!is_open()) {
-      content.resize(3);
+    std::string content{"fd="};
+    if (is_open())
       strings::append_num(content, handle_);
-    }
+    else
+      content += "closed";
     std::string_view view{content};
-    if (spec.precision) view = view.substr(0, *spec.precision);
+    if (const auto prec = spec.precision) view = view.substr(0, *prec);
     return spec.write_padded(out, view, spec.width);
   }
 

--- a/corvid/filesys/os_file.h
+++ b/corvid/filesys/os_file.h
@@ -17,6 +17,7 @@
 #pragma once
 #include <algorithm>
 #include <cerrno>
+#include <cstdint>
 #include <linux/fscrypt.h>
 #include <utility>
 #include <csignal>

--- a/corvid/filesys/os_file.h
+++ b/corvid/filesys/os_file.h
@@ -471,27 +471,6 @@ public:
   [[nodiscard]] file_handle_t operator*() const noexcept { return handle_; }
 
 #pragma endregion
-#pragma region Formatting
-
-  // Render as `fd=<handle>` for an open file, or `fd=closed`. As a
-  // `self_rendering_formatter` target, it applies the spec's width, fill, and
-  // align, plus precision (truncating the rendered text), itself, since it
-  // knows its own length. Any dynamic width/precision arrives already
-  // resolved.
-  template<corvid::CharType CharT, typename OutIt>
-  OutIt
-  format_to_spec(const corvid::parsed_spec<CharT>& spec, OutIt out) const {
-    std::string content{"fd="};
-    if (is_open())
-      strings::append_num(content, handle_);
-    else
-      content += "closed";
-    std::string_view view{content};
-    if (const auto prec = spec.precision) view = view.substr(0, *prec);
-    return spec.write_padded(out, view, spec.width);
-  }
-
-#pragma endregion
 #pragma region Close and release
 
   // Close the file. Idempotent. Returns true when the file was open and is
@@ -656,10 +635,15 @@ private:
 
 #pragma region formatter
 
-// Format an `os_file` by self-rendering as `fd=<handle>` (or `fd=closed`),
-// applying the spec's width/fill/align and precision via `format_to_spec`.
+// Format an `os_file` as its handle, or `(closed)` when it holds no open file.
+// As a `nullable_formatter`, an open file forwards its handle to the `int`
+// formatter (so it takes the full integer spec grammar) while a closed one
+// renders the sentinel, padded to width.
 template<corvid::CharType CharT>
 struct std::formatter<corvid::filesys::os_file, CharT>
-    : corvid::self_rendering_formatter<CharT> {};
+    : corvid::nullable_formatter<int, CharT> {
+  constexpr formatter() noexcept
+      : corvid::nullable_formatter<int, CharT>{"(closed)"} {}
+};
 
 #pragma endregion

--- a/corvid/infra/relaxed_atomic.h
+++ b/corvid/infra/relaxed_atomic.h
@@ -24,6 +24,8 @@
 
 namespace corvid { inline namespace infra { inline namespace relaxed_atomicns {
 
+#pragma region relaxed_atomic
+
 // Thin wrapper around `std::atomic<T>`, providing only implicit conversion to
 // `T` and assignment from `T` while using relaxed memory ordering.  All other
 // `std::atomic<T>` operations are accessed using `operator->`.
@@ -41,12 +43,17 @@ namespace corvid { inline namespace infra { inline namespace relaxed_atomicns {
 template<typename T>
 class relaxed_atomic {
 public:
+#pragma region Types
+
   using value_type = T;
   using underlying_t = std::atomic<value_type>;
   using is_relaxed_atomic = std::true_type;
 
   static_assert(underlying_t::is_always_lock_free,
       "relaxed_atomic<T> requires T to be lock-free");
+
+#pragma endregion
+#pragma region Construction
 
   constexpr relaxed_atomic() noexcept(
       std::is_nothrow_default_constructible_v<T>)
@@ -58,6 +65,9 @@ public:
 
   relaxed_atomic(const relaxed_atomic&) = delete;
   relaxed_atomic& operator=(const relaxed_atomic&) = delete;
+
+#pragma endregion
+#pragma region Conversion and assignment
 
   // Conversion to `value_type` with relaxed semantics.
   operator value_type() const noexcept {
@@ -71,7 +81,8 @@ public:
     return desired;
   }
 
-  // Extended functionality.
+#pragma endregion
+#pragma region Extended functionality
 
   // Direct access to the underlying `std::atomic<T>`.
   [[nodiscard]] auto& underlying(this auto& self) noexcept {
@@ -148,9 +159,16 @@ public:
     return self.value_.fetch_sub(n, std::memory_order::relaxed) - n;
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   underlying_t value_{};
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region Aliases
 
 // Aliases matching the `std::atomic_*` typedef family.
 
@@ -210,5 +228,7 @@ using relaxed_atomic_size_t = relaxed_atomic<std::size_t>;
 using relaxed_atomic_ptrdiff_t = relaxed_atomic<std::ptrdiff_t>;
 using relaxed_atomic_intmax_t = relaxed_atomic<std::intmax_t>;
 using relaxed_atomic_uintmax_t = relaxed_atomic<std::uintmax_t>;
+
+#pragma endregion
 
 }}} // namespace corvid::infra::relaxed_atomicns

--- a/corvid/lang/ast_pred.h
+++ b/corvid/lang/ast_pred.h
@@ -16,10 +16,10 @@
 // limitations under the License.
 #pragma once
 #include <cstdint>
+#include <memory>
 #include <string_view>
 #include <variant>
 #include <vector>
-#include <memory>
 
 #include "../containers/core/transparent.h"
 #include "../enums.h"
@@ -28,6 +28,8 @@
 namespace corvid { inline namespace lang { namespace ast_pred {
 
 // Predicate Abstract Syntax Tree (AST) and DNF transform.
+
+#pragma region Values
 
 // Any single value for a key.
 using any_single_value = std::variant<std::monostate, std::string, int64_t>;
@@ -38,6 +40,9 @@ using any_value = std::variant<std::monostate, any_single_value,
 
 // Key for lookup, or a literal value.
 using key_or_value = std::variant<std::monostate, std::string, any_value>;
+
+#pragma endregion
+#pragma region operation
 
 // Operations for AST predicates.
 enum class operation : std::uint8_t {
@@ -67,6 +72,9 @@ consteval auto corvid_enum_spec(operation*) {
       wrapclip{}, operation{1}>();
 }
 
+#pragma endregion
+#pragma region lookup
+
 // AST predicate lookup.
 //
 // Returns `std::monostate` for missing keys.
@@ -85,6 +93,9 @@ struct map_lookup: public lookup {
 
   string_map<any_value> m;
 };
+
+#pragma endregion
+#pragma region node
 
 // Forward declaration of node.
 struct node;
@@ -194,6 +205,9 @@ public:
   }
 };
 
+#pragma endregion
+#pragma region Junctions
+
 // AST predicate junction.
 //
 // Junction for child nodes, which may be junctions or leaf nodes. Op is either
@@ -247,6 +261,9 @@ struct not_node final: public junction {
   explicit not_node(allow, Args&&... args)
       : not_node{allow::ctor, node_list{std::forward<Args>(args)...}} {}
 };
+
+#pragma endregion
+#pragma region Leaf nodes
 
 struct true_node final: public node {
   true_node(allow) : node{allow::ctor, operation::always_true} {}
@@ -313,6 +330,9 @@ struct absent_node final: public unary_leaf {
       : unary_leaf{allow::ctor, operation::absent, std::move(value)} {}
 };
 
+#pragma endregion
+#pragma region make
+
 template<operation op, typename... Args>
 std::shared_ptr<node> node::make(Args&&... args) {
   if constexpr (op == operation::and_junction)
@@ -344,6 +364,9 @@ template<operation op, typename... Args>
 [[nodiscard]] node_ptr make(Args&&... args) {
   return node::make<op>(std::forward<Args>(args)...);
 }
+
+#pragma endregion
+#pragma region dnf
 
 // Disjunctive Normal Form (DNF) conversion.
 //
@@ -529,4 +552,6 @@ private:
     return make<operation::or_junction>(std::move(converted_nodes));
   }
 };
+
+#pragma endregion
 }}} // namespace corvid::lang::ast_pred

--- a/corvid/lang/ast_pred.h
+++ b/corvid/lang/ast_pred.h
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #pragma once
+#include <cstdint>
 #include <string_view>
 #include <variant>
 #include <vector>

--- a/corvid/meta/concepts.h
+++ b/corvid/meta/concepts.h
@@ -23,9 +23,14 @@ namespace corvid { inline namespace meta { inline namespace concepts {
 // Note: Some of these definitions are universal concepts that apply anywhere,
 // while others enforce distinctions that are specific to this library.
 
+#pragma region Same type
+
 // `T` must be the same as `U`, ignoring cvref.
 template<typename T, typename U>
 concept SameAs = std::same_as<T, std::remove_cvref_t<U>>;
+
+#pragma endregion
+#pragma region Output streams
 
 // `T` must be a type derived from `std::basic_ostream<C>`.
 template<typename T, typename C>
@@ -45,6 +50,9 @@ concept AnyOStreamDerived = requires {
 template<typename T>
 concept OStreamable = requires(T t, std::ostream& os) { os << t; };
 
+#pragma endregion
+#pragma region Strings
+
 // `T` must be a `std::basic_string<C>`.
 template<typename T, typename C>
 concept BasicStdString = SameAs<std::basic_string<C>, T>;
@@ -58,6 +66,9 @@ template<typename T>
 concept AnyStdString = requires {
   typename T::value_type;
 } && BasicStdString<T, typename T::value_type>;
+
+#pragma endregion
+#pragma region Append targets
 
 // `T` must be an append target backed by an output iterator. Recognized
 // structurally by its `append_char_type` member, which names the code unit it
@@ -81,6 +92,9 @@ template<typename T>
 concept AnyAppendTarget =
     AnyOStreamDerived<T> || AnyStdString<T> || OutputIteratorAppendable<T>;
 
+#pragma endregion
+#pragma region Enums and integers
+
 // `T` must be an enum, which could be scoped or not.
 template<typename T>
 concept StdEnum = std::is_enum_v<std::remove_cvref_t<T>>;
@@ -100,6 +114,9 @@ concept Integer = std::integral<T> && (!Bool<T>);
 // `T` must be an enum or integral type.
 template<typename T>
 concept IntegerOrEnum = Integer<T> || StdEnum<T>;
+
+#pragma endregion
+#pragma region Null and characters
 
 // `T` must be nullptr_t.
 template<typename T>
@@ -127,6 +144,9 @@ concept CharArray =
     std::is_array_v<std::remove_cvref_t<T>> &&
     SameAs<char, std::remove_extent_t<T>>;
 
+#pragma endregion
+#pragma region String views
+
 // `T` must be implicitly convertible to `std::basic_string_view<C>`.
 template<typename T, typename C>
 concept BasicStringViewConvertible =
@@ -140,6 +160,9 @@ concept StringViewConvertible = BasicStringViewConvertible<T, char>;
 // type; `char_type_of_t<T>` names that type.
 template<typename T>
 concept StringViewLike = !std::is_void_v<char_type_of_t<T>>;
+
+#pragma endregion
+#pragma region Pointers
 
 // `T` must be a void pointer.
 template<typename T>
@@ -167,6 +190,9 @@ concept RawPointer = std::is_pointer_v<std::remove_cvref_t<T>>;
 template<typename T>
 concept SmartPointer = PointerLike<T> && (!RawPointer<T>);
 
+#pragma endregion
+#pragma region Ranges and optionals
+
 // `T` must be a range.
 template<typename T>
 concept Range = std::ranges::range<T>;
@@ -176,6 +202,9 @@ template<typename T>
 concept OptionalLike =
     Dereferenceable<T> && (!ScopedEnum<T>) && (!StringViewConvertible<T>) &&
     (!Range<T>);
+
+#pragma endregion
+#pragma region Pairs and tuples
 
 // `T` must be a `std::pair`.
 template<typename T>
@@ -192,6 +221,9 @@ concept StdTuple = is_tuple_v<T>;
 // `T` must be a `std::tuple` or convertible to a pair.
 template<typename T>
 concept TupleLike = StdTuple<T> || PairConvertible<T>;
+
+#pragma endregion
+#pragma region Arrays and spans
 
 // `T` must be a `std::array`.
 template<typename T>
@@ -224,10 +256,16 @@ template<typename T>
 concept StringViewConvertibleSpan =
     is_span_v<T> && StringViewConvertible<typename T::element_type>;
 
+#pragma endregion
+#pragma region Containers
+
 // `T` must be a container, which excludes strings and pairs. Strings of any
 // code unit are excluded via `StringViewLike`, not just `char` strings.
 template<typename T>
 concept Container = Range<T> && (!StringViewLike<T>) && (!PairConvertible<T>);
+
+#pragma endregion
+#pragma region Variants
 
 // `T` must be a `std::variant`.
 template<typename T>
@@ -237,6 +275,9 @@ concept Variant = is_variant_v<T>;
 template<typename T>
 concept MonoState = SameAs<std::monostate, T>;
 
+#pragma endregion
+#pragma region Keyed lookup
+
 // `T` must have a `find` method that takes a `T::key_type`.
 template<typename T>
 concept KeyFindable = has_key_find_v<T>;
@@ -244,6 +285,9 @@ concept KeyFindable = has_key_find_v<T>;
 // `T` must be a container that lacks a `find` method.
 template<typename T>
 concept RangeWithoutFind = Range<T> && (!KeyFindable<T>);
+
+#pragma endregion
+#pragma region Construction and comparison
 
 // `U` must be usable for constructing a `T`.
 template<typename T, typename U>
@@ -258,6 +302,9 @@ template<typename T, typename U>
 concept Viewable =
     Makeable<std::remove_cvref_t<T>, std::remove_cvref_t<U>> &&
     Comparable<std::remove_cvref_t<T>, std::remove_cvref_t<U>>;
+
+#pragma endregion
+#pragma region Callables
 
 // `F` must be callable with `Args` and return void.
 template<typename F, typename... Args>
@@ -281,5 +328,7 @@ template<class FN>
 concept MoveConsumable =
     !std::is_lvalue_reference_v<FN> &&
     !std::is_const_v<std::remove_reference_t<FN>>;
+
+#pragma endregion
 
 }}} // namespace corvid::meta::concepts

--- a/corvid/meta/containers.h
+++ b/corvid/meta/containers.h
@@ -22,10 +22,13 @@
 
 namespace corvid { inline namespace meta { inline namespace containers {
 
+#pragma region extract_field
+
 // Extract just the value or the entire key-value pair.
 enum class extract_field : bool { value, key_value };
 
-// Containers
+#pragma endregion
+#pragma region Element access
 
 // References value from container element, based on `field`
 template<auto field = extract_field::value>
@@ -76,17 +79,6 @@ template<auto field = extract_field::value>
   return ndx != -1 ? &container_element_v<field>(&c[ndx]) : nullptr;
 }
 
-// Compile-time search and replace for `std::string_view` array. It operates
-// on whole `std::string_view` elements, not substrings.
-// This function is most useful with `fixed_string`.
-template<size_t N>
-[[nodiscard]] consteval auto search_and_replace(
-    std::array<std::string, N> values, std::string from, std::string to) {
-  std::array<std::string, N> result;
-  for (size_t i = 0; i < N; ++i) {
-    result[i] = (values[i] == from) ? to : values[i];
-  }
-  return result;
-}
+#pragma endregion
 
 }}} // namespace corvid::meta::containers

--- a/corvid/meta/enums.h
+++ b/corvid/meta/enums.h
@@ -21,7 +21,7 @@
 
 namespace corvid { inline namespace meta { inline namespace enum_utils {
 
-// Enums
+#pragma region Underlying type
 
 // Cast enum to underlying integer value.
 //
@@ -40,6 +40,9 @@ template<typename E>
 template<typename E>
 using as_underlying_t = decltype(as_underlying(std::declval<E>()));
 
+#pragma endregion
+#pragma region Enum bounds
+
 PRAGMA_CLANG_DIAG(push);
 PRAGMA_CLANG_IGNORED_ENUM_CONSTEXPR_CONV;
 
@@ -54,6 +57,9 @@ constexpr auto max_scoped_enum_v =
     static_cast<E>(std::numeric_limits<as_underlying_t<E>>::max());
 
 PRAGMA_CLANG_DIAG(pop);
+
+#pragma endregion
+#pragma region Bit math
 
 // Note:
 // std::popcount() gives us how many bits are set.
@@ -70,5 +76,7 @@ PRAGMA_CLANG_DIAG(pop);
 [[nodiscard]] constexpr uint64_t highest_value_in_n_bits(uint64_t n) noexcept {
   return pow2(n) - 1;
 }
+
+#pragma endregion
 
 }}} // namespace corvid::meta::enum_utils

--- a/corvid/meta/formatting.h
+++ b/corvid/meta/formatting.h
@@ -1,0 +1,338 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+#include <cstdint>
+#include <format>
+
+#include "concepts.h"
+
+// Reusable `std::formatter` bases for the recurring shapes in this library:
+// forwarding a wrapper to its underlying value's formatter, the same with a
+// null state, and delegating a custom rendering to a `format_to` member. Each
+// reduces a per-type `std::formatter` specialization to a one-line `: base
+// {}`.
+namespace corvid { inline namespace meta { inline namespace formatting {
+
+namespace specs {
+
+enum class aligned : std::uint8_t { left, right, center };
+
+template<CharType CharT>
+struct parsed_spec {
+  std::size_t width = 0;
+  std::optional<std::size_t> precision; // Meaningful for numerics.
+  bool debug = false; // May be set externally by `set_debug_format`.
+  CharT fill = CharT(' ');
+  aligned align = aligned::left;
+  char sign = '-';        // `-` default, `+` always, ` ` space for positive.
+  bool alternate = false; // `#`
+  bool zero_pad = false;
+  bool has_locale = false;
+  CharT type = CharT(0); // Debug is '?'.
+  bool dynamic = false;  // Either dynamic width or precision was attempted.
+};
+
+template<CharType CharT>
+constexpr bool is_align(CharT c) {
+  return c == CharT('<') || c == CharT('>') || c == CharT('^');
+}
+
+template<CharType CharT>
+constexpr aligned to_aligned(CharT c) {
+  if (c == CharT('>')) return aligned::right;
+  if (c == CharT('^')) return aligned::center;
+  return aligned::left;
+}
+
+// Read a count (a width or precision) at `ndx`, advancing it
+template<CharType CharT>
+constexpr std::optional<std::size_t>
+read_count(std::basic_string_view<CharT> spec, std::size_t& ndx) {
+  const std::size_t n = spec.size();
+  if (ndx < n && spec[ndx] == CharT('{')) {
+    while (ndx < n && spec[ndx] != CharT('}')) ++ndx;
+    if (ndx < n) ++ndx;
+    return std::nullopt;
+  }
+  std::size_t value = 0;
+  for (; ndx < n && spec[ndx] >= CharT('0') && spec[ndx] <= CharT('9'); ++ndx)
+    value = (value * 10) + static_cast<std::size_t>(spec[ndx] - CharT('0'));
+  return value;
+}
+
+// Parse the standard format spec into a `parsed_spec`: fill, align, sign, the
+// `#` alternate flag, zero-pad, width, precision, the `L` locale flag, and the
+// type char, plus the derived `debug` (a `?` type) and `dynamic` (a `{}` width
+// or precision). A dynamic width or precision is only flagged; its value lives
+// in the format args, unreadable from a `string_view`.
+template<CharType CharT>
+constexpr auto parse_pad(std::basic_string_view<CharT> spec) {
+  parsed_spec<CharT> result{};
+  std::size_t ndx = 0;
+  const std::size_t cnt = spec.size();
+  // [fill] align
+  if (cnt >= 2 && is_align(spec[1])) {
+    result.fill = spec[0];
+    result.align = to_aligned(spec[1]);
+    ndx = 2;
+  } else if (cnt >= 1 && is_align(spec[0])) {
+    result.align = to_aligned(spec[0]);
+    ndx = 1;
+  }
+  // sign
+  if (ndx < cnt &&
+      (spec[ndx] == CharT('+') || spec[ndx] == CharT('-') ||
+          spec[ndx] == CharT(' ')))
+  {
+    result.sign = static_cast<char>(spec[ndx]);
+    ++ndx;
+  }
+  // `#` alternate
+  if (ndx < cnt && spec[ndx] == CharT('#')) {
+    result.alternate = true;
+    ++ndx;
+  }
+  // `0` zero-pad
+  if (ndx < cnt && spec[ndx] == CharT('0')) {
+    result.zero_pad = true;
+    ++ndx;
+  }
+  // width
+  if (const auto width = read_count(spec, ndx)) result.width = *width;
+  // `.` precision
+  if (ndx < cnt && spec[ndx] == CharT('.')) {
+    ++ndx;
+    result.precision = read_count(spec, ndx);
+  }
+  // `L` locale
+  if (ndx < cnt && spec[ndx] == CharT('L')) {
+    result.has_locale = true;
+    ++ndx;
+  }
+  // type: the one remaining char, if any
+  if (ndx < cnt) result.type = spec[ndx];
+
+  // The `?` type is debug. Set-only: `set_debug_format` may have turned debug
+  // on externally even when the spec carries no `?`.
+  if (result.type == CharT('?')) result.debug = true;
+
+  // A `{` flags a dynamic width or precision (value unreadable here).
+  if (spec.find(CharT('{')) != spec.npos) result.dynamic = true;
+
+  return result;
+}
+
+template<CharType CharT, CharType InCharT, typename OutIt>
+constexpr OutIt write_repeat(OutIt out, InCharT c, std::size_t count) {
+  for (std::size_t i = 0; i < count; ++i)
+    *out++ = static_cast<CharT>(static_cast<wchar_t>(c));
+  return out;
+}
+
+template<CharType CharT, CharType InCharT, typename OutIt>
+constexpr OutIt write_sv(OutIt out, std::basic_string_view<InCharT> sv) {
+  for (const auto c : sv) *out++ = static_cast<CharT>(static_cast<wchar_t>(c));
+  return out;
+}
+
+constexpr std::pair<size_t, size_t> calc_padding(aligned align,
+    std::size_t content_width, std::size_t total_width) {
+  std::size_t lead = 0;
+  std::size_t trail = 0;
+  if (total_width > content_width) {
+    const std::size_t pad = total_width - content_width;
+    lead =
+        align == aligned::right ? pad
+        : align == aligned::center
+            ? pad / 2
+            : 0;
+    trail = pad - lead;
+  }
+  return {lead, trail};
+}
+
+// Emit `content` (narrow, 7-bit ASCII) widened to `CharT`, padded to `width`
+// with `fill` per `align`. A width no larger than the content is a no-op
+// (width is a minimum). Used to render a `nullable_formatter`'s null sentinel.
+template<CharType CharT, typename OutIt>
+constexpr OutIt write_padded(OutIt out, std::string_view content, CharT fill,
+    aligned align, std::size_t width) {
+  auto [lead, trail] = calc_padding(align, content.size(), width);
+  out = write_repeat<CharT>(out, fill, lead);
+  out = write_sv<CharT>(out, content);
+  out = write_repeat<CharT>(out, fill, trail);
+  return out;
+}
+
+} // namespace specs
+
+// Whether a null renders as an empty field or the text sentinel (default
+// `(null)`). Selected independently for the plain and debug specs of
+// `nullable_formatter`.
+enum class null_formatting : bool { empty = false, sentinel = true };
+
+// Base for a `std::formatter` on a wrapper that should format exactly like
+// some underlying value of type `U`. It inherits the underlying type's
+// formatter, so it reuses the full spec grammar (fill, align, width,
+// precision, and the `?` debug spec), and forwards by converting the wrapper
+// to `const U&`.
+//
+// A deriving specialization needs only `: forwarding_formatter<U, CharT> {}`.
+// The wrapper type is deduced at format time and must be convertible to `U`
+// (explicit conversion is fine, since the cast is explicit).
+template<typename U, CharType CharT>
+struct forwarding_formatter: std::formatter<U, CharT> {
+  template<typename W, typename FormatContext>
+  auto format(const W& w, FormatContext& ctx) const {
+    return std::formatter<U, CharT>::format(static_cast<const U&>(w), ctx);
+  }
+};
+
+// Base for a `std::formatter` on a nullable, pointer-like wrapper. It inherits
+// the pointee/element type `U`'s formatter and forwards the dereferenced value
+// with its full spec grammar; a null wrapper instead renders either an empty
+// field or a text sentinel (default `(null)`).
+//
+// `PlainNull` and `DebugNull` independently select what a null shows under a
+// plain spec and under the `?` debug spec. `null_formatting::sentinel` (the
+// default for both) shows the sentinel, padded by the spec's fill/align/width;
+// `null_formatting::empty` shows an empty field, rendered through the
+// inherited formatter so a dynamic width still holds. A string wrapper, where
+// null reads as empty, passes `..., null_formatting::empty>` so a plain null
+// is empty while a debug null still shows the sentinel.
+//
+// A deriving specialization needs only `: nullable_formatter<U, CharT> {}`.
+// The wrapper type is deduced at format time and must be contextually
+// convertible to `bool` and dereferenceable to `U`. To customize the sentinel
+// text, give the deriving formatter a default constructor that delegates to
+// the marker constructor, e.g. a `file_handle` formatter: `constexpr
+// formatter() : nullable_formatter<int, CharT>{"closed"} {}`.
+//
+// Only fill, align, and width reach the sentinel; it is a fixed string, so
+// precision and type are meaningless for it, while the present value still
+// honors the whole spec through the inherited formatter. A dynamic width or
+// precision combined with the debug spec is rejected, since the sentinel's own
+// padding cannot read an argument bound to the real format context.
+template<typename U, CharType CharT,
+    null_formatting PlainNull = null_formatting::sentinel,
+    null_formatting DebugNull = null_formatting::sentinel>
+struct nullable_formatter: std::formatter<U, CharT> {
+  using base = std::formatter<U, CharT>;
+
+  constexpr nullable_formatter() = default;
+  constexpr explicit nullable_formatter(std::string_view marker)
+      : marker_{marker} {}
+
+  // Offered only when the underlying formatter has it, so a containing range
+  // or map can enable element quoting; also records debug mode for the
+  // sentinel.
+  constexpr void set_debug_format()
+  requires requires(base b) { b.set_debug_format(); }
+  {
+    spec_.debug = true;
+    base::set_debug_format();
+  }
+
+  constexpr auto parse(std::basic_format_parse_context<CharT>& ctx) {
+    const auto begin = ctx.begin();
+    const auto it = base::parse(ctx);
+    spec_ = specs::parse_pad(std::basic_string_view<CharT>{begin,
+        static_cast<std::size_t>(it - begin)});
+    if (spec_.debug && spec_.dynamic)
+      throw std::format_error("dynamic is unsupported");
+    return it;
+  }
+
+  template<typename W, typename FormatContext>
+  auto format(const W& w, FormatContext& ctx) const {
+    if (w) return base::format(*w, ctx);
+    // A null shows the sentinel or an empty field per the spec mode. The
+    // sentinel is padded by our own fill/align/width so the base's debug
+    // quoting is bypassed; an empty field goes through the inherited formatter
+    // so a dynamic width is still honored.
+    if constexpr (PlainNull == null_formatting::sentinel &&
+                  DebugNull == null_formatting::sentinel)
+    {
+      return pad_sentinel(ctx);
+    } else {
+      const null_formatting mode = spec_.debug ? DebugNull : PlainNull;
+      return mode == null_formatting::sentinel
+                 ? pad_sentinel(ctx)
+                 : base::format(U{}, ctx);
+    }
+  }
+
+private:
+  template<typename FormatContext>
+  auto pad_sentinel(FormatContext& ctx) const {
+    return specs::write_padded<CharT>(ctx.out(), marker_, spec_.fill,
+        spec_.align, spec_.width);
+  }
+
+  std::string_view marker_{"(null)"};
+  specs::parsed_spec<CharT> spec_;
+};
+
+// Base for a `std::formatter` on a type that renders itself through a
+// `format_to(out)` member, the modern analog of `operator<<`. A deriving
+// specialization needs only `: format_to_formatter<CharT> {}`; the type is
+// deduced at format time.
+//
+// Supports the empty spec (plain rendering) and the `?` debug spec. In debug
+// mode it calls `debug_format_to(out)` when the type provides one, otherwise
+// it falls back to `format_to` (a type without a debug rendering reads the
+// same in either mode). `set_debug_format` lets the type auto-quote inside the
+// std range and map formatters. Both `format_to` and `debug_format_to` must
+// return the advanced output iterator.
+//
+// Fill, align, width, and precision are not supported: padding needs the
+// rendered length, which would require materializing the rendering into a
+// temporary. Add that here (render to a temporary, then pad through a
+// `std::formatter<basic_string_view<CharT>>`) if a caller needs it; until then
+// this streams straight to the output with no buffer.
+template<CharType CharT>
+struct format_to_formatter {
+  constexpr void set_debug_format() { spec_.debug = true; }
+
+  constexpr auto parse(std::basic_format_parse_context<CharT>& ctx) ->
+      typename std::basic_format_parse_context<CharT>::iterator {
+    const auto begin = ctx.begin();
+    const auto it = ctx.end();
+    spec_ = specs::parse_pad(std::basic_string_view<CharT>{begin,
+        static_cast<std::size_t>(it - begin)});
+    if (spec_.debug && spec_.dynamic)
+      throw std::format_error("dynamic is unsupported");
+    return it;
+  }
+
+  template<typename T, typename FormatContext>
+  auto format(const T& obj, FormatContext& ctx) const {
+    if constexpr (requires { obj.format_to_spec(spec_, ctx.out()); })
+      return obj.format_to_spec(spec_, ctx.out());
+
+    if (spec_.debug) {
+      if constexpr (requires { obj.debug_format_to(ctx.out()); })
+        return obj.debug_format_to(ctx.out());
+    }
+    return obj.format_to(ctx.out());
+  }
+
+private:
+  specs::parsed_spec<CharT> spec_;
+};
+
+}}} // namespace corvid::meta::formatting

--- a/corvid/meta/formatting.h
+++ b/corvid/meta/formatting.h
@@ -29,10 +29,14 @@ namespace corvid { inline namespace meta { inline namespace formatting {
 
 namespace specs {
 
-enum class aligned : std::uint8_t { left, right, center };
-
+// A parsed standard format spec: the individual fields, plus the operations to
+// parse a spec string into them and to emit a padded field. The fields are
+// public and the helpers are a few methods on top; this is a struct with
+// benefits, not a tightly encapsulated value type.
 template<CharType CharT>
 struct parsed_spec {
+  enum class aligned : std::uint8_t { left, right, center };
+
   std::size_t width = 0;
   std::optional<std::size_t> precision; // Meaningful for numerics.
   bool debug = false; // May be set externally by `set_debug_format`.
@@ -44,139 +48,131 @@ struct parsed_spec {
   bool has_locale = false;
   CharT type = CharT(0); // Debug is '?'.
   bool dynamic = false;  // Either dynamic width or precision was attempted.
+
+  // Parse the standard format spec into this instance.
+  constexpr void parse_pad(std::basic_string_view<CharT> spec) {
+    std::size_t ndx = 0;
+    const std::size_t cnt = spec.size();
+    // [fill] align
+    if (cnt >= 2 && is_align(spec[1])) {
+      fill = spec[0];
+      align = to_aligned(spec[1]);
+      ndx = 2;
+    } else if (cnt >= 1 && is_align(spec[0])) {
+      align = to_aligned(spec[0]);
+      ndx = 1;
+    }
+    // sign
+    if (ndx < cnt &&
+        (spec[ndx] == CharT('+') || spec[ndx] == CharT('-') ||
+            spec[ndx] == CharT(' ')))
+    {
+      sign = static_cast<char>(spec[ndx]);
+      ++ndx;
+    }
+    // `#` alternate
+    if (ndx < cnt && spec[ndx] == CharT('#')) {
+      alternate = true;
+      ++ndx;
+    }
+    // `0` zero-pad
+    if (ndx < cnt && spec[ndx] == CharT('0')) {
+      zero_pad = true;
+      ++ndx;
+    }
+    // width
+    if (const auto w = read_count(spec, ndx)) width = *w;
+    // `.` precision
+    if (ndx < cnt && spec[ndx] == CharT('.')) {
+      ++ndx;
+      precision = read_count(spec, ndx);
+    }
+    // `L` locale
+    if (ndx < cnt && spec[ndx] == CharT('L')) {
+      has_locale = true;
+      ++ndx;
+    }
+    // type: the one remaining char, if any
+    if (ndx < cnt) type = spec[ndx];
+
+    // The `?` type is debug.
+    if (type == CharT('?')) debug = true;
+
+    // A `{` flags a dynamic width or precision (value unreadable here).
+    if (spec.find(CharT('{')) != spec.npos) dynamic = true;
+  }
+
+  // Emit `content` (narrow, 7-bit ASCII) widened to `CharT`, padded to this
+  // spec's `width` with its `fill` per its `align`. A width no larger than the
+  // content is a no-op (width is a minimum).
+  template<typename OutIt>
+  constexpr OutIt write_padded(OutIt out, std::string_view content) const {
+    auto [lead, trail] = calc_padding(align, content.size(), width);
+    out = write_repeat(out, fill, lead);
+    out = write_sv(out, content);
+    out = write_repeat(out, fill, trail);
+    return out;
+  }
+
+private:
+  static constexpr bool is_align(CharT c) {
+    return c == CharT('<') || c == CharT('>') || c == CharT('^');
+  }
+
+  static constexpr aligned to_aligned(CharT c) {
+    if (c == CharT('>')) return aligned::right;
+    if (c == CharT('^')) return aligned::center;
+    return aligned::left;
+  }
+
+  // Read a count (a width or precision) at `ndx`, advancing it.
+  static constexpr std::optional<std::size_t>
+  read_count(std::basic_string_view<CharT> spec, std::size_t& ndx) {
+    const std::size_t n = spec.size();
+    if (ndx < n && spec[ndx] == CharT('{')) {
+      while (ndx < n && spec[ndx] != CharT('}')) ++ndx;
+      if (ndx < n) ++ndx;
+      return std::nullopt;
+    }
+    std::size_t value = 0;
+    for (; ndx < n && spec[ndx] >= CharT('0') && spec[ndx] <= CharT('9');
+        ++ndx)
+      value = (value * 10) + static_cast<std::size_t>(spec[ndx] - CharT('0'));
+    return value;
+  }
+
+  static constexpr std::pair<size_t, size_t> calc_padding(aligned align,
+      std::size_t content_width, std::size_t total_width) {
+    std::size_t lead = 0;
+    std::size_t trail = 0;
+    if (total_width > content_width) {
+      const std::size_t pad = total_width - content_width;
+      lead =
+          align == aligned::right ? pad
+          : align == aligned::center
+              ? pad / 2
+              : 0;
+      trail = pad - lead;
+    }
+    return {lead, trail};
+  }
+
+  template<CharType InCharT, typename OutIt>
+  static constexpr OutIt
+  write_repeat(OutIt out, InCharT c, std::size_t count) {
+    for (std::size_t i = 0; i < count; ++i)
+      *out++ = static_cast<CharT>(static_cast<wchar_t>(c));
+    return out;
+  }
+
+  template<CharType InCharT, typename OutIt>
+  static constexpr OutIt
+  write_sv(OutIt out, std::basic_string_view<InCharT> sv) {
+    for (const auto c : sv)
+      *out++ = static_cast<CharT>(static_cast<wchar_t>(c));
+    return out;
+  }
 };
-
-template<CharType CharT>
-constexpr bool is_align(CharT c) {
-  return c == CharT('<') || c == CharT('>') || c == CharT('^');
-}
-
-template<CharType CharT>
-constexpr aligned to_aligned(CharT c) {
-  if (c == CharT('>')) return aligned::right;
-  if (c == CharT('^')) return aligned::center;
-  return aligned::left;
-}
-
-// Read a count (a width or precision) at `ndx`, advancing it
-template<CharType CharT>
-constexpr std::optional<std::size_t>
-read_count(std::basic_string_view<CharT> spec, std::size_t& ndx) {
-  const std::size_t n = spec.size();
-  if (ndx < n && spec[ndx] == CharT('{')) {
-    while (ndx < n && spec[ndx] != CharT('}')) ++ndx;
-    if (ndx < n) ++ndx;
-    return std::nullopt;
-  }
-  std::size_t value = 0;
-  for (; ndx < n && spec[ndx] >= CharT('0') && spec[ndx] <= CharT('9'); ++ndx)
-    value = (value * 10) + static_cast<std::size_t>(spec[ndx] - CharT('0'));
-  return value;
-}
-
-// Parse the standard format spec into a `parsed_spec`: fill, align, sign, the
-// `#` alternate flag, zero-pad, width, precision, the `L` locale flag, and the
-// type char, plus the derived `debug` (a `?` type) and `dynamic` (a `{}` width
-// or precision). A dynamic width or precision is only flagged; its value lives
-// in the format args, unreadable from a `string_view`.
-template<CharType CharT>
-constexpr auto parse_pad(std::basic_string_view<CharT> spec) {
-  parsed_spec<CharT> result{};
-  std::size_t ndx = 0;
-  const std::size_t cnt = spec.size();
-  // [fill] align
-  if (cnt >= 2 && is_align(spec[1])) {
-    result.fill = spec[0];
-    result.align = to_aligned(spec[1]);
-    ndx = 2;
-  } else if (cnt >= 1 && is_align(spec[0])) {
-    result.align = to_aligned(spec[0]);
-    ndx = 1;
-  }
-  // sign
-  if (ndx < cnt &&
-      (spec[ndx] == CharT('+') || spec[ndx] == CharT('-') ||
-          spec[ndx] == CharT(' ')))
-  {
-    result.sign = static_cast<char>(spec[ndx]);
-    ++ndx;
-  }
-  // `#` alternate
-  if (ndx < cnt && spec[ndx] == CharT('#')) {
-    result.alternate = true;
-    ++ndx;
-  }
-  // `0` zero-pad
-  if (ndx < cnt && spec[ndx] == CharT('0')) {
-    result.zero_pad = true;
-    ++ndx;
-  }
-  // width
-  if (const auto width = read_count(spec, ndx)) result.width = *width;
-  // `.` precision
-  if (ndx < cnt && spec[ndx] == CharT('.')) {
-    ++ndx;
-    result.precision = read_count(spec, ndx);
-  }
-  // `L` locale
-  if (ndx < cnt && spec[ndx] == CharT('L')) {
-    result.has_locale = true;
-    ++ndx;
-  }
-  // type: the one remaining char, if any
-  if (ndx < cnt) result.type = spec[ndx];
-
-  // The `?` type is debug. Set-only: `set_debug_format` may have turned debug
-  // on externally even when the spec carries no `?`.
-  if (result.type == CharT('?')) result.debug = true;
-
-  // A `{` flags a dynamic width or precision (value unreadable here).
-  if (spec.find(CharT('{')) != spec.npos) result.dynamic = true;
-
-  return result;
-}
-
-template<CharType CharT, CharType InCharT, typename OutIt>
-constexpr OutIt write_repeat(OutIt out, InCharT c, std::size_t count) {
-  for (std::size_t i = 0; i < count; ++i)
-    *out++ = static_cast<CharT>(static_cast<wchar_t>(c));
-  return out;
-}
-
-template<CharType CharT, CharType InCharT, typename OutIt>
-constexpr OutIt write_sv(OutIt out, std::basic_string_view<InCharT> sv) {
-  for (const auto c : sv) *out++ = static_cast<CharT>(static_cast<wchar_t>(c));
-  return out;
-}
-
-constexpr std::pair<size_t, size_t> calc_padding(aligned align,
-    std::size_t content_width, std::size_t total_width) {
-  std::size_t lead = 0;
-  std::size_t trail = 0;
-  if (total_width > content_width) {
-    const std::size_t pad = total_width - content_width;
-    lead =
-        align == aligned::right ? pad
-        : align == aligned::center
-            ? pad / 2
-            : 0;
-    trail = pad - lead;
-  }
-  return {lead, trail};
-}
-
-// Emit `content` (narrow, 7-bit ASCII) widened to `CharT`, padded to `width`
-// with `fill` per `align`. A width no larger than the content is a no-op
-// (width is a minimum). Used to render a `nullable_formatter`'s null sentinel.
-template<CharType CharT, typename OutIt>
-constexpr OutIt write_padded(OutIt out, std::string_view content, CharT fill,
-    aligned align, std::size_t width) {
-  auto [lead, trail] = calc_padding(align, content.size(), width);
-  out = write_repeat<CharT>(out, fill, lead);
-  out = write_sv<CharT>(out, content);
-  out = write_repeat<CharT>(out, fill, trail);
-  return out;
-}
 
 } // namespace specs
 
@@ -250,7 +246,7 @@ struct nullable_formatter: std::formatter<U, CharT> {
   constexpr auto parse(std::basic_format_parse_context<CharT>& ctx) {
     const auto begin = ctx.begin();
     const auto it = base::parse(ctx);
-    spec_ = specs::parse_pad(std::basic_string_view<CharT>{begin,
+    spec_.parse_pad(std::basic_string_view<CharT>{begin,
         static_cast<std::size_t>(it - begin)});
     if (spec_.debug && spec_.dynamic)
       throw std::format_error("dynamic is unsupported");
@@ -279,8 +275,7 @@ struct nullable_formatter: std::formatter<U, CharT> {
 private:
   template<typename FormatContext>
   auto pad_sentinel(FormatContext& ctx) const {
-    return specs::write_padded<CharT>(ctx.out(), marker_, spec_.fill,
-        spec_.align, spec_.width);
+    return spec_.write_padded(ctx.out(), marker_);
   }
 
   std::string_view marker_{"(null)"};
@@ -312,7 +307,7 @@ struct format_to_formatter {
       typename std::basic_format_parse_context<CharT>::iterator {
     const auto begin = ctx.begin();
     const auto it = ctx.end();
-    spec_ = specs::parse_pad(std::basic_string_view<CharT>{begin,
+    spec_.parse_pad(std::basic_string_view<CharT>{begin,
         static_cast<std::size_t>(it - begin)});
     if (spec_.debug && spec_.dynamic)
       throw std::format_error("dynamic is unsupported");

--- a/corvid/meta/formatting.h
+++ b/corvid/meta/formatting.h
@@ -273,8 +273,7 @@ struct spec_parser: parsed_spec<CharT> {
     if (ndx < cnt && spec[ndx] == CharT('.')) {
       ++ndx;
       ndx = precision_arg.parse(spec, ndx);
-      if (const auto fixed = precision_arg.get_fixed())
-        base::precision = *fixed;
+      base::precision = precision_arg.get_fixed();
     }
     // `L` locale
     if (ndx < cnt && spec[ndx] == CharT('L')) {
@@ -559,7 +558,7 @@ struct self_rendering_formatter {
       // Use a buffer to apply width and precision, if needed.
       if (width || prec) {
         std::basic_string<CharT> buffer;
-        format_to_it(obj, std::back_inserter(buffer));
+        (void)format_to_it(obj, std::back_inserter(buffer));
 
         std::basic_string_view<CharT> content = buffer;
         if (prec) content = content.substr(0, *prec);
@@ -574,7 +573,7 @@ struct self_rendering_formatter {
 #pragma endregion
 #pragma region Helpers
 
-  auto format_to_it(const auto& obj, auto it) const {
+  [[nodiscard]] auto format_to_it(const auto& obj, auto it) const {
     if (spec_.debug) {
       if constexpr (requires { obj.debug_format_to(it); })
         return obj.debug_format_to(it);

--- a/corvid/meta/formatting.h
+++ b/corvid/meta/formatting.h
@@ -539,24 +539,46 @@ struct self_rendering_formatter {
 
   template<typename T, typename FormatContext>
   auto format(const T& obj, FormatContext& ctx) const {
+    auto width =
+        spec_.width_arg.is_dynamic()
+            ? spec_.width_arg.get_dynamic(ctx)
+            : spec_.width;
+    const auto prec =
+        spec_.precision_arg.is_dynamic()
+            ? spec_.precision_arg.get_dynamic(ctx)
+            : spec_.precision;
     if constexpr (requires { obj.format_to_spec(spec_, ctx.out()); }) {
-      // Pass copy with dynamic width/precision resolved to concrete values.
+      // Use `format_to_spec` for maximum flexibility.
       parsed_spec<CharT> resolved = spec_;
-      if (spec_.width_arg.is_dynamic())
-        resolved.width = spec_.width_arg.get_dynamic(ctx);
-      if (spec_.precision_arg.is_dynamic())
-        resolved.precision = spec_.precision_arg.get_dynamic(ctx);
+      resolved.width = width;
+      resolved.precision = prec;
 
       return obj.format_to_spec(resolved, ctx.out());
     } else {
-      // No spec handling: stream the rendering, honoring the `?` debug spec
-      // when the type offers a `debug_format_to`.
-      if (spec_.debug) {
-        if constexpr (requires { obj.debug_format_to(ctx.out()); })
-          return obj.debug_format_to(ctx.out());
+      // Use a buffer to apply width and precision, if needed.
+      if (width || prec) {
+        std::basic_string<CharT> buffer;
+        format_to_it(obj, std::back_inserter(buffer));
+
+        std::basic_string_view<CharT> content = buffer;
+        if (prec) content = content.substr(0, *prec);
+        return spec_.write_padded(ctx.out(), content, width);
       }
-      return obj.format_to(ctx.out());
+
+      // No padding needed, so call directly.
+      return format_to_it(obj, ctx.out());
     }
+  }
+
+#pragma endregion
+#pragma region Helpers
+
+  auto format_to_it(const auto& obj, auto& it) {
+    if (spec_.debug) {
+      if constexpr (requires { obj.debug_format_to(it); })
+        return obj.debug_format_to(it);
+    }
+    return obj.format_to(it);
   }
 
 #pragma endregion

--- a/corvid/meta/formatting.h
+++ b/corvid/meta/formatting.h
@@ -15,8 +15,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #pragma once
+#include <array>
 #include <cstdint>
 #include <format>
+#include <optional>
+#include <string>
+#include <type_traits>
 
 #include "concepts.h"
 
@@ -27,15 +31,106 @@
 // {}`.
 namespace corvid { inline namespace meta { inline namespace formatting {
 
-namespace specs {
-
 // A parsed standard format spec: the individual fields, plus the operations to
 // parse a spec string into them and to emit a padded field. The fields are
 // public and the helpers are a few methods on top; this is a struct with
 // benefits, not a tightly encapsulated value type.
 template<CharType CharT>
 struct parsed_spec {
+#pragma region Types
   enum class aligned : std::uint8_t { left, right, center };
+
+  enum class arg_kind : std::uint8_t { none, fixed, automatic, manual };
+
+  // An argument value containing a width or precision field. This can be a
+  // fixed value `10`, an auto `{}`, a manual `{n}`, or absent. `value` carries
+  // the fixed value or the manual arg id.
+  struct arg_value_t {
+    arg_kind kind = arg_kind::none;
+    std::size_t value = 0;
+
+    // Read an arg value from `spec` at `ndx`, returning an index past the
+    // consumed text.
+    [[nodiscard]] constexpr std::size_t
+    parse(std::basic_string_view<CharT> spec, std::size_t ndx) {
+      *this = make_from_parse(spec, ndx);
+      return ndx;
+    }
+
+    // Read an arg value (a width or precision) at `ndx`, advancing it. A
+    // `{...}` is dynamic: empty is auto, digits are a manual arg id.
+    [[nodiscard]] static constexpr arg_value_t
+    make_from_parse(std::basic_string_view<CharT> spec, std::size_t& ndx) {
+      const std::size_t n = spec.size();
+      if (ndx < n && spec[ndx] == CharT('{')) {
+        ++ndx;
+        std::size_t id = 0;
+        bool has_id = false;
+        for (; ndx < n && spec[ndx] >= CharT('0') && spec[ndx] <= CharT('9');
+            ++ndx)
+        {
+          id = (id * 10) + static_cast<std::size_t>(spec[ndx] - CharT('0'));
+          has_id = true;
+        }
+        if (ndx < n && spec[ndx] == CharT('}')) ++ndx;
+        return has_id ? arg_value_t{arg_kind::manual, id}
+                      : arg_value_t{arg_kind::automatic, 0};
+      }
+      std::size_t value = 0;
+      bool any = false;
+      for (; ndx < n && spec[ndx] >= CharT('0') && spec[ndx] <= CharT('9');
+          ++ndx)
+      {
+        value =
+            (value * 10) + static_cast<std::size_t>(spec[ndx] - CharT('0'));
+        any = true;
+      }
+      return any ? arg_value_t{arg_kind::fixed, value}
+                 : arg_value_t{arg_kind::none, 0};
+    }
+
+    [[nodiscard]] bool is_dynamic() const {
+      return kind == arg_kind::automatic || kind == arg_kind::manual;
+    }
+
+    [[nodiscard]] bool is_empty() const { return kind == arg_kind::none; }
+
+    [[nodiscard]] std::optional<size_t> get_arg_id() const {
+      if (kind != arg_kind::manual) return std::nullopt;
+      return value;
+    }
+
+    [[nodiscard]] std::optional<size_t> get_fixed() const {
+      if (kind != arg_kind::fixed) return std::nullopt;
+      return value;
+    }
+
+    template<typename FormatContext>
+    [[nodiscard]] std::size_t get_dynamic(FormatContext& ctx) const {
+      if (!is_dynamic()) return 0;
+      return get_dynamic_num(ctx, value);
+    }
+
+    // Resolve a dynamic width or precision: arg `id` as a non-negative
+    // integer.
+    template<typename FormatContext>
+    static std::size_t get_dynamic_num(FormatContext& ctx, std::size_t id) {
+      return std::visit_format_arg(
+          [](auto value) -> std::size_t {
+            using T = std::remove_cvref_t<decltype(value)>;
+            if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
+              if constexpr (std::is_signed_v<T>)
+                if (value < 0) throw std::format_error("negative arg");
+              return static_cast<std::size_t>(value);
+            } else
+              throw std::format_error("arg is not an integer");
+          },
+          ctx.arg(id));
+    }
+  };
+
+#pragma endregion
+#pragma region Fields
 
   std::size_t width = 0;
   std::optional<std::size_t> precision; // Meaningful for numerics.
@@ -47,10 +142,35 @@ struct parsed_spec {
   bool zero_pad = false;
   bool has_locale = false;
   CharT type = CharT(0); // Debug is '?'.
-  bool dynamic = false;  // Either dynamic width or precision was attempted.
 
-  // Parse the standard format spec into this instance.
-  constexpr void parse_pad(std::basic_string_view<CharT> spec) {
+  arg_value_t width_arg;
+  arg_value_t precision_arg;
+
+#pragma endregion
+
+  // TODO: These four fields are obsolete and will be replaced by the two
+  // `arg_value` fields above.
+  //
+  // A dynamic width or precision draws its value from a format arg at format
+  // time. `*_arg_id` holds that arg's index once known: read straight from a
+  // manual `{n}`, or claimed from the parse context for an auto `{}`. The
+  // `*_arg_auto` flags record that the spec wrote `{}`, so a delegating
+  // formatter knows it must claim the id itself rather than read it here.
+  std::optional<std::size_t> width_arg_id;
+  std::optional<std::size_t> precision_arg_id;
+  bool width_arg_auto = false;
+  bool precision_arg_auto = false;
+
+  // Whether any width or precision is dynamic.
+  [[nodiscard]] constexpr bool is_dynamic() const {
+    return width_arg_id || precision_arg_id || width_arg_auto ||
+           precision_arg_auto;
+  }
+
+  // Parse the standard format spec into this instance, stopping at the closing
+  // `}` (as there may be more after it). Returns the count of code units
+  // consumed, which is the offset of that `}`.
+  constexpr std::size_t parse_pad(std::basic_string_view<CharT> spec) {
     std::size_t ndx = 0;
     const std::size_t cnt = spec.size();
     // [fill] align
@@ -81,33 +201,89 @@ struct parsed_spec {
       ++ndx;
     }
     // width
-    if (const auto w = read_count(spec, ndx)) width = *w;
+    {
+      ndx = width_arg.parse(spec, ndx);
+      // TODO: Remove the following when arg_value_t::get_dynamic() obsoletes
+      // it.
+      if (width_arg.kind == arg_kind::fixed)
+        width = width_arg.value;
+      else if (width_arg.kind == arg_kind::automatic)
+        width_arg_auto = true;
+      else if (width_arg.kind == arg_kind::manual)
+        width_arg_id = width_arg.value;
+    }
     // `.` precision
     if (ndx < cnt && spec[ndx] == CharT('.')) {
       ++ndx;
-      precision = read_count(spec, ndx);
+      ndx = precision_arg.parse(spec, ndx);
+      // TODO: Remove the following when arg_value_t::get_dynamic() obsoletes
+      // it.
+      if (precision_arg.kind == arg_kind::fixed)
+        precision = precision_arg.value;
+      else if (precision_arg.kind == arg_kind::automatic)
+        precision_arg_auto = true;
+      else if (precision_arg.kind == arg_kind::manual)
+        precision_arg_id = precision_arg.value;
     }
     // `L` locale
     if (ndx < cnt && spec[ndx] == CharT('L')) {
       has_locale = true;
       ++ndx;
     }
-    // type: the one remaining char, if any
-    if (ndx < cnt) type = spec[ndx];
-
+    // type: the one remaining char before the closing `}`, if any
+    if (ndx < cnt && spec[ndx] != CharT('}')) {
+      type = spec[ndx];
+      ++ndx;
+    }
     // The `?` type is debug.
     if (type == CharT('?')) debug = true;
 
-    // A `{` flags a dynamic width or precision (value unreadable here).
-    if (spec.find(CharT('{')) != spec.npos) dynamic = true;
+    return ndx;
   }
 
-  // Emit `content` (narrow, 7-bit ASCII) widened to `CharT`, padded to this
-  // spec's `width` with its `fill` per its `align`. A width no larger than the
-  // content is a no-op (width is a minimum).
+  // Resolve the width to apply, reading a dynamic width's arg or returning the
+  // fixed `width`.
+  // TODO: Remove this when arg_value_t::get_dynamic() obsoletes it.
+  template<typename FormatContext>
+  [[nodiscard]] std::size_t get_dynamic_width(FormatContext& ctx) const {
+    return width_arg_id ? arg_value_t::get_dynamic_num(ctx, *width_arg_id)
+                        : width;
+  }
+
+  // Rewrite the spec to make all dynamic fields explicit. In other words,
+  // every auto `{}` is replaced by a manual `{n}` with the claimed id `n` so
+  // that the base reads the same arg the auto field would have.
+  //
+  // Only call once the ids are claimed; assumes any dynamic field here is
+  // auto, as a format string cannot mix auto and manual indexing.
+  [[nodiscard]] std::basic_string<CharT> rewrite_spec_as_explicit(
+      std::basic_string_view<CharT> spec) const {
+    std::array<std::size_t, 2> ids{};
+    std::size_t got = 0;
+    if (width_arg_auto) ids[got++] = *width_arg_id;
+    if (precision_arg_auto) ids[got++] = *precision_arg_id;
+
+    std::basic_string<CharT> out;
+    out.reserve(spec.size() + (got * 4));
+    std::size_t next = 0;
+    for (std::size_t i = 0; i < spec.size(); ++i) {
+      out.push_back(spec[i]);
+      if (spec[i] == CharT('{') && i + 1 < spec.size() &&
+          spec[i + 1] == CharT('}'))
+        append_decimal(out, ids[next++]);
+    }
+    return out;
+  }
+
+  // Emit `content`.
+  //
+  // The input is (narrow, 7-bit ASCII), so it's widened to `CharT`. It is
+  // then padded to `field_width` with this spec's `fill` per its `align`. A
+  // width no larger than the content is a no-op (width is a minimum).
   template<typename OutIt>
-  constexpr OutIt write_padded(OutIt out, std::string_view content) const {
-    auto [lead, trail] = calc_padding(align, content.size(), width);
+  [[nodiscard]] constexpr OutIt write_padded(OutIt out,
+      std::string_view content, std::size_t field_width) const {
+    auto [lead, trail] = calc_padding(align, content.size(), field_width);
     out = write_repeat(out, fill, lead);
     out = write_sv(out, content);
     out = write_repeat(out, fill, trail);
@@ -125,20 +301,17 @@ private:
     return aligned::left;
   }
 
-  // Read a count (a width or precision) at `ndx`, advancing it.
-  static constexpr std::optional<std::size_t>
-  read_count(std::basic_string_view<CharT> spec, std::size_t& ndx) {
-    const std::size_t n = spec.size();
-    if (ndx < n && spec[ndx] == CharT('{')) {
-      while (ndx < n && spec[ndx] != CharT('}')) ++ndx;
-      if (ndx < n) ++ndx;
-      return std::nullopt;
-    }
-    std::size_t value = 0;
-    for (; ndx < n && spec[ndx] >= CharT('0') && spec[ndx] <= CharT('9');
-        ++ndx)
-      value = (value * 10) + static_cast<std::size_t>(spec[ndx] - CharT('0'));
-    return value;
+  // Append `v` as decimal digits, widened to `CharT`.
+  // TODO: I know we're very low in the stack, but do we have to reinvent this
+  // particular wheel?
+  static void append_decimal(std::basic_string<CharT>& out, std::size_t v) {
+    CharT buf[20];
+    std::size_t len = 0;
+    do {
+      buf[len++] = static_cast<CharT>(CharT('0') + (v % 10));
+      v /= 10;
+    } while (v != 0);
+    while (len != 0) out.push_back(buf[--len]);
   }
 
   static constexpr std::pair<size_t, size_t> calc_padding(aligned align,
@@ -173,8 +346,6 @@ private:
     return out;
   }
 };
-
-} // namespace specs
 
 // Whether a null renders as an empty field or the text sentinel (default
 // `(null)`). Selected independently for the plain and debug specs of
@@ -220,9 +391,11 @@ struct forwarding_formatter: std::formatter<U, CharT> {
 //
 // Only fill, align, and width reach the sentinel; it is a fixed string, so
 // precision and type are meaningless for it, while the present value still
-// honors the whole spec through the inherited formatter. A dynamic width or
-// precision combined with the debug spec is rejected, since the sentinel's own
-// padding cannot read an argument bound to the real format context.
+// honors the whole spec through the inherited formatter. A dynamic width
+// reaches the sentinel, too: a manual id is read from the spec, and an auto
+// `{}` is claimed from the parse context and re-presented to the base as an
+// explicit id, so the sentinel and the present value resolve the same
+// argument.
 template<typename U, CharType CharT,
     null_formatting PlainNull = null_formatting::sentinel,
     null_formatting DebugNull = null_formatting::sentinel>
@@ -244,13 +417,37 @@ struct nullable_formatter: std::formatter<U, CharT> {
   }
 
   constexpr auto parse(std::basic_format_parse_context<CharT>& ctx) {
+    if consteval {
+      // Compile-time validation: let the base consume any dynamic arg ids and
+      // check the spec. The recovered ids are only needed at format time, and
+      // a manually constructed parse context cannot run those checks during
+      // constant evaluation anyway.
+      return base::parse(ctx);
+    }
+
     const auto begin = ctx.begin();
-    const auto it = base::parse(ctx);
-    spec_.parse_pad(std::basic_string_view<CharT>{begin,
-        static_cast<std::size_t>(it - begin)});
-    if (spec_.debug && spec_.dynamic)
-      throw std::format_error("dynamic is unsupported");
-    return it;
+    const auto spec_text = std::basic_string_view<CharT>{begin,
+        static_cast<std::size_t>(ctx.end() - begin)};
+    const auto consumed = spec_.parse_pad(spec_text);
+
+    // The sentinel resolves its own dynamic width, so when it will be shown we
+    // must learn the arg id. A manual `{n}` is in the text (and the base reads
+    // it directly), but an auto `{}` has no id there: claim it from the
+    // context and re-present the spec to the base with explicit ids. Otherwise
+    // the base parses the real spec.
+    constexpr bool plain_sentinel = PlainNull == null_formatting::sentinel;
+    constexpr bool debug_sentinel = DebugNull == null_formatting::sentinel;
+    const bool sentinel_shown = spec_.debug ? debug_sentinel : plain_sentinel;
+    if (sentinel_shown && (spec_.width_arg_auto || spec_.precision_arg_auto)) {
+      if (spec_.width_arg_auto) spec_.width_arg_id = ctx.next_arg_id();
+      if (spec_.precision_arg_auto) spec_.precision_arg_id = ctx.next_arg_id();
+      const auto synthetic = spec_.rewrite_spec_as_explicit(
+          std::basic_string_view<CharT>{begin, consumed});
+      std::basic_format_parse_context<CharT> sctx(synthetic);
+      base::parse(sctx);
+      return begin + consumed;
+    }
+    return base::parse(ctx);
   }
 
   template<typename W, typename FormatContext>
@@ -275,11 +472,12 @@ struct nullable_formatter: std::formatter<U, CharT> {
 private:
   template<typename FormatContext>
   auto pad_sentinel(FormatContext& ctx) const {
-    return spec_.write_padded(ctx.out(), marker_);
+    return spec_.write_padded(ctx.out(), marker_,
+        spec_.get_dynamic_width(ctx));
   }
 
   std::string_view marker_{"(null)"};
-  specs::parsed_spec<CharT> spec_;
+  parsed_spec<CharT> spec_;
 };
 
 // Base for a `std::formatter` on a type that renders itself through a
@@ -303,13 +501,13 @@ template<CharType CharT>
 struct format_to_formatter {
   constexpr void set_debug_format() { spec_.debug = true; }
 
-  constexpr auto parse(std::basic_format_parse_context<CharT>& ctx) ->
-      typename std::basic_format_parse_context<CharT>::iterator {
+  constexpr auto parse(std::basic_format_parse_context<CharT>& ctx)
+      -> std::basic_format_parse_context<CharT>::iterator {
     const auto begin = ctx.begin();
     const auto it = ctx.end();
     spec_.parse_pad(std::basic_string_view<CharT>{begin,
         static_cast<std::size_t>(it - begin)});
-    if (spec_.debug && spec_.dynamic)
+    if (spec_.debug && spec_.is_dynamic())
       throw std::format_error("dynamic is unsupported");
     return it;
   }
@@ -327,7 +525,7 @@ struct format_to_formatter {
   }
 
 private:
-  specs::parsed_spec<CharT> spec_;
+  parsed_spec<CharT> spec_;
 };
 
 }}} // namespace corvid::meta::formatting

--- a/corvid/meta/formatting.h
+++ b/corvid/meta/formatting.h
@@ -487,9 +487,20 @@ private:
   }
 
   template<typename FormatContext>
+  [[nodiscard]] std::optional<std::size_t>
+  get_precision(FormatContext& ctx) const {
+    if (spec_.precision_arg.is_dynamic())
+      return spec_.precision_arg.get_dynamic(ctx);
+    return spec_.precision;
+  }
+
+  template<typename FormatContext>
   auto pad_sentinel(FormatContext& ctx) const {
     const std::size_t field_width = get_width(ctx);
-    return spec_.write_padded(ctx.out(), marker_, field_width);
+    std::string_view content = marker_;
+    if (const auto prec = get_precision(ctx))
+      content = content.substr(0, *prec);
+    return spec_.write_padded(ctx.out(), content, field_width);
   }
 
 #pragma endregion

--- a/corvid/meta/formatting.h
+++ b/corvid/meta/formatting.h
@@ -114,6 +114,9 @@ struct parsed_spec {
 #pragma region spec_parser
 
 // Format spec parser: all of the bits that are only needed internally.
+//
+// Note that this works correctly with valid specs, but does not guarantee
+// detecting and rejecting invalid ones.
 template<CharType CharT>
 struct spec_parser: parsed_spec<CharT> {
 #pragma region Types

--- a/corvid/meta/formatting.h
+++ b/corvid/meta/formatting.h
@@ -92,33 +92,35 @@ struct parsed_spec {
                  : arg_value_t{arg_kind::none, 0};
     }
 
-    [[nodiscard]] bool is_dynamic() const {
+    [[nodiscard]] constexpr bool is_dynamic() const {
       return kind == arg_kind::automatic || kind == arg_kind::manual;
     }
 
-    [[nodiscard]] bool is_empty() const { return kind == arg_kind::none; }
+    [[nodiscard]] constexpr bool is_empty() const {
+      return kind == arg_kind::none;
+    }
 
-    [[nodiscard]] bool is_automatic() const {
+    [[nodiscard]] constexpr bool is_automatic() const {
       return kind == arg_kind::automatic;
     }
 
-    [[nodiscard]] std::optional<size_t> get_arg_id() const {
+    [[nodiscard]] constexpr std::optional<size_t> get_arg_id() const {
       if (kind != arg_kind::manual) return std::nullopt;
       return value;
     }
 
-    [[nodiscard]] std::optional<size_t> get_fixed() const {
+    [[nodiscard]] constexpr std::optional<size_t> get_fixed() const {
       if (kind != arg_kind::fixed) return std::nullopt;
       return value;
     }
 
-    [[nodiscard]] std::optional<size_t> get_automatic() const {
+    [[nodiscard]] constexpr std::optional<size_t> get_automatic() const {
       if (kind != arg_kind::automatic) return std::nullopt;
       return value;
     }
 
     template<typename FormatContext>
-    [[nodiscard]] std::size_t get_dynamic(FormatContext& ctx) const {
+    [[nodiscard]] constexpr std::size_t get_dynamic(FormatContext& ctx) const {
       if (!is_dynamic()) return 0;
       return get_dynamic_num(ctx, value);
     }
@@ -126,7 +128,8 @@ struct parsed_spec {
     // Resolve a dynamic width or precision: arg `id` as a non-negative
     // integer.
     template<typename FormatContext>
-    static std::size_t get_dynamic_num(FormatContext& ctx, std::size_t id) {
+    static constexpr std::size_t
+    get_dynamic_num(FormatContext& ctx, std::size_t id) {
       return std::visit_format_arg(
           [](auto value) -> std::size_t {
             using T = std::remove_cvref_t<decltype(value)>;
@@ -503,11 +506,12 @@ private:
 // std range and map formatters. Both `format_to` and `debug_format_to` must
 // return the advanced output iterator.
 //
-// Fill, align, width, and precision are not supported: padding needs the
-// rendered length, which would require materializing the rendering into a
-// temporary. Add that here (render to a temporary, then pad through a
-// `std::formatter<basic_string_view<CharT>>`) if a caller needs it; until then
-// this streams straight to the output with no buffer.
+// A type that only provides `format_to`/`debug_format_to` streams straight to
+// the output with no padding. A type that instead provides `format_to_spec(s,
+// out)` receives the parsed spec and applies fill, align, width, and precision
+// itself (it knows its own rendered length). Any dynamic width or precision is
+// resolved against the format args before the call, so `format_to_spec` sees
+// concrete `s.width` / `s.precision` and never touches the format context.
 template<CharType CharT>
 struct self_rendering_formatter {
 #pragma region Parse
@@ -517,12 +521,18 @@ struct self_rendering_formatter {
   constexpr auto parse(std::basic_format_parse_context<CharT>& ctx)
       -> std::basic_format_parse_context<CharT>::iterator {
     const auto begin = ctx.begin();
-    const auto it = ctx.end();
-    spec_.parse_pad(std::basic_string_view<CharT>{begin,
-        static_cast<std::size_t>(it - begin)});
-    if (spec_.debug && spec_.is_dynamic())
-      throw std::format_error("dynamic is unsupported");
-    return it;
+    const auto spec_text = std::basic_string_view<CharT>{begin,
+        static_cast<std::size_t>(ctx.end() - begin)};
+    const auto consumed = spec_.parse_pad(spec_text);
+    // An automatic `{}` width or precision has no id in the spec string, so
+    // claim one from the parse context now, width before precision to match
+    // arg order; format time reads it back from `value`.
+    if (spec_.width_arg.is_automatic())
+      spec_.width_arg.value = ctx.next_arg_id();
+    if (spec_.precision_arg.is_automatic())
+      spec_.precision_arg.value = ctx.next_arg_id();
+    // Stop at the spec-terminating `}`
+    return begin + consumed;
   }
 
 #pragma endregion
@@ -530,14 +540,25 @@ struct self_rendering_formatter {
 
   template<typename T, typename FormatContext>
   auto format(const T& obj, FormatContext& ctx) const {
-    if constexpr (requires { obj.format_to_spec(spec_, ctx.out()); })
-      return obj.format_to_spec(spec_, ctx.out());
-
-    if (spec_.debug) {
-      if constexpr (requires { obj.debug_format_to(ctx.out()); })
-        return obj.debug_format_to(ctx.out());
+    if constexpr (requires { obj.format_to_spec(spec_, ctx.out()); }) {
+      // Resolve any dynamic width/precision against the args now, so the type
+      // sees concrete values and never touches the format context.
+      parsed_spec<CharT> resolved = spec_;
+      if (resolved.width_arg.is_dynamic())
+        resolved.width = resolved.width_arg.get_dynamic(ctx);
+      if (resolved.precision_arg.is_dynamic())
+        resolved.precision = resolved.precision_arg.get_dynamic(ctx);
+      return obj.format_to_spec(resolved, ctx.out());
+    } else {
+      // No spec handling: stream the rendering, honoring the `?` debug spec
+      // when the type offers a `debug_format_to`. The `else` matters: it keeps
+      // `format_to` from being required of a `format_to_spec`-only type.
+      if (spec_.debug) {
+        if constexpr (requires { obj.debug_format_to(ctx.out()); })
+          return obj.debug_format_to(ctx.out());
+      }
+      return obj.format_to(ctx.out());
     }
-    return obj.format_to(ctx.out());
   }
 
 #pragma endregion

--- a/corvid/meta/formatting.h
+++ b/corvid/meta/formatting.h
@@ -503,7 +503,7 @@ private:
 };
 
 #pragma endregion
-#pragma region self_rendering_formatter
+#pragma region self_rendering
 
 // Base for a `std::formatter` on a type that renders itself through a
 // `format_to(out)` member: the modern analog of `operator<<`.

--- a/corvid/meta/formatting.h
+++ b/corvid/meta/formatting.h
@@ -72,16 +72,16 @@ struct parsed_spec {
   }
 
   // Write `content` with padding.
-  template<typename OutIt>
+  template<CharType InCharT, typename OutIt>
   [[nodiscard]] constexpr OutIt
-  write_padded(OutIt out, std::string_view content) const {
+  write_padded(OutIt out, std::basic_string_view<InCharT> content) const {
     return write_padded(out, content, width);
   }
 
   // Write `content` with padding, overriding width.
-  template<typename OutIt>
+  template<CharType InCharT, typename OutIt>
   [[nodiscard]] constexpr OutIt write_padded(OutIt out,
-      std::string_view content, std::size_t field_width) const {
+      std::basic_string_view<InCharT> content, std::size_t field_width) const {
     auto [lead, trail] = calc_padding(alignment, content.size(), field_width);
     out = write_repeat(out, fill, lead);
     out = write_sv(out, content);

--- a/corvid/meta/formatting.h
+++ b/corvid/meta/formatting.h
@@ -31,6 +31,8 @@
 // {}`.
 namespace corvid { inline namespace meta { inline namespace formatting {
 
+#pragma region parsed_spec
+
 // A parsed standard format spec: the individual fields, plus the operations to
 // parse a spec string into them and to emit a padded field. The fields are
 // public and the helpers are a few methods on top; this is a struct with
@@ -44,7 +46,8 @@ struct parsed_spec {
 
   // An argument value containing a width or precision field. This can be a
   // fixed value `10`, an auto `{}`, a manual `{n}`, or absent. `value` carries
-  // the fixed value or the manual arg id.
+  // the fixed value, the manual arg id, or the auto arg id once claimed from
+  // the parse context.
   struct arg_value_t {
     arg_kind kind = arg_kind::none;
     std::size_t value = 0;
@@ -95,6 +98,10 @@ struct parsed_spec {
 
     [[nodiscard]] bool is_empty() const { return kind == arg_kind::none; }
 
+    [[nodiscard]] bool is_automatic() const {
+      return kind == arg_kind::automatic;
+    }
+
     [[nodiscard]] std::optional<size_t> get_arg_id() const {
       if (kind != arg_kind::manual) return std::nullopt;
       return value;
@@ -102,6 +109,11 @@ struct parsed_spec {
 
     [[nodiscard]] std::optional<size_t> get_fixed() const {
       if (kind != arg_kind::fixed) return std::nullopt;
+      return value;
+    }
+
+    [[nodiscard]] std::optional<size_t> get_automatic() const {
+      if (kind != arg_kind::automatic) return std::nullopt;
       return value;
     }
 
@@ -147,24 +159,11 @@ struct parsed_spec {
   arg_value_t precision_arg;
 
 #pragma endregion
-
-  // TODO: These four fields are obsolete and will be replaced by the two
-  // `arg_value` fields above.
-  //
-  // A dynamic width or precision draws its value from a format arg at format
-  // time. `*_arg_id` holds that arg's index once known: read straight from a
-  // manual `{n}`, or claimed from the parse context for an auto `{}`. The
-  // `*_arg_auto` flags record that the spec wrote `{}`, so a delegating
-  // formatter knows it must claim the id itself rather than read it here.
-  std::optional<std::size_t> width_arg_id;
-  std::optional<std::size_t> precision_arg_id;
-  bool width_arg_auto = false;
-  bool precision_arg_auto = false;
+#pragma region Operations
 
   // Whether any width or precision is dynamic.
   [[nodiscard]] constexpr bool is_dynamic() const {
-    return width_arg_id || precision_arg_id || width_arg_auto ||
-           precision_arg_auto;
+    return width_arg.is_dynamic() || precision_arg.is_dynamic();
   }
 
   // Parse the standard format spec into this instance, stopping at the closing
@@ -201,29 +200,13 @@ struct parsed_spec {
       ++ndx;
     }
     // width
-    {
-      ndx = width_arg.parse(spec, ndx);
-      // TODO: Remove the following when arg_value_t::get_dynamic() obsoletes
-      // it.
-      if (width_arg.kind == arg_kind::fixed)
-        width = width_arg.value;
-      else if (width_arg.kind == arg_kind::automatic)
-        width_arg_auto = true;
-      else if (width_arg.kind == arg_kind::manual)
-        width_arg_id = width_arg.value;
-    }
+    ndx = width_arg.parse(spec, ndx);
+    if (const auto fixed = width_arg.get_fixed()) width = *fixed;
     // `.` precision
     if (ndx < cnt && spec[ndx] == CharT('.')) {
       ++ndx;
       ndx = precision_arg.parse(spec, ndx);
-      // TODO: Remove the following when arg_value_t::get_dynamic() obsoletes
-      // it.
-      if (precision_arg.kind == arg_kind::fixed)
-        precision = precision_arg.value;
-      else if (precision_arg.kind == arg_kind::automatic)
-        precision_arg_auto = true;
-      else if (precision_arg.kind == arg_kind::manual)
-        precision_arg_id = precision_arg.value;
+      if (const auto fixed = precision_arg.get_fixed()) precision = *fixed;
     }
     // `L` locale
     if (ndx < cnt && spec[ndx] == CharT('L')) {
@@ -241,15 +224,6 @@ struct parsed_spec {
     return ndx;
   }
 
-  // Resolve the width to apply, reading a dynamic width's arg or returning the
-  // fixed `width`.
-  // TODO: Remove this when arg_value_t::get_dynamic() obsoletes it.
-  template<typename FormatContext>
-  [[nodiscard]] std::size_t get_dynamic_width(FormatContext& ctx) const {
-    return width_arg_id ? arg_value_t::get_dynamic_num(ctx, *width_arg_id)
-                        : width;
-  }
-
   // Rewrite the spec to make all dynamic fields explicit. In other words,
   // every auto `{}` is replaced by a manual `{n}` with the claimed id `n` so
   // that the base reads the same arg the auto field would have.
@@ -260,8 +234,8 @@ struct parsed_spec {
       std::basic_string_view<CharT> spec) const {
     std::array<std::size_t, 2> ids{};
     std::size_t got = 0;
-    if (width_arg_auto) ids[got++] = *width_arg_id;
-    if (precision_arg_auto) ids[got++] = *precision_arg_id;
+    if (const auto id = width_arg.get_automatic()) ids[got++] = *id;
+    if (const auto id = precision_arg.get_automatic()) ids[got++] = *id;
 
     std::basic_string<CharT> out;
     out.reserve(spec.size() + (got * 4));
@@ -290,6 +264,8 @@ struct parsed_spec {
     return out;
   }
 
+#pragma endregion
+#pragma region Helpers
 private:
   static constexpr bool is_align(CharT c) {
     return c == CharT('<') || c == CharT('>') || c == CharT('^');
@@ -345,12 +321,20 @@ private:
       *out++ = static_cast<CharT>(static_cast<wchar_t>(c));
     return out;
   }
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region null_formatting
 
 // Whether a null renders as an empty field or the text sentinel (default
 // `(null)`). Selected independently for the plain and debug specs of
 // `nullable_formatter`.
 enum class null_formatting : bool { empty = false, sentinel = true };
+
+#pragma endregion
+#pragma region forwarding_formatter
 
 // Base for a `std::formatter` on a wrapper that should format exactly like
 // some underlying value of type `U`. It inherits the underlying type's
@@ -368,6 +352,9 @@ struct forwarding_formatter: std::formatter<U, CharT> {
     return std::formatter<U, CharT>::format(static_cast<const U&>(w), ctx);
   }
 };
+
+#pragma endregion
+#pragma region nullable_formatter
 
 // Base for a `std::formatter` on a nullable, pointer-like wrapper. It inherits
 // the pointee/element type `U`'s formatter and forwards the dereferenced value
@@ -400,11 +387,16 @@ template<typename U, CharType CharT,
     null_formatting PlainNull = null_formatting::sentinel,
     null_formatting DebugNull = null_formatting::sentinel>
 struct nullable_formatter: std::formatter<U, CharT> {
+#pragma region Construction
+
   using base = std::formatter<U, CharT>;
 
   constexpr nullable_formatter() = default;
   constexpr explicit nullable_formatter(std::string_view marker)
       : marker_{marker} {}
+
+#pragma endregion
+#pragma region Parse
 
   // Offered only when the underlying formatter has it, so a containing range
   // or map can enable element quoting; also records debug mode for the
@@ -435,12 +427,15 @@ struct nullable_formatter: std::formatter<U, CharT> {
     // it directly), but an auto `{}` has no id there: claim it from the
     // context and re-present the spec to the base with explicit ids. Otherwise
     // the base parses the real spec.
-    constexpr bool plain_sentinel = PlainNull == null_formatting::sentinel;
-    constexpr bool debug_sentinel = DebugNull == null_formatting::sentinel;
-    const bool sentinel_shown = spec_.debug ? debug_sentinel : plain_sentinel;
-    if (sentinel_shown && (spec_.width_arg_auto || spec_.precision_arg_auto)) {
-      if (spec_.width_arg_auto) spec_.width_arg_id = ctx.next_arg_id();
-      if (spec_.precision_arg_auto) spec_.precision_arg_id = ctx.next_arg_id();
+    constexpr bool is_plain_sentinel = PlainNull == null_formatting::sentinel;
+    constexpr bool is_debug_sentinel = DebugNull == null_formatting::sentinel;
+    const bool is_sentinel_shown =
+        spec_.debug ? is_debug_sentinel : is_plain_sentinel;
+    const bool is_width_auto = spec_.width_arg.is_automatic();
+    const bool is_precision_auto = spec_.precision_arg.is_automatic();
+    if (is_sentinel_shown && (is_width_auto || is_precision_auto)) {
+      if (is_width_auto) spec_.width_arg.value = ctx.next_arg_id();
+      if (is_precision_auto) spec_.precision_arg.value = ctx.next_arg_id();
       const auto synthetic = spec_.rewrite_spec_as_explicit(
           std::basic_string_view<CharT>{begin, consumed});
       std::basic_format_parse_context<CharT> sctx(synthetic);
@@ -449,6 +444,9 @@ struct nullable_formatter: std::formatter<U, CharT> {
     }
     return base::parse(ctx);
   }
+
+#pragma endregion
+#pragma region Format
 
   template<typename W, typename FormatContext>
   auto format(const W& w, FormatContext& ctx) const {
@@ -469,21 +467,34 @@ struct nullable_formatter: std::formatter<U, CharT> {
     }
   }
 
+#pragma endregion
+#pragma region Helpers
 private:
   template<typename FormatContext>
   auto pad_sentinel(FormatContext& ctx) const {
-    return spec_.write_padded(ctx.out(), marker_,
-        spec_.get_dynamic_width(ctx));
+    const std::size_t field_width =
+        spec_.width_arg.is_dynamic()
+            ? spec_.width_arg.get_dynamic(ctx)
+            : spec_.width;
+    return spec_.write_padded(ctx.out(), marker_, field_width);
   }
+
+#pragma endregion
+#pragma region Data members
 
   std::string_view marker_{"(null)"};
   parsed_spec<CharT> spec_;
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region self_rendering_formatter
 
 // Base for a `std::formatter` on a type that renders itself through a
 // `format_to(out)` member, the modern analog of `operator<<`. A deriving
-// specialization needs only `: format_to_formatter<CharT> {}`; the type is
-// deduced at format time.
+// specialization needs only `: self_rendering_formatter<CharT> {}`; the type
+// is deduced at format time.
 //
 // Supports the empty spec (plain rendering) and the `?` debug spec. In debug
 // mode it calls `debug_format_to(out)` when the type provides one, otherwise
@@ -498,7 +509,9 @@ private:
 // `std::formatter<basic_string_view<CharT>>`) if a caller needs it; until then
 // this streams straight to the output with no buffer.
 template<CharType CharT>
-struct format_to_formatter {
+struct self_rendering_formatter {
+#pragma region Parse
+
   constexpr void set_debug_format() { spec_.debug = true; }
 
   constexpr auto parse(std::basic_format_parse_context<CharT>& ctx)
@@ -512,6 +525,9 @@ struct format_to_formatter {
     return it;
   }
 
+#pragma endregion
+#pragma region Format
+
   template<typename T, typename FormatContext>
   auto format(const T& obj, FormatContext& ctx) const {
     if constexpr (requires { obj.format_to_spec(spec_, ctx.out()); })
@@ -524,8 +540,14 @@ struct format_to_formatter {
     return obj.format_to(ctx.out());
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   parsed_spec<CharT> spec_;
+
+#pragma endregion
 };
+
+#pragma endregion
 
 }}} // namespace corvid::meta::formatting

--- a/corvid/meta/formatting.h
+++ b/corvid/meta/formatting.h
@@ -547,8 +547,9 @@ struct self_rendering_formatter {
         spec_.precision_arg.is_dynamic()
             ? spec_.precision_arg.get_dynamic(ctx)
             : spec_.precision;
+
+    // When available, use `format_to_spec` for maximum flexibility.
     if constexpr (requires { obj.format_to_spec(spec_, ctx.out()); }) {
-      // Use `format_to_spec` for maximum flexibility.
       parsed_spec<CharT> resolved = spec_;
       resolved.width = width;
       resolved.precision = prec;
@@ -573,7 +574,7 @@ struct self_rendering_formatter {
 #pragma endregion
 #pragma region Helpers
 
-  auto format_to_it(const auto& obj, auto& it) {
+  auto format_to_it(const auto& obj, auto it) const {
     if (spec_.debug) {
       if constexpr (requires { obj.debug_format_to(it); })
         return obj.debug_format_to(it);

--- a/corvid/meta/formatting.h
+++ b/corvid/meta/formatting.h
@@ -32,15 +32,93 @@
 namespace corvid { inline namespace meta { inline namespace formatting {
 
 #pragma region parsed_spec
-
-// A parsed standard format spec: the individual fields, plus the operations to
-// parse a spec string into them and to emit a padded field. The fields are
-// public and the helpers are a few methods on top; this is a struct with
-// benefits, not a tightly encapsulated value type.
+// Parsed format spec, with formatting-related helpers.
 template<CharType CharT>
 struct parsed_spec {
-#pragma region Types
   enum class aligned : std::uint8_t { left, right, center };
+
+#pragma region Fields
+
+  std::size_t width = 0;
+  std::optional<std::size_t> precision; // Meaningful for numerics.
+  bool debug = false; // May be set externally by `set_debug_format`.
+  CharT fill = CharT(' ');
+  aligned alignment = aligned::left;
+  char sign = '-';        // `-` default, `+` always, ` ` space for positive.
+  bool alternate = false; // `#`
+  bool zero_pad = false;
+  bool has_locale = false;
+  CharT type = CharT(0); // Debug is '?'.
+
+#pragma endregion
+#pragma region Operations
+
+  // Write character `c`, `count` times.
+  template<CharType InCharT, typename OutIt>
+  static constexpr OutIt
+  write_repeat(OutIt out, InCharT c, std::size_t count) {
+    for (std::size_t i = 0; i < count; ++i)
+      *out++ = static_cast<CharT>(static_cast<wchar_t>(c));
+    return out;
+  }
+
+  // Write `sv`, widening each char to `CharT`.
+  template<CharType InCharT, typename OutIt>
+  static constexpr OutIt
+  write_sv(OutIt out, std::basic_string_view<InCharT> sv) {
+    for (const auto c : sv)
+      *out++ = static_cast<CharT>(static_cast<wchar_t>(c));
+    return out;
+  }
+
+  // Write `content` with padding.
+  template<typename OutIt>
+  [[nodiscard]] constexpr OutIt
+  write_padded(OutIt out, std::string_view content) const {
+    return write_padded(out, content, width);
+  }
+
+  // Write `content` with padding, overriding width.
+  template<typename OutIt>
+  [[nodiscard]] constexpr OutIt write_padded(OutIt out,
+      std::string_view content, std::size_t field_width) const {
+    auto [lead, trail] = calc_padding(alignment, content.size(), field_width);
+    out = write_repeat(out, fill, lead);
+    out = write_sv(out, content);
+    out = write_repeat(out, fill, trail);
+    return out;
+  }
+
+  // Calculate the left and right padding counts for `content_width` in a field
+  // of `total_width`, based on `alignment`.
+  static constexpr std::pair<size_t, size_t> calc_padding(aligned alignment,
+      std::size_t content_width, std::size_t total_width) {
+    std::size_t lead = 0;
+    std::size_t trail = 0;
+    if (total_width > content_width) {
+      const std::size_t pad = total_width - content_width;
+      lead =
+          alignment == aligned::right ? pad
+          : alignment == aligned::center
+              ? pad / 2
+              : 0;
+      trail = pad - lead;
+    }
+    return {lead, trail};
+  }
+
+#pragma endregion
+};
+
+#pragma endregion
+#pragma region spec_parser
+
+// Format spec parser: all of the bits that are only needed internally.
+template<CharType CharT>
+struct spec_parser: parsed_spec<CharT> {
+#pragma region Types
+  using base = parsed_spec<CharT>;
+  using aligned = base::aligned;
 
   enum class arg_kind : std::uint8_t { none, fixed, automatic, manual };
 
@@ -96,17 +174,8 @@ struct parsed_spec {
       return kind == arg_kind::automatic || kind == arg_kind::manual;
     }
 
-    [[nodiscard]] constexpr bool is_empty() const {
-      return kind == arg_kind::none;
-    }
-
     [[nodiscard]] constexpr bool is_automatic() const {
       return kind == arg_kind::automatic;
-    }
-
-    [[nodiscard]] constexpr std::optional<size_t> get_arg_id() const {
-      if (kind != arg_kind::manual) return std::nullopt;
-      return value;
     }
 
     [[nodiscard]] constexpr std::optional<size_t> get_fixed() const {
@@ -117,6 +186,12 @@ struct parsed_spec {
     [[nodiscard]] constexpr std::optional<size_t> get_automatic() const {
       if (kind != arg_kind::automatic) return std::nullopt;
       return value;
+    }
+
+    template<typename ParseContext>
+    constexpr void claim_next_automatic(ParseContext& ctx) {
+      if (!is_automatic()) return;
+      value = ctx.next_arg_id();
     }
 
     template<typename FormatContext>
@@ -147,17 +222,6 @@ struct parsed_spec {
 #pragma endregion
 #pragma region Fields
 
-  std::size_t width = 0;
-  std::optional<std::size_t> precision; // Meaningful for numerics.
-  bool debug = false; // May be set externally by `set_debug_format`.
-  CharT fill = CharT(' ');
-  aligned align = aligned::left;
-  char sign = '-';        // `-` default, `+` always, ` ` space for positive.
-  bool alternate = false; // `#`
-  bool zero_pad = false;
-  bool has_locale = false;
-  CharT type = CharT(0); // Debug is '?'.
-
   arg_value_t width_arg;
   arg_value_t precision_arg;
 
@@ -172,16 +236,16 @@ struct parsed_spec {
   // Parse the standard format spec into this instance, stopping at the closing
   // `}` (as there may be more after it). Returns the count of code units
   // consumed, which is the offset of that `}`.
-  constexpr std::size_t parse_pad(std::basic_string_view<CharT> spec) {
+  constexpr std::size_t parse(std::basic_string_view<CharT> spec) {
     std::size_t ndx = 0;
     const std::size_t cnt = spec.size();
     // [fill] align
     if (cnt >= 2 && is_align(spec[1])) {
-      fill = spec[0];
-      align = to_aligned(spec[1]);
+      base::fill = spec[0];
+      base::alignment = to_alignment(spec[1]);
       ndx = 2;
     } else if (cnt >= 1 && is_align(spec[0])) {
-      align = to_aligned(spec[0]);
+      base::alignment = to_alignment(spec[0]);
       ndx = 1;
     }
     // sign
@@ -189,40 +253,41 @@ struct parsed_spec {
         (spec[ndx] == CharT('+') || spec[ndx] == CharT('-') ||
             spec[ndx] == CharT(' ')))
     {
-      sign = static_cast<char>(spec[ndx]);
+      base::sign = static_cast<char>(spec[ndx]);
       ++ndx;
     }
     // `#` alternate
     if (ndx < cnt && spec[ndx] == CharT('#')) {
-      alternate = true;
+      base::alternate = true;
       ++ndx;
     }
     // `0` zero-pad
     if (ndx < cnt && spec[ndx] == CharT('0')) {
-      zero_pad = true;
+      base::zero_pad = true;
       ++ndx;
     }
     // width
     ndx = width_arg.parse(spec, ndx);
-    if (const auto fixed = width_arg.get_fixed()) width = *fixed;
+    if (const auto fixed = width_arg.get_fixed()) base::width = *fixed;
     // `.` precision
     if (ndx < cnt && spec[ndx] == CharT('.')) {
       ++ndx;
       ndx = precision_arg.parse(spec, ndx);
-      if (const auto fixed = precision_arg.get_fixed()) precision = *fixed;
+      if (const auto fixed = precision_arg.get_fixed())
+        base::precision = *fixed;
     }
     // `L` locale
     if (ndx < cnt && spec[ndx] == CharT('L')) {
-      has_locale = true;
+      base::has_locale = true;
       ++ndx;
     }
     // type: the one remaining char before the closing `}`, if any
     if (ndx < cnt && spec[ndx] != CharT('}')) {
-      type = spec[ndx];
+      base::type = spec[ndx];
       ++ndx;
     }
     // The `?` type is debug.
-    if (type == CharT('?')) debug = true;
+    if (base::type == CharT('?')) base::debug = true;
 
     return ndx;
   }
@@ -252,21 +317,6 @@ struct parsed_spec {
     return out;
   }
 
-  // Emit `content`.
-  //
-  // The input is (narrow, 7-bit ASCII), so it's widened to `CharT`. It is
-  // then padded to `field_width` with this spec's `fill` per its `align`. A
-  // width no larger than the content is a no-op (width is a minimum).
-  template<typename OutIt>
-  [[nodiscard]] constexpr OutIt write_padded(OutIt out,
-      std::string_view content, std::size_t field_width) const {
-    auto [lead, trail] = calc_padding(align, content.size(), field_width);
-    out = write_repeat(out, fill, lead);
-    out = write_sv(out, content);
-    out = write_repeat(out, fill, trail);
-    return out;
-  }
-
 #pragma endregion
 #pragma region Helpers
 private:
@@ -274,15 +324,13 @@ private:
     return c == CharT('<') || c == CharT('>') || c == CharT('^');
   }
 
-  static constexpr aligned to_aligned(CharT c) {
+  static constexpr aligned to_alignment(CharT c) {
     if (c == CharT('>')) return aligned::right;
     if (c == CharT('^')) return aligned::center;
     return aligned::left;
   }
 
   // Append `v` as decimal digits, widened to `CharT`.
-  // TODO: I know we're very low in the stack, but do we have to reinvent this
-  // particular wheel?
   static void append_decimal(std::basic_string<CharT>& out, std::size_t v) {
     CharT buf[20];
     std::size_t len = 0;
@@ -291,38 +339,6 @@ private:
       v /= 10;
     } while (v != 0);
     while (len != 0) out.push_back(buf[--len]);
-  }
-
-  static constexpr std::pair<size_t, size_t> calc_padding(aligned align,
-      std::size_t content_width, std::size_t total_width) {
-    std::size_t lead = 0;
-    std::size_t trail = 0;
-    if (total_width > content_width) {
-      const std::size_t pad = total_width - content_width;
-      lead =
-          align == aligned::right ? pad
-          : align == aligned::center
-              ? pad / 2
-              : 0;
-      trail = pad - lead;
-    }
-    return {lead, trail};
-  }
-
-  template<CharType InCharT, typename OutIt>
-  static constexpr OutIt
-  write_repeat(OutIt out, InCharT c, std::size_t count) {
-    for (std::size_t i = 0; i < count; ++i)
-      *out++ = static_cast<CharT>(static_cast<wchar_t>(c));
-    return out;
-  }
-
-  template<CharType InCharT, typename OutIt>
-  static constexpr OutIt
-  write_sv(OutIt out, std::basic_string_view<InCharT> sv) {
-    for (const auto c : sv)
-      *out++ = static_cast<CharT>(static_cast<wchar_t>(c));
-    return out;
   }
 
 #pragma endregion
@@ -366,11 +382,8 @@ struct forwarding_formatter: std::formatter<U, CharT> {
 //
 // `PlainNull` and `DebugNull` independently select what a null shows under a
 // plain spec and under the `?` debug spec. `null_formatting::sentinel` (the
-// default for both) shows the sentinel, padded by the spec's fill/align/width;
-// `null_formatting::empty` shows an empty field, rendered through the
-// inherited formatter so a dynamic width still holds. A string wrapper, where
-// null reads as empty, passes `..., null_formatting::empty>` so a plain null
-// is empty while a debug null still shows the sentinel.
+// default for both) shows the sentinel while `null_formatting::empty` shows an
+// empty field; both honor width.
 //
 // A deriving specialization needs only `: nullable_formatter<U, CharT> {}`.
 // The wrapper type is deduced at format time and must be contextually
@@ -378,32 +391,23 @@ struct forwarding_formatter: std::formatter<U, CharT> {
 // text, give the deriving formatter a default constructor that delegates to
 // the marker constructor, e.g. a `file_handle` formatter: `constexpr
 // formatter() : nullable_formatter<int, CharT>{"closed"} {}`.
-//
-// Only fill, align, and width reach the sentinel; it is a fixed string, so
-// precision and type are meaningless for it, while the present value still
-// honors the whole spec through the inherited formatter. A dynamic width
-// reaches the sentinel, too: a manual id is read from the spec, and an auto
-// `{}` is claimed from the parse context and re-presented to the base as an
-// explicit id, so the sentinel and the present value resolve the same
-// argument.
 template<typename U, CharType CharT,
     null_formatting PlainNull = null_formatting::sentinel,
     null_formatting DebugNull = null_formatting::sentinel>
 struct nullable_formatter: std::formatter<U, CharT> {
-#pragma region Construction
-
   using base = std::formatter<U, CharT>;
 
-  constexpr nullable_formatter() = default;
-  constexpr explicit nullable_formatter(std::string_view marker)
+#pragma region Construction
+
+  constexpr nullable_formatter() noexcept = default;
+
+  constexpr explicit nullable_formatter(std::string_view marker) noexcept
       : marker_{marker} {}
 
 #pragma endregion
 #pragma region Parse
 
-  // Offered only when the underlying formatter has it, so a containing range
-  // or map can enable element quoting; also records debug mode for the
-  // sentinel.
+  // Allow containing range to enable element quoting.
   constexpr void set_debug_format()
   requires requires(base b) { b.set_debug_format(); }
   {
@@ -412,35 +416,36 @@ struct nullable_formatter: std::formatter<U, CharT> {
   }
 
   constexpr auto parse(std::basic_format_parse_context<CharT>& ctx) {
-    if consteval {
-      // Compile-time validation: let the base consume any dynamic arg ids and
-      // check the spec. The recovered ids are only needed at format time, and
-      // a manually constructed parse context cannot run those checks during
-      // constant evaluation anyway.
-      return base::parse(ctx);
-    }
+    // Compile-time validation: let the base consume any dynamic arg ids and
+    // check the spec. The recovered ids are only needed at format time, and
+    // a manually constructed parse context cannot run those checks during
+    // constant evaluation anyway.
+    if consteval { return base::parse(ctx); }
 
     const auto begin = ctx.begin();
     const auto spec_text = std::basic_string_view<CharT>{begin,
         static_cast<std::size_t>(ctx.end() - begin)};
-    const auto consumed = spec_.parse_pad(spec_text);
+    const auto consumed = spec_.parse(spec_text);
 
     // The sentinel resolves its own dynamic width, so when it will be shown we
     // must learn the arg id. A manual `{n}` is in the text (and the base reads
     // it directly), but an auto `{}` has no id there: claim it from the
     // context and re-present the spec to the base with explicit ids. Otherwise
     // the base parses the real spec.
-    constexpr bool is_plain_sentinel = PlainNull == null_formatting::sentinel;
-    constexpr bool is_debug_sentinel = DebugNull == null_formatting::sentinel;
     const bool is_sentinel_shown =
-        spec_.debug ? is_debug_sentinel : is_plain_sentinel;
-    const bool is_width_auto = spec_.width_arg.is_automatic();
-    const bool is_precision_auto = spec_.precision_arg.is_automatic();
-    if (is_sentinel_shown && (is_width_auto || is_precision_auto)) {
-      if (is_width_auto) spec_.width_arg.value = ctx.next_arg_id();
-      if (is_precision_auto) spec_.precision_arg.value = ctx.next_arg_id();
+        spec_.debug ? DebugNull == null_formatting::sentinel
+                    : PlainNull == null_formatting::sentinel;
+    const bool is_any_auto =
+        spec_.width_arg.is_automatic() || spec_.precision_arg.is_automatic();
+
+    // When showing the sentinel using automatic width or precision, claim the
+    // id and rewrite the spec to make it explicit for the base.
+    if (is_sentinel_shown && is_any_auto) {
+      spec_.width_arg.claim_next_automatic(ctx);
+      spec_.precision_arg.claim_next_automatic(ctx);
       const auto synthetic = spec_.rewrite_spec_as_explicit(
           std::basic_string_view<CharT>{begin, consumed});
+
       std::basic_format_parse_context<CharT> sctx(synthetic);
       base::parse(sctx);
       return begin + consumed;
@@ -453,7 +458,9 @@ struct nullable_formatter: std::formatter<U, CharT> {
 
   template<typename W, typename FormatContext>
   auto format(const W& w, FormatContext& ctx) const {
+    // When underlying value is present, just pass it through.
     if (w) return base::format(*w, ctx);
+
     // A null shows the sentinel or an empty field per the spec mode. The
     // sentinel is padded by our own fill/align/width so the base's debug
     // quoting is bypassed; an empty field goes through the inherited formatter
@@ -474,11 +481,15 @@ struct nullable_formatter: std::formatter<U, CharT> {
 #pragma region Helpers
 private:
   template<typename FormatContext>
+  [[nodiscard]] auto get_width(FormatContext& ctx) const {
+    return spec_.width_arg.is_dynamic()
+               ? spec_.width_arg.get_dynamic(ctx)
+               : spec_.width;
+  }
+
+  template<typename FormatContext>
   auto pad_sentinel(FormatContext& ctx) const {
-    const std::size_t field_width =
-        spec_.width_arg.is_dynamic()
-            ? spec_.width_arg.get_dynamic(ctx)
-            : spec_.width;
+    const std::size_t field_width = get_width(ctx);
     return spec_.write_padded(ctx.out(), marker_, field_width);
   }
 
@@ -486,7 +497,7 @@ private:
 #pragma region Data members
 
   std::string_view marker_{"(null)"};
-  parsed_spec<CharT> spec_;
+  spec_parser<CharT> spec_;
 
 #pragma endregion
 };
@@ -495,23 +506,10 @@ private:
 #pragma region self_rendering_formatter
 
 // Base for a `std::formatter` on a type that renders itself through a
-// `format_to(out)` member, the modern analog of `operator<<`. A deriving
-// specialization needs only `: self_rendering_formatter<CharT> {}`; the type
-// is deduced at format time.
+// `format_to(out)` member: the modern analog of `operator<<`.
 //
-// Supports the empty spec (plain rendering) and the `?` debug spec. In debug
-// mode it calls `debug_format_to(out)` when the type provides one, otherwise
-// it falls back to `format_to` (a type without a debug rendering reads the
-// same in either mode). `set_debug_format` lets the type auto-quote inside the
-// std range and map formatters. Both `format_to` and `debug_format_to` must
-// return the advanced output iterator.
-//
-// A type that only provides `format_to`/`debug_format_to` streams straight to
-// the output with no padding. A type that instead provides `format_to_spec(s,
-// out)` receives the parsed spec and applies fill, align, width, and precision
-// itself (it knows its own rendered length). Any dynamic width or precision is
-// resolved against the format args before the call, so `format_to_spec` sees
-// concrete `s.width` / `s.precision` and never touches the format context.
+// A deriving specialization needs only `: self_rendering_formatter<CharT> {}`;
+// the type is deduced at format time.
 template<CharType CharT>
 struct self_rendering_formatter {
 #pragma region Parse
@@ -523,14 +521,15 @@ struct self_rendering_formatter {
     const auto begin = ctx.begin();
     const auto spec_text = std::basic_string_view<CharT>{begin,
         static_cast<std::size_t>(ctx.end() - begin)};
-    const auto consumed = spec_.parse_pad(spec_text);
+    const auto consumed = spec_.parse(spec_text);
+
     // An automatic `{}` width or precision has no id in the spec string, so
-    // claim one from the parse context now, width before precision to match
-    // arg order; format time reads it back from `value`.
+    // claim one from the parse context now.
     if (spec_.width_arg.is_automatic())
       spec_.width_arg.value = ctx.next_arg_id();
     if (spec_.precision_arg.is_automatic())
       spec_.precision_arg.value = ctx.next_arg_id();
+
     // Stop at the spec-terminating `}`
     return begin + consumed;
   }
@@ -541,18 +540,17 @@ struct self_rendering_formatter {
   template<typename T, typename FormatContext>
   auto format(const T& obj, FormatContext& ctx) const {
     if constexpr (requires { obj.format_to_spec(spec_, ctx.out()); }) {
-      // Resolve any dynamic width/precision against the args now, so the type
-      // sees concrete values and never touches the format context.
+      // Pass copy with dynamic width/precision resolved to concrete values.
       parsed_spec<CharT> resolved = spec_;
-      if (resolved.width_arg.is_dynamic())
-        resolved.width = resolved.width_arg.get_dynamic(ctx);
-      if (resolved.precision_arg.is_dynamic())
-        resolved.precision = resolved.precision_arg.get_dynamic(ctx);
+      if (spec_.width_arg.is_dynamic())
+        resolved.width = spec_.width_arg.get_dynamic(ctx);
+      if (spec_.precision_arg.is_dynamic())
+        resolved.precision = spec_.precision_arg.get_dynamic(ctx);
+
       return obj.format_to_spec(resolved, ctx.out());
     } else {
       // No spec handling: stream the rendering, honoring the `?` debug spec
-      // when the type offers a `debug_format_to`. The `else` matters: it keeps
-      // `format_to` from being required of a `format_to_spec`-only type.
+      // when the type offers a `debug_format_to`.
       if (spec_.debug) {
         if constexpr (requires { obj.debug_format_to(ctx.out()); })
           return obj.debug_format_to(ctx.out());
@@ -564,7 +562,7 @@ struct self_rendering_formatter {
 #pragma endregion
 #pragma region Data members
 private:
-  parsed_spec<CharT> spec_;
+  spec_parser<CharT> spec_;
 
 #pragma endregion
 };

--- a/corvid/meta/forwarding_address.h
+++ b/corvid/meta/forwarding_address.h
@@ -23,10 +23,12 @@
 
 namespace corvid { inline namespace meta {
 
+#pragma region address_forwarder
+
 // CRTP base for objects that need to remain addressable after being moved out
 // of visibility, such as by being captured into a `std::function` and/or a
 // lambda. Maintains a non-owning `Derived**` that is updated on each move to
-// track the new location, and nulled on destruction to prevent wild writes.
+// track the new location, and is nulled on destruction to prevent wild writes.
 //
 // It is your responsibility to clear the forwarding address of the
 // currently active instance before what it points to leaves scope. Otherwise,
@@ -42,17 +44,22 @@ namespace corvid { inline namespace meta {
 //
 //   Foo* ptr = nullptr;
 //   Foo f;
-//   f.forwarding_address() = &ptr;  // ptr tracks f
-//   auto g = std::move(f);          // ptr now tracks g
+//   f.forwarding_address() = &ptr;    // ptr tracks f
+//   auto g = std::move(f);            // ptr now tracks g
 //   g.forwarding_address() = nullptr; // clear once stable
 template<typename Derived>
 class address_forwarder {
 public:
+#pragma region Accessors
+
   // Reference to the external tracking pointer. Set to `&ptr` to have `ptr`
   // follow this object across moves; assign `nullptr` to stop tracking.
   [[nodiscard]] Derived**& forwarding_address() noexcept {
     return forwarding_address_;
   }
+
+#pragma endregion
+#pragma region Construction
 
   // The clang-tidy warning is generally good advice, but it also blocks
   // compilation.
@@ -61,7 +68,6 @@ public:
 
 protected:
   // NOLINTBEGIN(bugprone-crtp-constructor-accessibility)
-
   address_forwarder(address_forwarder&& o) noexcept
       : forwarding_address_{std::exchange(o.forwarding_address_, nullptr)} {
     if (forwarding_address_)
@@ -96,12 +102,21 @@ public:
   address_forwarder&& as_base_move() noexcept { return std::move(*this); }
 
   // NOLINTEND(bugprone-crtp-constructor-accessibility)
+
+#pragma endregion
+#pragma region Data members
 private:
   Derived** forwarding_address_{};
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region AddressForwarder
 
 template<typename T>
 concept AddressForwarder = std::derived_from<std::remove_cvref_t<T>,
     address_forwarder<std::remove_cvref_t<T>>>;
 
+#pragma endregion
 }} // namespace corvid::meta

--- a/corvid/meta/maybe.h
+++ b/corvid/meta/maybe.h
@@ -23,6 +23,8 @@ namespace corvid { inline namespace meta { inline namespace maybe_types {
 // with `[[no_unique_address]]` inside a struct or class to avoid any space
 // overhead.
 
+#pragma region empty_t
+
 // Empty type used when `maybe_t` is disabled.
 //
 // Note that it can be explicitly constructed on anything, so that default
@@ -34,12 +36,18 @@ struct empty_t {
   explicit constexpr empty_t(Args&&...) noexcept {}
 };
 
+#pragma endregion
+#pragma region maybe_t
+
 // Maybe bool type: `T` if `Enabled` is true, otherwise `empty_t`.
 //
 // Usage:
 //   [[no_unique_address]] maybe_t<int, Enabled> int_or_missing{42};
 template<typename T, bool Enabled = false>
 using maybe_t = std::conditional_t<Enabled, T, empty_t>;
+
+#pragma endregion
+#pragma region maybe_void_t
 
 // Maybe void type: `T` if `T` is not void, otherwise `empty_t`.
 //
@@ -48,4 +56,5 @@ using maybe_t = std::conditional_t<Enabled, T, empty_t>;
 template<typename T = void>
 using maybe_void_t = maybe_t<T, !std::is_void_v<T>>;
 
+#pragma endregion
 }}} // namespace corvid::meta::maybe_types

--- a/corvid/meta/meta_shared.h
+++ b/corvid/meta/meta_shared.h
@@ -18,6 +18,7 @@
 #pragma once
 #include <array>
 #include <bit>
+#include <cstdint>
 #include <cstdlib>
 #include <functional>
 #include <memory>

--- a/corvid/meta/naming.h
+++ b/corvid/meta/naming.h
@@ -19,9 +19,7 @@
 
 namespace corvid { inline namespace meta { inline namespace naming {
 
-//
-// Typename
-//
+#pragma region type_name
 
 // Extract fully qualified type name.
 //
@@ -52,4 +50,5 @@ std::string type_name(T&&) {
   return type_name<T>();
 }
 
+#pragma endregion
 }}} // namespace corvid::meta::naming

--- a/corvid/meta/pragmas.h
+++ b/corvid/meta/pragmas.h
@@ -19,6 +19,8 @@
 
 namespace corvid { inline namespace meta { inline namespace pragmas {
 
+#pragma region Suppression
+
 // Glue to silence overeager warnings.
 #define PRAGMA_DIAG_HELPER(action) _Pragma(#action)
 #ifdef __clang__
@@ -54,4 +56,5 @@ namespace corvid { inline namespace meta { inline namespace pragmas {
 #define PRAGMA_CLANG_IGNORED_ENUM_CONSTEXPR_CONV
 #endif
 
+#pragma endregion
 }}} // namespace corvid::meta::pragmas

--- a/corvid/meta/traits.h
+++ b/corvid/meta/traits.h
@@ -24,9 +24,7 @@ namespace corvid { inline namespace meta { inline namespace traits {
 // Note: Some of these definitions are universal traits that apply anywhere,
 // while others enforce distinctions that are specific to this library.
 
-//
-// Specialization
-//
+#pragma region Specialization
 
 // Determine whether `T` is a specialization of `B`.
 //
@@ -38,7 +36,9 @@ constexpr bool is_specialization_of_v = false;
 template<template<typename...> typename B, typename... Args>
 constexpr bool is_specialization_of_v<B<Args...>, B> = true;
 
-// Detect.
+#pragma endregion
+#pragma region Detection
+#pragma region Character, boolean
 
 // Determine whether `T` is a `char`.
 template<typename T>
@@ -79,6 +79,9 @@ using char_type_of_t = char_type_of<T>::type;
 template<typename T>
 constexpr bool is_bool_v = std::is_same_v<std::remove_cvref_t<T>, bool>;
 
+#pragma endregion
+#pragma region Tuple, variant
+
 // Determine whether `T` is a `std::variant`.
 template<typename T>
 constexpr bool is_variant_v = is_specialization_of_v<T, std::variant>;
@@ -112,6 +115,9 @@ template<typename T>
 requires(!std::same_as<T, std::remove_cvref_t<T>>)
 constexpr bool is_pair_convertible_v<T> =
     is_pair_convertible_v<std::remove_cvref_t<T>>;
+
+#pragma endregion
+#pragma region Sequences
 
 // Determine whether `T` is a `std::array`.
 // Note: Can't use `is_specialization_of_v` because `std::array` specializes
@@ -166,6 +172,10 @@ template<typename T>
 constexpr bool is_initializer_list_v =
     is_specialization_of_v<T, std::initializer_list>;
 
+#pragma endregion
+#pragma endregion
+#pragma region pointers
+
 inline namespace pointers {
 
 // Get underlying element type of a raw or smart pointer.
@@ -184,6 +194,10 @@ template<typename T>
 using pointer_element_t = decltype(details::pointer_element<T>(0));
 
 } // namespace pointers
+
+#pragma endregion
+#pragma region keyfinding
+
 inline namespace keyfinding {
 
 // Determine whether `T` has a `find` method which takes a `T::key_type`.
@@ -202,4 +216,6 @@ constexpr bool has_key_find_v =
     details::has_key_find_method<std::remove_cvref_t<T>>::value;
 
 } // namespace keyfinding
+
+#pragma endregion
 }}} // namespace corvid::meta::traits

--- a/corvid/proto/dns_resolver.h
+++ b/corvid/proto/dns_resolver.h
@@ -28,6 +28,8 @@
 
 namespace corvid { inline namespace proto {
 
+#pragma region dns_resolver
+
 // Resolves hostnames to `net_endpoint` values via `getaddrinfo`.
 struct dns_resolver {
   // Resolve a hostname to a list of `net_endpoint` values.
@@ -78,4 +80,5 @@ struct dns_resolver {
   }
 };
 
+#pragma endregion
 }} // namespace corvid::proto

--- a/corvid/proto/dns_resolver.h
+++ b/corvid/proto/dns_resolver.h
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #pragma once
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/corvid/proto/endian.h
+++ b/corvid/proto/endian.h
@@ -31,6 +31,8 @@ namespace corvid { inline namespace proto {
 // identical in implementation; both names are provided so that call
 // sites read naturally.
 
+#pragma region Byte swapping
+
 inline auto swap_always(auto v) noexcept { return std::byteswap(v); }
 
 inline __uint128_t swap_always(__uint128_t v) noexcept {
@@ -50,6 +52,9 @@ inline auto swap_not_little(auto v) noexcept {
   return swap_always(v);
 }
 
+#pragma endregion
+#pragma region Host/network
+
 inline uint16_t hton16(uint16_t v) noexcept { return swap_not_big(v); }
 inline uint16_t ntoh16(uint16_t v) noexcept { return swap_not_big(v); }
 inline uint32_t hton32(uint32_t v) noexcept { return swap_not_big(v); }
@@ -59,4 +64,5 @@ inline uint64_t ntoh64(uint64_t v) noexcept { return swap_not_big(v); }
 inline __uint128_t hton128(__uint128_t v) noexcept { return swap_not_big(v); }
 inline __uint128_t ntoh128(__uint128_t v) noexcept { return swap_not_big(v); }
 
+#pragma endregion
 }} // namespace corvid::proto

--- a/corvid/proto/epoll/epoll_http_server.h
+++ b/corvid/proto/epoll/epoll_http_server.h
@@ -17,6 +17,7 @@
 #pragma once
 #include <atomic>
 #include <compare>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>

--- a/corvid/proto/epoll/epoll_loop.h
+++ b/corvid/proto/epoll/epoll_loop.h
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <chrono>
 #include <cerrno>
+#include <cstdint>
 #include <format>
 #include <memory>
 #include <mutex>

--- a/corvid/proto/io_uring/iou_loop.h
+++ b/corvid/proto/io_uring/iou_loop.h
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <concepts>
 #include <cstddef>
+#include <cstdint>
 #include <exception>
 #include <functional>
 #include <memory>

--- a/corvid/proto/io_uring/iou_wrap.h
+++ b/corvid/proto/io_uring/iou_wrap.h
@@ -18,6 +18,7 @@
 #include <liburing.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <chrono>
 #include <limits>
 #include <linux/time_types.h>

--- a/corvid/proto/iov_msghdr.h
+++ b/corvid/proto/iov_msghdr.h
@@ -37,12 +37,16 @@ namespace corvid { inline namespace proto {
 // Fwd.
 struct iov_msghdr_test;
 
+#pragma region iov_msghdr
+
 // Scatter/gather socket I/O support using `msghdr` and `sendmsg`. Wraps the
 // `msghdr` and the `iovec` array. Use `iov_msghdr_sender` for sending and
 // `iov_msghdr_receiver` for receiving.
 template<bool SENDER>
 class iov_msghdr {
 public:
+#pragma region Types
+
   static constexpr bool is_sender = SENDER;
   static constexpr bool is_receiver = !SENDER;
   static constexpr size_t npos = std::numeric_limits<size_t>::max();
@@ -57,6 +61,9 @@ public:
     size_t index{};
     size_t offset{};
   };
+
+#pragma endregion
+#pragma region Construction
 
   // Default constructor, allowing segments to be added with `append`. POSIX
   // requires `IOV_MAX` to be at least 16, while Linux typically allows 1024.
@@ -76,6 +83,9 @@ public:
     update();
   }
 
+#pragma endregion
+#pragma region Accessors
+
   // Full access to `msghdr`.
   [[nodiscard]] decltype(auto) header(this auto& self) noexcept {
     return (self.msgh_);
@@ -85,6 +95,9 @@ public:
   [[nodiscard]] auto segments() const noexcept {
     return std::span{segments_}.subspan(first_index_);
   }
+
+#pragma endregion
+#pragma region Modifiers
 
   // Full clear.
   void clear() noexcept { (void)do_clear(); }
@@ -127,9 +140,15 @@ public:
     return append(data.data(), data.size_bytes());
   }
 
+#pragma endregion
+#pragma region Capacity
+
   [[nodiscard]] bool empty() const noexcept { return size_ == 0; }
 
   [[nodiscard]] size_t size() const noexcept { return size_; }
+
+#pragma endregion
+#pragma region I/O
 
   // Compact the segments if there is excessive slack. Completely optional, and
   // only useful if you have a long-running instance and never quite finish
@@ -222,6 +241,8 @@ public:
 
   [[nodiscard]] const auto& last_op() const noexcept { return last_op_; }
 
+#pragma endregion
+#pragma region Implementation
 private:
   friend struct iov_msghdr_test;
 
@@ -335,14 +356,24 @@ private:
     return do_set_last(npos, npos, npos) && false;
   }
 
+#pragma endregion
+#pragma region Data members
+
   msghdr msgh_{};
   std::vector<iovec> segments_;
   size_t first_index_{};
   size_t size_{};
   op_results last_op_{};
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region Aliases
 
 // I/O vector for sending or receiving.
 using iov_msghdr_sender = iov_msghdr<true>;
 using iov_msghdr_receiver = iov_msghdr<false>;
+
+#pragma endregion
 }} // namespace corvid::proto

--- a/corvid/proto/iov_msghdr.h
+++ b/corvid/proto/iov_msghdr.h
@@ -18,6 +18,7 @@
 #include <compare>
 #include <concepts>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <limits>
 #include <optional>

--- a/corvid/proto/ipv4_addr.h
+++ b/corvid/proto/ipv4_addr.h
@@ -32,6 +32,8 @@ namespace corvid { inline namespace proto {
 
 using namespace strings::cases;
 
+#pragma region ipv4_addr
+
 // IPv4 address, stored as a 32-bit value in host byte order.
 //
 // Default-constructs to an empty state. Construction is available from four
@@ -46,9 +48,12 @@ using namespace strings::cases;
 // is only introduced at the `in_addr` boundary.
 class ipv4_addr {
 public:
+#pragma region Types
+
   using byte_array = std::array<uint8_t, 4>;
 
-  // Constructors.
+#pragma endregion
+#pragma region Construction
 
   // Default-constructs to the "any" address (0.0.0.0), which is empty.
   constexpr ipv4_addr() noexcept = default;
@@ -75,7 +80,8 @@ public:
   // Construct from a POSIX `in_addr` (which is in network byte order).
   explicit ipv4_addr(const in_addr& a) noexcept : addr_{ntohl(a.s_addr)} {}
 
-  // Named address constants.
+#pragma endregion
+#pragma region Constants
 
   // The "any" address (0.0.0.0): typically used to bind to all interfaces.
   static const ipv4_addr any;
@@ -86,6 +92,9 @@ public:
   // The limited broadcast address (255.255.255.255).
   static const ipv4_addr broadcast;
 
+#pragma endregion
+#pragma region Emptiness
+
   // Whether this address is empty, which is also the "any" address
   // ("0.0.0.0").
   [[nodiscard]] constexpr bool empty() const noexcept { return !addr_; }
@@ -93,7 +102,8 @@ public:
   // Return whether this has a non-any address.
   [[nodiscard]] constexpr operator bool() const noexcept { return !empty(); }
 
-  // Parsing.
+#pragma endregion
+#pragma region Parsing
 
   // Parse from dotted-decimal notation (e.g., "192.168.1.1").
   // Returns `std::nullopt` if the string is not a valid IPv4 address.
@@ -122,7 +132,8 @@ public:
     return ipv4_addr{result};
   }
 
-  // Accessors.
+#pragma endregion
+#pragma region Accessors
 
   // Return the four octets in network order (most significant first).
   [[nodiscard]] constexpr byte_array octets() const noexcept {
@@ -133,7 +144,8 @@ public:
   // Return the raw address in host byte order.
   [[nodiscard]] constexpr uint32_t to_uint32() const noexcept { return addr_; }
 
-  // Classification predicates.
+#pragma endregion
+#pragma region Classification
 
   // True if this is the "any" address (0.0.0.0).
   [[nodiscard]] constexpr bool is_any() const noexcept { return !addr_; }
@@ -161,12 +173,16 @@ public:
            (addr_ & 0xffff0000U) == 0xc0a80000U;
   }
 
+#pragma endregion
+#pragma region Comparison
+
   // Comparison (lexicographic on the host-byte-order value, which is also
   // numerically correct for IPv4 ordering).
   [[nodiscard]] friend constexpr auto
   operator<=>(const ipv4_addr&, const ipv4_addr&) noexcept = default;
 
-  // Formatting.
+#pragma endregion
+#pragma region Formatting
 
   // Format as dotted-decimal (e.g., "192.168.1.1").
   [[nodiscard]] constexpr std::string to_string() const {
@@ -183,12 +199,20 @@ public:
     return in_addr{.s_addr = htonl(addr_)};
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   uint32_t addr_{}; // Host byte order.
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region Constant definitions
 
 constexpr ipv4_addr ipv4_addr::any{uint32_t{0}};
 constexpr ipv4_addr ipv4_addr::loopback{uint32_t{0x7f000001U}};
 constexpr ipv4_addr ipv4_addr::broadcast{uint32_t{0xffffffffU}};
 
+#pragma endregion
 }} // namespace corvid::proto

--- a/corvid/proto/ipv6_addr.h
+++ b/corvid/proto/ipv6_addr.h
@@ -33,6 +33,8 @@
 
 namespace corvid { inline namespace proto {
 
+#pragma region ipv6_addr
+
 // IPv6 address.
 //
 // `ipv6_addr` wraps a 128-bit IPv6 address as 16 bytes in network order. It
@@ -44,12 +46,15 @@ namespace corvid { inline namespace proto {
 // for the alternative.
 class ipv6_addr {
 public:
+#pragma region Types
+
   using byte_array = std::array<uint8_t, 16>;
   using word_array = std::array<uint16_t, 8>;
   static_assert(sizeof(in6_addr) == sizeof(byte_array));
   static_assert(std::is_trivially_copyable_v<in6_addr>);
 
-  // Constructors.
+#pragma endregion
+#pragma region Construction
 
   // Default-constructs to the "any" address (::), which is empty.
   constexpr ipv6_addr() noexcept = default;
@@ -85,9 +90,14 @@ public:
             uint8_t(a.s6_addr[12]), uint8_t(a.s6_addr[13]),
             uint8_t(a.s6_addr[14]), uint8_t(a.s6_addr[15])} {}
 
-  // Named address constants.
+#pragma endregion
+#pragma region Constants
+
   static const ipv6_addr any;
   static const ipv6_addr loopback;
+
+#pragma endregion
+#pragma region Emptiness
 
   // Whether this address is empty, which is also the "any" address ("::").
   [[nodiscard]] constexpr bool empty() const noexcept {
@@ -98,7 +108,8 @@ public:
   // Return whether this has a non-any address.
   [[nodiscard]] constexpr operator bool() const noexcept { return !empty(); }
 
-  // Parsing.
+#pragma endregion
+#pragma region Parsing
 
   // Parse from IPv6 colon-hex notation, including "::" compression and
   // IPv4-embedded tails such as `::ffff:192.168.1.1`.
@@ -117,7 +128,8 @@ public:
     return ipv6_addr{groups_to_bytes(groups)};
   }
 
-  // Accessors.
+#pragma endregion
+#pragma region Accessors
 
   // Return the 16 bytes in network order.
   [[nodiscard]] constexpr const byte_array& bytes() const noexcept {
@@ -130,7 +142,8 @@ public:
         word_at(5), word_at(6), word_at(7)};
   }
 
-  // Classification predicates.
+#pragma endregion
+#pragma region Classification
 
   [[nodiscard]] constexpr bool is_any() const noexcept { return empty(); }
 
@@ -153,10 +166,14 @@ public:
     return (bytes_[0] & 0xfeU) == 0xfcU;
   }
 
+#pragma endregion
+#pragma region Comparison
+
   [[nodiscard]] friend constexpr auto
   operator<=>(const ipv6_addr&, const ipv6_addr&) noexcept = default;
 
-  // Formatting.
+#pragma endregion
+#pragma region Formatting
 
   // Format using lowercase hex with RFC 5952-style zero-run compression.
   [[nodiscard]] constexpr std::string to_string() const {
@@ -208,6 +225,8 @@ public:
     return std::bit_cast<in6_addr>(bytes_);
   }
 
+#pragma endregion
+#pragma region Implementation
 private:
   // Parse the IPv4-embedded tail token (e.g., "192.168.1.1") and append two
   // 16-bit groups to `groups`, advancing `group_count`. Returns false if
@@ -370,12 +389,20 @@ private:
     while (len-- > 0) out += buffer[len];
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   byte_array bytes_{};
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region Constant definitions
 
 constexpr ipv6_addr ipv6_addr::any{};
 constexpr ipv6_addr ipv6_addr::loopback{uint16_t{0}, uint16_t{0}, uint16_t{0},
     uint16_t{0}, uint16_t{0}, uint16_t{0}, uint16_t{0}, uint16_t{1}};
 
+#pragma endregion
 }} // namespace corvid::proto

--- a/corvid/proto/misc/base-64.h
+++ b/corvid/proto/misc/base-64.h
@@ -27,6 +27,8 @@
 
 namespace corvid { inline namespace proto {
 
+#pragma region detail
+
 namespace detail {
 constexpr std::string_view alpha =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -43,6 +45,9 @@ constexpr std::array<uint8_t, 256> make_base64_decode_table() noexcept {
 inline constexpr auto base64_decode_table = make_base64_decode_table();
 } // namespace detail
 
+#pragma endregion
+#pragma region base_64
+
 // Small Base64 helper for protocol code that needs RFC 4648-style text
 // encoding of arbitrary bytes.
 //
@@ -51,6 +56,8 @@ inline constexpr auto base64_decode_table = make_base64_decode_table();
 // optimized by resizing without initialization because -o3 is smart enough to
 // elide the expansion checks due to knowing the size up front.
 struct base_64 {
+#pragma region Encode
+
   [[nodiscard]] static std::string encode(std::span<const uint8_t> bytes) {
     std::string out;
     out.reserve(((bytes.size() + 2) / 3) * 4);
@@ -88,6 +95,9 @@ struct base_64 {
   [[nodiscard]] static std::string encode(std::string_view bytes) {
     return encode(strings::as_byte_span(bytes));
   }
+
+#pragma endregion
+#pragma region Decode
 
   // Decode a Base64-encoded string (RFC 4648). Returns the decoded bytes, or
   // an empty vector if `encoded` contains invalid characters or has a length
@@ -155,6 +165,9 @@ struct base_64 {
 
     return out;
   }
+
+#pragma endregion
 };
 
+#pragma endregion
 }} // namespace corvid::proto

--- a/corvid/proto/misc/http_head_codec.h
+++ b/corvid/proto/misc/http_head_codec.h
@@ -44,12 +44,17 @@ namespace corvid { inline namespace proto { inline namespace http_proto {
 
 using namespace std::string_view_literals;
 
+#pragma region http_version
+
 // HTTP protocol version.
 enum class http_version : uint8_t { invalid, http_0_9, http_1_0, http_1_1 };
 consteval auto corvid_enum_spec(http_version*) {
   return corvid::enums::sequence::make_sequence_enum_spec<http_version,
       "invalid,HTTP/0.9,HTTP/1.0,HTTP/1.1">();
 }
+
+#pragma endregion
+#pragma region http_method
 
 // HTTP request method.
 enum class http_method : uint8_t {
@@ -70,6 +75,9 @@ consteval auto corvid_enum_spec(http_method*) {
       http_method{1}>();
 }
 
+#pragma endregion
+#pragma region after_response
+
 // Connection disposition: whether to keep a connection alive after responding
 // or to close it.
 enum class after_response : uint8_t { close = 0, keep_alive = 1 };
@@ -77,6 +85,9 @@ consteval auto corvid_enum_spec(after_response*) {
   return corvid::enums::sequence::make_sequence_enum_spec<after_response,
       "close,keep-alive">();
 }
+
+#pragma endregion
+#pragma region content_type_value
 
 // Canonical media type from a `Content-Type` header field.
 // `unknown`: header present but value not recognized.
@@ -92,6 +103,9 @@ consteval auto corvid_enum_spec(content_type_value*) {
       content_type_value{1}>();
 }
 
+#pragma endregion
+#pragma region transfer_encoding_value
+
 // Transfer encoding from a `Transfer-Encoding` header field.
 // `unknown`: header present but value not recognized.
 enum class transfer_encoding_value : uint8_t { unknown, identity, chunked };
@@ -101,6 +115,9 @@ consteval auto corvid_enum_spec(transfer_encoding_value*) {
       transfer_encoding_value, "unknown,identity,chunked">();
 }
 
+#pragma endregion
+#pragma region upgrade_value
+
 // Upgrade protocol from an `Upgrade` header field.
 // `unknown`: header present but value not recognized.
 enum class upgrade_value : uint8_t { unknown, websocket };
@@ -109,6 +126,9 @@ consteval auto corvid_enum_spec(upgrade_value*) {
   return corvid::enums::sequence::make_sequence_enum_spec<upgrade_value,
       "unknown,websocket">();
 }
+
+#pragma endregion
+#pragma region http_status_code
 
 // HTTP response status code.
 enum class http_status_code : uint16_t {
@@ -192,6 +212,9 @@ consteval auto corvid_enum_spec(http_status_code*) {
       "LOOP_DETECTED,,NOT_EXTENDED,NETWORK_AUTHENTICATION_REQUIRED">();
 }
 
+#pragma endregion
+#pragma region http_constants
+
 // Old-school struct as namespace.
 struct http_constants {
   static constexpr auto valid_field_name_chars =
@@ -201,6 +224,9 @@ struct http_constants {
   static constexpr auto crlfcrlf = "\r\n\r\n"sv;
 };
 
+#pragma endregion
+#pragma region http_headers
+
 // Ordered multimap of HTTP header fields with O(1) average lookup.
 //
 // Insertion order is preserved via `entries_`. A parallel `index_` maps
@@ -209,6 +235,8 @@ struct http_constants {
 //
 // Field names are normalized in the index to "Content-Type" form.
 class http_headers: http_constants {
+#pragma region Types
+
   struct field_line {
     std::string name;
     std::string value;
@@ -217,14 +245,23 @@ class http_headers: http_constants {
   using index_vector = std::vector<size_t>;
   using index_map = string_unordered_map<index_vector>;
 
+#pragma endregion
+#pragma region Data members
+
   field_line_vector entries_;
   index_map index_;
 
+#pragma endregion
+
 public:
+#pragma region value_range
+
   // A lazy, non-owning view over all field values for a given field name,
   // returned by `get_values`. Iterates in insertion order.
   class value_range {
   public:
+#pragma region iterator
+
     class iterator {
     public:
       using iterator_category = std::forward_iterator_tag;
@@ -277,6 +314,8 @@ public:
       }
     };
 
+#pragma endregion
+
     [[nodiscard]] iterator begin() const noexcept {
       return {entries_, indices_->begin(), indices_->end()};
     }
@@ -299,6 +338,9 @@ public:
         const index_vector& indices) noexcept
         : entries_{&entries}, indices_{&indices} {}
   };
+
+#pragma endregion
+#pragma region Validation
 
   // Normalize a field name to Train-Case, in place. Only alphanumeric
   // characters, hyphens, and the token special characters are permitted.
@@ -353,6 +395,9 @@ public:
     return true;
   }
 
+#pragma endregion
+#pragma region Modifiers
+
   // Add a field line from parts, storing `field_name` and `field_value`
   // as-is (no validation or normalization). If specified `raw_field_name` is
   // stored for the line, while `field_name` is stored for the index.
@@ -404,6 +449,9 @@ public:
     return add_raw(normal_field_name, std::string{field_value}, field_name);
   }
 
+#pragma endregion
+#pragma region Accessors
+
   // Return a `string_view` into the field value for the field line whose
   // name matches `field_name`. The `field_name` is expected to be
   // normalized. Returns `std::nullopt` if not found, as opposed to empty if
@@ -445,6 +493,9 @@ public:
     return {entries_, ref};
   }
 
+#pragma endregion
+#pragma region Parsing
+
   // Add a field line by parsing `line`, which does not include the trailing
   // crlf. Must not be empty: the caller is responsible for detecting the
   // end-of-headers blank line. The field name is required to be non-empty
@@ -477,6 +528,9 @@ public:
     return true;
   }
 
+#pragma endregion
+#pragma region Serialization
+
   // Serialize all headers into wire format, which is the block of text after
   // the request/status line. Tombstoned entries (empty name) are skipped.
   //
@@ -495,11 +549,17 @@ public:
     out += crlf;
   }
 
+#pragma endregion
+#pragma region Iteration
+
   // Ordered iteration (insertion order).
   [[nodiscard]] auto begin() const noexcept { return entries_.begin(); }
   [[nodiscard]] auto end() const noexcept { return entries_.end(); }
   [[nodiscard]] bool empty() const noexcept { return entries_.empty(); }
   [[nodiscard]] size_t size() const noexcept { return entries_.size(); }
+
+#pragma endregion
+#pragma region Removal
 
   // Tombstone all entries for the normalized `field_name` and remove it
   // from the index entirely.
@@ -510,7 +570,12 @@ public:
     for (size_t ndx : it->second) entries_[ndx].name.clear();
     index_.erase(it);
   }
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region http_options
 
 // Parsed representation of key HTTP header fields. Populated from an
 // `http_headers` instance after parsing via `extract`, and written back
@@ -519,11 +584,16 @@ public:
 // `std::nullopt` means the corresponding header was absent. For enum fields,
 // `unknown` means the header was present but the value was not recognized.
 struct http_options {
+#pragma region Data members
+
   std::optional<after_response> connection;
   std::optional<size_t> content_length;
   std::optional<content_type_value> content_type;
   std::optional<transfer_encoding_value> transfer_encoding;
   std::optional<upgrade_value> upgrade;
+
+#pragma endregion
+#pragma region Operations
 
   // Populate all fields by parsing `headers`. Call after headers are parsed.
   void extract(http_headers& headers) {
@@ -569,6 +639,8 @@ struct http_options {
                : after_response::close;
   }
 
+#pragma endregion
+#pragma region Implementation
 private:
   bool do_extract_connection(http_headers& headers) {
     bool has_close{};
@@ -653,7 +725,12 @@ private:
       }
     }
   }
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region head_base
 
 // Shared base for `request_head` and `response_head`. Holds the fields common
 // to both: the HTTP version, the parsed header fields, and the extracted
@@ -664,14 +741,22 @@ struct head_base: http_constants {
   http_options options;
 };
 
+#pragma endregion
+#pragma region request_head
+
 // HTTP request head, consisting of the request line and the header fields.
 // The body is not included.
 //
 // Obtained via `parse` after `terminated_text_parser` delivers the head (the
 // bytes before the crlfcrlf sentinel).
 struct request_head: head_base {
+#pragma region Data members
+
   http_method method{};
   std::string target;
+
+#pragma endregion
+#pragma region Operations
 
   // Reset to default-constructed state.
   void clear() {
@@ -772,12 +857,19 @@ struct request_head: head_base {
     return result;
   }
 
+#pragma endregion
+#pragma region Implementation
 private:
   bool fail(std::string failure) {
     target = std::move(failure);
     return false;
   }
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region response_head
 
 // HTTP response head, consisting of the status line and the header fields.
 // The body is not included.
@@ -785,8 +877,13 @@ private:
 // Populate the fields and call `serialize` to produce the wire-format response
 // string to pass to `epoll_stream_conn::send`.
 struct response_head: head_base {
+#pragma region Data members
+
   http_status_code status_code{};
   std::string reason;
+
+#pragma endregion
+#pragma region Operations
 
   // Reset to default-constructed state.
   void clear() {
@@ -869,10 +966,16 @@ struct response_head: head_base {
     return resp.serialize();
   }
 
+#pragma endregion
+#pragma region Implementation
 private:
   bool fail(std::string failure) {
     reason = std::move(failure);
     return false;
   }
+
+#pragma endregion
 };
+
+#pragma endregion
 }}} // namespace corvid::proto::http_proto

--- a/corvid/proto/misc/sha-1.h
+++ b/corvid/proto/misc/sha-1.h
@@ -23,6 +23,8 @@
 
 namespace corvid { inline namespace proto {
 
+#pragma region sha_1
+
 // Small SHA-1 helper used by protocol code that needs a stable 20-byte digest.
 // This is suitable for non-security-critical protocol work such as the
 // WebSocket handshake.
@@ -30,8 +32,13 @@ namespace corvid { inline namespace proto {
 // Not touched by human hands. Vibe-coded by Claude for use in WebSocket
 // accept-key computation, then factored out by Codex.
 struct sha_1 {
+#pragma region Types
+
   using digest_t = std::array<uint32_t, 5>;
   using bytes_t = std::array<uint8_t, 20>;
+
+#pragma endregion
+#pragma region Operations
 
   [[nodiscard]] static digest_t digest(std::string_view msg) {
     digest_t out{};
@@ -115,10 +122,15 @@ struct sha_1 {
     return raw;
   }
 
+#pragma endregion
+#pragma region Implementation
 private:
   static constexpr uint32_t rol(uint32_t v, unsigned n) noexcept {
     return (v << n) | (v >> (32U - n));
   }
+
+#pragma endregion
 };
 
+#pragma endregion
 }} // namespace corvid::proto

--- a/corvid/proto/misc/terminated_text_parser.h
+++ b/corvid/proto/misc/terminated_text_parser.h
@@ -21,6 +21,8 @@
 
 namespace corvid { inline namespace proto {
 
+#pragma region terminated_text_parser
+
 // Parser for sentinel-terminated text frames, designed for line-oriented
 // protocols such as HTTP, SMTP, and POP3.
 //
@@ -62,6 +64,8 @@ namespace corvid { inline namespace proto {
 // the pointed-to bytes must outlive the `state`.
 class terminated_text_parser {
 public:
+#pragma region state
+
   // Persistent state for `terminated_text_parser`. Intended to live in the
   // connection so that parse progress is preserved across `on_data` calls.
   //
@@ -96,8 +100,14 @@ public:
     size_t bytes_scanned_{};
   };
 
+#pragma endregion
+#pragma region Construction
+
   // Construct a parser over `s`. The `state` must outlive the parser.
   explicit terminated_text_parser(state& s) noexcept : state_{s} {}
+
+#pragma endregion
+#pragma region Operations
 
   // Using the associated state, try to parse one sentinel-terminated frame
   // from `input`.
@@ -173,8 +183,13 @@ public:
     return state_.bytes_scanned_;
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   state& state_;
+
+#pragma endregion
 };
 
+#pragma endregion
 }} // namespace corvid::proto

--- a/corvid/proto/misc/utf8-checker.h
+++ b/corvid/proto/misc/utf8-checker.h
@@ -20,6 +20,8 @@
 
 namespace corvid { inline namespace proto {
 
+#pragma region utf8_checker
+
 // Incremental UTF-8 validator.
 //
 // Use `is_valid`, or feed one chunk after another via `consume`. The validator
@@ -28,8 +30,13 @@ namespace corvid { inline namespace proto {
 // most common case, which is 7-bit ASCII.
 class utf8_checker {
 public:
+#pragma region Types
+
   // Result of incremental UTF-8 validation.
   enum class validation : uint8_t { complete, incomplete, failed };
+
+#pragma endregion
+#pragma region Operations
 
   [[nodiscard]] static constexpr bool is_valid(
       std::string_view input) noexcept {
@@ -58,6 +65,9 @@ public:
     max_cont_ = 0xBF;
   }
 
+#pragma endregion
+#pragma region Accessors
+
   [[nodiscard]] constexpr validation state() const noexcept { return state_; }
   [[nodiscard]] constexpr bool is_complete() const noexcept {
     return state_ == validation::complete;
@@ -69,6 +79,8 @@ public:
     return state_ == validation::failed;
   }
 
+#pragma endregion
+#pragma region Implementation
 private:
   [[nodiscard]] constexpr bool consume_lead_byte(uint8_t byte) noexcept {
     if (byte <= 0x7F) return true;
@@ -123,10 +135,16 @@ private:
     return true;
   }
 
+#pragma endregion
+#pragma region Data members
+
   validation state_{validation::complete};
   uint8_t remaining_{};
   uint8_t min_cont_{0x80};
   uint8_t max_cont_{0xBF};
+
+#pragma endregion
 };
 
+#pragma endregion
 }} // namespace corvid::proto

--- a/corvid/proto/quic/http3_conn.h
+++ b/corvid/proto/quic/http3_conn.h
@@ -29,6 +29,7 @@
 #include <nghttp3/nghttp3.h>
 #include <openssl/rand.h>
 
+#include "../../meta/pragmas.h"
 #include "../../infra/exception_firewalls.h"
 #include "../../infra/log.h"
 #include "../../strings/conversion.h"
@@ -938,8 +939,9 @@ private:
   // The nghttp3 callback table. Identical for both roles (only the `_new`
   // entry point differs); unmentioned slots are value-initialized to null,
   // which nghttp3 treats as "callback not installed".
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmissing-designated-field-initializers"
+  PRAGMA_DIAG(push)
+  PRAGMA_CLANG_IGNORED("-Wmissing-designated-field-initializers")
+  PRAGMA_GCC_IGNORED("-Wmissing-field-initializers")
   static constexpr nghttp3_callbacks callbacks{
       .acked_stream_data = &on_acked_stream_data,
       .stream_close = &on_stream_close,
@@ -957,7 +959,7 @@ private:
       .rand = &on_rand,
       .recv_settings2 = &on_recv_settings,
   };
-#pragma clang diagnostic pop
+  PRAGMA_DIAG(pop)
 
   using conn_ptr =
       std::unique_ptr<nghttp3_conn, decltype([](nghttp3_conn* p) noexcept {

--- a/corvid/proto/quic/quic_conn.h
+++ b/corvid/proto/quic/quic_conn.h
@@ -30,6 +30,7 @@
 #include <openssl/rand.h>
 #include <openssl/ssl.h>
 
+#include "../../meta/pragmas.h"
 #include "../net_endpoint.h"
 #include "../../enums/bool_enums.h"
 #include "../../concurrency/timeouts.h"
@@ -1050,10 +1051,11 @@ private:
     return success(try_or_log(std::forward<F>(fn)));
   }
 
-// Callback tables, one per role. Unmentioned slots are value-initialized to
-// null, which is what ngtcp2 expects for optional callbacks.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wmissing-designated-field-initializers"
+  // Callback tables, one per role. Unmentioned slots are value-initialized to
+  // null, which is what ngtcp2 expects for optional callbacks.
+  PRAGMA_DIAG(push)
+  PRAGMA_CLANG_IGNORED("-Wmissing-designated-field-initializers")
+  PRAGMA_GCC_IGNORED("-Wmissing-field-initializers")
   static constexpr ngtcp2_callbacks server_callbacks{
       .recv_client_initial = &ngtcp2_crypto_recv_client_initial_cb,
       .recv_crypto_data = &ngtcp2_crypto_recv_crypto_data_cb,
@@ -1118,7 +1120,7 @@ private:
       .get_new_connection_id2 = &on_get_new_connection_id2,
       .get_path_challenge_data2 = &on_get_path_challenge_data2,
   };
-#pragma clang diagnostic pop
+  PRAGMA_DIAG(pop)
 
   // The shim retrieves our `ngtcp2_conn*` via the conn_ref's `get_conn`
   // callback, which lets it find us starting from just an SSL pointer.

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -39,6 +39,8 @@
 
 namespace corvid { inline namespace sim {
 
+#pragma region GamePhase
+
 // Different phases of the game.
 enum class GamePhase : uint8_t {
   invalid,
@@ -52,6 +54,9 @@ consteval auto corvid_enum_spec(GamePhase*) {
       "build,wave,game_over,victory", wrapclip{}, GamePhase::build>();
 }
 
+#pragma endregion
+#pragma region WaveTick
+
 // Tick from start of wave.
 enum class WaveTick : uint32_t {
   invalid = std::numeric_limits<uint32_t>::max()
@@ -59,6 +64,9 @@ enum class WaveTick : uint32_t {
 consteval auto corvid_enum_spec(WaveTick*) {
   return corvid::enums::sequence::make_sequence_enum_spec<WaveTick, "">();
 }
+
+#pragma endregion
+#pragma region UiCanvasEvent
 
 // Mouse click events.
 enum class UiCanvasEvent : uint8_t {
@@ -75,12 +83,18 @@ consteval auto corvid_enum_spec(UiCanvasEvent*) {
       "click,dblclick,contextmenu,dragstart,dragmove,dragend">();
 }
 
+#pragma endregion
+#pragma region UiMouseButton
+
 // Mouse buttons.
 enum class UiMouseButton : uint8_t { left, middle, right, other };
 consteval auto corvid_enum_spec(UiMouseButton*) {
   return corvid::enums::sequence::make_sequence_enum_spec<UiMouseButton,
       "left,middle,right,other">();
 }
+
+#pragma endregion
+#pragma region EnemySpawn
 
 // Enemy spawn definition for a wave.
 struct EnemySpawn {
@@ -89,11 +103,17 @@ struct EnemySpawn {
   PathId pathId{};
 };
 
+#pragma endregion
+#pragma region WaveDefinition
+
 // All of the enemy spawns for a wave.
 struct WaveDefinition {
   std::vector<EnemySpawn> enemies; // Sorted by `startTicks`
   uint32_t resourceInflux{};       // Resources rewarded at start of wave
 };
+
+#pragma endregion
+#pragma region CategoryDefinition
 
 // Top-level category in the build menu. Each category has its own `Appearance`
 // (including the glyph that doubles as a hotkey) and a `flavorText` shown when
@@ -104,6 +124,9 @@ struct CategoryDefinition {
   std::string flavorText;  // Shown in the info box on hover.
   Appearance appearance;   // Glyph, radius, and colors for the category cell.
 };
+
+#pragma endregion
+#pragma region EntityDefinition
 
 // Full definition of one entity type, combining display metadata with the
 // component template used to register and spawn it.
@@ -120,6 +143,9 @@ struct EntityDefinition {
 
 // Collection of `EntityDefinition`s, keyed by `entityName`.
 using EntityDefinitions = string_unordered_map<EntityDefinition>;
+
+#pragma endregion
+#pragma region DefenderSummary
 
 // Human-focused summary of a defender, used for both the build menu and the
 // selected tab.
@@ -140,6 +166,9 @@ struct DefenderSummary {
 // defenders only. Note that these are not indexed by `entityTemplateIndex`.
 using DefenderMenu = std::vector<DefenderSummary>;
 
+#pragma endregion
+#pragma region MapDesign
+
 // Everything needed to play one map: paths, sprites, entity definitions,
 // derived defender menu, and wave schedule. Self-contained so that
 // `SimGame` can hold multiple `MapDesign`s, all read in from map files.
@@ -153,6 +182,9 @@ struct MapDesign {
   DefenderMenu defenderMenu;
   std::vector<WaveDefinition> waves;
 };
+
+#pragma endregion
+#pragma region UiCanvasInput
 
 // Input from the UI canvas, such as mouse clicks and drags. Includes `command`
 // and `parameters` for when the mouse location is paired with an action.
@@ -180,11 +212,17 @@ struct UiCanvasInput {
   }
 };
 
+#pragma endregion
+#pragma region UiActionField
+
 // Input from the UI for actions, such as form submissions.
 struct UiActionField {
   std::string key;
   std::string value;
 };
+
+#pragma endregion
+#pragma region UiActionInput
 
 // Represents an action input from the UI, such as pressing a button. Can
 // include related data, such as form fields.
@@ -194,6 +232,9 @@ struct UiActionInput {
   std::vector<UiActionField> fields;
 };
 
+#pragma endregion
+#pragma region UiState
+
 // Current state of the UI, for inclusion in a `WorldDelta` to the client.
 struct UiState {
   std::optional<bool> placementAllowed;
@@ -202,10 +243,18 @@ struct UiState {
   std::optional<DefenderSummary> defenderSummary;
 };
 
+#pragma endregion
+#pragma region SimGame
+
 // Game simulation.
 class SimGame {
 public:
+#pragma region Construction
+
   explicit SimGame() { (void)resetMap(); }
+
+#pragma endregion
+#pragma region Map management
 
   // Load all maps from the maps directory and activate the first one.
   [[nodiscard]] bool loadMap() {
@@ -239,6 +288,9 @@ public:
     selectedDefender_ = {};
     return true;
   }
+
+#pragma endregion
+#pragma region Simulation
 
   // Run all physics and game logic for the current tick, without advancing the
   // counter. To advance the counter, call `tick` after streaming the state to
@@ -312,6 +364,9 @@ public:
     return true;
   }
 
+#pragma endregion
+#pragma region UI input
+
   // Record most recent action intent from the UI canvas.
   [[nodiscard]] bool handleUiCanvas(const UiCanvasInput& input) {
     // Drag a defender ghost.
@@ -363,9 +418,15 @@ public:
     return true;
   }
 
+#pragma endregion
+#pragma region Accessors
+
   // Access the current map design (for streaming and inspection).
   [[nodiscard]] const MapDesign& mapDesign() const { return *mapDesign_; }
   [[nodiscard]] const UiState& uiState() const { return uiState_; }
+
+#pragma endregion
+#pragma region Extraction
 
   // Extract a snapshot of the paths for `WorldSnapshot`, calling back
   // `cbPath(PathId, Position)` for each joint.
@@ -421,6 +482,8 @@ public:
     return true;
   }
 
+#pragma endregion
+#pragma region Implementation
 private:
   // Find `EntityDefinition` by name.
   [[nodiscard]] const EntityDefinition* findEntityDef(
@@ -673,6 +736,8 @@ private:
     }
   }
 
+#pragma endregion
+#pragma region Data members
 private:
   SimWorld world_;
 
@@ -706,6 +771,9 @@ private:
   // Handle to the currently selected defender, used to clear its range
   // circle when deselected.
   SimWorld::Handle selectedDefender_;
+
+#pragma endregion
+#pragma region Map loading
 
   // Walk up from the executable to find the `corvid/sim/maps` directory.
   [[nodiscard]] static std::filesystem::path findSimMapsDir() {
@@ -772,7 +840,12 @@ private:
     world_.setEntityTemplateStore(&mapDesign_->entityTemplateStore);
     return registerPaths();
   }
+
+#pragma endregion
 };
+
+#pragma endregion
+#pragma region loadMapFromJson
 
 // Parse a single map JSON file into `out`. The caller is responsible for
 // calling `finalizeMapDesign` and `registerPaths` afterward.
@@ -1058,6 +1131,9 @@ SimGame::loadMapFromJson(const std::filesystem::path& file, MapDesign& out) {
 }
 // NOLINTEND(readability-function-cognitive-complexity)
 
+#pragma endregion
+#pragma region buildMapEntityCsvReport
+
 [[nodiscard]] inline std::string SimGame::buildMapEntityCsvReport(
     const MapDesign& design) {
   auto csv_escape = [](std::string_view value) {
@@ -1116,4 +1192,5 @@ SimGame::loadMapFromJson(const std::filesystem::path& file, MapDesign& out) {
   return oss.str();
 }
 
+#pragma endregion
 }} // namespace corvid::sim

--- a/corvid/sim/sim_game.h
+++ b/corvid/sim/sim_game.h
@@ -16,6 +16,7 @@
 // limitations under the License.
 #pragma once
 #include <charconv>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <map>

--- a/corvid/sim/sim_ws_handler.h
+++ b/corvid/sim/sim_ws_handler.h
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <memory>
 

--- a/corvid/strings/conversion.h
+++ b/corvid/strings/conversion.h
@@ -380,34 +380,5 @@ append_utf8(std::string& out, uint32_t code_point) {
 }
 
 #pragma endregion
-#pragma region consteval
-
-// Simple compile-time integer parser.
-template<std::integral U>
-[[nodiscard]] consteval std::optional<U> parse_int(std::string_view sv) {
-  if (sv.empty()) return std::nullopt;
-  const bool neg = (sv.front() == '-');
-  if (neg) {
-    if constexpr (std::is_unsigned_v<U>) return std::nullopt;
-    sv.remove_prefix(1);
-    if (sv.empty()) return std::nullopt;
-  }
-  // For signed types, accumulate in the negative domain so the most-negative
-  // value of a signed type stays representable; its magnitude exceeds the
-  // positive maximum.
-  U value{};
-  for (const char c : sv) {
-    if (!strings::is_digit(c)) return std::nullopt;
-    U digit = c - '0';
-    if constexpr (std::is_signed_v<U>) digit = -digit;
-    value *= 10;
-    value += digit;
-  }
-  if constexpr (std::is_signed_v<U>)
-    if (!neg) value = -value;
-  return value;
-}
-
-#pragma endregion
 
 }} // namespace corvid::strings::conversion

--- a/corvid/strings/fixed_string.h
+++ b/corvid/strings/fixed_string.h
@@ -23,6 +23,7 @@
 
 #include "../meta.h"
 #include "cstring_view.h"
+#include "../meta/formatting.h"
 
 namespace corvid::strings { inline namespace fixed {
 
@@ -196,24 +197,10 @@ using fixed_string = basic_fixed_string<char, N>;
 
 }} // namespace corvid::strings::fixed
 
-// `basic_fixed_string` exposes `begin`/`end`, so without this it would be
-// claimed by the std range formatter and print as a list of chars. Disabling
-// its range format leaves the string formatter below as the only match.
 template<corvid::CharType CharT, std::size_t N>
 constexpr std::range_format
     std::format_kind<corvid::strings::basic_fixed_string<CharT, N>> =
         std::range_format::disabled;
-
-// Formatter for `basic_fixed_string`, narrow or wide. It is pure delegation:
-// inherit the `std::basic_string_view` formatter for the full spec grammar
-// (fill, align, width, precision, `?`) and forward `view()`.
 template<corvid::CharType CharT, std::size_t N>
 struct std::formatter<corvid::strings::basic_fixed_string<CharT, N>, CharT>
-    : std::formatter<std::basic_string_view<CharT>, CharT> {
-  template<typename FormatContext>
-  auto format(const corvid::strings::basic_fixed_string<CharT, N>& s,
-      FormatContext& ctx) const {
-    return std::formatter<std::basic_string_view<CharT>, CharT>::format(
-        s.view(), ctx);
-  }
-};
+    : corvid::forwarding_formatter<std::basic_string_view<CharT>, CharT> {};

--- a/corvid/strings/string_view_wrapper.h
+++ b/corvid/strings/string_view_wrapper.h
@@ -26,6 +26,7 @@
 #include <utility>
 
 #include "../meta/concepts.h"
+#include "../meta/formatting.h"
 
 namespace corvid { inline namespace stringviewwrapper {
 
@@ -307,91 +308,8 @@ concept StringViewWrapperChild =
 template<corvid::StringViewWrapperChild W>
 constexpr std::range_format std::format_kind<W> = std::range_format::disabled;
 
-// Formatter for any `string_view_wrapper` child (opt_string_view,
-// cstring_view, enum_name), narrow or wide.
-//
-// Inherits the `std::basic_string_view` formatter for the full spec grammar
-// (fill, align, width, precision, and the `?` debug spec) and formats the
-// wrapper's view, so a wrapper renders exactly like the string_view it holds:
-// `{}` prints the contents, `{:?}` prints the quoted, escaped debug form.
-//
-// A null wrapper (null distinct from empty) stays transparent under `{}`,
-// printing as empty, and prints as the unquoted marker `(null)` under `{:?}`.
-// The marker is distinct from an empty string (`""`) and from a string whose
-// contents are those letters (`"(null)"`). Fill, align, width, and precision
-// apply to the marker too: a second formatter captures the spec with its `?`
-// stripped and formats the marker through that, so the base's debug quoting is
-// bypassed while its padding is reused. A dynamic width or precision combined
-// with the debug spec (`{:{}?}`) is rejected with a `std::format_error`: its
-// argument is bound to the real parse context, which the local marker parse
-// cannot read, so the marker could not honor it, and silently dropping the
-// padding would corrupt tabular output. The rejection is value-independent
-// (null or not); to get dynamic width with debug on a known non-null wrapper,
-// format its `view()` directly.
-//
-// Only a context whose char type matches the wrapper's is claimed; cross-type
-// transcoding is out of scope.
 template<corvid::StringViewWrapperChild W, corvid::CharType CharT>
 requires std::same_as<CharT, typename W::char_t>
 struct std::formatter<W, CharT>
-    : std::formatter<std::basic_string_view<CharT>, CharT> {
-  using base = std::formatter<std::basic_string_view<CharT>, CharT>;
-
-  // The range and map formatters turn on element debug through this rather
-  // than a spec `?`, so mirror their call into `debug_` to keep null elements
-  // rendering as `(null)` inside a range. A container enables debug here only
-  // when no element spec was given, so it never carries element width; a bare
-  // (empty-spec) marker is correct. Guard against clobbering a width that a
-  // `?`-bearing spec already captured.
-  constexpr void set_debug_format() {
-    const bool was_debug = debug_;
-    debug_ = true;
-    base::set_debug_format();
-    if (!was_debug) parse_marker({});
-  }
-
-  constexpr auto parse(auto& ctx) {
-    auto it = base::parse(ctx);
-    // The debug `?` type is terminal, so a `?` just before the spec end means
-    // debug mode, the only case that changes how a null is rendered. The
-    // marker matters only in debug mode, so capture its spec only then.
-    if (it != ctx.begin() && *std::prev(it) == static_cast<CharT>('?')) {
-      debug_ = true;
-      // Capture the spec without the `?` so a null can be padded as the bare
-      // `(null)` marker, reusing the base's fill/align/width without its debug
-      // quoting. A dynamic `{...}` width or precision binds its arg to the
-      // real context, which the local marker parse cannot read, so the marker
-      // could not honor it; reject the spec rather than silently drop the
-      // padding and corrupt tabular output. (Fill cannot be `{`, so any `{` is
-      // a dynamic arg.)
-      std::basic_string_view<CharT> spec{std::to_address(ctx.begin()),
-          static_cast<size_t>(std::prev(it) - ctx.begin())};
-      if (spec.find(static_cast<CharT>('{')) != spec.npos)
-        throw std::format_error(
-            "dynamic width or precision is unsupported "
-            "with the debug spec for a string_view_wrapper");
-      parse_marker(spec);
-    }
-    return it;
-  }
-
-  template<typename FormatContext>
-  auto format(const W& w, FormatContext& ctx) const {
-    if (w.null() && debug_) {
-      static constexpr CharT marker[]{CharT('('), CharT('n'), CharT('u'),
-          CharT('l'), CharT('l'), CharT(')')};
-      return marker_.format(std::basic_string_view<CharT>{marker, 6}, ctx);
-    }
-    return base::format(w.view(), ctx);
-  }
-
-private:
-  // Parse `spec` (the padding spec, no `?`) into the marker formatter.
-  constexpr void parse_marker(std::basic_string_view<CharT> spec) {
-    std::basic_format_parse_context<CharT> ctx{spec};
-    marker_.parse(ctx);
-  }
-
-  bool debug_{false};
-  base marker_;
-};
+    : corvid::nullable_formatter<std::basic_string_view<CharT>, CharT,
+          corvid::null_formatting::empty> {};

--- a/corvid/strings/strings_shared.h
+++ b/corvid/strings/strings_shared.h
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <cassert>
 #include <charconv>
+#include <cstdint>
 #include <cstdlib>
 #include <concepts>
 #include <functional>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,13 @@ endif()
 if(USE_LIBSTDCPP)
     # Rely on whichever clang is available and the default libstdc++ install.
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -march=native -Wall -Wextra -Werror -std=c++23")
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        # At -O3, gcc raises false-positive -Wmaybe-uninitialized and
+        # -Warray-bounds from inside libstdc++ and Catch2 template
+        # instantiations, not from Corvid code, so they cannot be suppressed at
+        # the source. Keep them as warnings but do not fail the build on them.
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=maybe-uninitialized -Wno-error=array-bounds")
+    endif()
 else()
     # Use Clang 22 and avoid pulling in GCC.
     set(CMAKE_CXX_COMPILER "/usr/bin/clang++-22")

--- a/tests/enum_formatter_test.cpp
+++ b/tests/enum_formatter_test.cpp
@@ -114,13 +114,41 @@ TEST_CASE("Debug spec escapes special characters", "[EnumFormatterTest]") {
   }
 }
 
-TEST_CASE("Rejects unsupported format specs", "[EnumFormatterTest]") {
+TEST_CASE("Honors width, align, fill, and precision", "[EnumFormatterTest]") {
   if (true) {
-    // A bad spec in a literal format string is a compile error, so the throw
-    // path is reachable only through a runtime format string. The only
-    // accepted specs are the empty spec and `?`.
+    // A named sequence value pads its stored view; default align is left.
+    CHECK(std::format("{:8}", hue::red) == "red     ");
+    CHECK(std::format("{:>8}", hue::red) == "     red");
+    CHECK(std::format("{:^8}", hue::red) == "  red   ");
+    CHECK(std::format("{:*<8}", hue::red) == "red*****");
+    // Precision truncates the rendering.
+    CHECK(std::format("{:.2}", hue::green) == "gr");
+    CHECK(std::format("{:6.2}", hue::green) == "gr    ");
+    // A bitmask combination and a numeric form go through a buffer, then pad.
+    CHECK(std::format("{:>14}", rgb::yellow) == "   red + green");
+    CHECK(std::format("{:.3}", rgb::yellow) == "red");
+    CHECK(std::format("{:>6}", rgb::black) == "  0x00");
+    // Dynamic width and precision pull from later args.
+    CHECK(std::format("{:{}}", hue::blue, 6) == "blue  ");
+    CHECK(std::format("{:.{}}", hue::blue, 2) == "bl");
+    // The debug spec pads the quoted rendering.
+    CHECK(std::format("{:8?}", hue::red) == R"("red"   )");
+    // Wide widens both fill and content.
+    CHECK(std::format(L"{:>6}", hue::red) == L"   red");
+    CHECK(std::format(L"{:*^15}", rgb::yellow) == L"**red + green**");
+  }
+}
+
+TEST_CASE("Rejects specs that don't apply to a name", "[EnumFormatterTest]") {
+  if (true) {
+    // Fill/align, width, precision, and `?` are accepted; sign, `#`, zero-pad,
+    // locale, and any non-`?` type are not. A bad spec in a literal format
+    // string is a compile error, so the throw path is reachable only through a
+    // runtime format string.
     hue h = hue::red;
     CHECK(std::vformat("{:?}", std::make_format_args(h)) == R"("red")");
+    CHECK_THROWS_AS(std::vformat("{:+}", std::make_format_args(h)),
+        std::format_error);
     CHECK_THROWS_AS(std::vformat("{:0?}", std::make_format_args(h)),
         std::format_error);
     CHECK_THROWS_AS(std::vformat("{:x}", std::make_format_args(h)),

--- a/tests/formatting_test.cpp
+++ b/tests/formatting_test.cpp
@@ -203,17 +203,29 @@ TEST_CASE("WritePadded", "[parsed_spec]") {
   spec.alignment = align::right;
   spec.width = 5;
   std::string out;
-  (void)spec.write_padded(std::back_inserter(out), "xy");
+  (void)spec.write_padded(std::back_inserter(out), "xy"sv);
   CHECK(out == "   xy");
 }
 
 TEST_CASE("WidePadded", "[parsed_spec]") {
-  // The narrow content is widened to the spec's code unit.
   parsed_spec<wchar_t> spec;
   spec.alignment = parsed_spec<wchar_t>::aligned::right;
+
+  // Narrow content is widened to the spec's code unit.
   std::wstring out;
-  (void)spec.write_padded(std::back_inserter(out), "ab", 5);
+  (void)spec.write_padded(std::back_inserter(out), "ab"sv, 5);
   CHECK(out == L"   ab");
+
+  // Already-wide content pads without re-widening (the self-rendering case).
+  std::wstring wide;
+  (void)spec.write_padded(std::back_inserter(wide), L"cd"sv, 5);
+  CHECK(wide == L"   cd");
+
+  // The default-width overload is generic over the input width too.
+  spec.width = 5;
+  std::wstring deflt;
+  (void)spec.write_padded(std::back_inserter(deflt), L"ef"sv);
+  CHECK(deflt == L"   ef");
 }
 
 #pragma endregion
@@ -496,6 +508,10 @@ TEST_CASE("SelfRendering", "[self_rendering_formatter]") {
   CHECK(std::format("{:{}}", greeter{"x"}, 5) == "hi x ");
   // The `?` spec routes to debug_format_to.
   CHECK(std::format("{:?}", greeter{"bob"}) == "<bob>");
+
+  // Wide formatting drives the buffer path with already-wide content.
+  CHECK(std::format(L"{:>8}", greeter{"x"}) == L"    hi x");
+  CHECK(std::format(L"{:.2}", greeter{"x"}) == L"hi");
 }
 
 TEST_CASE("FormatToSpec", "[self_rendering_formatter]") {

--- a/tests/formatting_test.cpp
+++ b/tests/formatting_test.cpp
@@ -79,7 +79,7 @@ struct greeter {
 };
 
 // A `self_rendering_formatter` target that applies the spec itself through a
-// `format_to_spec` member (the path `os_file` uses).
+// `format_to_spec` member.
 struct dashes {
   template<CharType CharT, typename OutIt>
   OutIt format_to_spec(const parsed_spec<CharT>& spec, OutIt out) const {

--- a/tests/formatting_test.cpp
+++ b/tests/formatting_test.cpp
@@ -430,6 +430,23 @@ TEST_CASE("DynamicWidthSentinel", "[nullable_formatter]") {
   CHECK(std::format("{:{}}", nbox<int>{&n}, 6) == "    42");
 }
 
+TEST_CASE("PrecisionSentinel", "[nullable_formatter]") {
+  // Precision caps the sentinel just as the base caps a present value, so a
+  // null cell stays within a precision-bounded column. The base must accept
+  // precision (string_view here; an int base rejects it before format).
+  using sbox = nbox<std::string_view>;
+  CHECK(std::format("{:.3}", sbox{}) == "(nu");
+  CHECK(std::format("{:.3?}", sbox{}) == "(nu");
+  // Width still pads the capped text.
+  CHECK(std::format("{:6.3}", sbox{}) == "(nu   ");
+  CHECK(std::format("{:>6.3}", sbox{}) == "   (nu");
+  // Dynamic precision resolves the claimed arg for the sentinel.
+  CHECK(std::format("{:.{}}", sbox{}, 3) == "(nu");
+  // A present value caps through the base, for parity.
+  std::string_view sv = "hello";
+  CHECK(std::format("{:.3}", sbox{&sv}) == "hel");
+}
+
 TEST_CASE("CustomMarker", "[nullable_formatter]") {
   CHECK(std::format("{}", closing_handle{}) == "closed");
   CHECK(std::format("{:8}", closing_handle{}) == "closed  ");

--- a/tests/formatting_test.cpp
+++ b/tests/formatting_test.cpp
@@ -1,0 +1,499 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+#include <format>
+#include <iterator>
+#include <string>
+#include <string_view>
+
+#include "../corvid/meta/formatting.h"
+#include "catch2_main.h"
+
+using namespace std::literals;
+using namespace corvid;
+
+// NOLINTBEGIN(readability-function-cognitive-complexity,
+// readability-function-size)
+
+// These tests exercise the formatter bases in `corvid/meta/formatting.h`
+// directly, with minimal local wrapper types, rather than relying on the
+// library types that happen to derive from them.
+
+#pragma region Local wrapper types
+
+namespace {
+
+// A wrapper convertible to `const int&`, for `forwarding_formatter`.
+struct fbox {
+  int v = 0;
+  operator const int&() const noexcept { return v; }
+};
+
+// A pointer-like wrapper for `nullable_formatter`. It is contextually
+// convertible to bool and dereferences to the element. The two null modes ride
+// along as template parameters so one wrapper covers every combination.
+template<typename T, null_formatting Plain = null_formatting::sentinel,
+    null_formatting Debug = Plain>
+struct nbox {
+  const T* ptr = nullptr;
+  explicit operator bool() const noexcept { return ptr != nullptr; }
+  const T& operator*() const noexcept { return *ptr; }
+};
+
+// A nullable wrapper with a custom sentinel, set through the marker
+// constructor the docs describe.
+struct closing_handle {
+  const int* ptr = nullptr;
+  explicit operator bool() const noexcept { return ptr != nullptr; }
+  const int& operator*() const noexcept { return *ptr; }
+};
+
+// A `self_rendering_formatter` target that renders through a `format_to`
+// member, with a distinct `debug_format_to` for the `?` spec. The base applies
+// width and precision to the rendered text via a buffer.
+struct greeter {
+  std::string_view who;
+  template<typename OutIt>
+  OutIt format_to(OutIt out) const {
+    return std::format_to(out, "hi {}", who);
+  }
+  template<typename OutIt>
+  OutIt debug_format_to(OutIt out) const {
+    return std::format_to(out, "<{}>", who);
+  }
+};
+
+// A `self_rendering_formatter` target that applies the spec itself through a
+// `format_to_spec` member (the path `os_file` uses).
+struct dashes {
+  template<CharType CharT, typename OutIt>
+  OutIt format_to_spec(const parsed_spec<CharT>& spec, OutIt out) const {
+    std::string_view content = "----";
+    if (const auto prec = spec.precision) content = content.substr(0, *prec);
+    return spec.write_padded(out, content, spec.width);
+  }
+};
+
+} // namespace
+
+template<CharType CharT>
+struct std::formatter<fbox, CharT>: corvid::forwarding_formatter<int, CharT> {
+};
+
+template<typename T, corvid::null_formatting Plain,
+    corvid::null_formatting Debug, corvid::CharType CharT>
+struct std::formatter<nbox<T, Plain, Debug>, CharT>
+    : corvid::nullable_formatter<T, CharT, Plain, Debug> {};
+
+template<corvid::CharType CharT>
+struct std::formatter<closing_handle, CharT>
+    : corvid::nullable_formatter<int, CharT> {
+  constexpr formatter() : corvid::nullable_formatter<int, CharT>{"closed"} {}
+};
+
+template<corvid::CharType CharT>
+struct std::formatter<greeter, CharT>
+    : corvid::self_rendering_formatter<CharT> {};
+
+template<corvid::CharType CharT>
+struct std::formatter<dashes, CharT>: corvid::self_rendering_formatter<CharT> {
+};
+
+#pragma endregion
+#pragma region Compile-time checks
+
+namespace {
+
+using cps = parsed_spec<char>;
+using align = cps::aligned;
+
+// `calc_padding` is constexpr; verify the split for each alignment, the
+// odd-pad bias toward the trailing side, and the no-room case.
+static_assert(cps::calc_padding(align::left, 3, 10).first == 0);
+static_assert(cps::calc_padding(align::left, 3, 10).second == 7);
+static_assert(cps::calc_padding(align::right, 3, 10).first == 7);
+static_assert(cps::calc_padding(align::right, 3, 10).second == 0);
+static_assert(cps::calc_padding(align::center, 3, 10).first == 3);
+static_assert(cps::calc_padding(align::center, 3, 10).second == 4);
+static_assert(cps::calc_padding(align::center, 4, 10).first == 3);
+static_assert(cps::calc_padding(align::center, 4, 10).second == 3);
+static_assert(cps::calc_padding(align::right, 5, 3).first == 0);
+static_assert(cps::calc_padding(align::right, 5, 3).second == 0);
+
+using sp = spec_parser<char>;
+using avt = sp::arg_value_t;
+
+// `make_from_parse` classifies a width/precision argument; it is constexpr.
+constexpr avt parse_arg(std::string_view s) {
+  std::size_t ndx = 0;
+  return avt::make_from_parse(s, ndx);
+}
+static_assert(parse_arg("10").kind == sp::arg_kind::fixed);
+static_assert(parse_arg("10").value == 10);
+static_assert(parse_arg("{}").is_automatic());
+static_assert(parse_arg("{7}").kind == sp::arg_kind::manual);
+static_assert(parse_arg("{7}").value == 7);
+static_assert(parse_arg("xyz").kind == sp::arg_kind::none);
+
+// `parse` is constexpr; spot-check a fully loaded spec.
+constexpr sp parse_spec(std::string_view s) {
+  sp p;
+  (void)p.parse(s);
+  return p;
+}
+static_assert(parse_spec("*^10.3Lf}").fill == '*');
+static_assert(parse_spec("*^10.3Lf}").width == 10);
+static_assert(parse_spec("*^10.3Lf}").precision == 3);
+static_assert(parse_spec("*^10.3Lf}").has_locale);
+static_assert(parse_spec("*^10.3Lf}").type == 'f');
+
+} // namespace
+
+#pragma endregion
+#pragma region parsed_spec
+
+TEST_CASE("WritePrimitives", "[parsed_spec]") {
+  std::string s;
+  cps::write_repeat(std::back_inserter(s), '*', 3);
+  CHECK(s == "***");
+
+  s.clear();
+  cps::write_repeat(std::back_inserter(s), '-', 0);
+  CHECK(s.empty());
+
+  s.clear();
+  cps::write_sv(std::back_inserter(s), "abc"sv);
+  CHECK(s == "abc");
+}
+
+TEST_CASE("WritePadded", "[parsed_spec]") {
+  auto render = [](align a, char fill, std::size_t w, std::string_view c) {
+    cps spec;
+    spec.alignment = a;
+    spec.fill = fill;
+    std::string out;
+    (void)spec.write_padded(std::back_inserter(out), c, w);
+    return out;
+  };
+  CHECK(render(align::left, ' ', 6, "ab") == "ab    ");
+  CHECK(render(align::right, ' ', 6, "ab") == "    ab");
+  CHECK(render(align::center, ' ', 6, "ab") == "  ab  ");
+  // Odd padding biases toward the trailing side.
+  CHECK(render(align::center, '*', 7, "ab") == "**ab***");
+  // Width narrower than content adds nothing.
+  CHECK(render(align::left, ' ', 1, "abc") == "abc");
+
+  // The one-argument overload uses `spec.width`.
+  cps spec;
+  spec.alignment = align::right;
+  spec.width = 5;
+  std::string out;
+  (void)spec.write_padded(std::back_inserter(out), "xy");
+  CHECK(out == "   xy");
+}
+
+TEST_CASE("WidePadded", "[parsed_spec]") {
+  // The narrow content is widened to the spec's code unit.
+  parsed_spec<wchar_t> spec;
+  spec.alignment = parsed_spec<wchar_t>::aligned::right;
+  std::wstring out;
+  (void)spec.write_padded(std::back_inserter(out), "ab", 5);
+  CHECK(out == L"   ab");
+}
+
+#pragma endregion
+#pragma region spec_parser
+
+TEST_CASE("ArgValue", "[spec_parser]") {
+  // The member `parse` advances the index past the consumed text.
+  avt a;
+  CHECK(a.parse("10x", 0) == 2);
+  CHECK(a.kind == sp::arg_kind::fixed);
+  CHECK(a.value == 10);
+  CHECK(a.get_fixed() == 10);
+  CHECK_FALSE(a.is_dynamic());
+
+  avt b;
+  CHECK(b.parse("{}", 0) == 2);
+  CHECK(b.is_automatic());
+  CHECK(b.is_dynamic());
+  CHECK(b.get_automatic() == 0);
+  CHECK(b.get_fixed() == std::nullopt);
+
+  avt c;
+  CHECK(c.parse("{12}", 0) == 4);
+  CHECK(c.kind == sp::arg_kind::manual);
+  CHECK(c.value == 12);
+  CHECK(c.is_dynamic());
+  CHECK_FALSE(c.is_automatic());
+
+  avt d;
+  CHECK(d.parse("z", 0) == 0);
+  CHECK(d.kind == sp::arg_kind::none);
+  CHECK_FALSE(d.is_dynamic());
+}
+
+TEST_CASE("ParseSpec", "[spec_parser]") {
+  {
+    sp p;
+    CHECK(p.parse("") == 0);
+    CHECK(p.width == 0);
+    CHECK(p.alignment == sp::aligned::left);
+    CHECK(p.fill == ' ');
+    CHECK(p.sign == '-');
+    CHECK_FALSE(p.alternate);
+    CHECK_FALSE(p.zero_pad);
+    CHECK_FALSE(p.has_locale);
+    CHECK(p.type == '\0');
+    CHECK_FALSE(p.debug);
+  }
+  {
+    // `parse` stops at and returns the offset of the closing brace.
+    sp p;
+    CHECK(p.parse("5}") == 1);
+    CHECK(p.width == 5);
+  }
+  {
+    sp p;
+    CHECK(p.parse("d}") == 1);
+    CHECK(p.type == 'd');
+  }
+  {
+    sp p;
+    p.parse(">8}");
+    CHECK(p.alignment == sp::aligned::right);
+    CHECK(p.width == 8);
+  }
+  {
+    sp p;
+    p.parse("*^6}");
+    CHECK(p.fill == '*');
+    CHECK(p.alignment == sp::aligned::center);
+    CHECK(p.width == 6);
+  }
+  {
+    sp p;
+    p.parse(" 5}");
+    CHECK(p.sign == ' ');
+    CHECK(p.width == 5);
+  }
+  {
+    sp p;
+    p.parse("#}");
+    CHECK(p.alternate);
+  }
+  {
+    sp p;
+    p.parse("06}");
+    CHECK(p.zero_pad);
+    CHECK(p.width == 6);
+  }
+  {
+    sp p;
+    p.parse(".3f}");
+    CHECK(p.precision == 3);
+    CHECK(p.type == 'f');
+  }
+  {
+    sp p;
+    p.parse("L}");
+    CHECK(p.has_locale);
+  }
+  {
+    sp p;
+    p.parse("?}");
+    CHECK(p.type == '?');
+    CHECK(p.debug);
+  }
+  {
+    sp p;
+    CHECK(p.parse("*^+#010.3Lf}") == 11);
+    CHECK(p.fill == '*');
+    CHECK(p.alignment == sp::aligned::center);
+    CHECK(p.sign == '+');
+    CHECK(p.alternate);
+    CHECK(p.zero_pad);
+    CHECK(p.width == 10);
+    CHECK(p.precision == 3);
+    CHECK(p.has_locale);
+    CHECK(p.type == 'f');
+  }
+}
+
+TEST_CASE("IsDynamic", "[spec_parser]") {
+  {
+    sp p;
+    p.parse("5.2}");
+    CHECK_FALSE(p.is_dynamic());
+  }
+  {
+    sp p;
+    p.parse("{}}");
+    CHECK(p.is_dynamic());
+    CHECK(p.width_arg.is_automatic());
+  }
+  {
+    sp p;
+    p.parse(".{}}");
+    CHECK(p.is_dynamic());
+    CHECK(p.precision_arg.is_automatic());
+  }
+  {
+    sp p;
+    p.parse("{3}}");
+    CHECK(p.is_dynamic());
+    CHECK(p.width_arg.kind == sp::arg_kind::manual);
+    CHECK(p.width_arg.value == 3);
+  }
+}
+
+TEST_CASE("RewriteExplicit", "[spec_parser]") {
+  // Each automatic `{}` becomes a manual `{n}` with its claimed id, so the
+  // base reads the same argument. (The claim is simulated here by setting the
+  // value the parse context would have supplied.)
+  {
+    sp p;
+    p.parse("{}.{}}");
+    p.width_arg.value = 2;
+    p.precision_arg.value = 5;
+    CHECK(p.rewrite_spec_as_explicit("{}.{}") == "{2}.{5}");
+  }
+  {
+    sp p;
+    p.parse(".{}}");
+    p.precision_arg.value = 7;
+    CHECK(p.rewrite_spec_as_explicit(".{}") == ".{7}");
+  }
+}
+
+#pragma endregion
+#pragma region forwarding_formatter
+
+TEST_CASE("Forwarding", "[forwarding_formatter]") {
+  // The wrapper reuses the full int spec grammar.
+  CHECK(std::format("{}", fbox{42}) == "42");
+  CHECK(std::format("{:5}", fbox{7}) == "    7");
+  CHECK(std::format("{:#x}", fbox{255}) == "0xff");
+  CHECK(std::format("{:+}", fbox{5}) == "+5");
+  CHECK(std::format("{:{}}", fbox{7}, 4) == "   7");
+}
+
+#pragma endregion
+#pragma region nullable_formatter
+
+TEST_CASE("Present", "[nullable_formatter]") {
+  int n = 42;
+  int big = 255;
+  CHECK(std::format("{}", nbox<int>{&n}) == "42");
+  CHECK(std::format("{:5}", nbox<int>{&n}) == "   42");
+  CHECK(std::format("{:#x}", nbox<int>{&big}) == "0xff");
+  CHECK(std::format("{:{}}", nbox<int>{&n}, 4) == "  42");
+
+  // String elements forward the debug spec's quoting too.
+  std::string_view sv = "hi";
+  CHECK(std::format("{}", nbox<std::string_view>{&sv}) == "hi");
+  CHECK(std::format("{:>5}", nbox<std::string_view>{&sv}) == "   hi");
+  CHECK(std::format("{:?}", nbox<std::string_view>{&sv}) == "\"hi\"");
+}
+
+TEST_CASE("Sentinel", "[nullable_formatter]") {
+  CHECK(std::format("{}", nbox<int>{}) == "(null)");
+  CHECK(std::format("{:8}", nbox<int>{}) == "(null)  ");
+  CHECK(std::format("{:>8}", nbox<int>{}) == "  (null)");
+  CHECK(std::format("{:^8}", nbox<int>{}) == " (null) ");
+  CHECK(std::format("{:*^10}", nbox<int>{}) == "**(null)**");
+}
+
+TEST_CASE("DynamicWidthSentinel", "[nullable_formatter]") {
+  // Automatic `{}`: the id is claimed and the spec rewritten for the base.
+  CHECK(std::format("{:{}}", nbox<int>{}, 8) == "(null)  ");
+  // Manual `{n}`: read directly.
+  CHECK(std::format("{0:{1}}", nbox<int>{}, 8) == "(null)  ");
+  CHECK(std::format("{0:>{1}}", nbox<int>{}, 8) == "  (null)");
+  // A present value still resolves dynamic width through the base.
+  int n = 42;
+  CHECK(std::format("{:{}}", nbox<int>{&n}, 6) == "    42");
+}
+
+TEST_CASE("CustomMarker", "[nullable_formatter]") {
+  CHECK(std::format("{}", closing_handle{}) == "closed");
+  CHECK(std::format("{:8}", closing_handle{}) == "closed  ");
+  CHECK(std::format("{:>8}", closing_handle{}) == "  closed");
+  int n = 7;
+  CHECK(std::format("{}", closing_handle{&n}) == "7");
+}
+
+TEST_CASE("Empty", "[nullable_formatter]") {
+  using empty_text = nbox<std::string_view, null_formatting::empty>;
+  CHECK(std::format("{}", empty_text{}) == "");
+  // An empty field still honors width, via the inherited formatter.
+  CHECK(std::format("{:4}", empty_text{}) == "    ");
+  std::string_view sv = "hi";
+  CHECK(std::format("{}", empty_text{&sv}) == "hi");
+}
+
+TEST_CASE("DebugVsPlain", "[nullable_formatter]") {
+  // Plain spec shows empty; debug spec shows the sentinel.
+  using mixed = nbox<std::string_view, null_formatting::empty,
+      null_formatting::sentinel>;
+  CHECK(std::format("{}", mixed{}) == "");
+  CHECK(std::format("{:?}", mixed{}) == "(null)");
+
+  // The reverse selection. Empty mode formats a default-constructed underlying
+  // value through the base, so an empty string under the debug spec renders
+  // quoted.
+  using mixed2 = nbox<std::string_view, null_formatting::sentinel,
+      null_formatting::empty>;
+  CHECK(std::format("{}", mixed2{}) == "(null)");
+  CHECK(std::format("{:?}", mixed2{}) == "\"\"");
+}
+
+#pragma endregion
+#pragma region self_rendering_formatter
+
+TEST_CASE("SelfRendering", "[self_rendering_formatter]") {
+  // No spec: the rendered text passes through directly.
+  CHECK(std::format("{}", greeter{"bob"}) == "hi bob");
+  // Width and alignment pad the rendered text (via a buffer).
+  CHECK(std::format("{:10}", greeter{"bob"}) == "hi bob    ");
+  CHECK(std::format("{:>10}", greeter{"bob"}) == "    hi bob");
+  CHECK(std::format("{:^10}", greeter{"bob"}) == "  hi bob  ");
+  // Precision truncates the rendered text.
+  CHECK(std::format("{:.2}", greeter{"bob"}) == "hi");
+  // Dynamic width is resolved before padding.
+  CHECK(std::format("{:{}}", greeter{"x"}, 5) == "hi x ");
+  // The `?` spec routes to debug_format_to.
+  CHECK(std::format("{:?}", greeter{"bob"}) == "<bob>");
+}
+
+TEST_CASE("FormatToSpec", "[self_rendering_formatter]") {
+  CHECK(std::format("{}", dashes{}) == "----");
+  CHECK(std::format("{:6}", dashes{}) == "----  ");
+  CHECK(std::format("{:>6}", dashes{}) == "  ----");
+  CHECK(std::format("{:^8}", dashes{}) == "  ----  ");
+  // Precision truncates the self-rendered text.
+  CHECK(std::format("{:.2}", dashes{}) == "--");
+  CHECK(std::format("{:6.2}", dashes{}) == "--    ");
+  // Dynamic width arrives already resolved.
+  CHECK(std::format("{:{}}", dashes{}, 6) == "----  ");
+}
+
+#pragma endregion
+
+// NOLINTEND(readability-function-cognitive-complexity,
+// readability-function-size)

--- a/tests/iou_loop_test.cpp
+++ b/tests/iou_loop_test.cpp
@@ -17,6 +17,7 @@
 #include "../corvid/proto/io_uring/iou_loop.h"
 #include "../corvid/filesys/net_socket.h"
 #include "../corvid/enums/enum_conversion.h"
+#include "../corvid/meta/pragmas.h"
 
 #include <atomic>
 #include <chrono>
@@ -32,6 +33,13 @@
 using namespace corvid;
 using namespace corvid::filesys;
 using namespace corvid::iouring;
+
+// The `bound_*` helpers derive from a CRTP `address_forwarder` base, so
+// designated-initializing them (`bound_timeout{.when = ...}`) leaves the base
+// value-initialized. gcc reports that base as a missing field initializer;
+// clang does not. The base is correctly value-initialized, so silence it on
+// gcc for this test.
+PRAGMA_GCC_IGNORED("-Wmissing-field-initializers")
 using namespace std::chrono_literals;
 
 namespace {

--- a/tests/meta_test.cpp
+++ b/tests/meta_test.cpp
@@ -774,10 +774,10 @@ TEST_CASE("SelfAssign", "[AddressForwarder]") {
   a.forwarding_address() = &ptr;
 
   // Self-assignment must not corrupt state.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wself-move"
+  PRAGMA_DIAG(push)
+  PRAGMA_IGNORED("-Wself-move")
   a = std::move(a);
-#pragma clang diagnostic pop
+  PRAGMA_DIAG(pop)
   // After self-move `ptr` still points to `a`.
   CHECK(ptr == &a);
 }

--- a/tests/osfile_tests.cpp
+++ b/tests/osfile_tests.cpp
@@ -25,6 +25,7 @@
 #include "catch2_main.h"
 
 #include <cstdlib>
+#include <format>
 #include <fcntl.h>
 #include <string_view>
 #include <unistd.h>
@@ -420,6 +421,49 @@ TEST_CASE("MmapMaskString", "[OsFile]") {
     CHECK((parse_enum("hugetlb + growsdown", bad)) ==
           (M::hugetlb | M::growsdown));
   }
+}
+
+TEST_CASE("Formatter", "[OsFile]") {
+  // An open file renders as `fd=<handle>`, a closed one as `fd=closed`. Open
+  // files adopt a sentinel handle we never owned and release it before
+  // destruction so no real fd is touched; closed temporaries hold -1.
+  os_file open_file{42};
+  CHECK(std::format("{}", open_file) == "fd=42");
+  (void)open_file.release();
+  CHECK(std::format("{}", os_file{}) == "fd=closed");
+
+  // Width, fill, and align come from the spec and pad the whole rendering.
+  os_file seven{7};
+  CHECK(std::format("{:>8}", seven) == "    fd=7");
+  CHECK(std::format("{:*<8}", seven) == "fd=7****");
+  (void)seven.release();
+
+  // Width is a minimum: a field narrower than the content is a no-op.
+  CHECK(std::format("{:>4}", os_file{}) == "fd=closed");
+
+  // Precision truncates the rendered text (string-formatter semantics).
+  os_file big{12345};
+  CHECK(std::format("{:.2}", big) == "fd");
+  CHECK(std::format("{:.5}", big) == "fd=12");
+  (void)big.release();
+
+  // Dynamic width resolves whether the arg is automatic `{}` or a manual id.
+  os_file dyn{7};
+  CHECK(std::format("{:>{}}", dyn, 8) == "    fd=7");
+  CHECK(std::format("{0:>{1}}", dyn, 8) == "    fd=7");
+  (void)dyn.release();
+  CHECK(std::format("{:>{}}", os_file{}, 11) == "  fd=closed");
+
+  // Dynamic precision resolves the same way.
+  os_file dp{12345};
+  CHECK(std::format("{:.{}}", dp, 4) == "fd=1");
+  (void)dp.release();
+
+  // Code-unit-generic: the same wrapper formats under wide formatting.
+  os_file wide{9};
+  CHECK(std::format(L"{}", wide) == L"fd=9");
+  (void)wide.release();
+  CHECK(std::format(L"{:>11}", os_file{}) == L"  fd=closed");
 }
 
 #pragma endregion

--- a/tests/osfile_tests.cpp
+++ b/tests/osfile_tests.cpp
@@ -424,46 +424,40 @@ TEST_CASE("MmapMaskString", "[OsFile]") {
 }
 
 TEST_CASE("Formatter", "[OsFile]") {
-  // An open file renders as `fd=<handle>`, a closed one as `fd=closed`. Open
-  // files adopt a sentinel handle we never owned and release it before
-  // destruction so no real fd is touched; closed temporaries hold -1.
+  // An open file forwards its handle to the int formatter, a closed one
+  // renders the `(closed)` sentinel. Open files adopt a sentinel handle we
+  // never owned and release it before destruction so no real fd is touched;
+  // closed temporaries hold -1.
   os_file open_file{42};
-  CHECK(std::format("{}", open_file) == "fd=42");
+  CHECK(std::format("{}", open_file) == "42");
   (void)open_file.release();
-  CHECK(std::format("{}", os_file{}) == "fd=closed");
+  CHECK(std::format("{}", os_file{}) == "(closed)");
 
-  // Width, fill, and align come from the spec and pad the whole rendering.
+  // Width, fill, and align come from the spec. The handle formats as an int,
+  // so it right-aligns by default.
   os_file seven{7};
-  CHECK(std::format("{:>8}", seven) == "    fd=7");
-  CHECK(std::format("{:*<8}", seven) == "fd=7****");
+  CHECK(std::format("{:>8}", seven) == "       7");
+  CHECK(std::format("{:*<8}", seven) == "7*******");
   (void)seven.release();
 
-  // Width is a minimum: a field narrower than the content is a no-op.
-  CHECK(std::format("{:>4}", os_file{}) == "fd=closed");
+  // The sentinel honors width and align; width is a minimum, so a field
+  // narrower than the sentinel is a no-op.
+  CHECK(std::format("{:>11}", os_file{}) == "   (closed)");
+  CHECK(std::format("{:>4}", os_file{}) == "(closed)");
 
-  // Precision truncates the rendered text (string-formatter semantics).
-  os_file big{12345};
-  CHECK(std::format("{:.2}", big) == "fd");
-  CHECK(std::format("{:.5}", big) == "fd=12");
-  (void)big.release();
-
-  // Dynamic width resolves whether the arg is automatic `{}` or a manual id.
+  // Dynamic width resolves whether the arg is automatic `{}` or a manual id,
+  // for both the handle and the sentinel.
   os_file dyn{7};
-  CHECK(std::format("{:>{}}", dyn, 8) == "    fd=7");
-  CHECK(std::format("{0:>{1}}", dyn, 8) == "    fd=7");
+  CHECK(std::format("{:>{}}", dyn, 8) == "       7");
+  CHECK(std::format("{0:>{1}}", dyn, 8) == "       7");
   (void)dyn.release();
-  CHECK(std::format("{:>{}}", os_file{}, 11) == "  fd=closed");
-
-  // Dynamic precision resolves the same way.
-  os_file dp{12345};
-  CHECK(std::format("{:.{}}", dp, 4) == "fd=1");
-  (void)dp.release();
+  CHECK(std::format("{:>{}}", os_file{}, 11) == "   (closed)");
 
   // Code-unit-generic: the same wrapper formats under wide formatting.
   os_file wide{9};
-  CHECK(std::format(L"{}", wide) == L"fd=9");
+  CHECK(std::format(L"{}", wide) == L"9");
   (void)wide.release();
-  CHECK(std::format(L"{:>11}", os_file{}) == L"  fd=closed");
+  CHECK(std::format(L"{:>11}", os_file{}) == L"   (closed)");
 }
 
 #pragma endregion

--- a/tests/string_view_wrapper_test.cpp
+++ b/tests/string_view_wrapper_test.cpp
@@ -25,6 +25,8 @@
 
 using namespace corvid;
 using namespace corvid::literals;
+using namespace std::string_literals;
+using namespace std::string_view_literals;
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
@@ -72,7 +74,7 @@ TEST_CASE("Null marker honors fill, align, and width",
   }
 }
 
-TEST_CASE("Dynamic width is fine without debug, rejected with it",
+TEST_CASE("Dynamic width works with and without the debug spec",
     "[StringViewWrapperTest]") {
   if (true) {
     // Without debug, the base handles dynamic width for both content and the
@@ -80,17 +82,15 @@ TEST_CASE("Dynamic width is fine without debug, rejected with it",
     CHECK(std::format("{:{}}", "hi"_optsv, 5) == "hi   ");
     CHECK(std::format("{:>{}}", 0_optsv, 5) == "     ");
 
-    // With the debug spec, the null marker cannot read an arg bound to the
-    // real context, so the spec is rejected outright, the same for null and
-    // non-null. A literal would fail at compile time, so reach the throw via a
-    // runtime format string.
+    // With debug, the null marker resolves its own dynamic width and the
+    // present value goes through the base. Reached via a runtime format string
+    // (vformat) to exercise the runtime parse path on its own.
     auto nul = 0_optsv;
     auto present = "hi"_optsv;
-    int w = 5;
-    CHECK_THROWS_AS(std::vformat("{:{}?}", std::make_format_args(nul, w)),
-        std::format_error);
-    CHECK_THROWS_AS(std::vformat("{:{}?}", std::make_format_args(present, w)),
-        std::format_error);
+    int w = 8;
+    CHECK(std::vformat("{:{}?}", std::make_format_args(nul, w)) == "(null)  ");
+    CHECK(std::vformat("{:{}?}", std::make_format_args(present, w)) ==
+          R"("hi"    )");
   }
 }
 
@@ -123,6 +123,176 @@ TEST_CASE("Wide formatting widens the content", "[StringViewWrapperTest]") {
     opt_wstring_view wnull{};
     CHECK(std::format(L"{:?}", wnull) == L"(null)");
     CHECK(std::format(L"{:>10?}", wnull) == L"    (null)");
+  }
+}
+
+// The blocks below frame the subject between other fields that consume their
+// own (sometimes dynamic) width/precision args, so a miscounted arg id on the
+// subject would shift the trailing field and show up in the output. Each
+// present-value check is run for both `opt_string_view` and
+// `std::string_view`, which must agree; only the null cases are wrapper-only.
+// Surrounding fields use strings and ints, not floats, to keep expected output
+// exact.
+
+TEST_CASE("Static width and precision, framed, match std::string_view",
+    "[StringViewWrapperTest]") {
+  if (true) {
+    const auto opt = "hello"_optsv;
+    const auto sv = "hello"sv;
+
+    // No spec; width as a minimum (a too-small width is a no-op); alignment.
+    CHECK(std::format("{:2}[{}]{:<2}", "X", opt, "Y") == "X [hello]Y ");
+    CHECK(std::format("{:2}[{}]{:<2}", "X", sv, "Y") == "X [hello]Y ");
+    CHECK(std::format("{:2}[{:2}]{:<2}", "X", opt, "Y") == "X [hello]Y ");
+    CHECK(std::format("{:2}[{:2}]{:<2}", "X", sv, "Y") == "X [hello]Y ");
+    CHECK(std::format("{:2}[{:8}]{:<2}", "X", opt, "Y") == "X [hello   ]Y ");
+    CHECK(std::format("{:2}[{:8}]{:<2}", "X", sv, "Y") == "X [hello   ]Y ");
+    CHECK(std::format("{:2}[{:>8}]{:<2}", "X", opt, "Y") == "X [   hello]Y ");
+    CHECK(std::format("{:2}[{:>8}]{:<2}", "X", sv, "Y") == "X [   hello]Y ");
+
+    // Precision truncates; precision 0; precision past the end; with width.
+    CHECK(std::format("{:2}[{:.3}]{:<2}", "X", opt, "Y") == "X [hel]Y ");
+    CHECK(std::format("{:2}[{:.3}]{:<2}", "X", sv, "Y") == "X [hel]Y ");
+    CHECK(std::format("{:2}[{:.0}]{:<2}", "X", opt, "Y") == "X []Y ");
+    CHECK(std::format("{:2}[{:.0}]{:<2}", "X", sv, "Y") == "X []Y ");
+    CHECK(std::format("{:2}[{:.9}]{:<2}", "X", opt, "Y") == "X [hello]Y ");
+    CHECK(std::format("{:2}[{:.9}]{:<2}", "X", sv, "Y") == "X [hello]Y ");
+    CHECK(std::format("{:2}[{:8.3}]{:<2}", "X", opt, "Y") == "X [hel     ]Y ");
+    CHECK(std::format("{:2}[{:8.3}]{:<2}", "X", sv, "Y") == "X [hel     ]Y ");
+    CHECK(
+        std::format("{:2}[{:>8.3}]{:<2}", "X", opt, "Y") == "X [     hel]Y ");
+    CHECK(std::format("{:2}[{:>8.3}]{:<2}", "X", sv, "Y") == "X [     hel]Y ");
+  }
+}
+
+TEST_CASE("Dynamic width and precision, framed, match std::string_view",
+    "[StringViewWrapperTest]") {
+  if (true) {
+    const auto opt = "hello"_optsv;
+    const auto sv = "hello"sv;
+
+    // Dynamic width on the subject, framed by a dynamic width before and a
+    // dynamic precision after.
+    CHECK(std::format("{:{}}[{:{}}]{:.{}}", "X", 2, opt, 8, "Yo", 1) ==
+          "X [hello   ]Y");
+    CHECK(std::format("{:{}}[{:{}}]{:.{}}", "X", 2, sv, 8, "Yo", 1) ==
+          "X [hello   ]Y");
+
+    // Dynamic precision on the subject.
+    CHECK(std::format("{:{}}[{:.{}}]{:.{}}", "X", 2, opt, 3, "Yo", 1) ==
+          "X [hel]Y");
+    CHECK(std::format("{:{}}[{:.{}}]{:.{}}", "X", 2, sv, 3, "Yo", 1) ==
+          "X [hel]Y");
+
+    // Dynamic width and precision on the subject.
+    CHECK(std::format("{:{}}[{:{}.{}}]{:.{}}", "X", 2, opt, 8, 3, "Yo", 1) ==
+          "X [hel     ]Y");
+    CHECK(std::format("{:{}}[{:{}.{}}]{:.{}}", "X", 2, sv, 8, 3, "Yo", 1) ==
+          "X [hel     ]Y");
+
+    // Mixed: static width with dynamic precision, then the reverse.
+    CHECK(std::format("{:{}}[{:8.{}}]{:.{}}", "X", 2, opt, 3, "Yo", 1) ==
+          "X [hel     ]Y");
+    CHECK(std::format("{:{}}[{:8.{}}]{:.{}}", "X", 2, sv, 3, "Yo", 1) ==
+          "X [hel     ]Y");
+    CHECK(std::format("{:{}}[{:{}.3}]{:.{}}", "X", 2, opt, 8, "Yo", 1) ==
+          "X [hel     ]Y");
+    CHECK(std::format("{:{}}[{:{}.3}]{:.{}}", "X", 2, sv, 8, "Yo", 1) ==
+          "X [hel     ]Y");
+
+    // Manual indexing, subject in the middle.
+    CHECK(std::format("{0:{1}}[{2:{3}.{4}}]{5:.{6}}", "X", 2, opt, 8, 3, "Yo",
+              1) == "X [hel     ]Y");
+    CHECK(std::format("{0:{1}}[{2:{3}.{4}}]{5:.{6}}", "X", 2, sv, 8, 3, "Yo",
+              1) == "X [hel     ]Y");
+  }
+}
+
+TEST_CASE("Null under a plain spec renders empty like an empty view, framed",
+    "[StringViewWrapperTest]") {
+  if (true) {
+    const auto nul = 0_optsv;
+    const std::string_view empty{};
+
+    CHECK(std::format("[{}]", nul) == std::format("[{}]", empty));
+    CHECK(std::format("[{}]", nul) == "[]");
+    CHECK(std::format("[{:5}]", nul) == std::format("[{:5}]", empty));
+    CHECK(std::format("[{:5}]", nul) == "[     ]");
+    CHECK(std::format("[{:>5}]", nul) == "[     ]");
+    CHECK(std::format("[{:.3}]", nul) == "[]");
+    CHECK(std::format("[{:5.3}]", nul) == "[     ]");
+
+    // A transparent null routes through the base, so even a dynamic width
+    // works today; framed to confirm the trailing field is unshifted.
+    CHECK(std::format("{:{}}[{:{}}]{:.{}}", "X", 2, nul, 5, "Yo", 1) ==
+          "X [     ]Y");
+    CHECK(std::format("{:{}}[{:{}}]{:.{}}", "X", 2, empty, 5, "Yo", 1) ==
+          "X [     ]Y");
+  }
+}
+
+TEST_CASE("Null marker honors fill, align, and static width, framed",
+    "[StringViewWrapperTest]") {
+  if (true) {
+    const auto nul = 0_optsv;
+
+    CHECK(std::format("{:2}[{:?}]{:<2}", "X", nul, "Y") == "X [(null)]Y ");
+    CHECK(
+        std::format("{:2}[{:10?}]{:<2}", "X", nul, "Y") == "X [(null)    ]Y ");
+    CHECK(std::format("{:2}[{:>10?}]{:<2}", "X", nul, "Y") ==
+          "X [    (null)]Y ");
+    CHECK(std::format("{:2}[{:*^10?}]{:<2}", "X", nul, "Y") ==
+          "X [**(null)**]Y ");
+  }
+}
+
+TEST_CASE("Empty-present differs from null under the debug spec",
+    "[StringViewWrapperTest]") {
+  if (true) {
+    const auto empty = ""_optsv; // present, zero-length
+    const auto nul = 0_optsv;    // absent
+
+    // Plain: both render empty.
+    CHECK(std::format("[{}]", empty) == "[]");
+    CHECK(std::format("[{}]", nul) == "[]");
+
+    // Debug: a present empty quotes to "", a null shows the marker.
+    CHECK(std::format("[{:?}]", empty) == R"([""])");
+    CHECK(std::format("[{:?}]", nul) == "[(null)]");
+
+    // Static width reaches both, padding different content.
+    CHECK(std::format("[{:6?}]", empty) == R"([""    ])");
+    CHECK(std::format("[{:6?}]", nul) == "[(null)]");
+  }
+}
+
+// Dynamic width on the null marker, resolved via the synthetic parse-context
+// trick (plan_dynamic_format_spec). Auto `{}` claims the arg id from the parse
+// context; manual `{n}` reads it from the spec. The framed cases prove the
+// claim does not shift a trailing field's arg.
+TEST_CASE("Null marker honors DYNAMIC width under the debug spec",
+    "[StringViewWrapperTest]") {
+  if (true) {
+    const auto nul = 0_optsv;
+
+    // Auto-indexed dynamic width, alone, with fill and alignment.
+    CHECK(std::format("{:{}?}", nul, 10) == "(null)    ");
+    CHECK(std::format("{:>{}?}", nul, 10) == "    (null)");
+    CHECK(std::format("{:*^{}?}", nul, 10) == "**(null)**");
+
+    // Manual-indexed dynamic width.
+    CHECK(std::format("{0:{1}?}", nul, 10) == "(null)    ");
+
+    // Framed: the trailing field must still read its own arg, proving the
+    // marker's arg-id claim did not shift the count. Auto, then manual.
+    CHECK(std::format("{:{}}[{:{}?}]{:.{}}", "X", 2, nul, 10, "Yo", 1) ==
+          "X [(null)    ]Y");
+    CHECK(std::format("{0:{1}}[{2:{3}?}]{4:.{5}}", "X", 2, nul, 10, "Yo", 1) ==
+          "X [(null)    ]Y");
+
+    // Code-unit generic.
+    const opt_wstring_view wnul{};
+    CHECK(std::format(L"{:{}?}", wnul, 10) == L"(null)    ");
   }
 }
 

--- a/tests/strings_test.cpp
+++ b/tests/strings_test.cpp
@@ -1481,52 +1481,6 @@ TEST_CASE("ParseNum", "[StringUtilsTest]") {
 }
 
 #pragma endregion
-#pragma region ParseInt
-
-TEST_CASE("ParseInt", "[StringUtilsTest]") {
-  // `parse_int` is consteval, so every call must be a constant expression.
-  if (true) {
-    // Decimal parsing of positive values.
-    static_assert(strings::parse_int<int>("0") == 0);
-    static_assert(strings::parse_int<int>("7") == 7);
-    static_assert(strings::parse_int<int>("123") == 123);
-    static_assert(strings::parse_int<int>("2147483647") == 2147483647);
-  }
-  if (true) {
-    // Negative values are accepted for signed types.
-    static_assert(strings::parse_int<int>("-1") == -1);
-    static_assert(strings::parse_int<int>("-123") == -123);
-    // The most-negative value is representable even though its magnitude
-    // exceeds the positive maximum.
-    static_assert(strings::parse_int<int>("-2147483648") == -2147483647 - 1);
-    static_assert(strings::parse_int<int8_t>("-128") == int8_t{-128});
-  }
-  if (true) {
-    // Negative values are rejected for unsigned types.
-    static_assert(strings::parse_int<unsigned>("-1") == std::nullopt);
-    static_assert(strings::parse_int<unsigned>("42") == 42u);
-  }
-  if (true) {
-    // Empty input, a lone sign, and non-digit characters all fail.
-    static_assert(strings::parse_int<int>("") == std::nullopt);
-    static_assert(strings::parse_int<int>("-") == std::nullopt);
-    static_assert(strings::parse_int<int>("abc") == std::nullopt);
-    static_assert(strings::parse_int<int>("12a") == std::nullopt);
-    static_assert(strings::parse_int<int>("1 2") == std::nullopt);
-    static_assert(strings::parse_int<int>("+5") == std::nullopt);
-  }
-  if (true) {
-    // Works with other integral widths.
-    static_assert(
-        strings::parse_int<int64_t>("9223372036854775807") ==
-        9223372036854775807LL);
-    static_assert(strings::parse_int<uint8_t>("255") == uint8_t{255});
-  }
-  // A runtime CHECK keeps the case visible in the test report.
-  CHECK(strings::parse_int<int>("123") == 123);
-}
-
-#pragma endregion
 #pragma region AppendNum
 
 TEST_CASE("AppendNum", "[StringUtilsTest]") {

--- a/wsl-instructions.md
+++ b/wsl-instructions.md
@@ -31,4 +31,4 @@ sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-16 100 \
 --slave /usr/bin/g++ g++ /usr/bin/g++-16
 ```
 9. In the repo, run `code .`, which brings up VSCode remotely.
-10. Run `./cleanbuild.sh tidy` to build the tests with clang-tidy enabled. You can specify `libstdcpp` or `libcxx` as the first argument to choose the standard library.
+10. Run `./cleanbuild.sh tidy` to build the tests with clang-tidy enabled. See usage for how to select compiler and standard library.

--- a/wsl-instructions.md
+++ b/wsl-instructions.md
@@ -21,5 +21,14 @@ sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-22 100 \
 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-22
 sudo apt install -y catch22 ccache strace
 ```
-8. In the repo, run `code .`, which brings up VSCode remotely.
-9. Run `./cleanbuild.sh tidy` to build the tests with clang-tidy enabled. You can specify `libstdcpp` or `libcxx` as the first argument to choose the standard library.
+8. Install the latest GCC for its libstdc++.
+```
+sudo apt install -y software-properties-common
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+sudo apt update
+sudo apt install -y gcc-16 g++-16 libstdc++-16-dev
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-16 100 \
+--slave /usr/bin/g++ g++ /usr/bin/g++-16
+```
+9. In the repo, run `code .`, which brings up VSCode remotely.
+10. Run `./cleanbuild.sh tidy` to build the tests with clang-tidy enabled. You can specify `libstdcpp` or `libcxx` as the first argument to choose the standard library.


### PR DESCRIPTION
## Summary

Extracts the repeating `std::formatter` shapes in the library into a small set
of reusable bases (`corvid/meta/formatting.h`), migrates the existing
hand-written formatters onto them, and upgrades the enum formatter to parse the
full standard spec (fill/align/width/precision). Alongside that: a
behavior-neutral `#pragma region` organization pass over the headers, plus a
handful of GCC/libstdc++ build-compatibility fixes.

## Formatter bases (new `corvid/meta/formatting.h`)

- `parsed_spec` / `spec_parser` - parse the standard format mini-language (fill,
  align, sign, `#`, `0`, width, precision, `L`, type/`?`), including dynamic
  width/precision (`{}` auto and `{n}` manual), with padding/truncation helpers
  (`write_padded`, etc.).
- `forwarding_formatter<U>` - format a wrapper exactly as its underlying `U`
  (inherits `std::formatter<U>`, so the full grammar including `?` debug).
- `nullable_formatter<U, ...>` - pointer-like wrapper: forwards `*w` to `U`'s
  formatter when present, and renders a sentinel (default `(null)`) or an empty
  field when null. `null_formatting` selects which, independently for the plain
  and `?` specs.
- `self_rendering_formatter` - for a type that renders itself through a
  `format_to(out)` / `format_to_spec(spec, out)` member.

Each collapses a per-type specialization to a one-line `: base {}`.

## Formatters migrated onto the bases

- `strong_type` -> `forwarding_formatter`.
- `custom_handle` -> `nullable_formatter<T>` (`operator*` adjusted to return
  `element_type` so the base can dereference it).
- `string_view_wrapper` family (opt_string_view, cstring_view, enum_name) ->
  `nullable_formatter<basic_string_view<CharT>, null_formatting::empty>`.
- `os_file` -> `nullable_formatter<int>` with a `(closed)` sentinel.

## Enum formatter upgrade

Rewrote `std::formatter` for registered enums to parse the full spec and honor
fill/align/width/precision (previously only the empty spec and `?` were
accepted):

- No width/precision: streams straight to the output, no intermediate string
  (unchanged fast path).
- A named sequence value pads its stored name view in place (no buffer); a
  bitmask combination, a numeric fallback, or the `?` debug spec render into a
  small buffer first.
- The numeric fallback (unnamed sequence value -> decimal; bitmask residual
  bits -> hex) is the integer's plain default rendering. Sign/`#`/zero-pad/
  locale/non-`?` type are rejected, since they do not apply to a name; to
  format the number with numeric options, format the underlying value via
  `operator*`.

## Behavior changes (heads up)

- `os_file`: an open file now formats as its bare handle (via the `int`
  formatter, so it right-aligns by default), a closed one as `(closed)` -
  previously `fd=<n>` / `fd=closed` via a self-rendering path. Precision no
  longer applies (the `int` formatter has none).
- Registered enums now honor fill/align/width/precision instead of rejecting
  them.

## Organization + build compatibility

- Codebase-wide `#pragma region`/`#pragma endregion` structure across the
  headers. Compiler-ignored, so behavior-neutral.
- Portable diagnostic pragmas: `quic_conn` / `http3_conn` swap clang-only
  `#pragma clang diagnostic` for the `PRAGMA_*` macros and add GCC's
  `-Wmissing-field-initializers` suppression.
- `archetype_scene`: factored a `some_component_ptr` helper out of a lambda gcc
  cannot pack-expand.
- CMake: stop treating GCC `-O3` false-positive `-Wmaybe-uninitialized` /
  `-Warray-bounds` (raised inside libstdc++/Catch2, not Corvid) as errors.
- Consolidated the bespoke consteval `parse_int` into the existing `parse_num`
  at its one call site (`sequence_enum`), removing `parse_int` and its tests.

## Tests

- New `tests/formatting_test.cpp` covering `spec_parser`,
  `forwarding_formatter`, `nullable_formatter`, and `self_rendering_formatter`.
- Expanded `enum_formatter_test`, `osfile_tests`, and
  `string_view_wrapper_test` for the new spec handling and sentinels.

## Test plan

- Verified this session: `./cleanbuild.sh enum_formatter_test.cpp` and
  `./cleanbuild.sh osfile_tests.cpp` pass (narrow + wide).
- Full suite: `./cleanbuild.sh` (the standard pre-merge clean build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
