### PR TITLE
Enum hardening: exact wrap math, named-enum concept, hex parsing; incremental cleanbuild

### DIFF
--- a/.claude/skills/build-and-test/SKILL.md
+++ b/.claude/skills/build-and-test/SKILL.md
@@ -14,7 +14,9 @@ lives in `tests/` only; there is no root one. Build output lands in
 ## Commands
 
 ```sh
-./cleanbuild.sh                  # clean build + run all tests (libc++)
+./cleanbuild.sh                  # build + run all tests (libc++); incremental
+                                 # when the configuration is unchanged
+./cleanbuild.sh clean            # force a wipe + full recompile
 ./cleanbuild.sh libstdcpp        # use libstdc++
 ./cleanbuild.sh tidy             # also run clang-tidy
 ./cleanbuild.sh asan             # build + run with ASAN + UBSAN

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ When a function can fail, prefer returning a status over `void`. See [error-hand
 
 ## Build System
 
-Build and run one test with `./cleanbuild.sh/.ps1 <name>_test.cpp` (the common case; the arg is the test source filename), or `./cleanbuild.sh/.ps1` for a clean build of the whole suite. Never hand-run cmake/ninja in `tests/build/` (stale dir breaks FetchContent). Run `./format_all.sh/.ps1` before committing. See the `build-and-test` skill for the full menu (libstdc++, clang-tidy, sanitizers, MSAN setup) and the Catch2 test-writing conventions.
+Build and run one test with `./cleanbuild.sh/.ps1 <name>_test.cpp` (the common case; the arg is the test source filename), or `./cleanbuild.sh/.ps1` for the whole suite (incremental when the configuration is unchanged; add `clean` to force a full rebuild). Never hand-run cmake/ninja in `tests/build/` (stale dir breaks FetchContent). Run `./format_all.sh/.ps1` before committing. See the `build-and-test` skill for the full menu (libstdc++, clang-tidy, sanitizers, MSAN setup) and the Catch2 test-writing conventions.
 
 ## Code Style
 

--- a/TODO
+++ b/TODO
@@ -171,3 +171,27 @@ Tooling improvements.
 10. Similarly, integrate CTrack for a different approach to timing.
 11. Install `rr`, for replay debugging
 
+-----
+
+Project ideas (2026-07-07). Larger arcs, not single fixes. Ordered roughly by appeal.
+
+P1. WebTransport over HTTP/3. The QUIC/HTTP/3 stack (proto/quic/roadmap.md) is done through a live HTTP/3 GET over the router, and quic_conn_handlers already wires on_recv_datagram / on_ack_datagram / on_lost_datagram with no consumer. WebTransport is the layer that consumes them: extended CONNECT, session negotiation (SETTINGS_WT_*), capsule protocol, session-scoped streams and datagrams. Same wrapping discipline as the ngtcp2/nghttp3 work. Payoff: Chrome speaks WebTransport natively, so the demo is a browser talking to our server with no JS library.
+
+P2. Revive CorvidSim on WebTransport. The tower-defense sim (sim/roadmap.md) has its combat loop stubbed behind `#if 0` (damage, kills, cooldowns, economy). Swap its WebSocket transport for WebTransport datagrams (unreliable state deltas) plus streams (reliable control). Natural second act to P1; also exercises the ECS.
+
+P3. QUIC connection migration + CID rotation. The one [planned] transport milestone in proto/quic/roadmap.md: NEW_CONNECTION_ID / RETIRE_CONNECTION_ID, path validation tokens, stateless reset, 4-tuple migration. Exercises the router's multi-key sessions under load, and forces the deferred interop test against `curl --http3` (which in turn forces the client cert-verification decision).
+
+P4. Native-Windows networking substrate. proto/ is Linux-only (epoll, io_uring), but ngtcp2/nghttp3/OpenSSL are portable; only the datagram substrate is not. An IOCP / overlapped-UDP backend behind the existing iou_dgram_router plugin seam would let QUIC (and P1) run natively on Windows.
+
+P5. corvid_assert / contract-violation framework: item 32 above. Unblocks the commented-out precondition tests and dovetails with error-handling-policy.md category 2.
+
+P6. Fuzzing: tooling item 3 above. Corvid is unusually fuzz-rich; harness candidates are json_parser, http_head_codec, the WebSocket frame parser, terminated_text_parser, base64, utf8_checker, and QUIC packet/CID parsing.
+
+P7. Bitmask-enum round 2: items 18c (binary printer), 18d (string-to-bitmask parser with a compile-time sorted name map), and 18f (some()/all() comparators) above, as one project.
+
+P8. Formatter forwarding helper. strings/roadmap.md stage 2 is paused on exactly this: a CRTP base or generator that turns "inherit and forward to the underlying type's formatter" into a one-line declaration, plus factoring the format_kind-disabling pattern. Then knock out the deferred tail (enum_variant, os_file, ...).
+
+P9. ECS scene graph. ecs/roadmap.md next-steps item 1 is already designed: scene_graph of scene_node objects holding generation-checked entity handles, JIT pruning of stale nodes, cascading deletion, optional tree-authoritative lifetime. First consumer could be P2.
+
+P10. PID auto-tuner: item 22 above. Self-contained and numerically fun; thematically adjacent to the game's flight-assist brake controller.
+

--- a/cleanbuild.ps1
+++ b/cleanbuild.ps1
@@ -1,6 +1,8 @@
 # cleanbuild.ps1 - Windows build driver for the portable and CUDA test
-# buckets. Mirrors cleanbuild.sh's role on Linux: configure a fresh, optimized
-# (release) build against the MSVC STL and run ctest. Like the Linux clang/gcc
+# buckets. Mirrors cleanbuild.sh's role on Linux: configure an optimized
+# (release) build against the MSVC STL and run ctest. The build is incremental
+# when the configuration is unchanged; pass `clean` to force a fresh configure
+# and full recompile. Like the Linux clang/gcc
 # split, the compiler is selectable: clang++ (default) or MSVC cl. clang++ uses
 # a GNU-style driver targeting the MSVC ABI (the same driver as Linux clang),
 # and is also what compiles the CUDA bucket. ASAN is supported under clang++,
@@ -18,6 +20,8 @@
 #
 # Usage (args combine in any order):
 #   ./cleanbuild.ps1                     clang++, portable + CUDA suite, ctest
+#                                        (incremental when config is unchanged)
+#   ./cleanbuild.ps1 clean               force a fresh configure + full recompile
 #   ./cleanbuild.ps1 reconfigure         configure-only full refresh of tests/build
 #                                        (regenerates compile_commands.json for clangd)
 #   ./cleanbuild.ps1 strings_test.cpp    build and run just that one test
@@ -41,13 +45,15 @@ $clangXx = "$llvmRoot/bin/clang++.exe"
 
 # Parse args: a *.cpp or *.cu name selects one test; clang|cl picks the
 # compiler; asan picks the sanitizer; tidy runs clang-tidy during the build;
-# cudacheck runs the CUDA tests under compute-sanitizer (the device analog of asan).
+# cudacheck runs the CUDA tests under compute-sanitizer (the device analog of
+# asan); clean forces a fresh configure and full recompile.
 $testName = ''
 $compiler = 'clang'
 $sanitizer = ''
 $cudacheck = $false
 $tidy = $false
 $reconfigure = $false
+$clean = $false
 foreach ($a in $Rest) {
   switch -Regex ($a) {
     '\.(cpp|cu)$' { $testName = $a }
@@ -57,7 +63,8 @@ foreach ($a in $Rest) {
     '^cudacheck$' { $cudacheck = $true }
     '^(tidy|--tidy)$' { $tidy = $true }
     '^reconfigure$' { $reconfigure = $true }
-    default { throw "Unrecognized argument '$a' (expected <name>_test.cpp, <name>_test.cu, clang|cl, asan, tidy, cudacheck, or reconfigure)" }
+    '^clean$' { $clean = $true }
+    default { throw "Unrecognized argument '$a' (expected <name>_test.cpp, <name>_test.cu, clang|cl, asan, tidy, cudacheck, clean, or reconfigure)" }
   }
 }
 if ($sanitizer -and $compiler -eq 'cl') {
@@ -79,7 +86,7 @@ if ($tidy -and ($sanitizer -or $cudacheck)) {
 }
 # reconfigure is a configure-only full refresh of tests/build (for clangd's
 # compile_commands.json); it builds nothing and takes no other mode.
-if ($reconfigure -and ($testName -or $sanitizer -or $cudacheck -or $tidy -or ($compiler -eq 'cl'))) {
+if ($reconfigure -and ($testName -or $sanitizer -or $cudacheck -or $tidy -or $clean -or ($compiler -eq 'cl'))) {
   throw 'reconfigure is a standalone configure-only refresh; it takes no test name, compiler, or analysis mode.'
 }
 
@@ -137,6 +144,21 @@ if ($cudacheck -and -not $cudaArgs) {
   throw 'cudacheck needs the CUDA toolkit (nvcc + a GPU) in the default clang++ build.'
 }
 
+# A named test scopes the build (--target) and the run (ctest -R), not the
+# configure: the full configure is a strict superset (TEST_NAME only prunes
+# targets), so leaving it out of the configure args lets single-test and
+# full-suite runs share one signature and one object cache, and keeps
+# compile_commands.json complete for clangd. Validate the filename here so a
+# typo gets a clear error rather than ninja's "unknown target".
+$stem = ''
+if ($testName) {
+  $buckets = @('portable', 'windows', 'cuda', 'cuda/windows')
+  if (-not ($buckets | Where-Object { Test-Path (Join-Path $srcDir "$_/$testName") })) {
+    throw "test source '$testName' not found under tests/ ($($buckets -join ', '))"
+  }
+  $stem = [IO.Path]::GetFileNameWithoutExtension($testName)
+}
+
 # Configure fresh. `cmake --fresh` clears the cache and CMakeFiles/ and
 # reconfigures in place WITHOUT deleting tests/build - on Windows clangd keeps an
 # open handle to compile_commands.json, which would block a directory wipe (a
@@ -147,7 +169,6 @@ if ($cudacheck -and -not $cudaArgs) {
 # path).
 $cfg = @('--fresh', '-S', $srcDir, '-B', $bldDir, '-G', 'Ninja',
   "-DCMAKE_CXX_COMPILER=$cxx", '-DCMAKE_BUILD_TYPE=Release')
-if ($testName) { $cfg += "-DTEST_NAME=$testName" }
 if ($sanitizer) { $cfg += "-DSANITIZER=$sanitizer" }
 if ($tidy) {
   $clangTidy = "$llvmRoot/bin/clang-tidy.exe"
@@ -170,25 +191,32 @@ $cfgLabel = if ($tidy) { 'Release, asserts-live' } else { 'Release' }
 Write-Host "Compiler: $compiler   Mode: $mode ($cfgLabel)$(if ($testName) { "   Test: $testName" })"
 
 # Signature of everything that determines the configuration (the configure args
-# themselves). When a single-file build is requested and the build dir already
-# carries a matching signature, the configuration cannot have changed, so skip
-# the cold reconfigure (the ~20s of nvcc/find_package probing that would only
-# reproduce identical build files) and rebuild just that target. A full build, a
-# changed option, a different file, or a first run all fall through to configure.
+# themselves). When the build dir already carries a matching signature, the
+# configuration cannot have changed, so skip the cold reconfigure (the ~20s of
+# nvcc/find_package probing that would only reproduce identical build files)
+# and let ninja rebuild incrementally. A changed option, a first run, or an
+# explicit `clean` falls through to the fresh configure, which wipes
+# CMakeFiles/ (where ninja keeps every object file) and so recompiles
+# everything. tidy always takes the fresh path: clang-tidy runs as part of
+# compilation, so an incremental no-op build would analyze nothing and report
+# a falsely clean summary. reconfigure always configures (that is its job).
 # Editing CMakeLists.txt still reconfigures: `cmake --build` re-runs CMake when
 # the lists file is newer than the cache. Mirrors cleanbuild.sh.
 $sigFile = Join-Path $bldDir '.cleanbuild-config'
 $configSig = ($cfg -join '|')
-$reuse = $testName -and (Test-Path $sigFile) -and
+$reuse = -not ($clean -or $tidy -or $reconfigure) -and (Test-Path $sigFile) -and
   (Test-Path (Join-Path $bldDir 'CMakeCache.txt')) -and
   ((Get-Content $sigFile -Raw).Trim() -eq $configSig)
 
 if ($reuse) {
-  Write-Host "Reusing configured build dir for $testName (config unchanged); skipping reconfigure."
-  # "Clean" still means a fresh executable: drop just this target's binary so it
-  # relinks, leaving the cached objects and configuration in place.
-  $stem = [IO.Path]::GetFileNameWithoutExtension($testName)
-  Remove-Item (Join-Path $bldDir "release_bin/$stem.exe") -Force -ErrorAction SilentlyContinue
+  if ($testName) {
+    Write-Host "Reusing configured build dir for $testName (config unchanged); skipping reconfigure."
+    # A named test still gets a fresh executable: drop just this target's binary
+    # so it relinks, leaving the cached objects and configuration in place.
+    Remove-Item (Join-Path $bldDir "release_bin/$stem.exe") -Force -ErrorAction SilentlyContinue
+  } else {
+    Write-Host 'Reusing configured build dir (config unchanged); incremental build.'
+  }
 } else {
   cmake @cfg
   if ($LASTEXITCODE) { throw "configure failed ($LASTEXITCODE)" }
@@ -197,8 +225,7 @@ if ($reuse) {
 }
 
 # reconfigure stops here: the configure above already regenerated a full
-# compile_commands.json (no TEST_NAME filter), which is all clangd needs. No
-# build, no ctest.
+# compile_commands.json, which is all clangd needs. No build, no ctest.
 if ($reconfigure) {
   Write-Host "Reconfigured $bldDir; compile_commands.json refreshed for clangd."
   exit 0
@@ -217,19 +244,21 @@ if ($cudacheck) {
   }
 }
 
-# Build, keep-going so all failures surface in one pass. cudacheck (without a
-# single named test) builds only the cuda targets. tidy tees the build output to
-# a log (clang-tidy warnings stream during compilation) and does NOT throw on a
-# nonzero result: a .clang-tidy WarningsAsErrors fails the build, but we still
-# want to reach the summary, and a real compile break surfaces via ctest below.
+# Build, keep-going so all failures surface in one pass. A named test builds
+# only its target; cudacheck (without a single named test) builds only the cuda
+# targets. tidy tees the build output to a log (clang-tidy warnings stream
+# during compilation) and does NOT throw on a nonzero result: a .clang-tidy
+# WarningsAsErrors fails the build, but we still want to reach the summary, and
+# a real compile break surfaces via ctest below.
 $tidyLog = Join-Path $bldDir 'tidy.log'
+$tgtArgs = if ($testName) { @('--target', $stem) } else { @() }
 if ($tidy) {
-  cmake --build $bldDir -- -k 0 2>&1 | Tee-Object $tidyLog
+  cmake --build $bldDir @tgtArgs -- -k 0 2>&1 | Tee-Object $tidyLog
 } elseif ($cudacheck -and -not $testName) {
   cmake --build $bldDir --target $cudaTests -- -k 0
   if ($LASTEXITCODE) { throw "build failed ($LASTEXITCODE)" }
 } else {
-  cmake --build $bldDir -- -k 0
+  cmake --build $bldDir @tgtArgs -- -k 0
   if ($LASTEXITCODE) { throw "build failed ($LASTEXITCODE)" }
 }
 
@@ -244,9 +273,17 @@ if ($tidy -and $cudaArgs) {
   $db = Join-Path $bldDir 'compile_commands.json'
   $cuSources = @((Get-Content $db -Raw | ConvertFrom-Json) |
     Where-Object { $_.file -like '*.cu' } | ForEach-Object { $_.file } | Sort-Object -Unique)
-  Write-Host "Running clang-tidy on $($cuSources.Count) CUDA source(s) (the build launcher skips .cu)..."
-  foreach ($src in $cuSources) {
-    & $clangTidy -p $bldDir --quiet $src 2>&1 | Add-Content $tidyLog
+  # A named test scopes this pass too: just that file for a .cu, none for a
+  # .cpp (the compile DB always lists every .cu now that the configure is
+  # unfiltered).
+  if ($testName) {
+    $cuSources = @($cuSources | Where-Object { [IO.Path]::GetFileName($_) -eq $testName })
+  }
+  if ($cuSources.Count) {
+    Write-Host "Running clang-tidy on $($cuSources.Count) CUDA source(s) (the build launcher skips .cu)..."
+    foreach ($src in $cuSources) {
+      & $clangTidy -p $bldDir --quiet $src 2>&1 | Add-Content $tidyLog
+    }
   }
 }
 
@@ -311,7 +348,6 @@ if ($cudacheck) {
 # notest_* sources opt out of CTest, so a build-everything run skips them (the
 # point of the prefix). But an explicit single-file request means "build AND run
 # this one", so run the binary directly, mirroring cleanbuild.sh.
-$stem = if ($testName) { [IO.Path]::GetFileNameWithoutExtension($testName) } else { '' }
 if ($stem -like 'notest_*') {
   $bin = Join-Path $bldDir "release_bin/$stem.exe"
   if (Test-Path $bin) {
@@ -323,7 +359,11 @@ if ($stem -like 'notest_*') {
     $ctestRc = 1
   }
 } else {
-  ctest --test-dir $bldDir --output-on-failure
+  # A named test runs alone: the unfiltered configure registers every test, so
+  # scope ctest to the one target.
+  $ctestArgs = @('--test-dir', $bldDir, '--output-on-failure')
+  if ($stem) { $ctestArgs += @('-R', "^$stem$") }
+  ctest @ctestArgs
   $ctestRc = $LASTEXITCODE
 }
 

--- a/cleanbuild.sh
+++ b/cleanbuild.sh
@@ -17,6 +17,8 @@ set -e
 # is clang-only. Add "tidy" to run clang-tidy during the
 # build. Add a sanitizer mode ("asan" [which includes ubsan], "tsan", "ubsan",
 # or "msan") to instrument the build with the corresponding LLVM sanitizer.
+# The build is incremental when the configuration is unchanged; add "clean" to
+# force a wipe, fresh configure, and full recompile.
 # Add "coverage" to build with source-based coverage instrumentation and run
 # llvm-profdata/llvm-cov after tests pass; mutually exclusive with sanitizers
 # and tidy. Add "scan" to skip the build and run the Clang Static Analyzer
@@ -48,10 +50,11 @@ sanitizer=""
 use_coverage=false
 use_scan=false
 use_reconfigure=false
+use_clean=false
 test_name=""
 target_name=""
 
-usage="Usage: $0 [all | reconfigure | [testname.cpp|testname.cu] [clang|gcc] [libstdcpp|libcxx] [tidy] [asan|tsan|ubsan|msan] [coverage] [scan]]"
+usage="Usage: $0 [all | reconfigure | [testname.cpp|testname.cu] [clang|gcc] [libstdcpp|libcxx] [clean] [tidy] [asan|tsan|ubsan|msan] [coverage] [scan]]"
 
 # Enforce the core/utils band layering before any build (fast, static, and
 # build-independent). See corvid/deps.md.
@@ -93,7 +96,7 @@ if [[ $# -gt 0 && "$1" != "libstdcpp" && "$1" != "libcxx" \
       && "$1" != "tidy" && "$1" != "--tidy" \
       && "$1" != "asan" && "$1" != "tsan" && "$1" != "ubsan" \
       && "$1" != "msan" && "$1" != "coverage" && "$1" != "scan" \
-      && "$1" != "reconfigure" ]]; then
+      && "$1" != "clean" && "$1" != "reconfigure" ]]; then
   if [[ "$1" == *.cpp || "$1" == *.cu ]]; then
     test_name="$1"
     target_name="${test_name%.*}"
@@ -127,6 +130,9 @@ for arg in "$@"; do
     reconfigure)
       use_reconfigure=true
       ;;
+    clean)
+      use_clean=true
+      ;;
     *)
       echo "$usage" >&2
       exit 1
@@ -153,7 +159,7 @@ fi
 # the analyzer on every TU itself, so combining with anything that affects
 # the build (sanitizers, tidy, coverage, single-test filter) is meaningless.
 if $use_scan; then
-  if [[ -n "$sanitizer" ]] || $use_tidy || $use_coverage || [[ -n "$test_name" ]]; then
+  if [[ -n "$sanitizer" ]] || $use_tidy || $use_coverage || $use_clean || [[ -n "$test_name" ]]; then
     echo "$0: 'scan' takes no other arguments (configure-only static analysis)" >&2
     exit 1
   fi
@@ -162,7 +168,7 @@ fi
 # reconfigure is a configure-only full refresh of tests/build (for clangd's
 # compile_commands.json); it builds nothing and takes no other mode.
 if $use_reconfigure; then
-  if [[ -n "$sanitizer" ]] || $use_tidy || $use_coverage || $use_scan || [[ -n "$test_name" ]]; then
+  if [[ -n "$sanitizer" ]] || $use_tidy || $use_coverage || $use_scan || $use_clean || [[ -n "$test_name" ]]; then
     echo "$0: 'reconfigure' takes no other arguments (configure-only refresh)" >&2
     exit 1
   fi
@@ -235,10 +241,21 @@ else
   TIDY_OPTION=""
 fi
 
+# A named test scopes the build (--target) and the run (ctest -R), not the
+# configure: the full configure is a strict superset (TEST_NAME only prunes
+# targets), so leaving it out of the configure args lets single-test and
+# full-suite runs share one signature and one object cache, and keeps
+# compile_commands.json complete for clangd. Validate the filename here so a
+# typo gets a clear error rather than ninja's "unknown target".
 if [[ -n "$test_name" ]]; then
-  TEST_NAME_OPTION="-DTEST_NAME=$test_name"
-else
-  TEST_NAME_OPTION=""
+  found=false
+  for bucket in portable linux cuda; do
+    [[ -f "tests/$bucket/$test_name" ]] && found=true
+  done
+  if ! $found; then
+    echo "$0: test source '$test_name' not found under tests/{portable,linux,cuda}/" >&2
+    exit 1
+  fi
 fi
 
 if [[ -n "$sanitizer" ]]; then
@@ -276,27 +293,39 @@ buildRoot="tests/build"
 buildDir="$buildRoot/release_bin"
 sigFile="$buildRoot/.cleanbuild-config"
 
-# Signature of everything that determines the CMake configuration. When a
-# single-file build is requested and the existing build dir already carries a
-# matching signature, the configuration cannot have changed, so we skip the
-# wipe and the cold reconfigure (~19s of nvcc/find_package probing that would
-# only reproduce identical build files) and rebuild just the one target. A full
-# build, a changed option, a different file, or a first run all fall through to
-# the clean path. Editing CMakeLists.txt still reconfigures: `cmake --build`
-# re-runs CMake itself when the lists file is newer than the cache.
-configSig="$LIBSTD_OPTION|$TIDY_OPTION|$TEST_NAME_OPTION|$SAN_OPTION|$COV_OPTION|$CUDA_OPTION|$NDEBUG_OPTION|CC=$CC|CXX=$CXX"
+# Signature of everything that determines the CMake configuration. When the
+# existing build dir already carries a matching signature, the configuration
+# cannot have changed, so we skip the wipe and the cold reconfigure (~19s of
+# nvcc/find_package probing that would only reproduce identical build files)
+# and let ninja rebuild incrementally. A changed option, a first run, or an
+# explicit "clean" falls through to the wipe-and-reconfigure path. Some modes
+# always take that path: tidy because clang-tidy runs as part of compilation,
+# so an incremental no-op build would analyze nothing and report a falsely
+# clean summary; msan because the ignorelist affects codegen but is not a
+# ninja dependency, so an incremental build would keep stale objects after an
+# ignorelist edit (CCACHE_EXTRAFILES only fixes ccache hits on recompiles, not
+# skipped recompiles); scan and reconfigure because they are configure-only.
+# Editing CMakeLists.txt still reconfigures: `cmake --build` re-runs CMake
+# itself when the lists file is newer than the cache.
+configSig="$LIBSTD_OPTION|$TIDY_OPTION|$SAN_OPTION|$COV_OPTION|$CUDA_OPTION|$NDEBUG_OPTION|CC=$CC|CXX=$CXX"
 
 reuse=false
-if [[ -n "$test_name" ]] && ! $use_scan &&
+if ! $use_clean && ! $use_tidy && ! $use_scan && ! $use_reconfigure &&
+  [[ "$sanitizer" != "msan" ]] &&
   [[ -f "$sigFile" && "$(cat "$sigFile")" == "$configSig" ]]; then
   reuse=true
 fi
 
 if $reuse; then
-  echo "Reusing configured build dir for $test_name (config unchanged); skipping wipe and reconfigure."
-  # "Clean" still means a fresh executable: drop just this target's binary so
-  # it relinks, leaving the cached objects and configuration in place.
-  rm -f "$buildDir/$target_name"
+  if [[ -n "$test_name" ]]; then
+    echo "Reusing configured build dir for $test_name (config unchanged); skipping wipe and reconfigure."
+    # A named test still gets a fresh executable: drop just this target's
+    # binary so it relinks, leaving the cached objects and configuration in
+    # place.
+    rm -f "$buildDir/$target_name"
+  else
+    echo "Reusing configured build dir (config unchanged); incremental build."
+  fi
 else
   # Clean any stray artifacts from a legacy in-source build at the repo root.
   rm -f CMakeCache.txt cmake_install.cmake ClangExeProject.sln build.ninja
@@ -312,15 +341,14 @@ else
   mkdir -p "$buildRoot" "$buildDir"
 
   # Run cmake to configure the project with Ninja and the selected compiler.
-  cmake -S tests -B "$buildRoot" -G "Ninja" $LIBSTD_OPTION $TIDY_OPTION $TEST_NAME_OPTION $SAN_OPTION $COV_OPTION $CUDA_OPTION $NDEBUG_OPTION
+  cmake -S tests -B "$buildRoot" -G "Ninja" $LIBSTD_OPTION $TIDY_OPTION $SAN_OPTION $COV_OPTION $CUDA_OPTION $NDEBUG_OPTION
 
   # Record the signature so the next matching single-file run can reuse this.
   echo "$configSig" >"$sigFile"
 fi
 
 # reconfigure stops here: the configure above already regenerated a full
-# compile_commands.json (no TEST_NAME filter), which is all clangd needs. No
-# build, no ctest.
+# compile_commands.json, which is all clangd needs. No build, no ctest.
 if $use_reconfigure; then
   echo "Reconfigured $buildRoot; compile_commands.json refreshed for clangd."
   exit 0
@@ -372,7 +400,7 @@ if $use_scan; then
   exit 0
 fi
 
-# Run the build (this will compile everything from scratch)
+# Run the build: everything from scratch after a wipe, incremental on reuse.
 if $use_tidy; then
   tidyLogFile="$(pwd)/$buildRoot/tidy.log"
   if [[ -n "$target_name" ]]; then
@@ -403,6 +431,11 @@ if [[ -z "${CTEST_PARALLEL_LEVEL:-}" ]]; then
 fi
 if [[ -z "$sanitizer" ]]; then
   ctest_args+=(--stop-on-failure)
+fi
+# A named test runs alone: the unfiltered configure registers every test, so
+# scope ctest to the one target.
+if [[ -n "$target_name" ]]; then
+  ctest_args+=(-R "^${target_name}$")
 fi
 
 # Coverage: each test process writes its own raw profile to
@@ -485,15 +518,21 @@ if $use_coverage; then
 
   # Collect every test binary (skip notest_* since they don't run). Pass the
   # first as the positional binary and the rest via -object= so llvm-cov sees
-  # all counters.
-  shopt -s nullglob
+  # all counters. A named test scopes the report to its own binary: on a
+  # reused tree, binaries from earlier runs may exist but ran nothing, and
+  # their zero counters would dilute the report.
   bins=()
-  for f in "$buildDir"/*; do
-    base="$(basename "$f")"
-    [[ "$base" == notest_* ]] && continue
-    [[ -x "$f" && -f "$f" ]] && bins+=("$f")
-  done
-  shopt -u nullglob
+  if [[ -n "$target_name" ]]; then
+    bins=("$buildDir/$target_name")
+  else
+    shopt -s nullglob
+    for f in "$buildDir"/*; do
+      base="$(basename "$f")"
+      [[ "$base" == notest_* ]] && continue
+      [[ -x "$f" && -f "$f" ]] && bins+=("$f")
+    done
+    shopt -u nullglob
+  fi
   if [[ ${#bins[@]} -eq 0 ]]; then
     echo "No test binaries found in $buildDir/" >&2
     exit 1

--- a/corvid/cuda/windows/game/engine.cuh
+++ b/corvid/cuda/windows/game/engine.cuh
@@ -70,6 +70,9 @@ namespace corvid::cuda {
 
 #pragma region engine
 
+// Members are grouped by subsystem, not by size; the padding is immaterial
+// for a class instantiated exactly once.
+// NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 class engine {
 public:
   engine() { init(); }
@@ -1259,19 +1262,26 @@ private:
     if (maximized) SDL_MaximizeWindow(win_);
   }
 
-  void save_window_geometry() {
-    if (geom_path_.empty()) return;
-    const bool maximized =
-        (SDL_GetWindowFlags(win_) & SDL_WINDOW_MAXIMIZED) != 0;
-    int x = 0;
-    int y = 0;
-    int w = 0;
-    int h = 0;
-    SDL_GetWindowPosition(win_, &x, &y);
-    SDL_GetWindowSize(win_, &w, &h);
-    std::ofstream out{geom_path_, std::ios::trunc};
-    out << x << ' ' << y << ' ' << w << ' ' << h << ' ' << (maximized ? 1 : 0)
-        << '\n';
+  void save_window_geometry() noexcept {
+    try {
+      if (geom_path_.empty()) return;
+      const bool maximized =
+          (SDL_GetWindowFlags(win_) & SDL_WINDOW_MAXIMIZED) != 0;
+      int x = 0;
+      int y = 0;
+      int w = 0;
+      int h = 0;
+      SDL_GetWindowPosition(win_, &x, &y);
+      SDL_GetWindowSize(win_, &w, &h);
+      std::ofstream out{geom_path_, std::ios::trunc};
+      out << x << ' ' << y << ' ' << w << ' ' << h << ' '
+          << (maximized ? 1 : 0) << '\n';
+    }
+    // NOLINTNEXTLINE(bugprone-empty-catch)
+    catch (const std::exception&) {
+      // Ignore any error writing the file, since this is just a convenience
+      // for the user and not critical to the title's function.
+    }
   }
 
 #pragma endregion

--- a/corvid/enums/bitmask_enum.h
+++ b/corvid/enums/bitmask_enum.h
@@ -15,13 +15,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #pragma once
+#include <cassert>
+
 #include "enums_shared.h"
 #include "../strings/fixed_string_utils.h"
 #include "../strings/targeting.h"
 #include "../strings/conversion.h"
 #include "../strings/delimiting.h"
 #include "../strings/splitting.h"
-#include "../containers/core/opt_find.h"
 #include "enum_registry.h"
 #include "scoped_enum.h"
 
@@ -30,9 +31,9 @@ inline namespace enums { namespace bitmask {
 
 #pragma region bitmask spec
 
-// A bitmask enum is a scoped enum (aka `enum class`) whose values are
-// made of bits that can be independently referenced. It satisfies the
-// BitmaskType named requirements, as defined by
+// A bitmask enum is a scoped enum (aka `enum class`) whose values are made of
+// bits that can be independently referenced. It satisfies the BitmaskType
+// named requirements, as defined by
 // https://en.cppreference.com/w/cpp/named_req/BitmaskType, while providing
 // some additional functionality.
 
@@ -99,7 +100,7 @@ inline namespace internal {
 
 // valid_bits_v
 //
-// The valid bits of the enum, as mask..
+// The valid bits of the enum, as mask.
 template<typename E>
 constexpr auto valid_bits_v = registry::enum_spec_v<E>.valid_bits_v;
 
@@ -154,7 +155,7 @@ template<BitmaskEnum E>
 }
 
 template<BitmaskEnum E>
-constexpr const E& operator|=(E& l, E r) noexcept {
+constexpr E& operator|=(E& l, E r) noexcept {
   return l = l | r;
 }
 
@@ -167,7 +168,7 @@ template<BitmaskEnum E>
 }
 
 template<BitmaskEnum E>
-constexpr const E& operator&=(E& l, E r) noexcept {
+constexpr E& operator&=(E& l, E r) noexcept {
   return l = l & r;
 }
 
@@ -180,7 +181,7 @@ template<BitmaskEnum E>
 }
 
 template<BitmaskEnum E>
-constexpr const E& operator^=(E& l, E r) noexcept {
+constexpr E& operator^=(E& l, E r) noexcept {
   return l = l ^ r;
 }
 
@@ -208,7 +209,7 @@ template<BitmaskEnum E>
 }
 
 template<BitmaskEnum E>
-constexpr const E& operator+=(E& l, E r) noexcept {
+constexpr E& operator+=(E& l, E r) noexcept {
   return l = l + r;
 }
 
@@ -221,7 +222,7 @@ template<BitmaskEnum E>
 }
 
 template<BitmaskEnum E>
-constexpr const E& operator-=(E& l, E r) noexcept {
+constexpr E& operator-=(E& l, E r) noexcept {
   return l = l - r;
 }
 
@@ -271,12 +272,12 @@ template<std::integral T>
 // This is the number of distinct values that are valid, if and only if valid
 // bits are contiguous.
 //
-// Note: If `max_value_v` is the same as the maximum value of `size_t`, returns
-// 0, which is confusing but technically correct, which is the best kind of
-// correct.
+// Note: A mask spanning all 64 bits wraps the count to 0, because the true
+// count (2^64) does not fit. This is confusing but technically correct, which
+// is the best kind of correct.
 template<BitmaskEnum E>
 [[nodiscard]] constexpr auto range_length() noexcept {
-  return to_integer<size_t>(max_value<E>()) + 1;
+  return static_cast<size_t>(valid_bits_v<E>) + 1;
 }
 
 #pragma endregion
@@ -303,6 +304,7 @@ template<BitmaskEnum E>
 // Note: `ndx` is 1-based, so `make_at(1)` sets the least significant bit.
 template<BitmaskEnum E>
 [[nodiscard]] constexpr E make_at(size_t ndx) noexcept {
+  assert(ndx >= 1 && ndx <= sizeof(std::underlying_type_t<E>) * 8);
   return make<E>(std::underlying_type_t<E>{1} << (ndx - 1));
 }
 
@@ -411,7 +413,7 @@ template<BitmaskEnum E>
 namespace details {
 // Helper function to append bitmask to target, using bit names.
 template<ScopedEnum E, size_t N>
-auto& do_bit_append(AppendTarget auto& target, E v,
+constexpr auto& do_bit_append(AppendTarget auto& target, E v,
     const std::array<std::string_view, N>& names) {
   static constexpr strings::delim plus(" + ");
   bool first{true};
@@ -436,7 +438,7 @@ auto& do_bit_append(AppendTarget auto& target, E v,
 
 // Helper function to append bitmask to target, using value names.
 template<ScopedEnum E, size_t N>
-auto& do_value_append(AppendTarget auto& target, E v,
+constexpr auto& do_value_append(AppendTarget auto& target, E v,
     const std::array<std::string_view, N>& names) {
   static constexpr strings::delim plus(" + ");
   constexpr size_t all_valid_bits = valid_bits_v<E>;
@@ -486,12 +488,15 @@ auto& do_value_append(AppendTarget auto& target, E v,
 template<ScopedEnum E, wrapclip bitclip = wrapclip{}, E validbits = E{},
     std::size_t N = 0>
 struct bitmask_enum_names_spec
-    : public bitmask_enum_spec<E, meta::as_underlying(validbits), bitclip> {
+    : public bitmask_enum_spec<E,
+          static_cast<std::make_unsigned_t<std::underlying_type_t<E>>>(
+              validbits),
+          bitclip> {
   constexpr bitmask_enum_names_spec(
       const std::array<std::string_view, N>& name_list)
       : names(name_list) {}
 
-  [[nodiscard]] auto& append(AppendTarget auto& target, E v) const {
+  [[nodiscard]] constexpr auto& append(AppendTarget auto& target, E v) const {
     if constexpr (N == bits_length<E>())
       return details::do_bit_append(target, v, names);
     else if constexpr (N)
@@ -501,10 +506,11 @@ struct bitmask_enum_names_spec
   }
 
   // Look up a bitmask value from `sv`. A bitmask may be given as one or more
-  // names or numbers joined by '+' (e.g. "red + blue"); each piece is looked
-  // up and the results are OR'd together. Every piece must be non-empty, so a
-  // leading, trailing, or doubled '+' is rejected. On success, sets `v` and
-  // returns true; on failure, returns false without setting `v`.
+  // names or numbers (decimal, or hex with a "0x" prefix) joined by '+' (e.g.
+  // "red + blue"); each piece is looked up and the results are OR'd together.
+  // Every piece must be non-empty, so a leading, trailing, or doubled '+' is
+  // rejected. On success, sets `v` and returns true; on failure, returns false
+  // without setting `v`.
   [[nodiscard]] bool lookup(E& v, std::string_view sv) const {
     E result{};
     E piece_value{};
@@ -550,7 +556,7 @@ struct bitmask_enum_names_spec
 // with the msb. For each non-empty name, sets the corresponding bit as valid.
 // Do not put a leading comma in the name list.
 //
-/// Whitespace is trimmed. An empty string or hyphen means invalid.
+// Whitespace is trimmed. An empty string or hyphen means invalid.
 template<strings::fixed_string bit_names>
 consteval uint64_t calc_valid_bits_from_bit_names() {
   static_assert(!strings::trim(bit_names.view(), " -").starts_with(","));
@@ -578,7 +584,7 @@ consteval uint64_t calc_valid_bits_from_bit_names() {
 /// Whitespace is trimmed.
 template<strings::fixed_string bit_names>
 consteval uint64_t calc_valid_bits_from_value_names() {
-  static_assert(contains(bit_names.view(), ','));
+  static_assert(bit_names.view().contains(','));
   constexpr auto name_array = strings::fixed_split_trim<bit_names, " -">();
   static_assert(name_array.size() <= 64,
       "value names list exceeds maximum of 64 values");
@@ -594,14 +600,13 @@ consteval uint64_t calc_valid_bits_from_value_names() {
 #pragma region make spec
 
 // Make an `enum_spec_v` from its valid bits, marking `E` as a bitmask enum.
-// If the enum has named value that is the maximum, pass that in for validbits.
-// Otherwise, specify the number explicitly.
+// If the enum has a named value that is the maximum, pass that in for
+// `validbits`. Otherwise, cast the number to `E` explicitly.
 //
 // Set `bitclip` to `wrapclip::limit` to enable clipping.
 //
 // The numerical value is printed in hex.
-template<ScopedEnum E, IntegerOrEnum auto validbits = 0,
-    wrapclip bitclip = wrapclip{}>
+template<ScopedEnum E, E validbits = E{}, wrapclip bitclip = wrapclip{}>
 consteval auto make_bitmask_enum_spec() {
   return details::bitmask_enum_names_spec<E, bitclip, validbits, 0>{
       std::array<std::string_view, 0>{}};
@@ -631,8 +636,8 @@ consteval auto make_bitmask_enum_spec() {
   constexpr auto name_count = name_array.size();
   constexpr auto valid_bits =
       details::calc_valid_bits_from_bit_names<bit_names>();
-  return details::bitmask_enum_names_spec<E, bitclip, E{valid_bits},
-      name_count>{filtered_names};
+  return details::bitmask_enum_names_spec<E, bitclip,
+      static_cast<E>(valid_bits), name_count>{filtered_names};
 }
 
 // Make a `enum_spec_v` from a list of value names, marking `E` as a bitmask
@@ -663,8 +668,10 @@ template<ScopedEnum E, strings::fixed_string bit_names,
   constexpr auto name_count = name_array.size();
   constexpr auto valid_bits =
       details::calc_valid_bits_from_value_names<bit_names>();
-  return details::bitmask_enum_names_spec<E, bitclip, E{valid_bits},
-      name_count>{trimmed_names};
+  static_assert(name_count > valid_bits,
+      "value names must cover every valid bit combination");
+  return details::bitmask_enum_names_spec<E, bitclip,
+      static_cast<E>(valid_bits), name_count>{trimmed_names};
 }
 
 #pragma endregion

--- a/corvid/enums/enum_registry.h
+++ b/corvid/enums/enum_registry.h
@@ -76,18 +76,25 @@ constexpr inline auto enum_spec_v = base_enum_spec<std::byte>();
 
 namespace details {
 
-// Enum lookup helper to handle the case of numeric values, expecting empty
-// inputs.
+// Enum lookup helper to handle the case of numeric values, expecting
+// non-empty input.
 template<StdEnum E>
-[[nodiscard]] bool lookup_helper(E& v, std::string_view sv) {
+[[nodiscard]] constexpr bool lookup_helper(E& v, std::string_view sv) {
   // Input must be an integer. Caller checks for empty.
   assert(!sv.empty());
   char first = sv.front();
   if ((first < '0' || first > '9') && first != '-') return false;
 
+  // A "0x" or "0X" prefix selects hex, matching the printed residual form.
+  int base = 10;
+  if (sv.size() > 2 && sv[0] == '0' && (sv[1] == 'x' || sv[1] == 'X')) {
+    base = 16;
+    sv.remove_prefix(2);
+  }
+
   // Convert to enum value of integer.
   std::underlying_type_t<E> t;
-  auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), t);
+  auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), t, base);
   if (ec != std::errc{} || ptr != sv.data() + sv.size()) return false;
   v = static_cast<E>(t);
   return true;
@@ -96,7 +103,7 @@ template<StdEnum E>
 // Enum lookup helper to handle the case of numeric values, handling empty
 // inputs.
 template<StdEnum E>
-[[nodiscard]] bool lookup_helper_wrapper(E& v, std::string_view sv) {
+[[nodiscard]] constexpr bool lookup_helper_wrapper(E& v, std::string_view sv) {
   if (sv.empty()) return false;
   if (lookup_helper(v, sv)) return true;
   return false;

--- a/corvid/enums/sequence_enum.h
+++ b/corvid/enums/sequence_enum.h
@@ -84,6 +84,17 @@ struct sequence_enum_spec
 template<typename E>
 concept SequentialEnum = (registry::enum_spec_v<E>.seq_valid_v);
 
+// Concept for a sequential enum registered with a name list.
+//
+// Only the names form of `make_sequence_enum_spec` provides the name
+// machinery, so `enum_name`, `enum_named_value`, and the name lookup functions
+// require this; a value-form registration is sequential but nameless.
+template<typename E>
+concept NamedSequentialEnum =
+    SequentialEnum<E> && requires(std::string_view sv) {
+      registry::enum_spec_v<E>.intern_name(sv);
+    };
+
 #pragma endregion
 #pragma region internal
 
@@ -112,19 +123,14 @@ constexpr auto seq_min_num_v = as_underlying(seq_min_v<E>);
 
 // Number of distinct values in range, as a `uint64_t`.
 //
-// The subtraction is performed in the unsigned underlying type, where it is
-// exact for any signedness, so the count is always correct, with one
-// exception: a range spanning the full 64-bit underlying type wraps the count
-// to 0, because the true count (2^64) does not fit.
+// The subtraction of the widened values is exact for any underlying type and
+// signedness, so the count is always correct, with one exception: a range
+// spanning the full 64-bit underlying type wraps the count to 0, because the
+// true count (2^64) does not fit.
 template<typename E>
 constexpr auto seq_size_v =
-    static_cast<uint64_t>(
-        static_cast<std::make_unsigned_t<std::underlying_type_t<E>>>(
-            static_cast<std::make_unsigned_t<std::underlying_type_t<E>>>(
-                seq_max_num_v<E>) -
-            static_cast<std::make_unsigned_t<std::underlying_type_t<E>>>(
-                seq_min_num_v<E>))) +
-    1;
+    static_cast<uint64_t>(seq_max_num_v<E>) -
+    static_cast<uint64_t>(seq_min_num_v<E>) + 1;
 
 // Whether wrapping requires any work. A range spanning the entire underlying
 // type wraps by itself, because conversion to the type is modular.
@@ -140,28 +146,27 @@ template<typename E>
 constexpr bool seq_actually_wrap_v =
     seq_actually_need_wrap_v<E> && seq_wrap_v<E>;
 
-// The nonnegative residue of `r` modulo the sequence size, as the unsigned
-// underlying type.
+// The nonnegative residue of `r` modulo the sequence size.
 //
 // A negative `r` is folded exactly: its magnitude is computed in unsigned
 // arithmetic (safe even for the type's minimum) and reflected around the size,
 // so the result is always in `[0, size)` and adding it is equivalent to adding
 // `r`.
 template<SequentialEnum E>
-[[nodiscard]] constexpr auto
+[[nodiscard]] constexpr uint64_t
 seq_residue(std::underlying_type_t<E> r) noexcept {
-  using U = std::underlying_type_t<E>;
-  using UU = std::make_unsigned_t<U>;
   static_assert(seq_actually_need_wrap_v<E>);
-  constexpr auto size_u = static_cast<UU>(seq_size_v<E>);
-  if constexpr (std::is_signed_v<U>) {
+  constexpr auto size = seq_size_v<E>;
+  auto mag = static_cast<uint64_t>(r);
+  bool neg{};
+  if constexpr (std::is_signed_v<decltype(r)>) {
     if (r < 0) {
-      const auto rmod =
-          static_cast<UU>(static_cast<UU>(UU{} - static_cast<UU>(r)) % size_u);
-      return static_cast<UU>(rmod ? size_u - rmod : UU{});
+      neg = true;
+      mag = 0 - mag;
     }
   }
-  return static_cast<UU>(static_cast<UU>(r) % size_u);
+  const auto rem = mag % size;
+  return neg && rem ? size - rem : rem;
 }
 
 } // namespace internal
@@ -176,31 +181,21 @@ template<SequentialEnum E>
   // Wrapping is only meaningful if the underlying type is not a perfect fit.
   if constexpr (seq_actually_need_wrap_v<E>) {
     using U = decltype(u);
-    using UU = std::make_unsigned_t<U>;
     constexpr auto lo = seq_min_num_v<E>;
     constexpr auto hi = seq_max_num_v<E>;
     static_assert(lo <= hi);
-    constexpr auto size_u = static_cast<UU>(seq_size_v<E>);
+    constexpr auto size = seq_size_v<E>;
+    constexpr auto lo64 = static_cast<uint64_t>(lo);
+    constexpr auto hi64 = static_cast<uint64_t>(hi);
+    const auto u64 = static_cast<uint64_t>(u);
 
     // Below the range: count down from `hi`, so `lo - 1` maps to `hi`.
-    if constexpr (lo != std::numeric_limits<U>::min()) {
-      if (u < lo) {
-        const auto dist =
-            static_cast<UU>(static_cast<UU>(lo) - static_cast<UU>(u));
-        return static_cast<E>(static_cast<U>(
-            static_cast<UU>(hi) - static_cast<UU>((dist - 1) % size_u)));
-      }
-    }
+    if (u < lo)
+      return static_cast<E>(static_cast<U>(hi64 - ((lo64 - u64 - 1) % size)));
 
     // Above the range: count up from `lo`, so `hi + 1` maps to `lo`.
-    if constexpr (hi != std::numeric_limits<U>::max()) {
-      if (u > hi) {
-        const auto dist =
-            static_cast<UU>(static_cast<UU>(u) - static_cast<UU>(hi));
-        return static_cast<E>(static_cast<U>(
-            static_cast<UU>(lo) + static_cast<UU>((dist - 1) % size_u)));
-      }
-    }
+    if (u > hi)
+      return static_cast<E>(static_cast<U>(lo64 + ((u64 - hi64 - 1) % size)));
   }
   return static_cast<E>(u);
 }
@@ -254,15 +249,13 @@ template<SequentialEnum E>
 operator+(E l, std::underlying_type_t<E> r) noexcept {
   using U = std::underlying_type_t<E>;
   if constexpr (seq_actually_wrap_v<E>) {
-    using UU = std::make_unsigned_t<U>;
-    constexpr auto lo_u = static_cast<UU>(seq_min_num_v<E>);
-    constexpr auto size_u = static_cast<UU>(seq_size_v<E>);
-    const auto off = static_cast<UU>(static_cast<UU>(*l) - lo_u);
+    constexpr auto lo = static_cast<uint64_t>(seq_min_num_v<E>);
+    constexpr auto size = seq_size_v<E>;
+    const auto off = static_cast<uint64_t>(*l) - lo;
     const auto radd = seq_residue<E>(r);
     // Modular add of two offsets in `[0, size)`, phrased to avoid overflow.
-    const auto gap = static_cast<UU>(size_u - off);
-    const auto noff = static_cast<UU>(radd >= gap ? radd - gap : off + radd);
-    return static_cast<E>(static_cast<U>(lo_u + noff));
+    const auto noff = (radd >= size - off) ? radd - (size - off) : off + radd;
+    return static_cast<E>(static_cast<U>(lo + noff));
   } else {
     return static_cast<E>(static_cast<U>(*l + r));
   }
@@ -302,16 +295,14 @@ template<SequentialEnum E>
 operator-(E l, std::underlying_type_t<E> r) noexcept {
   using U = std::underlying_type_t<E>;
   if constexpr (seq_actually_wrap_v<E>) {
-    using UU = std::make_unsigned_t<U>;
-    constexpr auto lo_u = static_cast<UU>(seq_min_num_v<E>);
-    constexpr auto size_u = static_cast<UU>(seq_size_v<E>);
-    const auto off = static_cast<UU>(static_cast<UU>(*l) - lo_u);
+    constexpr auto lo = static_cast<uint64_t>(seq_min_num_v<E>);
+    constexpr auto size = seq_size_v<E>;
+    const auto off = static_cast<uint64_t>(*l) - lo;
     const auto rsub = seq_residue<E>(r);
     // Modular subtract of two offsets in `[0, size)`, phrased to avoid
     // overflow.
-    const auto noff =
-        static_cast<UU>(off >= rsub ? off - rsub : size_u - (rsub - off));
-    return static_cast<E>(static_cast<U>(lo_u + noff));
+    const auto noff = (off >= rsub) ? off - rsub : size - (rsub - off);
+    return static_cast<E>(static_cast<U>(lo + noff));
   } else {
     return static_cast<E>(static_cast<U>(*l - r));
   }
@@ -383,7 +374,7 @@ template<SequentialEnum E>
 
 // Look up the canonical name for value, or an empty view if it has none.
 // Requires `E` to be registered with a name list.
-template<SequentialEnum E>
+template<NamedSequentialEnum E>
 [[nodiscard]] constexpr cstring_view enum_as_view(E v) noexcept {
   return registry::enum_spec_v<E>.find_name_by_enum(v);
 }
@@ -391,7 +382,7 @@ template<SequentialEnum E>
 // Map a candidate name to the registry's own copy of it (interning), or an
 // empty view if it is not a registered name. Names only; never interprets
 // numeric text. Requires `E` to be registered with a name list.
-template<SequentialEnum E>
+template<NamedSequentialEnum E>
 [[nodiscard]] constexpr cstring_view
 enum_intern_name(std::string_view sv) noexcept {
   return registry::enum_spec_v<E>.intern_name(sv);
@@ -400,7 +391,7 @@ enum_intern_name(std::string_view sv) noexcept {
 // Linear search of a sequence enum's names for an exact match, returning the
 // enum, or nullopt. Names only; never interprets numeric text. Requires `E` to
 // be registered with a name list.
-template<SequentialEnum E>
+template<NamedSequentialEnum E>
 [[nodiscard]] constexpr std::optional<E>
 enum_find_by_name(std::string_view sv) noexcept {
   return registry::enum_spec_v<E>.find_enum_by_name(sv);
@@ -442,7 +433,7 @@ enum_find_by_name(std::string_view sv) noexcept {
 //
 //  auto c = "red"_color;  // OK
 //  auto d = "reed"_color; // Compile error: not a registered name
-template<SequentialEnum E>
+template<NamedSequentialEnum E>
 class enum_name: public string_view_wrapper<enum_name<E>> {
   using base = string_view_wrapper<enum_name<E>>;
   using base::operator->;
@@ -546,7 +537,7 @@ protected:
 // resolved at compile time by the same constructors. Use it where a call site
 // needs the validated name and its enum together (e.g. to skip a runtime
 // name->enum lookup), without adding a field to the bare string view.
-template<SequentialEnum E>
+template<NamedSequentialEnum E>
 class enum_named_value: enum_name<E> {
   using force_tag = enum_name<E>::force_tag;
 

--- a/corvid/enums/sequence_enum.h
+++ b/corvid/enums/sequence_enum.h
@@ -16,6 +16,7 @@
 // limitations under the License.
 #pragma once
 #include <algorithm>
+#include <cassert>
 #include <string>
 #include <string_view>
 #include <stdexcept>
@@ -92,7 +93,7 @@ inline namespace internal {
 template<typename E>
 constexpr auto seq_max_v = registry::enum_spec_v<E>.seq_max_v;
 
-// Minimum value (inclusive). Must be less than `seq_max_v`.
+// Minimum value (inclusive). Must be at most `seq_max_v`.
 template<typename E>
 constexpr auto seq_min_v = registry::enum_spec_v<E>.seq_min_v;
 
@@ -109,15 +110,29 @@ constexpr auto seq_max_num_v = as_underlying(seq_max_v<E>);
 template<typename E>
 constexpr auto seq_min_num_v = as_underlying(seq_min_v<E>);
 
-// Number of distinct values in range.
-// Wraps to 0 if it's the full range of the underlying type.
+// Number of distinct values in range, as a `uint64_t`.
+//
+// The subtraction is performed in the unsigned underlying type, where it is
+// exact for any signedness, so the count is always correct, with one
+// exception: a range spanning the full 64-bit underlying type wraps the count
+// to 0, because the true count (2^64) does not fit.
 template<typename E>
-constexpr auto seq_size_v = seq_max_num_v<E> - seq_min_num_v<E> + 1;
+constexpr auto seq_size_v =
+    static_cast<uint64_t>(
+        static_cast<std::make_unsigned_t<std::underlying_type_t<E>>>(
+            static_cast<std::make_unsigned_t<std::underlying_type_t<E>>>(
+                seq_max_num_v<E>) -
+            static_cast<std::make_unsigned_t<std::underlying_type_t<E>>>(
+                seq_min_num_v<E>))) +
+    1;
 
-// Whether wrapping is really needed. We don't need to wrap when the range
-// exactly fits the underlying type, because of modulo math.
+// Whether wrapping requires any work. A range spanning the entire underlying
+// type wraps by itself, because conversion to the type is modular.
 template<typename E>
-constexpr bool seq_actually_need_wrap_v = (seq_size_v<E> != 0);
+constexpr bool seq_actually_need_wrap_v =
+    seq_min_num_v<E> !=
+        std::numeric_limits<std::underlying_type_t<E>>::min() ||
+    seq_max_num_v<E> != std::numeric_limits<std::underlying_type_t<E>>::max();
 
 // Whether wrapping is really enabled. It's enabled only when we are asked to
 // wrap and actually need to.
@@ -125,19 +140,28 @@ template<typename E>
 constexpr bool seq_actually_wrap_v =
     seq_actually_need_wrap_v<E> && seq_wrap_v<E>;
 
-// Clip by modding to size when `mode` is `wrapclip::limit`.
-template<SequentialEnum E, wrapclip mode = wrapclip::limit>
-[[nodiscard]] constexpr auto clip(std::underlying_type_t<E> u) {
-  if constexpr (mode == wrapclip::limit && seq_actually_need_wrap_v<E>)
-    return u % seq_size_v<E>;
-  else
-    return u;
-}
-
-// Clip if wrapping enabled.
+// The nonnegative residue of `r` modulo the sequence size, as the unsigned
+// underlying type.
+//
+// A negative `r` is folded exactly: its magnitude is computed in unsigned
+// arithmetic (safe even for the type's minimum) and reflected around the size,
+// so the result is always in `[0, size)` and adding it is equivalent to adding
+// `r`.
 template<SequentialEnum E>
-[[nodiscard]] constexpr auto clip_if_wrap(std::underlying_type_t<E> u) {
-  return clip<E, seq_actually_wrap_v<E> ? wrapclip::limit : wrapclip::none>(u);
+[[nodiscard]] constexpr auto
+seq_residue(std::underlying_type_t<E> r) noexcept {
+  using U = std::underlying_type_t<E>;
+  using UU = std::make_unsigned_t<U>;
+  static_assert(seq_actually_need_wrap_v<E>);
+  constexpr auto size_u = static_cast<UU>(seq_size_v<E>);
+  if constexpr (std::is_signed_v<U>) {
+    if (r < 0) {
+      const auto rmod =
+          static_cast<UU>(static_cast<UU>(UU{} - static_cast<UU>(r)) % size_u);
+      return static_cast<UU>(rmod ? size_u - rmod : UU{});
+    }
+  }
+  return static_cast<UU>(static_cast<UU>(r) % size_u);
 }
 
 } // namespace internal
@@ -147,34 +171,48 @@ template<SequentialEnum E>
 
 // Cast integer value from underlying type to sequence, wrapping to keep it in
 // range.
-template<SequentialEnum E, wrapclip mode = wrapclip::limit>
+template<SequentialEnum E>
 [[nodiscard]] constexpr E make_safely(std::underlying_type_t<E> u) noexcept {
   // Wrapping is only meaningful if the underlying type is not a perfect fit.
   if constexpr (seq_actually_need_wrap_v<E>) {
+    using U = decltype(u);
+    using UU = std::make_unsigned_t<U>;
     constexpr auto lo = seq_min_num_v<E>;
     constexpr auto hi = seq_max_num_v<E>;
     static_assert(lo <= hi);
-    using U = decltype(u);
+    constexpr auto size_u = static_cast<UU>(seq_size_v<E>);
 
-    // Underflow is only possible if it starts above the underlying min.
+    // Below the range: count down from `hi`, so `lo - 1` maps to `hi`.
     if constexpr (lo != std::numeric_limits<U>::min()) {
-      if (u < lo) return E(hi + clip<E, mode>(u - lo + 1));
+      if (u < lo) {
+        const auto dist =
+            static_cast<UU>(static_cast<UU>(lo) - static_cast<UU>(u));
+        return static_cast<E>(static_cast<U>(
+            static_cast<UU>(hi) - static_cast<UU>((dist - 1) % size_u)));
+      }
     }
 
-    // Overflow is only possible if it ends below the underlying max.
+    // Above the range: count up from `lo`, so `hi + 1` maps to `lo`.
     if constexpr (hi != std::numeric_limits<U>::max()) {
-      if (u > hi) return E(lo + clip<E, mode>(u - hi - 1));
+      if (u > hi) {
+        const auto dist =
+            static_cast<UU>(static_cast<UU>(u) - static_cast<UU>(hi));
+        return static_cast<E>(static_cast<U>(
+            static_cast<UU>(lo) + static_cast<UU>((dist - 1) % size_u)));
+      }
     }
   }
   return static_cast<E>(u);
 }
 
-// Cast integer value from underlying type to sequence. When `wrapclip::limit`,
-// wraps value to ensure safety.
-template<SequentialEnum E, wrapclip mode = wrapclip::limit>
+// Cast integer value from underlying type to sequence.
+//
+// Wrapping is governed by the registration: only an `E` registered with
+// `wrapclip::limit` wraps. To wrap unconditionally, call `make_safely`.
+template<SequentialEnum E>
 [[nodiscard]] constexpr E make(std::underlying_type_t<E> u) noexcept {
   if constexpr (seq_actually_wrap_v<E>)
-    return make_safely<E, mode>(u);
+    return make_safely<E>(u);
   else
     return static_cast<E>(u);
 }
@@ -207,13 +245,27 @@ template<SequentialEnum E>
 
 // Only heterogeneous addition and subtraction operations are supported.
 //
-// When `wrapclip::limit`, all results are modulo the sequence size. Otherwise,
-// they are undefined when they exceed the range.
+// When registered with `wrapclip::limit`, all results are exact modulo the
+// sequence size, for any operand values, including ranges that hug the
+// extremes of the underlying type. Otherwise, they are undefined when they
+// exceed the range.
 template<SequentialEnum E>
 [[nodiscard]] constexpr E
 operator+(E l, std::underlying_type_t<E> r) noexcept {
-  return make<E, wrapclip::none>(
-      static_cast<std::underlying_type_t<E>>(*l + clip_if_wrap<E>(r)));
+  using U = std::underlying_type_t<E>;
+  if constexpr (seq_actually_wrap_v<E>) {
+    using UU = std::make_unsigned_t<U>;
+    constexpr auto lo_u = static_cast<UU>(seq_min_num_v<E>);
+    constexpr auto size_u = static_cast<UU>(seq_size_v<E>);
+    const auto off = static_cast<UU>(static_cast<UU>(*l) - lo_u);
+    const auto radd = seq_residue<E>(r);
+    // Modular add of two offsets in `[0, size)`, phrased to avoid overflow.
+    const auto gap = static_cast<UU>(size_u - off);
+    const auto noff = static_cast<UU>(radd >= gap ? radd - gap : off + radd);
+    return static_cast<E>(static_cast<U>(lo_u + noff));
+  } else {
+    return static_cast<E>(static_cast<U>(*l + r));
+  }
 }
 
 template<SequentialEnum E>
@@ -232,7 +284,7 @@ constexpr E& operator++(E& l) noexcept {
   if constexpr (seq_actually_wrap_v<E>)
     if (l == seq_max_v<E>) return l = seq_min_v<E>;
 
-  return l = E(l + 1);
+  return l = E(*l + 1);
 }
 
 template<SequentialEnum E>
@@ -248,8 +300,21 @@ template<SequentialEnum E>
 template<SequentialEnum E>
 [[nodiscard]] constexpr E
 operator-(E l, std::underlying_type_t<E> r) noexcept {
-  return make<E, wrapclip::none>(
-      static_cast<std::underlying_type_t<E>>(*l - clip_if_wrap<E>(r)));
+  using U = std::underlying_type_t<E>;
+  if constexpr (seq_actually_wrap_v<E>) {
+    using UU = std::make_unsigned_t<U>;
+    constexpr auto lo_u = static_cast<UU>(seq_min_num_v<E>);
+    constexpr auto size_u = static_cast<UU>(seq_size_v<E>);
+    const auto off = static_cast<UU>(static_cast<UU>(*l) - lo_u);
+    const auto rsub = seq_residue<E>(r);
+    // Modular subtract of two offsets in `[0, size)`, phrased to avoid
+    // overflow.
+    const auto noff =
+        static_cast<UU>(off >= rsub ? off - rsub : size_u - (rsub - off));
+    return static_cast<E>(static_cast<U>(lo_u + noff));
+  } else {
+    return static_cast<E>(static_cast<U>(*l - r));
+  }
 }
 
 template<SequentialEnum E>
@@ -303,8 +368,11 @@ template<std::integral T>
 #pragma region range_length
 
 // Length of range: the count of values in `[min, max]`, including any unnamed
-// gaps. Returns 0 when the range spans the full underlying type and the count
-// wraps, matching the bitmask `range_length`.
+// gaps.
+//
+// Follows `seq_size_v`: exact for every range and signedness, except that a
+// range spanning the full 64-bit underlying type returns 0 (matching the
+// bitmask `range_length` convention), because the true count does not fit.
 template<SequentialEnum E>
 [[nodiscard]] constexpr auto range_length() noexcept {
   return static_cast<size_t>(seq_size_v<E>);
@@ -317,7 +385,7 @@ template<SequentialEnum E>
 // Requires `E` to be registered with a name list.
 template<SequentialEnum E>
 [[nodiscard]] constexpr cstring_view enum_as_view(E v) noexcept {
-  return registry::enum_spec_v<std::decay_t<E>>.find_name_by_enum(v);
+  return registry::enum_spec_v<E>.find_name_by_enum(v);
 }
 
 // Map a candidate name to the registry's own copy of it (interning), or an
@@ -364,9 +432,9 @@ enum_find_by_name(std::string_view sv) noexcept {
 //
 //  void paint(color_name c) { ... }
 //
-//  paint{"red"};      // OK
-//  paint{"reed"};     // Compile error: not a registered name
-//  paint{color::red}; // OK
+//  paint("red");      // OK
+//  paint("reed");     // Compile error: not a registered name
+//  paint(color::red); // OK
 //
 //  consteval color_name operator""_color(const char* s, std::size_t n) {
 //    return color_name{s, n};
@@ -457,7 +525,7 @@ public:
 
   // Find enum at runtime. Can fail if `force` was used, hence the
   // `or_default`.
-  [[nodiscard]] E find_enum(E or_default = E{}) const noexcept {
+  [[nodiscard]] constexpr E find_enum(E or_default = E{}) const noexcept {
     return enum_find_by_name<E>(as_view()).value_or(or_default);
   }
 
@@ -508,12 +576,12 @@ public:
   // throws.
   static constexpr auto intern(std::string_view sv, E e) {
     if (const auto self = try_intern(sv, e); self) return *self;
-    throw std::invalid_argument("enum has no registered name to intern");
+    throw std::invalid_argument("not a registered name for this enum");
   }
 
   // Intern at runtime.
   //
-  // If `sv` does not  match a name, throws.
+  // If `sv` does not match a name, throws.
   static constexpr auto intern(std::string_view sv) {
     if (const auto self = try_intern(sv); self) return *self;
     throw std::invalid_argument("not a registered name for this enum");
@@ -524,7 +592,7 @@ public:
   // If `e` does not have a name, throws.
   static constexpr auto intern(E e) {
     if (const auto self = try_intern(e); self) return *self;
-    throw std::invalid_argument("enum has no registered name to intern");
+    throw std::invalid_argument("not a registered name for this enum");
   }
 
   // Attempt to intern `sv` and `e` at runtime.
@@ -532,7 +600,7 @@ public:
   // If `e` does not have a name, or if `sv` is nonempty and does not match it,
   // fails so that the caller can use the `force`.
   static constexpr std::optional<enum_named_value<E>>
-  try_intern([[maybe_unused]] std::string_view sv, E e) {
+  try_intern(std::string_view sv, E e) {
     const auto self = try_intern(e);
     if (!self) return std::nullopt;
     if (!sv.empty() && sv != *self) return std::nullopt;
@@ -550,7 +618,7 @@ public:
 
   // Attempt to intern `sv`. If `sv` does not match a name, fails.
   static constexpr std::optional<enum_named_value<E>> try_intern(
-      [[maybe_unused]] std::string_view sv) {
+      std::string_view sv) {
     const auto value = enum_find_by_name<E>(sv);
     if (!value) return std::nullopt;
     const auto name = enum_as_view(*value);
@@ -570,7 +638,7 @@ public:
   // The caller vouches for the bytes and their lifetime, and the result of
   // calls with equal contents do not necessarily share storage.
   //
-  //  Note: There is no `try_force` (or `triforce`), only do `force`.
+  // Note: There is no `try_force` (or `triforce`), only do `force`.
   static constexpr auto force(std::string_view sv, E e) {
     if (sv.empty())
       throw std::invalid_argument("empty string is not a valid name");
@@ -689,6 +757,17 @@ template<strings::fixed_string names, std::integral U, size_t NameCount,
       if (field_end == seg_end) break;
       field = field_end + 1;
     }
+
+    // Reject a segment whose last value would pass the top of the underlying
+    // type, which the unsigned `max` arithmetic below would otherwise wrap
+    // silently. Compared exactly in unsigned space, so an oversized `length`
+    // cannot truncate its way past the check.
+    using UU = std::make_unsigned_t<U>;
+    if (length - 1 >
+        static_cast<uint64_t>(
+            static_cast<UU>(std::numeric_limits<U>::max()) -
+            static_cast<UU>(start)))
+      throw std::invalid_argument("segment overflows underlying type");
 
     name_segments.segments[segment_ndx] = enum_segment<U>{start, length};
     if (segment_ndx == 0) name_segments.min = start;

--- a/crossplatform.md
+++ b/crossplatform.md
@@ -127,12 +127,16 @@ Linux (`./cleanbuild.sh`) is unchanged. The full menu (libc++/libstdc++,
 asan/tsan/ubsan/msan, scan, coverage, single-file) is documented in the
 build-and-test skill.
 
-Windows (`./cleanbuild.ps1`) does a fresh Release configure, build, and ctest:
+Windows (`./cleanbuild.ps1`) does a Release configure, build, and ctest,
+incrementally when the configuration is unchanged (`clean` forces a fresh
+configure and full recompile):
 
 - `./cleanbuild.ps1`: clang++, portable suite plus CUDA (when the toolkit and a
   GPU are present).
-- `./cleanbuild.ps1 <name>_test.cpp` or `<name>_test.cu`: one test (via
-  `-DTEST_NAME=`). A `.cu` needs the default clang++ in a plain mode.
+- `./cleanbuild.ps1 <name>_test.cpp` or `<name>_test.cu`: one test (built via
+  `--target`, run via a ctest filter; the configure itself is never filtered,
+  so single-test and full runs share one configuration and object cache). A
+  `.cu` needs the default clang++ in a plain mode.
 - `./cleanbuild.ps1 cl`: portable suite via MSVC cl (no CUDA; see section 3).
 - `./cleanbuild.ps1 asan`: ASAN (which carries UBSAN), clang++ only.
 - `./cleanbuild.ps1 tidy`: run clang-tidy (`USE_CLANG_TIDY=ON`) during the build,
@@ -148,8 +152,9 @@ one), configures Ninja with the chosen compiler, builds with `-k 0`, and runs
 ctest. CUDA auto-enables when `nvcc` is on PATH and the mode is the default
 clang++ plain one: it passes `CORVID_ENABLE_CUDA=ON`, `CMAKE_CUDA_COMPILER`
 pointing at `clang++`, and an explicit `CMAKE_CUDA_ARCHITECTURES` from
-`nvidia-smi`. It uses `cmake --fresh` rather than wiping `tests/build`, because
-clangd holds an open handle on `compile_commands.json` there. The other Linux
+`nvidia-smi`. When it does reconfigure, it uses `cmake --fresh` rather than
+wiping `tests/build`, because clangd holds an open handle on
+`compile_commands.json` there. The other Linux
 cleanbuild modes (libc++/libstdc++ choice, msan/tsan, analyze-build scan,
 llvm-cov coverage, compiler-rt/lld swaps) have no MSVC analog and are absent.
 

--- a/tests/cuda/cuda_device_test.cu
+++ b/tests/cuda/cuda_device_test.cu
@@ -97,7 +97,7 @@ TEST_CASE("cuda_device_attr anchors wrap the matching CUDA constants",
     "[cuda][enums]") {
   for (const auto& c : attr_cases) {
     CAPTURE(c.name);
-    const int underlying = *c.value; // underlying value
+    const auto underlying = static_cast<int>(c.value); // underlying value
     CHECK(underlying == c.code);
     CHECK(enum_as_string(c.value) == c.name); // enum -> string
     cuda_device_attr parsed{};

--- a/tests/cuda/cuda_status_test.cu
+++ b/tests/cuda/cuda_status_test.cu
@@ -51,7 +51,7 @@ constexpr status_case status_cases[] = {
 TEST_CASE("cuda_status values and string round-trip", "[cuda][enums]") {
   for (const auto& c : status_cases) {
     CAPTURE(c.name);
-    const int underlying = *c.value; // underlying value
+    const auto underlying = static_cast<int>(c.value); // underlying value
     CHECK(underlying == c.code);
     CHECK(enum_as_string(c.value) == c.name); // enum -> string
     cuda_status parsed{};

--- a/tests/portable/bitmask_enum_test.cpp
+++ b/tests/portable/bitmask_enum_test.cpp
@@ -891,6 +891,28 @@ TEST_CASE("ExtractEnum", "[BitMaskTest]") {
     CHECK(sv.empty());
     CHECK(e == (rgb::red + rgb::green));
 
+    // Hex numbers parse with a "0x" prefix, so the printed residual form
+    // round-trips.
+    sv = "0x2";
+    CHECK(extract_enum(e, sv));
+    CHECK(sv.empty());
+    CHECK(e == rgb::green);
+
+    sv = "red + 0x40";
+    CHECK(extract_enum(e, sv));
+    CHECK(sv.empty());
+    CHECK(e == rgb(0x44));
+
+    auto hex = enum_as_string(rgb(7 + 0x40));
+    sv = hex;
+    CHECK(sv == "red + green + blue + 0x40");
+    CHECK(extract_enum(e, sv));
+    CHECK(e == rgb(7 + 0x40));
+
+    // A bare "0x" is not a number.
+    sv = "0x";
+    CHECK_FALSE(extract_enum(e, sv));
+
     sv = "";
     CHECK_FALSE(extract_enum(e, sv));
     sv = " + ";
@@ -907,6 +929,48 @@ TEST_CASE("ExtractEnum", "[BitMaskTest]") {
 }
 #pragma endregion
 
+// Signed underlying type with the high bit valid. The mask is zero-extended
+// through the unsigned underlying type at registration, so it stays clean even
+// though `max_value` is negative.
+enum class i8_bits : std::int8_t {};
+consteval auto corvid_enum_spec(i8_bits*) {
+  return make_bitmask_enum_spec<i8_bits, "a,b,c,d,e,f,g,h">();
+}
+
+// Same, registered by value with a negative maximum.
+enum class i8_all : std::int8_t { all = -1 };
+consteval auto corvid_enum_spec(i8_all*) {
+  return make_bitmask_enum_spec<i8_all, i8_all::all>();
+}
+
+#pragma region SignedHighBit
+
+TEST_CASE("SignedHighBit", "[BitMaskTest]") {
+  if (true) {
+    static_assert(valid_bits_v<i8_bits> == 0xff);
+    static_assert(valid_bits_v<i8_all> == 0xff);
+    CHECK(bits_length<i8_bits>() == 8);
+    CHECK(range_length<i8_bits>() == 256);
+    CHECK(max_value<i8_bits>() == i8_bits{-1});
+    CHECK(flip(i8_bits{}) == i8_bits{-1});
+    CHECK(*make_at<i8_bits>(8) == int8_t{-128});
+    CHECK(range_length<i8_all>() == 256);
+    CHECK(max_value<i8_all>() == i8_all::all);
+  }
+  if (true) {
+    using namespace strings;
+    CHECK(enum_as_string(i8_bits(0x80)) == "a");
+    CHECK(enum_as_string(i8_bits(-1)) == "a + b + c + d + e + f + g + h");
+    CHECK(enum_as_string(i8_all(5)) == "0x05");
+
+    i8_bits e{};
+    std::string_view sv = "a + h";
+    CHECK(extract_enum(e, sv));
+    CHECK(e == i8_bits(0x81));
+  }
+}
+
+#pragma endregion
 #pragma region HoleyOps
 
 TEST_CASE("HoleyOps", "[BitMaskTest]") {

--- a/tests/portable/sequence_enum_test.cpp
+++ b/tests/portable/sequence_enum_test.cpp
@@ -665,6 +665,12 @@ TEST_CASE("ExtractEnum", "[SequentialEnumTest]") {
     CHECK(sv.empty());
     CHECK(e == tiger_pick::eeny);
 
+    // Hex numbers parse with a "0x" prefix.
+    sv = "0x3";
+    CHECK(extract_enum(e, sv));
+    CHECK(sv.empty());
+    CHECK(e == tiger_pick::moe);
+
     sv = "eeny";
     CHECK(extract_enum(e, sv));
     CHECK(sv.empty());

--- a/tests/portable/sequence_enum_test.cpp
+++ b/tests/portable/sequence_enum_test.cpp
@@ -172,6 +172,20 @@ consteval auto corvid_enum_spec(eu64_large*) {
       wrapclip::limit, eu64_large{UINT64_C(10000000000000000000)}>();
 }
 
+// Range of 120 to 127. Tests wrapping on a range hugging the top of int8_t.
+enum class e120_127 : int8_t {};
+consteval auto corvid_enum_spec(e120_127*) {
+  return make_sequence_enum_spec<e120_127, e120_127{127}, e120_127{120},
+      wrapclip::limit>();
+}
+
+// Range of 248 to 255. Tests wrapping on a range hugging the top of uint8_t.
+enum class eu248_255 : uint8_t {};
+consteval auto corvid_enum_spec(eu248_255*) {
+  return make_sequence_enum_spec<eu248_255, eu248_255{255}, eu248_255{248},
+      wrapclip::limit>();
+}
+
 #pragma region MakeSafely
 
 TEST_CASE("MakeSafely", "[SequentialEnumTest]") {
@@ -412,6 +426,56 @@ TEST_CASE("SafeOps", "[SequentialEnumTest]") {
     CHECK(*e == 0);
     e -= 4 * 4;
     CHECK(*e == 0);
+  }
+}
+
+#pragma endregion
+#pragma region WrapExtremes
+
+// Regression tests: the wrap reduction used to alias when the distance from
+// the range overflowed the underlying type, and wrap arithmetic used to alias
+// on ranges hugging the extremes of the underlying type.
+TEST_CASE("WrapExtremes", "[SequentialEnumTest]") {
+  // Inputs far outside a nonzero-min range.
+  if (true) {
+    CHECK(make_safely<e10_13>(int8_t{-128}) == e10_13{12});
+    CHECK(make_safely<e10_13>(int8_t{-119}) == e10_13{13});
+    CHECK(make_safely<eneg3_3>(int8_t{127}) == eneg3_3{1});
+    CHECK(make<eu64_large>(UINT64_C(0)) ==
+          eu64_large{UINT64_C(10000000000000000002)});
+    CHECK(make<eu64_large>(UINT64_C(5)) ==
+          eu64_large{UINT64_C(10000000000000000001)});
+    CHECK(make<e64_large>(std::numeric_limits<int64_t>::min()) ==
+          e64_large{1000000000000});
+    CHECK(make<e64_large>(std::numeric_limits<int64_t>::max()) ==
+          e64_large{1000000000000});
+  }
+  // Arithmetic on a range hugging the top of int8_t.
+  if (true) {
+    auto e = e120_127{127};
+    CHECK(e + 7 == e120_127{126});
+    CHECK(e + 127 == e120_127{126});
+    CHECK(e - 7 == e120_127{120});
+    CHECK(e120_127{120} - 7 == e120_127{121});
+    CHECK(e120_127{120} + int8_t{-7} == e120_127{121});
+    CHECK(e120_127{120} + int8_t{-128} == e120_127{120});
+    ++e;
+    CHECK(e == e120_127{120});
+    --e;
+    CHECK(e == e120_127{127});
+  }
+  // Arithmetic on a range hugging the top of uint8_t.
+  if (true) {
+    CHECK(eu248_255{255} + 3 == eu248_255{250});
+    CHECK(eu248_255{255} + 255 == eu248_255{254});
+    CHECK(eu248_255{248} - 1 == eu248_255{255});
+    CHECK(make<eu248_255>(uint8_t{0}) == eu248_255{248});
+    CHECK(make<eu248_255>(uint8_t{5}) == eu248_255{253});
+  }
+  // The range count is exact even for full-type ranges.
+  if (true) {
+    CHECK(range_length<e0_255>() == 256);
+    CHECK(range_length<eneg128_127>() == 256);
   }
 }
 

--- a/tests/portable/sequence_enum_test.cpp
+++ b/tests/portable/sequence_enum_test.cpp
@@ -481,6 +481,36 @@ TEST_CASE("WrapExtremes", "[SequentialEnumTest]") {
 
 #pragma endregion
 
+#pragma region NamedConcept
+
+// `NamedSequentialEnum` refines `SequentialEnum` to enums registered with a
+// name list, gating `enum_name`, `enum_named_value`, and the name lookups.
+//
+// Verified by instantiating `enum_name<e0_255>{"a"}`: before the concept, it
+// died inside the library ("no member named 'intern_name' in
+// 'sequence_enum_spec<e0_255, ...>'" at the `enum_intern_name` body, with the
+// user's line buried in the instantiation notes, plus a follow-on "call to
+// consteval function is not a constant expression"). With the concept, the
+// one error lands on the user's line: "constraints not satisfied for class
+// template 'enum_name' [with E = e0_255] ... because 'e0_255' does not
+// satisfy 'NamedSequentialEnum'".
+TEST_CASE("NamedConcept", "[SequentialEnumTest]") {
+  // Registered with names: sequential and named.
+  static_assert(SequentialEnum<e0_3>);
+  static_assert(NamedSequentialEnum<e0_3>);
+  static_assert(NamedSequentialEnum<tiger_pick>);
+
+  // Registered via the nameless value form: sequential but not named.
+  static_assert(SequentialEnum<e0_255>);
+  static_assert(!NamedSequentialEnum<e0_255>);
+
+  // Unregistered scoped enums are neither.
+  static_assert(!SequentialEnum<new_enum>);
+  static_assert(!NamedSequentialEnum<new_enum>);
+}
+
+#pragma endregion
+
 enum class tiger_nochoice : std::uint8_t { tiger };
 consteval auto corvid_enum_spec(tiger_nochoice*) {
   return make_sequence_enum_spec<tiger_nochoice, tiger_nochoice{}>();


### PR DESCRIPTION
## Summary

Hardens the sequence- and bitmask-enum machinery against overflow and aliasing at the extremes of the underlying type, tightens the registration API, and makes `cleanbuild` incremental by default.

### Sequence enums (`corvid/enums/sequence_enum.h`)

- `seq_size_v` is now computed in `uint64_t`, so the count is exact for any underlying type and signedness; only a range spanning the full 64-bit type wraps to 0 (documented, matching the bitmask `range_length` convention).
- `seq_actually_need_wrap_v` tests the range bounds against the underlying type's limits directly instead of inferring from a wrapped size.
- `make_safely` and the heterogeneous `operator+`/`operator-` are rewritten in explicit 64-bit modular arithmetic (new `seq_residue` helper folds a negative offset exactly, including the type's minimum). The old reduction aliased when the distance from the range overflowed the underlying type, and wrap arithmetic aliased on ranges hugging the type's extremes; the new `WrapExtremes` test locks in regressions for both.
- `make` and `make_safely` drop their `wrapclip` template parameter: wrapping is governed by the registration alone, with `make_safely` as the always-wrap escape hatch.
- New `NamedSequentialEnum` concept (a `SequentialEnum` registered with a name list) now gates `enum_name`, `enum_named_value`, `enum_as_view`, `enum_intern_name`, and `enum_find_by_name`, so misuse fails on the caller's line with a constraint error instead of deep in the spec internals (error texts recorded in the `NamedConcept` test).
- The segment builder rejects a name segment whose last value would pass the top of the underlying type, instead of silently wrapping.

### Bitmask enums (`corvid/enums/bitmask_enum.h`)

- `make_bitmask_enum_spec` now takes `validbits` as `E` rather than `IntegerOrEnum auto` (**breaking**: integer callers must cast to `E`), and the valid-bits mask is zero-extended through the unsigned underlying type, so signed underlying types with the high bit valid work correctly (new `SignedHighBit` tests).
- `range_length` derives from `valid_bits_v` instead of `max_value`, giving the exact count for signed types.
- The value-names form statically asserts that the name list covers every valid bit combination.
- `make_at` asserts its 1-based index is within the underlying type's width.
- Compound-assignment operators return `E&` instead of `const E&`.

### Enum registry (`corvid/enums/enum_registry.h`)

- Numeric enum lookup accepts hex with a `0x`/`0X` prefix, so the printed residual form of a bitmask (e.g. `"red + 0x40"`) round-trips through `extract_enum`. Covered in both test suites.

### Build system: incremental by default

`cleanbuild.sh` and `cleanbuild.ps1` now reuse the configured build dir whenever the configuration signature is unchanged, for full-suite runs as well as single-test runs; `clean` forces a wipe and full recompile. A named test no longer filters the configure (`TEST_NAME` is gone): it scopes the build via `--target` and the run via a ctest `-R` filter, so single-test and full runs share one object cache and `compile_commands.json` stays complete for clangd. Modes where incremental would be wrong always take the fresh path (`tidy`, `msan`, `scan`, `reconfigure`). Docs updated (CLAUDE.md, build-and-test skill, crossplatform.md).

### Misc

- `engine::save_window_geometry` is `noexcept` and swallows file-write errors (a failed geometry save is a lost convenience, not an engine fault); padding-analyzer suppression for the single-instance `engine` class.
- CUDA enum tests read the underlying value via `static_cast<int>` on the anchor.
- TODO: ten larger project ideas recorded.
- Comment typo/wording fixes alongside the code they touch.

## Test plan

- New regression suites: `WrapExtremes`, `NamedConcept` (sequence), `SignedHighBit` (bitmask), plus hex-parse cases in both `ExtractEnum` suites.
- Full suite via `./cleanbuild.ps1` / `./cleanbuild.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)