### PR TITLE
Proxy: registration-based runtime polymorphism

### DIFF
--- a/TODO
+++ b/TODO
@@ -12,7 +12,7 @@
    i. controllers/sopdt_plant.h: soptd_plant
    j. controllers/pid_controller.h: pid_controller
    k. strings/delimiting.h: delim
-   l. strings/fixed_string.h: fixed_string
+   l. meta/fixed_string.h: fixed_string
    m. strings/locating.h: location, pos_range
    n. strings/splitting.h: piece_generator
 

--- a/corvid/enums/bitmask_enum.h
+++ b/corvid/enums/bitmask_enum.h
@@ -557,7 +557,7 @@ struct bitmask_enum_names_spec
 // Do not put a leading comma in the name list.
 //
 // Whitespace is trimmed. An empty string or hyphen means invalid.
-template<strings::fixed_string bit_names>
+template<meta::fixed_string bit_names>
 consteval uint64_t calc_valid_bits_from_bit_names() {
   static_assert(!strings::trim(bit_names.view(), " -").starts_with(","));
   constexpr auto name_array = strings::fixed_split_trim<bit_names, " -">();
@@ -582,7 +582,7 @@ consteval uint64_t calc_valid_bits_from_bit_names() {
 // defines the valid bits.
 //
 /// Whitespace is trimmed.
-template<strings::fixed_string bit_names>
+template<meta::fixed_string bit_names>
 consteval uint64_t calc_valid_bits_from_value_names() {
   static_assert(bit_names.view().contains(','));
   constexpr auto name_array = strings::fixed_split_trim<bit_names, " -">();
@@ -627,7 +627,7 @@ consteval auto make_bitmask_enum_spec() {
 //
 // Prints the matching name for the value as a combination of bit names.
 // Any bits, valid or otherwise, that are not named are printed in hex.
-template<ScopedEnum E, strings::fixed_string bit_names,
+template<ScopedEnum E, meta::fixed_string bit_names,
     wrapclip bitclip = wrapclip{}>
 consteval auto make_bitmask_enum_spec() {
   constexpr auto name_array = strings::fixed_split_trim<bit_names, " -">();
@@ -659,7 +659,7 @@ consteval auto make_bitmask_enum_spec() {
 //
 // Prints the matching name for the value. Any residual value is printed in
 // hex, in combination with the known part of the value, if any.
-template<ScopedEnum E, strings::fixed_string bit_names,
+template<ScopedEnum E, meta::fixed_string bit_names,
     wrapclip bitclip = wrapclip{}>
 [[nodiscard]] consteval auto make_bitmask_enum_values_spec() {
   constexpr auto name_array = strings::fixed_split<bit_names>();

--- a/corvid/enums/sequence_enum.h
+++ b/corvid/enums/sequence_enum.h
@@ -695,7 +695,7 @@ struct segmented_names {
 // independently null-terminated span in place. The packed names are views into
 // this buffer, which is held as a template parameter and so has static
 // storage.
-template<strings::fixed_string names>
+template<meta::fixed_string names>
 [[nodiscard]] consteval auto make_nulled() {
   return strings::fixed_replaced<strings::fixed_replaced<names, '|', '\0'>(),
       ',', '\0'>();
@@ -713,8 +713,8 @@ template<strings::fixed_string names>
 // two-value gap costs about as much as the empty names while a new segment
 // also pays for its start value and the '|'. `min` and `max` are derived from
 // them. The packed names are views into `Nulled`.
-template<strings::fixed_string names, std::integral U, size_t NameCount,
-    size_t SegCount, strings::fixed_string Nulled = make_nulled<names>()>
+template<meta::fixed_string names, std::integral U, size_t NameCount,
+    size_t SegCount, meta::fixed_string Nulled = make_nulled<names>()>
 [[nodiscard]] consteval auto parse_segmented_names() {
   segmented_names<U, NameCount, SegCount> name_segments{};
   constexpr auto whole = names.view();
@@ -889,9 +889,8 @@ struct sequence_enum_names_spec
 // passed.
 //
 // Set `wrapseq` to `wrapclip::limit` to enable wrapping.
-template<ScopedEnum E, strings::fixed_string names,
-    wrapclip wrapseq = wrapclip{}, E minseq = E{},
-    strings::fixed_string Nulled = details::make_nulled<names>()>
+template<ScopedEnum E, meta::fixed_string names, wrapclip wrapseq = wrapclip{},
+    E minseq = E{}, meta::fixed_string Nulled = details::make_nulled<names>()>
 [[nodiscard]] consteval auto make_sequence_enum_spec() {
   using U = std::underlying_type_t<E>;
   constexpr auto whole = names.view();

--- a/corvid/meta.h
+++ b/corvid/meta.h
@@ -26,3 +26,4 @@
 #include "meta/forwarding_address.h"
 #include "meta/maybe.h"
 #include "meta/fixed_function.h"
+#include "meta/fixed_string.h"

--- a/corvid/meta/fixed_string.h
+++ b/corvid/meta/fixed_string.h
@@ -25,10 +25,6 @@
 #include "concepts.h"
 #include "formatting.h"
 
-// Not included by meta.h: like formatting.h, this header stays out of the
-// umbrella to keep <format> and <ostream> out of every TU. Include it
-// directly.
-
 // Forward declaration so `cview()` can name the return type without pulling
 // in the strings band. Using `cview()` requires including cstring_view.h.
 namespace corvid { inline namespace cstringview {

--- a/corvid/meta/fixed_string.h
+++ b/corvid/meta/fixed_string.h
@@ -16,16 +16,27 @@
 // limitations under the License.
 #pragma once
 #include <concepts>
+#include <cstddef>
 #include <format>
 #include <ostream>
 #include <string_view>
 #include <type_traits>
 
-#include "../meta.h"
-#include "cstring_view.h"
-#include "../meta/formatting.h"
+#include "concepts.h"
+#include "formatting.h"
 
-namespace corvid::strings { inline namespace fixed {
+// Not included by meta.h: like formatting.h, this header stays out of the
+// umbrella to keep <format> and <ostream> out of every TU. Include it
+// directly.
+
+// Forward declaration so `cview()` can name the return type without pulling
+// in the strings band. Using `cview()` requires including cstring_view.h.
+namespace corvid { inline namespace cstringview {
+template<typename T>
+class basic_cstring_view;
+}} // namespace corvid::cstringview
+
+namespace corvid { inline namespace meta { inline namespace fixed {
 
 #pragma region basic_fixed_string
 
@@ -120,7 +131,8 @@ struct basic_fixed_string {
     return view();
   }
 
-  // A fixed string is necessarily terminated.
+  // A fixed string is necessarily terminated. Only declared here; callers
+  // must include cstring_view.h.
   [[nodiscard]] constexpr basic_cstring_view<std::basic_string_view<char_t>>
   cview() const {
     return basic_cstring_view<std::basic_string_view<char_t>>{do_not_use,
@@ -195,14 +207,14 @@ using fixed_string = basic_fixed_string<char, N>;
 
 #pragma endregion
 
-}} // namespace corvid::strings::fixed
+}}} // namespace corvid::meta::fixed
 
 // NOLINTBEGIN(bugprone-std-namespace-modification)
 template<corvid::CharType CharT, std::size_t N>
 constexpr std::range_format
-    std::format_kind<corvid::strings::basic_fixed_string<CharT, N>> =
+    std::format_kind<corvid::meta::basic_fixed_string<CharT, N>> =
         std::range_format::disabled;
 template<corvid::CharType CharT, std::size_t N>
-struct std::formatter<corvid::strings::basic_fixed_string<CharT, N>, CharT>
+struct std::formatter<corvid::meta::basic_fixed_string<CharT, N>, CharT>
     : corvid::forwarding_formatter<std::basic_string_view<CharT>, CharT> {};
 // NOLINTEND(bugprone-std-namespace-modification)

--- a/corvid/meta/meta_shared.h
+++ b/corvid/meta/meta_shared.h
@@ -25,6 +25,7 @@
 #include <optional>
 #include <span>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <typeinfo>

--- a/corvid/meta/naming.h
+++ b/corvid/meta/naming.h
@@ -50,5 +50,45 @@ std::string type_name(T&&) {
   return type_name<T>();
 }
 
+// Extract a type name cleaned up for humans (and generated code).
+//
+// Builds on `type_name`, stripping elaborated-type keywords (MSVC spells
+// them), inline-namespace segments, and anonymous-namespace prefixes,
+// normalizing spacing, collapsing the expanded `std::string` spelling, and
+// spelling top-level const in the leading position. Best-effort, like
+// `type_name`; this band cannot use the string utilities, so the edits are
+// hand-rolled.
+template<typename T>
+std::string friendly_type_name() {
+  using TR = std::remove_reference_t<T>;
+  std::string r = type_name<std::remove_cv_t<TR>>();
+  auto replace = [&r](std::string_view what, std::string_view with) {
+    for (std::size_t pos{}; (pos = r.find(what, pos)) != std::string::npos;
+        pos += with.size())
+      r.replace(pos, what.size(), with);
+  };
+  replace("class ", "");
+  replace("struct ", "");
+  replace("enum ", "");
+  replace("__1::", "");
+  replace("__cxx11::", "");
+  replace("(anonymous namespace)::", "");
+  replace("`anonymous namespace'::", "");
+  replace("> >", ">>");
+  replace(", ", ",");
+  replace(
+      "std::basic_string<char,std::char_traits<char>,"
+      "std::allocator<char>>",
+      "std::string");
+  replace(",", ", ");
+  if (std::is_volatile_v<TR>) r = "volatile " + r;
+  if (std::is_const_v<TR>) r = "const " + r;
+  if (std::is_lvalue_reference_v<T>)
+    r += "&";
+  else if (std::is_rvalue_reference_v<T>)
+    r += "&&";
+  return r;
+}
+
 #pragma endregion
 }}} // namespace corvid::meta::naming

--- a/corvid/meta/naming.h
+++ b/corvid/meta/naming.h
@@ -74,7 +74,11 @@ std::string friendly_type_name() {
   replace("__cxx11::", "");
   replace("(anonymous namespace)::", "");
   replace("`anonymous namespace'::", "");
-  replace("> >", ">>");
+  // Collapse spaced closing brackets to a fixpoint: one pass cannot see the
+  // pair a replacement just created ("> > >" needs two). A blanket "> " to
+  // ">" replacement would handle any depth in one pass but is wrong, because
+  // that spelling also occurs before east const ("std::vector<int> const*").
+  while (r.contains("> >")) replace("> >", ">>");
   replace(", ", ",");
   replace(
       "std::basic_string<char,std::char_traits<char>,"

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -46,9 +46,25 @@ namespace corvid { inline namespace meta { namespace prox {
 // canonically names a method, given that a library cannot mint a member with a
 // caller-chosen name.
 template<fixed_string Name>
-struct key {
+struct method_key {
   static constexpr auto name_v = Name;
 };
+
+inline namespace literals {
+
+// UDL for method keys: `"name"_method` is a `method_key<"name">`.
+//
+// This must be a literal operator template: the literal itself binds as the
+// `fixed_string` template argument, which is what lets it reach NTTP
+// position. The ordinary `(const char*, size_t)` form cannot work, because
+// function parameters are runtime values, never constant expressions, even
+// under `consteval`.
+template<fixed_string Name>
+consteval auto operator""_method() noexcept {
+  return method_key<Name>{};
+}
+
+} // namespace literals
 
 // Method descriptor: a name plus the erased signature.
 //
@@ -60,22 +76,22 @@ struct key {
 // The signature fixes the erased ABI; a binding may return the declared result
 // type or anything convertible to it.
 //
-// A method derives from its `key`, so a method tag is usable anywhere its key
-// is, including `on` overload selection and deduction of `key<K>` from a
-// method argument. This also leaves the door open for bindings that overload
-// on the full method (signature included) if per-name overload sets are ever
-// supported.
+// A method derives from its `method_key`, so a method tag is usable anywhere
+// its key is, including `on` overload selection and deduction of
+// `method_key<K>` from a method argument. This also leaves the door open for
+// bindings that overload on the full method (signature included) if per-name
+// overload sets are ever supported.
 template<fixed_string Name, typename Sig>
 struct method;
 
 template<fixed_string Name, typename R, typename... Args>
-struct method<Name, R(Args...)>: key<Name> {
+struct method<Name, R(Args...)>: method_key<Name> {
   static constexpr bool const_v = false;
   using result_t = R;
 };
 
 template<fixed_string Name, typename R, typename... Args>
-struct method<Name, R(Args...) const>: key<Name> {
+struct method<Name, R(Args...) const>: method_key<Name> {
   static constexpr bool const_v = true;
   using result_t = R;
 };
@@ -134,7 +150,7 @@ concept Facade = requires(const F& f) { details::facade_probe(f); };
 //    template<typename T>
 //    requires ProxyRegistered<animal, T>
 //    struct proxy_impl<animal, T> {
-//      static void on(key<"speak">, const T& t) { t.speak(); }
+//      static void on(method_key<"speak">, const T& t) { t.speak(); }
 //    };
 //
 //    // Conforming `dog`, whose names line up: pure registration.
@@ -145,7 +161,7 @@ concept Facade = requires(const F& f) { details::facade_probe(f); };
 //    // Conforming `cat`, whose names differ: a custom impl, not registration.
 //    template<>
 //    struct proxy_impl<animal, cat> {
-//      static void on(key<"speak">, const cat& c) { c.meow(); }
+//      static void on(method_key<"speak">, const cat& c) { c.meow(); }
 //    };
 template<typename F, typename T>
 struct proxy_impl;
@@ -213,14 +229,14 @@ struct method_traits<method<Name, R(Args...)>> {
   template<typename F, typename T>
   static constexpr bool bound_v = requires(T& t, Args... args) {
     {
-      proxy_impl<F, T>::on(key<Name>{}, t, std::forward<Args>(args)...)
+      proxy_impl<F, T>::on(method_key<Name>{}, t, std::forward<Args>(args)...)
     } -> std::convertible_to<R>;
   };
 
   template<typename F, typename T>
   static consteval thunk_ptr_t make_thunk() noexcept {
     return [](void* target, Args... args) -> R {
-      return proxy_impl<F, T>::on(key<Name>{}, *static_cast<T*>(target),
+      return proxy_impl<F, T>::on(method_key<Name>{}, *static_cast<T*>(target),
           std::forward<Args>(args)...);
     };
   }
@@ -233,15 +249,15 @@ struct method_traits<method<Name, R(Args...) const>> {
   template<typename F, typename T>
   static constexpr bool bound_v = requires(const T& t, Args... args) {
     {
-      proxy_impl<F, T>::on(key<Name>{}, t, std::forward<Args>(args)...)
+      proxy_impl<F, T>::on(method_key<Name>{}, t, std::forward<Args>(args)...)
     } -> std::convertible_to<R>;
   };
 
   template<typename F, typename T>
   static consteval thunk_ptr_t make_thunk() noexcept {
     return [](const void* target, Args... args) -> R {
-      return proxy_impl<F, T>::on(key<Name>{}, *static_cast<const T*>(target),
-          std::forward<Args>(args)...);
+      return proxy_impl<F, T>::on(method_key<Name>{},
+          *static_cast<const T*>(target), std::forward<Args>(args)...);
     };
   }
 };
@@ -359,7 +375,7 @@ template<Facade F>
 struct proxy_impl<F, proxy_view<F>> {
   template<fixed_string K, typename... As>
   static constexpr decltype(auto)
-  on(key<K>, const proxy_view<F>& view, As&&... args) {
+  on(method_key<K>, const proxy_view<F>& view, As&&... args) {
     return view.template call<K>(std::forward<As>(args)...);
   }
 };

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -36,7 +36,8 @@
 // an explicit `proxy_impl` specialization or by registering the pair to a
 // facade author's boilerplate impl, in the same spirit as registered enums.
 // See "proxy.md" for the design.
-namespace corvid { inline namespace meta { namespace prox {
+namespace corvid { inline namespace meta {
+namespace prox {
 
 #pragma region Method and key
 
@@ -437,6 +438,46 @@ concept Proxiable =
 #pragma endregion
 #pragma region proxy_view
 
+namespace details {
+
+// Storage and const-method dispatch shared by the two view flavors, which
+// differ only in the constness of the erased target pointer.
+//
+// The `call` here serves const-qualified methods, the only dispatch a const
+// handle allows; `proxy_view` layers the unrestricted non-const overload on
+// top.
+template<Facade F, bool Const>
+class view_base {
+public:
+  using facade_t = F;
+
+  // Call the const-qualified facade method named `K`, forwarding `args`
+  // through the erased signature. The call is `noexcept` when the method is.
+  // Not `[[nodiscard]]`: discardability belongs to the facade method, not
+  // the dispatcher (the `std::invoke` precedent).
+  template<fixed_string K, typename... Args>
+  requires(vtbuild_t<F>::template is_const<K>())
+  // NOLINTNEXTLINE(modernize-use-nodiscard)
+  constexpr decltype(auto) call(Args&&... args) const
+      noexcept(vtbuild_t<F>::template is_noexcept<K>()) {
+    constexpr auto ndx = vtbuild_t<F>::template index_of<K>();
+    static_assert(ndx != vtbuild_t<F>::count_v, "no matching signature");
+    return std::get<ndx>(*vtable_)(target_, std::forward<Args>(args)...);
+  }
+
+protected:
+  using vtable_t = vtbuild_t<F>::vtable_t;
+  using target_ptr_t = std::conditional_t<Const, const void*, void*>;
+
+  constexpr view_base(target_ptr_t target, const vtable_t* vtable) noexcept
+      : target_{target}, vtable_{vtable} {}
+
+  target_ptr_t target_;
+  const vtable_t* vtable_;
+};
+
+} // namespace details
+
 // Forward declaration so the mutable view can befriend the const flavor.
 template<Facade F>
 class const_proxy_view;
@@ -455,53 +496,40 @@ class const_proxy_view;
 // `const_proxy_view`, where constness is part of the type and survives
 // copying.
 template<Facade F>
-class proxy_view {
+class proxy_view: public details::view_base<F, false> {
+  using base = details::view_base<F, false>;
   using vtbuild_t = details::vtbuild_t<F>;
-  using vtable_t = vtbuild_t::vtable_t;
 
 public:
-  using facade_t = F;
-
   // Converting constructor from an lvalue target. Intentionally implicit, like
   // `string_view` from `string`. Rvalues do not bind, so construction from a
   // temporary is rejected at compile time; const targets take a
   // `const_proxy_view`.
   template<typename T>
-  requires(Proxiable<T, F> && !std::is_const_v<T> &&
-              !std::same_as<T, proxy_view>)
+  requires(
+      Proxiable<T, F> && !std::is_const_v<T> && !std::same_as<T, proxy_view>)
   constexpr explicit(false) proxy_view(T& target) noexcept
-      : target_{std::addressof(target)}, vtable_{&details::vtable_for<F, T>} {}
+      : base{std::addressof(target), &details::vtable_for<F, T>} {}
 
   // Call the facade method named `K`, forwarding `args` through the erased
   // signature. The call is `noexcept` when the method is.
   //
-  // The const overload is constrained to const-qualified methods, mirroring
-  // the owning proxy's deep const. Not `[[nodiscard]]`: discardability
-  // belongs to the facade method, not the dispatcher (the `std::invoke`
-  // precedent).
+  // This overload dispatches every method; the inherited const overload,
+  // re-exposed by the using-declaration, is constrained to const-qualified
+  // methods, mirroring the owning proxy's deep const.
   template<fixed_string K, typename... Args>
   constexpr decltype(auto)
   call(Args&&... args) noexcept(vtbuild_t::template is_noexcept<K>()) {
     constexpr auto ndx = vtbuild_t::template index_of<K>();
     static_assert(ndx != vtbuild_t::count_v, "no matching signature");
-    return std::get<ndx>(*vtable_)(target_, std::forward<Args>(args)...);
+    return std::get<ndx>(
+        *this->vtable_)(this->target_, std::forward<Args>(args)...);
   }
 
-  template<fixed_string K, typename... Args>
-  requires(details::vtbuild_t<F>::template is_const<K>())
-  // NOLINTNEXTLINE(modernize-use-nodiscard)
-  constexpr decltype(auto) call(Args&&... args) const
-      noexcept(vtbuild_t::template is_noexcept<K>()) {
-    constexpr auto ndx = vtbuild_t::template index_of<K>();
-    static_assert(ndx != vtbuild_t::count_v, "no matching signature");
-    return std::get<ndx>(*vtable_)(target_, std::forward<Args>(args)...);
-  }
+  using base::call;
 
 private:
   friend const_proxy_view<F>;
-
-  void* target_;
-  const vtable_t* vtable_;
 };
 
 // Library-provided binding so that a view itself satisfies its own facade (as
@@ -538,45 +566,29 @@ struct proxy_impl<F, proxy_view<F>> {
 // type) dispatch table (the non-const slots are simply unreachable). The
 // target must outlive the view.
 template<Facade F>
-class const_proxy_view {
-  using vtbuild_t = details::vtbuild_t<F>;
-  using vtable_t = vtbuild_t::vtable_t;
+class const_proxy_view: public details::view_base<F, true> {
+  using base = details::view_base<F, true>;
 
 public:
-  using facade_t = F;
-
   // Converting constructor from an lvalue target, const or not. Intentionally
   // implicit; rvalues do not bind.
   template<typename T>
-  requires(Proxiable<std::remove_const_t<T>, F> &&
-              !std::same_as<std::remove_const_t<T>, const_proxy_view> &&
-              !std::same_as<std::remove_const_t<T>, proxy_view<F>>)
+  requires(
+      Proxiable<std::remove_const_t<T>, F> &&
+      !std::same_as<std::remove_const_t<T>, const_proxy_view> &&
+      !std::same_as<std::remove_const_t<T>, proxy_view<F>>)
   constexpr explicit(false) const_proxy_view(T& target) noexcept
-      : target_{std::addressof(target)},
-        vtable_{&details::vtable_for<F, std::remove_const_t<T>>} {}
+      : base{std::addressof(target),
+            &details::vtable_for<F, std::remove_const_t<T>>} {}
 
   // Converting constructor from the mutable view: dropping mutability is
   // implicit and safe, like `T*` to `const T*`. There is no path back.
   constexpr explicit(false)
       const_proxy_view(const proxy_view<F>& view) noexcept
-      : target_{view.target_}, vtable_{view.vtable_} {}
+      : base{view.target_, view.vtable_} {}
 
-  // Call the facade method named `K`, which must be const-qualified; the
-  // mutable methods do not exist on this view. The call is `noexcept` when
-  // the method is. Not `[[nodiscard]]`, as on the other handles.
-  template<fixed_string K, typename... Args>
-  requires(details::vtbuild_t<F>::template is_const<K>())
-  // NOLINTNEXTLINE(modernize-use-nodiscard)
-  constexpr decltype(auto) call(Args&&... args) const
-      noexcept(vtbuild_t::template is_noexcept<K>()) {
-    constexpr auto ndx = vtbuild_t::template index_of<K>();
-    static_assert(ndx != vtbuild_t::count_v, "no matching signature");
-    return std::get<ndx>(*vtable_)(target_, std::forward<Args>(args)...);
-  }
-
-private:
-  const void* target_;
-  const vtable_t* vtable_;
+  // `call` is inherited: the base's const-method dispatch is the entire
+  // interface, since the mutable methods do not exist on this view.
 };
 
 // Library-provided binding so that a const view satisfies its own facade
@@ -782,4 +794,25 @@ requires Proxiable<T, F>
 
 #pragma endregion
 
-}}} // namespace corvid::meta::prox
+} // namespace prox
+
+#pragma region Exports
+
+// Call-site vocabulary, exported to `corvid::meta`.
+//
+// Consuming an erased handle is ordinary type usage, as in
+// `do_stuff(proxy_view<foo_like>)`, so these names belong in the wider
+// namespace. The authoring vocabulary (`facade`, `method`, `proxy_impl`, and
+// the registration machinery) stays inside `prox`: those names are too
+// generic to export, and facade and impl authors are already working in that
+// domain.
+using prox::const_proxy_view;
+using prox::make_proxy;
+using prox::make_proxy_view;
+using prox::proxy;
+using prox::Proxiable;
+using prox::proxy_view;
+
+#pragma endregion
+
+}} // namespace corvid::meta

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -79,7 +79,7 @@ consteval auto operator""_method() noexcept {
 // The signature fixes the erased ABI; a binding may return the declared result
 // type or anything convertible to it.
 //
-// A `noexcept` qualifier is likewise honored: conformance then requires the
+// A `noexcept` qualifier is likewise honored. Conformance then requires the
 // binding itself to be noexcept-invocable, and the erased call (`call` through
 // a handle) is itself `noexcept`.
 //
@@ -91,8 +91,10 @@ consteval auto operator""_method() noexcept {
 namespace details {
 
 // Shared base for the four `method` flavors (`const` crossed with
-// `noexcept`): the qualification flags and result type, which are the only
-// things that vary. Also supplies the `method_key` base.
+// `noexcept`).
+//
+// It carries the qualification flags and the result type, which are the only
+// things that vary, and supplies the `method_key` base.
 template<fixed_string Name, bool Const, bool Noexcept, typename R>
 struct method_base: method_key<Name> {
   static constexpr bool const_v = Const;
@@ -310,7 +312,7 @@ struct method_traits<method<Name, R(Args...) const noexcept>>
 // A target is stored inline when it fits the buffer, is no more aligned than
 // `std::max_align_t`, and is nothrow-move-constructible (a proxy move
 // relocates an inline target, and proxy moves are unconditionally
-// `noexcept`); anything else lives in a unique-owned heap allocation.
+// `noexcept`). Anything else lives in a unique-owned heap allocation.
 inline constexpr std::size_t sbo_size = 2 * sizeof(void*);
 
 template<typename T>
@@ -318,10 +320,10 @@ constexpr inline bool sbo_eligible_v =
     sizeof(T) <= sbo_size && alignof(T) <= alignof(std::max_align_t) &&
     std::is_nothrow_move_constructible_v<T>;
 
-// Housekeeping thunks for the owning `proxy`: the analog of Rust's drop glue.
+// Housekeeping thunks for the owning `proxy`, the analog of Rust's drop glue.
 //
-// `sbo_relocate` move-constructs `*from` into `to` and destroys the source;
-// the heap path has none because a heap target moves by pointer steal.
+// `sbo_relocate` move-constructs `*from` into `to` and destroys the source.
+// The heap path has none because a heap target moves by pointer steal.
 template<typename T>
 void sbo_destroy(void* target) noexcept {
   static_cast<T*>(target)->~T();
@@ -362,7 +364,7 @@ struct vtable_builder<facade<Ms...>> {
   }
 
   // Qualification of the method named `K`. Both are `false` when no method
-  // has that name; rejecting an unknown name is `index_of`'s job.
+  // has that name, since rejecting an unknown name is `index_of`'s job.
   template<fixed_string K>
   static consteval bool is_const() noexcept {
     constexpr std::array<bool, sizeof...(Ms)> flags{Ms::const_v...};
@@ -386,9 +388,9 @@ struct vtable_builder<facade<Ms...>> {
     return {method_traits<Ms>::template make_thunk<F, T>()...};
   }
 
-  // Owning dispatch table: the facade methods plus housekeeping slots. A null
-  // `relocate` marks a heap-stored target, which moves by pointer steal
-  // rather than relocation.
+  // Owning dispatch table, carrying housekeeping slots alongside the facade
+  // methods. A null `relocate` marks a heap-stored target, which moves by
+  // pointer steal rather than relocation.
   struct owning_vtable_t {
     vtable_t methods;
     void (*destroy)(void*) noexcept;
@@ -444,7 +446,7 @@ namespace details {
 // differ only in the constness of the erased target pointer.
 //
 // The `call` here serves const-qualified methods, the only dispatch a const
-// handle allows; `proxy_view` layers the unrestricted non-const overload on
+// handle allows. `proxy_view` layers the unrestricted non-const overload on
 // top.
 template<Facade F, bool Const>
 class view_base {
@@ -452,9 +454,11 @@ public:
   using facade_t = F;
 
   // Call the const-qualified facade method named `K`, forwarding `args`
-  // through the erased signature. The call is `noexcept` when the method is.
-  // Not `[[nodiscard]]`: discardability belongs to the facade method, not
-  // the dispatcher (the `std::invoke` precedent).
+  // through the erased signature.
+  //
+  // The call is `noexcept` when the method is. It is not `[[nodiscard]]`,
+  // because discardability belongs to the facade method rather than the
+  // dispatcher (the `std::invoke` precedent).
   template<fixed_string K, typename... Args>
   requires(vtbuild_t<F>::template is_const<K>())
   // NOLINTNEXTLINE(modernize-use-nodiscard)
@@ -488,9 +492,9 @@ class const_proxy_view;
 // Two pointers: the target and the per-(facade, type) dispatch table. The
 // target must outlive the view.
 //
-// Deep-const as an instance: only const-qualified facade methods dispatch
+// Deep-const as an instance, so only const-qualified facade methods dispatch
 // through a `const proxy_view`. Because views are freely copyable, that is a
-// guardrail rather than a guarantee: copying a `const proxy_view` yields a
+// guardrail rather than a guarantee. Copying a `const proxy_view` yields a
 // mutable view onto the same target, much as a `T* const` pointer copies to
 // a plain `T*`. Code that means read-only access should use
 // `const_proxy_view`, where constness is part of the type and survives
@@ -503,7 +507,7 @@ class proxy_view: public details::view_base<F, false> {
 public:
   // Converting constructor from an lvalue target. Intentionally implicit, like
   // `string_view` from `string`. Rvalues do not bind, so construction from a
-  // temporary is rejected at compile time; const targets take a
+  // temporary is rejected at compile time. Const targets take a
   // `const_proxy_view`.
   template<typename T>
   requires(
@@ -514,7 +518,7 @@ public:
   // Call the facade method named `K`, forwarding `args` through the erased
   // signature. The call is `noexcept` when the method is.
   //
-  // This overload dispatches every method; the inherited const overload,
+  // This overload dispatches every method. The inherited const overload,
   // re-exposed by the using-declaration, is constrained to const-qualified
   // methods, mirroring the owning proxy's deep const.
   template<fixed_string K, typename... Args>
@@ -560,7 +564,7 @@ struct proxy_impl<F, proxy_view<F>> {
 // `const_iterator` to `proxy_view`'s `iterator`.
 //
 // Constness is part of the type, so unlike a `const proxy_view` it survives
-// copying: a const view only ever copies or converts to another const view.
+// copying. A const view only ever copies or converts to another const view.
 // It binds const and mutable targets alike, and dispatches only the
 // const-qualified facade methods, sharing the mutable view's per-(facade,
 // type) dispatch table (the non-const slots are simply unreachable). The
@@ -571,7 +575,7 @@ class const_proxy_view: public details::view_base<F, true> {
 
 public:
   // Converting constructor from an lvalue target, const or not. Intentionally
-  // implicit; rvalues do not bind.
+  // implicit. Rvalues do not bind.
   template<typename T>
   requires(
       Proxiable<std::remove_const_t<T>, F> &&
@@ -581,18 +585,18 @@ public:
       : base{std::addressof(target),
             &details::vtable_for<F, std::remove_const_t<T>>} {}
 
-  // Converting constructor from the mutable view: dropping mutability is
-  // implicit and safe, like `T*` to `const T*`. There is no path back.
+  // Converting constructor from the mutable view. Dropping mutability is
+  // implicit and safe, like `T*` to `const T*`, and there is no path back.
   constexpr explicit(false)
       const_proxy_view(const proxy_view<F>& view) noexcept
       : base{view.target_, view.vtable_} {}
 
-  // `call` is inherited: the base's const-method dispatch is the entire
+  // `call` is inherited. The base's const-method dispatch is the entire
   // interface, since the mutable methods do not exist on this view.
 };
 
 // Library-provided binding so that a const view satisfies its own facade
-// where that is possible: it dispatches only const methods, so the invariant
+// where that is possible. It dispatches only const methods, so the invariant
 // holds exactly for all-const facades.
 //
 // The `on` is itself constrained to const methods so that a mixed facade
@@ -632,14 +636,15 @@ requires Proxiable<T, F>
 //
 // Move-only. Small targets (at most `sbo_size` bytes, at most
 // `std::max_align_t` alignment, nothrow-move-constructible) are stored
-// inline; anything else lives in a unique-owned heap allocation. The owning
+// inline. Anything else lives in a unique-owned heap allocation. The owning
 // dispatch table carries destroy and relocate slots alongside the facade
 // methods, so destruction and moves work without knowing the target type.
 //
-// Unlike the shallow-const view, the proxy owns its target and is deep-const:
-// only const-qualified facade methods dispatch through a const proxy.
+// The proxy is deep-const, so only const-qualified facade methods dispatch
+// through a const proxy. Being move-only, it cannot be copied out of that
+// constness the way a view can.
 //
-// A default-constructed or moved-from proxy is empty: destructible,
+// A default-constructed or moved-from proxy is empty. It is destructible,
 // assignable, and testable via `operator bool`, but calling through it is
 // undefined behavior.
 template<Facade F>
@@ -650,7 +655,7 @@ class proxy {
 public:
   using facade_t = F;
 
-  // Inline storage capacity in bytes; see the class comment for the other
+  // Inline storage capacity in bytes. See the class comment for the other
   // inline-eligibility conditions.
   static constexpr std::size_t sbo_size = details::sbo_size;
 
@@ -673,8 +678,8 @@ public:
   }
 
   // Move construction and assignment leave the source empty. Inline targets
-  // relocate through the table's move slot; heap targets move by pointer
-  // steal.
+  // relocate through the table's move slot, while heap targets move by
+  // pointer steal.
   proxy(proxy&& other) noexcept { do_adopt(other); }
 
   proxy& operator=(proxy&& other) noexcept {
@@ -688,12 +693,13 @@ public:
   ~proxy() { do_reset(); }
 
   // Call the facade method named `K`, forwarding `args` through the erased
-  // signature. The call is `noexcept` when the method is.
+  // signature.
   //
-  // The const overload is constrained to const-qualified methods: deep const,
-  // enforced at overload resolution so the rejection is visible to `requires`
-  // probes as well. Not `[[nodiscard]]`: discardability belongs to the facade
-  // method, not the dispatcher (the `std::invoke` precedent).
+  // The call is `noexcept` when the method is. The const overload is
+  // constrained to const-qualified methods, enforcing deep const at overload
+  // resolution so the rejection is visible to `requires` probes as well. It
+  // is not `[[nodiscard]]`, because discardability belongs to the facade
+  // method rather than the dispatcher (the `std::invoke` precedent).
   template<fixed_string K, typename... Args>
   decltype(auto)
   call(Args&&... args) noexcept(vtbuild_t::template is_noexcept<K>()) {
@@ -763,8 +769,8 @@ private:
 // like the view.
 //
 // Calls forward through the proxy, with conditional `noexcept`. The const
-// overload serves const-qualified methods, matching the proxy's deep const;
-// the non-const overload serves the rest.
+// overload serves const-qualified methods, matching the proxy's deep const,
+// and the non-const overload serves the rest.
 template<Facade F>
 struct proxy_impl<F, proxy<F>> {
   template<fixed_string K, typename... Args>
@@ -803,8 +809,8 @@ requires Proxiable<T, F>
 // Consuming an erased handle is ordinary type usage, as in
 // `do_stuff(proxy_view<foo_like>)`, so these names belong in the wider
 // namespace. The authoring vocabulary (`facade`, `method`, `proxy_impl`, and
-// the registration machinery) stays inside `prox`: those names are too
-// generic to export, and facade and impl authors are already working in that
+// the registration machinery) stays inside `prox`, since those names are too
+// generic to export and facade and impl authors are already working in that
 // domain.
 using prox::const_proxy_view;
 using prox::make_proxy;

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -143,6 +143,14 @@ concept Facade = requires(const F& f) { details::probe(f); };
 // An explicit full specialization for one type outranks the boilerplate and
 // needs no registration.
 //
+// A facade author who factors the boilerplate bindings into a plain
+// inheritable class (with the partial specialization deriving from it) also
+// enables partial overrides: a type whose names line up except for one method
+// writes a full specialization that inherits that class, re-exposes its `on`
+// overloads with a using-declaration, and declares only the divergent
+// binding. See "proxy.md" for the mechanics and "proxy_test.cpp" for an
+// example in `proxy_impl_gunslinger`.
+//
 // For example, given `struct animal : facade<method<"speak", void() const>>`:
 //
 //    // Facade author's boilerplate, written once, serving any registered

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -344,9 +344,7 @@ public:
       : target_{std::addressof(target)}, vtable_{&details::vtable_for<F, T>} {}
 
   // Call the facade method named `K`, forwarding `args` through the erased
-  // signature. Fails to compile when no method has that name; the `if
-  // constexpr` discards the dispatch on that path so the `static_assert` is
-  // the only error emitted.
+  // signature.
   template<fixed_string K, typename... Args>
   constexpr decltype(auto) call(Args&&... args) const {
     constexpr auto ndx = vtbuild_t::template index_of<K>();

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -215,8 +215,8 @@ struct method<Name, R(Args...) const noexcept>
 //      };
 //      template<typename T>
 //      struct boilerplate : proxy_impl_base {
-//        static int on(method_key<"speak">, const T& t) {
-//          return t.speak();
+//        static void on(method_key<"speak">, const T& t) {
+//          t.speak();
 //        }
 //      };
 //    };

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -724,8 +724,9 @@ struct method_traits_base {
   // exactly after normalization, and whether they are merely viable through
   // the ordinary conversions a call performs.
   //
-  // Exactness is the validation probe's strictness; viability is overload-set
-  // resolution's fallback.
+  // Exactness is the validation probe's strictness; viability is how
+  // `resolve` tells an ambiguous call from an unmatched one when the ranking
+  // probe rejects it.
   template<typename... CallArgs>
   static constexpr bool exact_v =
       std::same_as<std::tuple<std::remove_cvref_t<CallArgs>...>, norm_args_t>;
@@ -1241,6 +1242,49 @@ template<typename... Es>
 using bases_of_t = decltype(std::tuple_cat(
     std::declval<typename entry_traits<Es>::bases_t>()...));
 
+// `rank_poison`: parameter type nothing converts to, making a probe overload
+// permanently non-viable.
+//
+// It stands in for the slots outside a key's candidate set, so a `rank_set`
+// can span the whole slot list positionally.
+struct rank_poison {
+  rank_poison() = delete;
+};
+
+// `rank_probe`: one synthetic overload standing in for the candidate slot at
+// index `Ndx` during overload ranking.
+//
+// The call operator's parameters are the slot's declared parameter list and
+// its constness mirrors the method's, so the implicit object parameter
+// participates exactly as it would in a real member overload set. The result
+// type carries the slot index out of a resolved call expression. Probes are
+// only ever named in unevaluated contexts, so the operators need no
+// definitions.
+template<std::size_t Ndx, bool Const, typename ArgsTuple>
+struct rank_probe;
+
+template<std::size_t Ndx, typename... Args>
+struct rank_probe<Ndx, false, std::tuple<Args...>> {
+  std::integral_constant<std::size_t, Ndx> operator()(Args...);
+};
+
+template<std::size_t Ndx, typename... Args>
+struct rank_probe<Ndx, true, std::tuple<Args...>> {
+  std::integral_constant<std::size_t, Ndx> operator()(Args...) const;
+};
+
+// `rank_set`: the synthetic overload set `resolve` hands to the compiler.
+//
+// A real call expression against it runs genuine C++ overload resolution
+// over the candidates, promotions, conversion ranks, and object-parameter
+// weighing included, which is what keeps `call<>` and the `api` forwarders
+// in exact agreement. A same-signature candidate pair merges legally and
+// stays ambiguous at the call, matching the sibling-collision semantics.
+template<typename... Probes>
+struct rank_set: Probes... {
+  using Probes::operator()...;
+};
+
 // `vtable_builder_impl`: the flattened core of the builder, over the full slot
 // list `Ss` (bases' methods first, in declaration order, then own, deduped),
 // the direct-base facades `Bs`, and the facade's own name `OwnName`.
@@ -1269,6 +1313,10 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
   // `base_t`: direct-base facade at index `Ndx`.
   template<std::size_t Ndx>
   using base_t = std::tuple_element_t<Ndx, std::tuple<Bs...>>;
+
+  // `slot_t`: flattened slot at index `Ndx`.
+  template<std::size_t Ndx>
+  using slot_t = std::tuple_element_t<Ndx, std::tuple<Ss...>>;
 
   using thunks_t = std::tuple<
       typename method_traits<typename Ss::method_t>::thunk_ptr_t...>;
@@ -1397,7 +1445,7 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
   }
 
   // `nonconst_flags`: per-slot flags marking the non-const methods, the
-  // tiebreak preference for dispatch through a mutable handle.
+  // tiebreak preference for `resolve_exact` through a mutable strict call.
   static consteval std::array<bool, count_v> nonconst_flags() noexcept {
     return {!Ss::const_v...};
   }
@@ -1406,13 +1454,11 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
   // unique non-const candidate.
   //
   // This is C++ overload resolution's object-parameter preference, applied
-  // as a tiebreak: through a mutable handle (`ConstOnly` false), a name
-  // overloaded on constness alone resolves to its non-const member, as a
-  // call on a non-const object would. Through a const handle the candidate
-  // set was already const-filtered, so there is nothing to prefer. The
-  // preference is uniform across a candidate set, so a sibling collision
-  // differing only in constness resolves the same way, matching the stated
-  // using-merge model.
+  // as a tiebreak for `resolve_exact`, whose exact-match filter cannot see
+  // the object parameter: through a mutable call (`ConstOnly` false), a
+  // const pair resolves to its non-const member, as a call on a non-const
+  // object would. `resolve` needs no such tiebreak, because the compiler
+  // weighs the object parameter itself during ranking.
   template<bool ConstOnly>
   static consteval std::pair<std::size_t, std::size_t>
   tally_preferring_nonconst(const std::array<bool, count_v>& flags) noexcept {
@@ -1426,44 +1472,61 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
     return whole;
   }
 
+  // `make_rank_set`: build the `rank_set` type for `Key`'s candidates.
+  //
+  // The set spans the whole slot list positionally; a non-candidate slot
+  // contributes a `rank_poison` overload no call can select, so the winning
+  // index needs no translation.
+  template<fixed_string Key, bool ConstOnly, std::size_t... Ndx>
+  static consteval auto make_rank_set(std::index_sequence<Ndx...>) noexcept {
+    return std::type_identity<
+        rank_set<std::conditional_t<candidates<Key, ConstOnly>()[Ndx],
+            rank_probe<Ndx, slot_t<Ndx>::const_v,
+                typename slot_t<Ndx>::method_t::args_t>,
+            rank_probe<Ndx, false, std::tuple<rank_poison>>>...>>{};
+  }
+
   // `resolve`: resolve `Key`, called with `CallArgs`, to a slot index, or to
   // `none_v` or `ambiguous_v`.
   //
   // An unqualified key with a single candidate resolves to it
   // unconditionally, so a call with unsuitable arguments still fails
   // directly at the thunk; a qualified key narrows the candidates to one
-  // facade's before the same rules run. A key over an overload set (per-name
-  // overloads within a facade, or a sibling collision) resolves the way a
-  // C++ call would after a using-merge: a unique exact signature match
-  // wins, else a unique viable candidate, with constness as the tiebreak
-  // within each tier (see `tally_preferring_nonconst`), and anything else
-  // is ambiguous. `ConstOnly` restricts the candidates to const-qualified
-  // methods, for dispatch through const handles.
+  // facade's before the same rules run. `ConstOnly` restricts the
+  // candidates to const-qualified methods, for dispatch through const
+  // handles.
   //
-  // The two tiers plus the tiebreak are deliberately not full C++
-  // implicit-conversion ranking: within the viable tier no candidate
-  // outranks another by conversion quality (a promotion does not beat a
-  // conversion), and an exact argument match on a const method outranks the
-  // object-parameter preference where real member overloading would weigh
-  // them together. Arguments first, constness second, predictably.
+  // A key over an overload set (per-name overloads within a facade, or a
+  // sibling collision) is ranked by the compiler rather than by a
+  // reimplementation of its rules: the candidates become a synthetic
+  // overload set (`make_rank_set`) and a real call expression against
+  // `CallArgs` picks the winner, whose result type carries the slot index.
+  // Dispatch therefore agrees with the `api` forwarders everywhere,
+  // promotions, conversion ranks, and the object-parameter weighing
+  // included. An ill-formed ranking call is classified by per-slot
+  // viability: some viable candidate means the call is ambiguous, none
+  // means nothing matched.
   template<fixed_string Key, bool ConstOnly, typename... CallArgs>
   static consteval std::size_t resolve() noexcept {
     constexpr auto cand = candidates<Key, ConstOnly>();
     const auto [cnt, at] = tally(cand);
     if (cnt < 2) return cnt ? at : none_v;
-    const auto [exact_cnt, exact_at] = tally_preferring_nonconst<ConstOnly>(
-        both(cand, exact_flags<CallArgs...>()));
-    if (exact_cnt == 1) return exact_at;
-    if (exact_cnt > 1) return ambiguous_v;
-    const auto [viable_cnt, viable_at] = tally_preferring_nonconst<ConstOnly>(
-        both(cand, viable_flags<CallArgs...>()));
-    if (viable_cnt == 1) return viable_at;
-    return viable_cnt ? ambiguous_v : none_v;
+    using set_t = decltype(make_rank_set<Key, ConstOnly>(
+        std::make_index_sequence<count_v>{}))::type;
+    using probe_t = std::conditional_t<ConstOnly, const set_t, set_t>;
+    if constexpr (requires(probe_t& p) { p(std::declval<CallArgs>()...); })
+      return decltype(std::declval<probe_t&>()(
+          std::declval<CallArgs>()...))::value;
+    else
+      return tally(both(cand, viable_flags<CallArgs...>())).first
+                 ? ambiguous_v
+                 : none_v;
   }
 
   // `resolve_exact`: resolve `Key` to the unique candidate whose declared
-  // parameters match `CallArgs` exactly, with the same constness tiebreak as
-  // `resolve`.
+  // parameters match `CallArgs` exactly, with a constness tiebreak standing
+  // in for the object-parameter weighing that `resolve` gets from the
+  // compiler.
   //
   // This is the validation probe's strictness: a merely-viable signature does
   // not count. The tiebreak is what lets the probe's mutable strict call

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -2015,6 +2015,7 @@ public:
   // NOLINTNEXTLINE(modernize-use-nodiscard)
   constexpr decltype(auto) call(Args&&... args) const
       noexcept(vtbuild_t<F>::template is_noexcept<Key, true, Args...>()) {
+    assert(vtable_);
     return dispatch<F, true, Key>(vtable_->thunks, target_,
         std::forward<Args>(args)...);
   }
@@ -2094,23 +2095,26 @@ public:
   // Intentionally implicit, like derived-to-base pointer conversion: the
   // target carries over unchanged and the dispatch table narrows to `F`'s by
   // following the embedded base-table pointers, so the upcast view dispatches
-  // exactly what a directly-built `F` view of the target would.
+  // exactly what a directly-built `F` view of the target would. An empty view
+  // upcasts to an empty view.
   template<Facade D>
   requires Extends<D, F>
   constexpr explicit(false) proxy_view(const proxy_view<D>& view) noexcept
-      : base{view.target_, details::upcast_vtable<F, D>(view.vtable_)} {}
+      : base{view.target_,
+            view ? details::upcast_vtable<F, D>(view.vtable_) : nullptr} {}
 
   // `proxy_view`: viewing constructor from an owning `proxy` of `F`, or of a
   // facade that extends it.
   //
   // Intentionally implicit, and lvalue-only, so a view cannot be left dangling
-  // by a temporary `proxy`. The `proxy` must be non-empty and must outlive the
-  // view. A const `proxy` takes a `const_proxy_view` instead, preserving deep
-  // const.
+  // by a temporary `proxy`. An empty `proxy` lends an empty view; otherwise
+  // the `proxy` must outlive the view. A const `proxy` takes a
+  // `const_proxy_view` instead, preserving deep const.
   template<Facade D, proxy_policy P>
   requires(std::same_as<D, F> || Extends<D, F>)
   explicit(false) proxy_view(proxy<D, P>& p) noexcept
-      : base{p.target(), details::upcast_vtable<F, D>(&p.vtable_->vt)} {}
+      : base{p ? p.target() : nullptr,
+            p ? details::upcast_vtable<F, D>(&p.vtable_->vt) : nullptr} {}
 
   // `proxy_view`: viewing constructor from a `shared_proxy` of `F`, or of a
   // facade that extends it, under the same rules as viewing an owning `proxy`;
@@ -2118,7 +2122,8 @@ public:
   template<Facade D>
   requires(std::same_as<D, F> || Extends<D, F>)
   explicit(false) proxy_view(shared_proxy<D>& p) noexcept
-      : base{p.target(), details::upcast_vtable<F, D>(p.vtable_)} {}
+      : base{p ? p.target() : nullptr,
+            p ? details::upcast_vtable<F, D>(p.vtable_) : nullptr} {}
 
   // `call`: call the facade method named `Key`, forwarding `args` through the
   // erased signature.
@@ -2131,6 +2136,7 @@ public:
   template<fixed_string Key, typename... Args>
   constexpr decltype(auto) call(Args&&... args) noexcept(
       vtbuild_t::template is_noexcept<Key, false, Args...>()) {
+    assert(this->vtable_);
     return details::dispatch<F, false, Key>(this->vtable_->thunks,
         this->target_, std::forward<Args>(args)...);
   }
@@ -2259,7 +2265,8 @@ public:
   requires Extends<D, F>
   constexpr explicit(false)
       const_proxy_view(const const_proxy_view<D>& view) noexcept
-      : base{view.target_, details::upcast_vtable<F, D>(view.vtable_)} {}
+      : base{view.target_,
+            view ? details::upcast_vtable<F, D>(view.vtable_) : nullptr} {}
 
   // `const_proxy_view`: upcasting constructor from the mutable view of a
   // facade that extends `F`, dropping mutability and upcasting in one implicit
@@ -2268,25 +2275,28 @@ public:
   requires Extends<D, F>
   constexpr explicit(false)
       const_proxy_view(const proxy_view<D>& view) noexcept
-      : base{view.target_, details::upcast_vtable<F, D>(view.vtable_)} {}
+      : base{view.target_,
+            view ? details::upcast_vtable<F, D>(view.vtable_) : nullptr} {}
 
   // `const_proxy_view`: viewing constructor from an owning `proxy` of `F`, or
   // of a facade that extends it.
   //
-  // Intentionally implicit, and lvalue-only. The proxy must be non-empty and
-  // must outlive the view. Mutable and const proxies alike yield the const
-  // view; there is no path back to mutability.
+  // Intentionally implicit, and lvalue-only. An empty `proxy` lends an empty
+  // view; otherwise the `proxy` must outlive the view. Mutable and const
+  // proxies alike yield the const view; there is no path back to mutability.
   template<Facade D, proxy_policy P>
   requires(std::same_as<D, F> || Extends<D, F>)
   explicit(false) const_proxy_view(const proxy<D, P>& p) noexcept
-      : base{p.target(), details::upcast_vtable<F, D>(&p.vtable_->vt)} {}
+      : base{p ? p.target() : nullptr,
+            p ? details::upcast_vtable<F, D>(&p.vtable_->vt) : nullptr} {}
 
   // `const_proxy_view`: viewing constructor from a `shared_proxy` of `F`, or
   // of a facade that extends it; see the owning-proxy constructor above.
   template<Facade D>
   requires(std::same_as<D, F> || Extends<D, F>)
   explicit(false) const_proxy_view(const shared_proxy<D>& p) noexcept
-      : base{p.target(), details::upcast_vtable<F, D>(p.vtable_)} {}
+      : base{p ? p.target() : nullptr,
+            p ? details::upcast_vtable<F, D>(p.vtable_) : nullptr} {}
 
   // No need for a `using` because `call` is inherited. The base's const-method
   // dispatch is the entire interface, since the mutable methods do not exist

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -165,7 +165,7 @@ struct method<Name, R(Args...) const noexcept>
 //        }
 //      };
 //      template<typename T>
-//      struct boilerplate {
+//      struct boilerplate : prox_impl {
 //        static int on(method_key<"speak">, const T& t) {
 //          return t.speak();
 //        }
@@ -204,9 +204,12 @@ concept Facade = requires(const F& f) { details::probe(f); };
 //
 // The derived facade's effective method list is the flattening of its bases'
 // lists, in declaration order, followed by its own; handles of the derived
-// facade dispatch inherited and own methods alike. Names must be unique
-// across the flattened list, so a facade cannot redeclare (or override) an
-// inherited method, and diamond composition is rejected.
+// facade dispatch inherited and own methods alike.
+//
+// Names must be unique across the flattened list, so for now a facade cannot
+// redeclare (or override) an inherited method, and diamond composition is
+// rejected. Both are limits of the current implementation rather than the
+// model, with relaxation paths recorded under Future in "proxy.md".
 //
 // Conformance is per facade, as with Rust supertraits: a type conforms to
 // `pet` by binding `pet`'s own methods through `proxy_impl<pet, T>` and
@@ -250,6 +253,20 @@ using api_base_t = api_base<F>::type;
 
 #pragma endregion
 #pragma region Registration and binding
+
+// Convenience base for binding classes: a facade's `boilerplate`, or a
+// registration-carried impl.
+//
+// Its sole member is a `method_key` alias, which lets a binding class spell
+// its `on` parameters without qualification: base-class members participate
+// in unqualified lookup, where the enclosing namespace's names do not.
+// Inheriting it is optional, and a binding class that inherits a boilerplate
+// already has it through that base. It also serves as documentation of what
+// the class is for.
+struct prox_impl {
+  template<fixed_string Name>
+  using method_key = prox::method_key<Name>;
+};
 
 // Binding point between a facade and a concrete type (Rust's `impl Trait for
 // Type`).
@@ -295,9 +312,10 @@ using api_base_t = api_base<F>::type;
 
 //    // Facade author's boilerplate, written once, serving any registered
 //    // type whose member names line up. The `api` is omitted here for
-//    //  brevity.
+//    // brevity. Inheriting `prox_impl` supplies the unqualified `method_key`
+//    // spelling.
 //    struct animal : facade<method<"speak", void() const>> {
-//    template<typename T> struct boilerplate {
+//      template<typename T> struct boilerplate : prox_impl {
 //        static void on(method_key<"speak">, const T& t) { t.speak(); }
 //      };
 //    };
@@ -310,7 +328,7 @@ using api_base_t = api_base<F>::type;
 //    // Conforming `cat`, whose names differ: the registration carries the
 //    // impl, here local to the hook itself.
 //    consteval auto corvid_proxy_spec(animal*, cat*) {
-//      struct as_animal {
+//      struct as_animal : prox_impl {
 //        static void on(method_key<"speak">, const cat& c) { c.meow(); }
 //      };
 //      return make_proxy_spec<animal, cat, as_animal>();
@@ -722,8 +740,9 @@ struct vtable_builder_impl<std::tuple<Ms...>, std::tuple<Bs...>> {
     std::tuple<const typename vtbuild_t<Bs>::vtable_t*...> bases;
   };
 
-  // Whether this facade transitively extends facade `B`. Strict: false when
-  // `B` is this facade itself.
+  // Whether this facade transitively extends facade `B`. Strict: the search
+  // covers the bases and their bases, never this facade itself, so a
+  // self-match is false.
   template<typename B>
   static consteval bool extends_facade() noexcept {
     return (
@@ -1068,7 +1087,7 @@ template<Facade F>
 }
 
 #pragma endregion
-#pragma region proxy_view
+#pragma region Views
 
 namespace details {
 
@@ -1103,15 +1122,23 @@ public:
         vtable_->thunks)(target_, std::forward<Args>(args)...);
   }
 
+  // An empty view (default-constructed) holds no target. It is testable and
+  // rebindable by assignment, but calling through it is undefined behavior,
+  // exactly as with an empty proxy.
+  [[nodiscard]] constexpr explicit operator bool() const noexcept {
+    return vtable_;
+  }
+
 protected:
   using vtable_t = vtbuild_t<F>::vtable_t;
   using target_ptr_t = std::conditional_t<Const, const void*, void*>;
 
+  constexpr view_base() noexcept = default;
   constexpr view_base(target_ptr_t target, const vtable_t* vtable) noexcept
       : target_{target}, vtable_{vtable} {}
 
-  target_ptr_t target_;
-  const vtable_t* vtable_;
+  target_ptr_t target_{};
+  const vtable_t* vtable_{};
 };
 
 } // namespace details
@@ -1135,6 +1162,10 @@ protected:
 // `const_proxy_view`, where constness is part of the type and survives
 // copying.
 //
+// A default-constructed view is empty, like a default-constructed proxy:
+// testable via `operator bool` and rebindable by assignment, but calling
+// through it is undefined behavior.
+//
 // When the facade defines a nested `api`, the view inherits it, so the
 // member-call sugar forwarders dispatch alongside `call`.
 template<Facade F>
@@ -1143,6 +1174,9 @@ class proxy_view: public details::view_base<F, false> {
   using vtbuild_t = details::vtbuild_t<F>;
 
 public:
+  // An empty view holds no target; see the class comment.
+  proxy_view() = default;
+
   // Converting constructor from an lvalue target.
   //
   // Intentionally implicit, like `string_view` from `string`. Rvalues do not
@@ -1241,6 +1275,9 @@ struct proxy_impl<F, proxy_view<D>> {
 // type) dispatch table (the non-const slots are simply unreachable). The
 // target must outlive the view.
 //
+// A default-constructed view is empty: testable via `operator bool` and
+// rebindable by assignment, but calling through it is undefined behavior.
+//
 // When the facade defines a nested `api`, the view inherits it. Only the const
 // forwarders are callable; a mutable forwarder fails inside its `call` if
 // used.
@@ -1249,6 +1286,9 @@ class const_proxy_view: public details::view_base<F, true> {
   using base = details::view_base<F, true>;
 
 public:
+  // An empty view holds no target; see the class comment.
+  const_proxy_view() = default;
+
   // Converting constructor from an lvalue target, const or not.
   //
   // Intentionally implicit. Rvalues do not bind. Handles of `F`, or of a
@@ -1547,6 +1587,7 @@ using prox::make_proxy_view;
 using prox::proxy;
 using prox::Proxiable;
 using prox::proxy_view;
+using prox::prox_impl;
 
 #pragma endregion
 

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -1095,10 +1095,10 @@ consteval bool same_chain_owners() noexcept {
            vtbuild_t<o2_t>::template extends_facade<o1_t>();
 }
 
-// `legal_overload_pair`: whether two same-name slots declared by the same
-// facade form a legal overload pair: distinct normalized argument lists, or
-// the same arguments with different constness (the const-pair idiom, a
-// mutable accessor and a read-only query sharing a name).
+// `legal_overload_pair`: whether two same-name slots form a legal overload
+// pair: distinct normalized argument lists, or the same arguments with
+// different constness (the const-pair idiom, a mutable accessor and a
+// read-only query sharing a name).
 //
 // The C++ member rules apply: the result type and `noexcept` do not
 // overload, so a pair distinguished by nothing else is a collision.
@@ -1114,26 +1114,27 @@ consteval bool legal_overload_pair() noexcept {
 // Post-dedup, a repeated slot type is only ever the self-pairing, so same-type
 // pairs are skipped.
 //
-// Within one declaring facade, a recurring method name is an overload set,
+// Within one extends chain, a recurring method name is an overload set,
 // legal when every pair differs in arguments or constness (see
-// `legal_overload_pair`). Across an extends chain a name may not recur at
-// all: a derived facade cannot redeclare (or overload, or override) an
-// inherited name, by design, because facades carry no implementations and
-// there is nothing to override.
+// `legal_overload_pair`), whether the declarations share a facade or span
+// levels: a base's `foo()` and a derived facade's `foo(int)` are different
+// functions that happen to share a spelling, exactly as within one facade.
+// A same-signature recurrence stays an error, since that is redeclaration
+// (or overriding), and facades carry no implementations, so there is
+// nothing to override.
 //
-// Unrelated sibling facades may collide on a method name freely, since every
-// facade is named and the qualified spelling is always available as the route
-// to a collided slot that the arguments cannot single out. Facade names must
+// Unrelated sibling facades may collide on a method name freely, including
+// on the full signature, since every facade is named and the qualified
+// spelling is always available as the route to a collided slot that the
+// arguments cannot single out; chain authors can see the base, so a chain's
+// same-signature recurrence is rejected eagerly instead. Facade names must
 // be unique within the composition, or qualified keys could themselves
 // collide.
 template<typename S1, typename... Ss>
 consteval bool no_chain_collision_against() noexcept {
-  return (
-      (std::same_as<S1, Ss> || S1::name_v != Ss::name_v ||
-          (std::same_as<typename S1::owner_t, typename Ss::owner_t>
-                  ? legal_overload_pair<S1, Ss>()
-                  : !same_chain_owners<S1, Ss>())) &&
-      ...);
+  return ((std::same_as<S1, Ss> || S1::name_v != Ss::name_v ||
+              !same_chain_owners<S1, Ss>() || legal_overload_pair<S1, Ss>()) &&
+          ...);
 }
 
 template<fixed_string OwnName, typename S1, typename... Ss>
@@ -1230,8 +1231,8 @@ struct vtable_builder_impl;
 template<typename... Ss, typename... Bs, fixed_string OwnName>
 struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
   static_assert((no_chain_collision_against<Ss, Ss...>() && ...),
-      "a method name may recur within one facade only as overloads differing "
-      "in arguments or constness, and never across an extends chain");
+      "a method name may recur within one extends chain only as overloads "
+      "differing in arguments or constness");
   static_assert((owner_names_unique_against<OwnName, Ss, Ss...>() && ...),
       "facade names must be unique within a composition");
 

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -1960,8 +1960,10 @@ consteval auto corvid_proxy_spec(F*, api_probe<G>*) noexcept {
 // the facade's (including the silently-truncating kind), and a forwarder body
 // dispatching a key with a different signature. Not caught: a missing
 // `noexcept` on a forwarder, by-value versus by-reference parameter spellings,
-// reference-to-value decay of a declared result, and a body dispatching the
-// wrong key with an identical signature.
+// reference-to-value decay of a declared result, a body dispatching the
+// wrong key with an identical signature, and a missing overload forwarder
+// whose probe call a same-name sibling forwarder absorbs by conversion,
+// landing exactly on the sibling's slot.
 //
 // Limitation: a composed facade whose flattened list collides on a
 // same-signature method name cannot validate, because the boilerplates drive

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -61,6 +61,8 @@
 // - `D`: a derived facade, one that extends `F` or `B`.
 // - `G`: a second facade, where two vary independently.
 // - `T`: the concrete target type behind a handle.
+// - `Handle`: a deduced handle parameter in the library's self-conformance
+//     bindings, binding the const and mutable flavors with one overload.
 // - `E`: one entry of a facade's list; `Es` is the whole pack (`name`,
 //     `extends`, and `method` entries).
 // - `Bs`: a facade's direct-base facades.
@@ -941,6 +943,21 @@ find_ancestor(const ancestry_t& ancestry, const void* tag) noexcept {
   return nullptr;
 }
 
+// `find_downcast_table`: `D`'s view table from `vt`'s birth ancestry, or null
+// when `vt` is null or the born family does not include `D`.
+//
+// The shared lookup behind every view-table `try_downcast`; `F` is the
+// handle's own facade, spelling the source table type, so call sites pass
+// both facades explicitly.
+template<Facade D, Facade F>
+[[nodiscard]] constexpr auto
+find_downcast_table(const typename vtbuild_t<F>::vtable_t* vt) noexcept
+    -> const vtbuild_t<D>::vtable_t* {
+  if (!vt) return nullptr;
+  return static_cast<const vtbuild_t<D>::vtable_t*>(
+      find_ancestor(*vt->ancestry, &facade_tag_v<D>));
+}
+
 // `make_ancestor_table`: build the ancestor table for a target born as (Born,
 // T, Sbo).
 //
@@ -1743,45 +1760,49 @@ struct vtable_builder<facade<Es...>>
   }
 };
 
-// `upcast_vtable`: narrow a dispatch-table pointer from facade `D` to `B`,
-// where `B` is `D` itself or a facade it extends, by following the embedded
-// direct-base table pointers.
+// `view_table_t`, `owning_table_t`: facade-to-table alias templates, the
+// families `upcast_table` walks over.
+template<Facade F>
+using view_table_t = vtbuild_t<F>::vtable_t;
+template<Facade F>
+using owning_table_t = vtbuild_t<F>::owning_vtable_t;
+
+// `upcast_table`: narrow a table pointer from facade `D` to `B`, where `B` is
+// `D` itself or a facade it extends, by following the embedded direct-base
+// table pointers. The shared walk behind `upcast_vtable` and
+// `upcast_owning_vtable`, which differ only in the table family `TableFor`
+// selects.
 //
 // The route is resolved at compile time; the runtime cost is one dependent
 // load per composition level crossed.
+template<template<Facade> class TableFor, Facade B, Facade D>
+[[nodiscard]] constexpr const TableFor<B>*
+upcast_table(const TableFor<D>* vt) noexcept {
+  if constexpr (std::same_as<B, D>) {
+    return vt;
+  } else {
+    constexpr auto ndx = vtbuild_t<D>::template base_route<B>();
+    static_assert(ndx != vtbuild_t<D>::base_count_v,
+        "the source facade does not extend the target facade");
+    return upcast_table<TableFor, B,
+        typename vtbuild_t<D>::template base_t<ndx>>(std::get<ndx>(vt->bases));
+  }
+}
+
+// `upcast_vtable`, `upcast_owning_vtable`: `upcast_table` over the dispatch
+// tables and the owning tables.
 template<Facade B, Facade D>
 [[nodiscard]] constexpr auto
 upcast_vtable(const typename vtbuild_t<D>::vtable_t* vt) noexcept
     -> const vtbuild_t<B>::vtable_t* {
-  if constexpr (std::same_as<B, D>) {
-    return vt;
-  } else {
-    constexpr auto ndx = vtbuild_t<D>::template base_route<B>();
-    static_assert(ndx != vtbuild_t<D>::base_count_v,
-        "the source facade does not extend the target facade");
-    return upcast_vtable<B, typename vtbuild_t<D>::template base_t<ndx>>(
-        std::get<ndx>(vt->bases));
-  }
+  return upcast_table<view_table_t, B, D>(vt);
 }
 
-// `upcast_owning_vtable`: narrow an owning-table pointer from facade `D` to
-// `B`, where `B` is `D` itself or a facade it extends.
-//
-// The owning counterpart of `upcast_vtable`, following the embedded
-// direct-base owning tables along the same compile-time-resolved route.
 template<Facade B, Facade D>
 [[nodiscard]] constexpr auto
 upcast_owning_vtable(const typename vtbuild_t<D>::owning_vtable_t* vt) noexcept
     -> const vtbuild_t<B>::owning_vtable_t* {
-  if constexpr (std::same_as<B, D>) {
-    return vt;
-  } else {
-    constexpr auto ndx = vtbuild_t<D>::template base_route<B>();
-    static_assert(ndx != vtbuild_t<D>::base_count_v,
-        "the source facade does not extend the target facade");
-    return upcast_owning_vtable<B,
-        typename vtbuild_t<D>::template base_t<ndx>>(std::get<ndx>(vt->bases));
-  }
+  return upcast_table<owning_table_t, B, D>(vt);
 }
 
 // `dispatch`: shared body of every handle's `call`.
@@ -2111,7 +2132,22 @@ protected:
 // Rust's `&mut dyn Trait`, ngcpp's `proxy_view`.
 //
 // Two pointers: the target and the per-(facade, type, born facade) dispatch
-// table. The target must outlive the view.
+// table. The target must outlive the view, and the standard limitations of
+// views apply.
+//
+// A view lent from an owning `proxy` is tied to that proxy's contents, not
+// just its lifetime: ownership is exclusive, so removing or replacing the
+// target (moving the proxy from, assigning over it, `extract`) invalidates
+// every view lent from it. An inline target is destroyed in place at that
+// moment; a heap target's remaining lifetime belongs to an owner the view
+// cannot track. Using an invalidated view is undefined behavior, exactly as
+// with any other view into an exclusively-owned container.
+//
+// A view lent from a `shared_proxy` does not share ownership (no view does),
+// so its validity follows the underlying object rather than the lending
+// handle: the view stays good as long as any owner keeps the object alive.
+// Code that needs to guarantee survival holds a `shared_proxy` copy instead
+// of a view.
 //
 // A view also converts implicitly from any handle of a facade that extends
 // `F` (Rust trait upcasting), and from an lvalue owning `proxy`, re-pointing
@@ -2173,7 +2209,8 @@ public:
   //
   // Intentionally implicit, and lvalue-only, so a view cannot be left dangling
   // by a temporary `proxy`. An empty `proxy` lends an empty view; otherwise
-  // the `proxy` must outlive the view. A const `proxy` takes a
+  // the view is good until the `proxy` dies or has its contents removed or
+  // replaced (see the class comment). A const `proxy` takes a
   // `const_proxy_view` instead, preserving deep const.
   template<Facade D, proxy_policy P>
   requires(std::same_as<D, F> || Extends<D, F>)
@@ -2182,8 +2219,9 @@ public:
             p ? details::upcast_vtable<F, D>(&p.vtable_->vt) : nullptr} {}
 
   // `proxy_view`: viewing constructor from a `shared_proxy` of `F`, or of a
-  // facade that extends it, under the same rules as viewing an owning `proxy`;
-  // the target must outlive the view, meaning at least one shared owner must.
+  // facade that extends it, under the same rules as viewing an owning
+  // `proxy`; the view does not share ownership, so it is good exactly as long
+  // as some owner keeps the target alive (see the class comment).
   template<Facade D>
   requires(std::same_as<D, F> || Extends<D, F>)
   explicit(false) proxy_view(shared_proxy<D>& p) noexcept
@@ -2224,12 +2262,9 @@ public:
   template<Facade D>
   requires Extends<D, F>
   [[nodiscard]] constexpr proxy_view<D> try_downcast() const noexcept {
-    if (!this->vtable_) return {};
-    const auto* table = details::find_ancestor(*this->vtable_->ancestry,
-        &details::facade_tag_v<D>);
+    const auto* table = details::find_downcast_table<D, F>(this->vtable_);
     if (!table) return {};
-    return proxy_view<D>{this->target_,
-        static_cast<const details::vtbuild_t<D>::vtable_t*>(table)};
+    return proxy_view<D>{this->target_, table};
   }
 
 private:
@@ -2249,27 +2284,20 @@ private:
 // implements `Trait` and meets its supertrait bounds).
 //
 // Calls forward through the wrapped view, with conditional `noexcept` so the
-// invariant also holds for facades with noexcept methods. The const overload
-// serves const-qualified methods, matching the view's instance-level deep
-// const. This makes facade-constrained generic code accept concrete and
-// erased arguments interchangeably, including derived-facade handles under a
-// base-facade bound, and allows views of views.
+// invariant also holds for facades with noexcept methods. The handle
+// parameter is deduced, serving const and mutable views with one overload,
+// so const methods route through the const `call` exactly as they would on
+// the view itself. This makes facade-constrained generic code accept
+// concrete and erased arguments interchangeably, including derived-facade
+// handles under a base-facade bound, and allows views of views.
 template<Facade F, Facade D>
 requires(std::same_as<D, F> || Extends<D, F>)
 struct proxy_impl<F, proxy_view<D>> {
   // `on`: the qualified spelling keeps the forwarded key unambiguous when
   // `D`'s flattened list collides on `Key`; see `qualified_key`.
-  template<fixed_string Key, typename... Args>
+  template<fixed_string Key, typename Handle, typename... Args>
   static constexpr decltype(auto)
-  on(method_key<Key>, proxy_view<D>& view, Args&&... args) noexcept(
-      noexcept(view.template call<details::qualified_key<F, Key>()>(
-          std::forward<Args>(args)...))) {
-    return view.template call<details::qualified_key<F, Key>()>(
-        std::forward<Args>(args)...);
-  }
-  template<fixed_string Key, typename... Args>
-  static constexpr decltype(auto)
-  on(method_key<Key>, const proxy_view<D>& view, Args&&... args) noexcept(
+  on(method_key<Key>, Handle& view, Args&&... args) noexcept(
       noexcept(view.template call<details::qualified_key<F, Key>()>(
           std::forward<Args>(args)...))) {
     return view.template call<details::qualified_key<F, Key>()>(
@@ -2285,7 +2313,8 @@ struct proxy_impl<F, proxy_view<D>> {
 // It binds const and mutable targets alike, and dispatches only the
 // const-qualified facade methods, sharing the mutable view's dispatch table
 // (the non-const slots are simply unreachable). The target must outlive the
-// view.
+// view, under the same lending and invalidation rules as `proxy_view` (see
+// its class comment).
 //
 // A default-constructed view is empty: testable via `operator bool` and
 // rebindable by assignment, but calling through it is undefined behavior.
@@ -2347,8 +2376,10 @@ public:
   // of a facade that extends it.
   //
   // Intentionally implicit, and lvalue-only. An empty `proxy` lends an empty
-  // view; otherwise the `proxy` must outlive the view. Mutable and const
-  // proxies alike yield the const view; there is no path back to mutability.
+  // view; otherwise the view is good until the `proxy` dies or has its
+  // contents removed or replaced (see `proxy_view`'s class comment). Mutable
+  // and const proxies alike yield the const view; there is no path back to
+  // mutability.
   template<Facade D, proxy_policy P>
   requires(std::same_as<D, F> || Extends<D, F>)
   explicit(false) const_proxy_view(const proxy<D, P>& p) noexcept
@@ -2376,12 +2407,9 @@ public:
   template<Facade D>
   requires Extends<D, F>
   [[nodiscard]] constexpr const_proxy_view<D> try_downcast() const noexcept {
-    if (!this->vtable_) return {};
-    const auto* table = details::find_ancestor(*this->vtable_->ancestry,
-        &details::facade_tag_v<D>);
+    const auto* table = details::find_downcast_table<D, F>(this->vtable_);
     if (!table) return {};
-    return const_proxy_view<D>{this->target_,
-        static_cast<const details::vtbuild_t<D>::vtable_t*>(table)};
+    return const_proxy_view<D>{this->target_, table};
   }
 
 private:
@@ -2906,18 +2934,11 @@ private:
 template<Facade F, Facade D, proxy_policy P>
 requires(std::same_as<D, F> || Extends<D, F>)
 struct proxy_impl<F, proxy<D, P>> {
-  // Qualified forwarding, as with the view bindings; see `qualified_key`.
-  template<fixed_string Key, typename... Args>
+  // Qualified forwarding, as with the view bindings; see `qualified_key`. The
+  // deduced handle parameter serves const and mutable proxies alike.
+  template<fixed_string Key, typename Handle, typename... Args>
   static decltype(auto)
-  on(method_key<Key>, proxy<D, P>& p, Args&&... args) noexcept(
-      noexcept(p.template call<details::qualified_key<F, Key>()>(
-          std::forward<Args>(args)...))) {
-    return p.template call<details::qualified_key<F, Key>()>(
-        std::forward<Args>(args)...);
-  }
-  template<fixed_string Key, typename... Args>
-  static decltype(auto)
-  on(method_key<Key>, const proxy<D, P>& p, Args&&... args) noexcept(
+  on(method_key<Key>, Handle& p, Args&&... args) noexcept(
       noexcept(p.template call<details::qualified_key<F, Key>()>(
           std::forward<Args>(args)...))) {
     return p.template call<details::qualified_key<F, Key>()>(
@@ -3053,6 +3074,11 @@ public:
   // `shared_proxy`: upcasting converting constructors from a `shared_proxy`
   // of a facade that extends `F`, sharing (copy) or transferring (move)
   // ownership. Intentionally implicit, like every handle upcast.
+  //
+  // The move flavor computes `vtable_` in the init list and moves `target_`
+  // in the body: members initialize in declaration order (`target_` first),
+  // and the `vtable_` initializer must read `other`'s emptiness before the
+  // move empties it.
   template<Facade D>
   requires Extends<D, F>
   explicit(false) shared_proxy(const shared_proxy<D>& other) noexcept
@@ -3133,12 +3159,14 @@ private:
 
   // `do_find_downcast`: `D`'s view table from the birth ancestry, or null when
   // the handle is empty or was not born as `D` or a facade extending it.
+  //
+  // The guard tests `target_`, which is what defines emptiness here: a
+  // moved-from or expired-lock handle keeps a stale non-null `vtable_`.
   template<Facade D>
   [[nodiscard]] const details::vtbuild_t<D>::vtable_t*
   do_find_downcast() const noexcept {
-    if (!vtable_) return nullptr;
-    return static_cast<const details::vtbuild_t<D>::vtable_t*>(
-        details::find_ancestor(*vtable_->ancestry, &details::facade_tag_v<D>));
+    if (!target_) return nullptr;
+    return details::find_downcast_table<D, F>(vtable_);
   }
 
   // `shared_proxy`: for `weak_proxy::lock` and `try_downcast`, whose vtable
@@ -3166,17 +3194,11 @@ private:
 template<Facade F, Facade D>
 requires(std::same_as<D, F> || Extends<D, F>)
 struct proxy_impl<F, shared_proxy<D>> {
-  template<fixed_string Key, typename... Args>
+  // The deduced handle parameter serves const and mutable handles alike, as
+  // with the other self-conformance bindings.
+  template<fixed_string Key, typename Handle, typename... Args>
   static decltype(auto)
-  on(method_key<Key>, shared_proxy<D>& p, Args&&... args) noexcept(
-      noexcept(p.template call<details::qualified_key<F, Key>()>(
-          std::forward<Args>(args)...))) {
-    return p.template call<details::qualified_key<F, Key>()>(
-        std::forward<Args>(args)...);
-  }
-  template<fixed_string Key, typename... Args>
-  static decltype(auto)
-  on(method_key<Key>, const shared_proxy<D>& p, Args&&... args) noexcept(
+  on(method_key<Key>, Handle& p, Args&&... args) noexcept(
       noexcept(p.template call<details::qualified_key<F, Key>()>(
           std::forward<Args>(args)...))) {
     return p.template call<details::qualified_key<F, Key>()>(
@@ -3226,10 +3248,9 @@ public:
   template<Facade D>
   requires Extends<D, F>
   explicit(false) weak_proxy(weak_proxy<D>&& other) noexcept
-      : vtable_{other.vtable_ ? details::upcast_vtable<F, D>(other.vtable_)
-                              : nullptr} {
-    target_ = std::move(other.target_);
-  }
+      : target_{std::move(other.target_)},
+        vtable_{other.vtable_ ? details::upcast_vtable<F, D>(other.vtable_)
+                              : nullptr} {}
 
   // `expired`: whether the target is already gone.
   //

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -120,13 +120,13 @@ namespace details {
 // Probe for the unique public `facade` base of `F`. Declared only; used in
 // unevaluated contexts.
 template<typename... Ms>
-auto facade_probe(const facade<Ms...>&) -> facade<Ms...>;
+auto probe(const facade<Ms...>&) -> facade<Ms...>;
 
 } // namespace details
 
 // Concept for a type derived from a single `facade` base.
 template<typename F>
-concept Facade = requires(const F& f) { details::facade_probe(f); };
+concept Facade = requires(const F& f) { details::probe(f); };
 
 #pragma endregion
 #pragma region Registration and binding
@@ -188,12 +188,10 @@ template<typename F, typename T>
 //
 // To register a pair, declare a `corvid_proxy_spec(F*, T*)` overload returning
 // `make_proxy_spec<F, T>()`, in the namespace of either the facade or the
-// type; it is found here by ADL. The library never defines this function:
-// declaring an overload IS the act of registration. The `corvid_` prefix
-// marks it as a cross-namespace protocol name, the same convention as
-// `corvid_enum_spec`; a plain verb like `register_proxy` would risk collision
-// in user namespaces and would not read as a Corvid hook. The pointer
-// parameters are never dereferenced; they only carry the types.
+// type; it is found here by ADL.
+//
+// The library never defines this function: declaring an overload IS the act of
+// registration.
 //
 // Registration gates a facade author's boilerplate impl; an explicit
 // `proxy_impl` specialization does not need it.
@@ -202,9 +200,10 @@ concept ProxyRegistered = requires {
   corvid_proxy_spec(static_cast<F*>(nullptr), static_cast<T*>(nullptr));
 };
 
-// Central access point for the registered spec, mirroring `enum_spec_v`. Each
-// specialization deduces its own type, so richer spec types can be introduced
-// later without touching existing registrations.
+// Central access point for the registered spec, mirroring `enum_spec_v`.
+//
+// Each specialization deduces its own type, so richer spec types can be
+// introduced later without touching existing registrations.
 template<typename F, typename T>
 requires ProxyRegistered<F, T>
 constexpr inline auto proxy_spec_v =
@@ -296,8 +295,7 @@ struct vtable_builder<facade<Ms...>> {
 
 // Facade-wide machinery for the derived facade type `F`.
 template<Facade F>
-using vtbuild_t =
-    vtable_builder<decltype(facade_probe(std::declval<const F&>()))>;
+using vtbuild_t = vtable_builder<decltype(probe(std::declval<const F&>()))>;
 
 // Per-(facade, type) dispatch table instance. The handle stores a pointer to
 // this; the table pointer lives in the handle, not in the target (a fat

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -139,6 +139,22 @@ struct method<Name, R(Args...) const noexcept>
 // Because identity is this named type rather than the method list, same-named
 // methods in unrelated facades cannot cross-contaminate. This is also why we
 // inherit from `facade` instead of just aliasing it.
+//
+// The facade body is also where the optional member-call sugar is authored: a
+// nested `api` type holding one deducing-this forwarder per method, which
+// every handle of the facade inherits. For example:
+//
+//    struct animal : facade<method<"speak", void() const>> {
+//      struct api {
+//        void speak(this const auto& self) {
+//          self.template call<"speak">();
+//        }
+//      };
+//    };
+//
+// With that in place, `handle.speak()` is sugar for `handle.call<"speak">()`,
+// dispatching through the same table. See "proxy.md" for the design and its
+// limits.
 template<typename... Methods>
 struct facade {};
 
@@ -154,6 +170,33 @@ auto probe(const facade<Ms...>&) -> facade<Ms...>;
 // Concept for a type derived from a single `facade` base.
 template<typename F>
 concept Facade = requires(const F& f) { details::probe(f); };
+
+namespace details {
+
+// Stand-in api base for facades that define no member-call sugar.
+struct no_api {};
+
+// Sugar base for handles of facade `F`.
+//
+// Yields the facade's nested `api` when it defines one, and the empty stand-in
+// otherwise. The selection has to be lazy (a specialization rather than a
+// `std::conditional_t`), because naming `F::api` when it does not exist is
+// ill-formed.
+template<typename F>
+struct api_base {
+  using type = no_api;
+};
+
+template<typename F>
+requires(requires { typename F::api; })
+struct api_base<F> {
+  using type = F::api;
+};
+
+template<typename F>
+using api_base_t = api_base<F>::type;
+
+} // namespace details
 
 #pragma endregion
 #pragma region Registration and binding
@@ -448,8 +491,11 @@ namespace details {
 // The `call` here serves const-qualified methods, the only dispatch a const
 // handle allows. `proxy_view` layers the unrestricted non-const overload on
 // top.
+//
+// This is also where the views pick up the facade's `api` base, keeping each
+// view a single-inheritance chain.
 template<Facade F, bool Const>
-class view_base {
+class view_base: public api_base_t<F> {
 public:
   using facade_t = F;
 
@@ -499,6 +545,9 @@ class const_proxy_view;
 // a plain `T*`. Code that means read-only access should use
 // `const_proxy_view`, where constness is part of the type and survives
 // copying.
+//
+// When the facade defines a nested `api`, the view inherits it, so the
+// member-call sugar forwarders dispatch alongside `call`.
 template<Facade F>
 class proxy_view: public details::view_base<F, false> {
   using base = details::view_base<F, false>;
@@ -569,6 +618,10 @@ struct proxy_impl<F, proxy_view<F>> {
 // const-qualified facade methods, sharing the mutable view's per-(facade,
 // type) dispatch table (the non-const slots are simply unreachable). The
 // target must outlive the view.
+//
+// When the facade defines a nested `api`, the view inherits it. Only the const
+// forwarders are callable; a mutable forwarder fails inside its `call` if
+// used.
 template<Facade F>
 class const_proxy_view: public details::view_base<F, true> {
   using base = details::view_base<F, true>;
@@ -647,8 +700,11 @@ requires Proxiable<T, F>
 // A default-constructed or moved-from proxy is empty. It is destructible,
 // assignable, and testable via `operator bool`, but calling through it is
 // undefined behavior.
+//
+// When the facade defines a nested `api`, the proxy inherits it, so the
+// member-call sugar forwarders dispatch alongside `call`.
 template<Facade F>
-class proxy {
+class proxy: public details::api_base_t<F> {
   using vtbuild_t = details::vtbuild_t<F>;
   using owning_vtable_t = vtbuild_t::owning_vtable_t;
 

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -87,36 +87,38 @@ consteval auto operator""_method() noexcept {
 // `method_key<K>` from a method argument. This also leaves the door open for
 // bindings that overload on the full method (signature included) if per-name
 // overload sets are ever supported.
+namespace details {
+
+// Shared base for the four `method` flavors (`const` crossed with
+// `noexcept`): the qualification flags and result type, which are the only
+// things that vary. Also supplies the `method_key` base.
+template<fixed_string Name, bool Const, bool Noexcept, typename R>
+struct method_base: method_key<Name> {
+  static constexpr bool const_v = Const;
+  static constexpr bool noexcept_v = Noexcept;
+  using result_t = R;
+};
+
+} // namespace details
+
 template<fixed_string Name, typename Sig>
 struct method;
 
 template<fixed_string Name, typename R, typename... Args>
-struct method<Name, R(Args...)>: method_key<Name> {
-  static constexpr bool const_v = false;
-  static constexpr bool noexcept_v = false;
-  using result_t = R;
+struct method<Name, R(Args...)>: details::method_base<Name, false, false, R> {
 };
 
 template<fixed_string Name, typename R, typename... Args>
-struct method<Name, R(Args...) const>: method_key<Name> {
-  static constexpr bool const_v = true;
-  static constexpr bool noexcept_v = false;
-  using result_t = R;
-};
+struct method<Name, R(Args...) const>
+    : details::method_base<Name, true, false, R> {};
 
 template<fixed_string Name, typename R, typename... Args>
-struct method<Name, R(Args...) noexcept>: method_key<Name> {
-  static constexpr bool const_v = false;
-  static constexpr bool noexcept_v = true;
-  using result_t = R;
-};
+struct method<Name, R(Args...) noexcept>
+    : details::method_base<Name, false, true, R> {};
 
 template<fixed_string Name, typename R, typename... Args>
-struct method<Name, R(Args...) const noexcept>: method_key<Name> {
-  static constexpr bool const_v = true;
-  static constexpr bool noexcept_v = true;
-  using result_t = R;
-};
+struct method<Name, R(Args...) const noexcept>
+    : details::method_base<Name, true, true, R> {};
 
 #pragma endregion
 #pragma region Facade
@@ -487,11 +489,11 @@ private:
 // interchangeably, and allows views of views.
 template<Facade F>
 struct proxy_impl<F, proxy_view<F>> {
-  template<fixed_string K, typename... As>
+  template<fixed_string K, typename... Args>
   static constexpr decltype(auto)
-  on(method_key<K>, const proxy_view<F>& view, As&&... args) noexcept(
-      noexcept(view.template call<K>(std::forward<As>(args)...))) {
-    return view.template call<K>(std::forward<As>(args)...);
+  on(method_key<K>, const proxy_view<F>& view, Args&&... args) noexcept(
+      noexcept(view.template call<K>(std::forward<Args>(args)...))) {
+    return view.template call<K>(std::forward<Args>(args)...);
   }
 };
 

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -143,9 +143,11 @@ struct method<Name, R(Args...) const noexcept>
 
 // Facade base: an interface definition.
 //
-// Derive a named struct from `facade`, listing the methods. For example:
+// Derive a named struct from `facade`, listing the facade's `name` and its
+// methods. For example:
 //
-//    struct animal : facade<method<"speak", void() const>> {};
+//    struct animal
+//        : facade<name<"animal">, method<"speak", void() const>> {};
 //
 // The derived type, `animal` here, IS the facade: it is the `F` in
 // `proxy_view<F>` and `proxy_impl<F, T>`, and the type registration keys on.
@@ -158,7 +160,9 @@ struct method<Name, R(Args...) const noexcept>
 // nested `api` type holding one deducing-this forwarder per method, which
 // every handle of the facade inherits. For example:
 //
-//    struct animal : facade<method<"speak", void() const>> {
+//    struct animal
+//        : facade<name<"animal">, //
+//            method<"speak", void() const>> {
 //      struct api {
 //        void speak(this const auto& self) {
 //          self.template call<"speak">();
@@ -198,19 +202,30 @@ concept Facade = requires(const F& f) { details::probe(f); };
 // `add_facade`).
 //
 // Listed in the facade's method list alongside the methods, conventionally
-// first. For example:
+// after the `name`. For example:
 //
-//    struct pet : facade<extends<animal>, method<"play", void()>> {};
+//    struct pet : facade<name<"pet">,
+//                     extends<animal>,
+//                     method<"play", void()>> {};
 //
 // The derived facade's effective method list is the flattening of its bases'
 // lists, in declaration order, followed by its own; handles of the derived
 // facade dispatch inherited and own methods alike.
 //
-// Names must be unique across the flattened list. A facade cannot redeclare
-// (or override) an inherited method, which is by design, because facades carry
-// no implementations and there is nothing to override. Diamond composition is
-// also rejected, but that is a limit of the current implementation rather than
-// the model, with the dedup path recorded under Future in "proxy.md".
+// A method name may not recur within one extends chain: a facade cannot
+// declare a name twice or redeclare (or override) an inherited one, which is
+// by design, because facades carry no implementations and there is nothing to
+// override.
+//
+// Unrelated sibling bases MAY collide on a method name: distinct signatures
+// form an overload set that unqualified calls resolve by argument, and a
+// same-signature collision is a lazy call-site error, reachable through the
+// facade-qualified key or an upcast handle.
+//
+// Diamond composition is supported: a shared ancestor reached through more
+// than one path flattens to a single set of slots (dedup by facade identity),
+// and since conformance is per facade there is only one binding to reach, no
+// matter the path.
 //
 // Conformance is per facade, as with Rust supertraits: a type conforms to
 // `pet` by binding `pet`'s own methods through `proxy_impl<pet, T>` and
@@ -224,6 +239,24 @@ concept Facade = requires(const F& f) { details::probe(f); };
 // trait upcasting); see the view constructors.
 template<Facade B>
 struct extends {};
+
+// Facade name entry: gives the facade a formal name, which qualifies its
+// methods.
+//
+// Listed in the facade's entry list, conventionally first. For example:
+//
+//    struct animal
+//        : facade<name<"animal">, //
+//            method<"speak", void() const>> {};
+//
+// Every method then answers to its facade-qualified name ("animal::speak")
+// as well as its plain one: a `call` key containing "::" matches the
+// declaring facade's name plus the method name. The qualified spelling is
+// what disambiguates sibling collisions, two `extends` bases declaring the
+// same method name. Facade names must be unique within a composition, and
+// would ideally be globally unique.
+template<fixed_string Name>
+struct name {};
 
 namespace details {
 
@@ -259,8 +292,9 @@ using api_base_t = api_base<F>::type;
 // registration-carried impl.
 //
 // Its sole member is a `method_key` alias, which lets a binding class spell
-// its `on` parameters without qualification: base-class members participate
+// its `on` parameters without qualification. Base-class members participate
 // in unqualified lookup, where the enclosing namespace's names do not.
+//
 // Inheriting it is optional, and a binding class that inherits a boilerplate
 // already has it through that base. It also serves as documentation of what
 // the class is for.
@@ -315,7 +349,10 @@ struct prox_impl {
 //    // type whose member names line up. The `api` is omitted here for
 //    // brevity. Inheriting `prox_impl` supplies the unqualified `method_key`
 //    // spelling.
-//    struct animal : facade<method<"speak", void() const>> {
+//    struct animal
+//        : facade<name<"animal">, //
+//            method<"speak", void() const>> {
+//      // Note: API omitted for brevity.
 //      template<typename T> struct boilerplate : prox_impl {
 //        static void on(method_key<"speak">, const T& t) { t.speak(); }
 //      };
@@ -534,6 +571,17 @@ struct method_traits_base {
   // ignored but a merely-convertible type does not match.
   using norm_args_t = std::tuple<std::remove_cvref_t<Args>...>;
 
+  // Whether `CallArgs` match the declared parameters exactly after
+  // normalization, and whether they are merely viable through the ordinary
+  // conversions a call performs. Exactness is the validation probe's
+  // strictness; viability is overload-set resolution's fallback.
+  template<typename... CallArgs>
+  static constexpr bool exact_v =
+      std::same_as<std::tuple<std::remove_cvref_t<CallArgs>...>, norm_args_t>;
+  template<typename... CallArgs>
+  static constexpr bool viable_v =
+      std::is_invocable_v<R (*)(Args...), CallArgs...>;
+
   template<typename F, typename T>
   static constexpr bool bound_v = requires(target_t<T>& t, Args... args) {
     {
@@ -631,49 +679,161 @@ template<Facade F, typename T>
 constexpr inline auto owning_vtable_for =
     vtbuild_t<F>::template make_owning_vtable<F, T>();
 
-// Slot index of the first method in `Ms` named `K`, or `sizeof...(Ms)` (as
-// an `npos` or `end` flag) when there is none.
-template<fixed_string K, typename... Ms>
-consteval std::size_t first_index_of() noexcept {
-  constexpr std::array<bool, sizeof...(Ms)> matches{(Ms::name_v == K)...};
+// Flattened dispatch slot: one facade method plus the facade that declared
+// it.
+//
+// The owner is `void` while the declaring facade is the one being built,
+// since a facade cannot name itself from inside its own list; an `extends`
+// entry retags its base's own slots with the base's type as it flattens
+// them, so in any facade's flattened list every inherited slot carries its
+// declaring facade.
+//
+// The owner is what keeps per-facade conformance intact through flattening
+// (an inherited method binds through `proxy_impl<Owner, T>`), and it is the
+// identity that dedup uses to collapse a shared ancestor reached through
+// more than one composition path (a diamond). The method's compile-time
+// surface is re-exposed so slot packs can be probed the way method packs
+// were.
+template<typename Owner, typename M>
+struct slot {
+  using owner_t = Owner;
+  using method_t = M;
+  static constexpr auto name_v = M::name_v;
+  static constexpr bool const_v = M::const_v;
+  static constexpr bool noexcept_v = M::noexcept_v;
+  using result_t = M::result_t;
+};
+
+// Retag base facade `B`'s own slots with `B` itself, leaving inherited slots
+// untouched, as `extends<B>` flattens B's list into the derived facade's.
+template<Facade B, typename S>
+struct retagged {
+  using type = S;
+};
+template<Facade B, typename M>
+struct retagged<B, slot<void, M>> {
+  using type = slot<B, M>;
+};
+
+template<Facade B, typename Slots>
+struct retag_slots;
+template<Facade B, typename... Ss>
+struct retag_slots<B, std::tuple<Ss...>> {
+  using type = std::tuple<typename retagged<B, Ss>::type...>;
+};
+template<Facade B, typename Slots>
+using retag_slots_t = retag_slots<B, Slots>::type;
+
+// First position of type `S` in `Ss`, for dedup's first-occurrence test.
+template<typename S, typename... Ss>
+consteval std::size_t first_index_of_type() noexcept {
+  constexpr std::array<bool, sizeof...(Ss)> matches{std::same_as<S, Ss>...};
   for (std::size_t ndx = 0; ndx != matches.size(); ++ndx)
     if (matches[ndx]) return ndx;
-  return sizeof...(Ms);
+  return sizeof...(Ss);
 }
 
-// Whether every method name in `Ms` is unique: each name's first occurrence
-// must be its own slot. Duplicates arise from composition (an inherited name
-// redeclared, or a diamond) as well as from a doubled declaration.
-template<typename... Ms>
-consteval bool unique_method_names() noexcept {
-  std::size_t ndx = 0;
-  return (... && (first_index_of<Ms::name_v, Ms...>() == ndx++));
+// Remove duplicate slot types, keeping first occurrences in order.
+//
+// A slot type recurs exactly when the same ancestor facade is reached
+// through more than one composition path, so this is what collapses a
+// diamond to a single set of slots. Per-facade conformance already yields
+// one `proxy_impl<Ancestor, T>` regardless of path (the effect of Rust's
+// coherence rule); dedup makes the flattened table agree.
+template<typename Slots>
+struct dedup_slots;
+template<typename... Ss>
+struct dedup_slots<std::tuple<Ss...>> {
+  template<std::size_t... Ndx>
+  static auto keep(std::index_sequence<Ndx...>) -> decltype(std::tuple_cat(
+      std::declval<std::conditional_t<first_index_of_type<Ss, Ss...>() == Ndx,
+          std::tuple<Ss>, std::tuple<>>>()...));
+  using type = decltype(keep(std::index_sequence_for<Ss...>{}));
+};
+template<typename Slots>
+using dedup_slots_t = dedup_slots<Slots>::type;
+
+// Thunk for one slot: an inherited method binds through its declaring
+// facade, an own method through `F` itself, so per-facade conformance
+// survives flattening verbatim and an upcast handle cannot disagree with the
+// derived one.
+template<typename F, typename T, typename S>
+consteval auto slot_thunk() noexcept {
+  using owner_t = std::conditional_t<std::is_void_v<typename S::owner_t>, F,
+      typename S::owner_t>;
+  return method_traits<typename S::method_t>::template make_thunk<owner_t,
+      T>();
+}
+
+// Name that qualifies slot `S`, in a facade whose own name is `OwnName`: the
+// declaring facade's name for an inherited slot, `OwnName` for an own one.
+template<fixed_string OwnName, typename S>
+consteval auto slot_owner_name() noexcept {
+  if constexpr (std::is_void_v<typename S::owner_t>)
+    return OwnName;
+  else
+    return vtbuild_t<typename S::owner_t>::name_v;
+}
+
+// Whether the declaring facades of two slots lie in one extends chain:
+// identical, or one extends the other, with the facade being built (`void`)
+// counting as extending every inherited owner.
+template<typename S1, typename S2>
+consteval bool same_chain_owners() noexcept {
+  using o1_t = S1::owner_t;
+  using o2_t = S2::owner_t;
+  if constexpr (std::is_void_v<o1_t> || std::is_void_v<o2_t> ||
+                std::same_as<o1_t, o2_t>)
+    return true;
+  else
+    return vtbuild_t<o1_t>::template extends_facade<o2_t>() ||
+           vtbuild_t<o2_t>::template extends_facade<o1_t>();
+}
+
+// The two collision detonators, each pitting slot `S1` against the whole list.
+// Post-dedup, a repeated slot type is only ever the self-pairing, so same-type
+// pairs are skipped.
+//
+// A method name may not recur within one extends chain (a doubled declaration,
+// or a derived facade redeclaring an inherited name, which is rejected by
+// design: facades carry no implementations, so there is nothing to override).
+// Unrelated sibling facades may collide on a method name freely, since every
+// facade is named and the qualified spelling is always available as the route
+// to a collided slot that the arguments cannot single out. Facade names must
+// be unique within the composition, or qualified keys could themselves
+// collide.
+template<typename S1, typename... Ss>
+consteval bool no_chain_collision_against() noexcept {
+  return ((std::same_as<S1, Ss> || S1::name_v != Ss::name_v ||
+              !same_chain_owners<S1, Ss>()) &&
+          ...);
+}
+
+template<fixed_string OwnName, typename S1, typename... Ss>
+consteval bool owner_names_unique_against() noexcept {
+  return (
+      (std::same_as<typename S1::owner_t, typename Ss::owner_t> ||
+          slot_owner_name<OwnName, S1>() != slot_owner_name<OwnName, Ss>()) &&
+      ...);
 }
 
 // Traits over one entry of a facade's declaration list, which mixes `method`
 // descriptors with `extends` composition entries.
 //
-// Each entry contributes methods to the flattened method list, base facades
-// to the direct-base list, thunk slots and base-table pointers to the
-// dispatch table, and a conformance term to `all_bound_v`.
+// Each entry contributes slots to the flattened list, base facades to the
+// direct-base list, base-table pointers to the dispatch table, and a
+// conformance term to `all_bound_v`.
 //
-// A `method` contributes itself, bound through `proxy_impl<F, T>`. An
-// `extends<B>` contributes B's already-flattened methods, with the thunks
-// copied from B's own table and conformance delegated to `B`, so an inherited
-// method's binding always comes from the facade that declared it and an upcast
-// handle cannot disagree with the derived one.
+// A `method` contributes itself as an own slot. An `extends<B>` contributes
+// B's already-flattened slots, retagged so B's own methods carry B, with
+// conformance delegated to `B`.
 template<typename M>
 struct entry_traits {
-  using methods_t = std::tuple<M>;
+  using slots_t = std::tuple<slot<void, M>>;
   using bases_t = std::tuple<>;
 
   template<typename F, typename T>
   static constexpr bool bound_v = method_traits<M>::template bound_v<F, T>;
-
-  template<typename F, typename T>
-  static consteval auto thunks() noexcept {
-    return std::tuple{method_traits<M>::template make_thunk<F, T>()};
-  }
 
   template<typename T>
   static consteval std::tuple<> base_vtables() noexcept {
@@ -683,16 +843,11 @@ struct entry_traits {
 
 template<Facade B>
 struct entry_traits<extends<B>> {
-  using methods_t = vtbuild_t<B>::flat_methods_t;
+  using slots_t = retag_slots_t<B, typename vtbuild_t<B>::flat_slots_t>;
   using bases_t = std::tuple<B>;
 
   template<typename F, typename T>
   static constexpr bool bound_v = vtbuild_t<B>::template all_bound_v<B, T>;
-
-  template<typename F, typename T>
-  static consteval auto thunks() noexcept {
-    return vtable_for<B, T>.thunks;
-  }
 
   template<typename T>
   static consteval auto base_vtables() noexcept {
@@ -700,35 +855,88 @@ struct entry_traits<extends<B>> {
   }
 };
 
-// Flattened method list and direct-base list of a facade's entry pack.
+template<fixed_string Name>
+struct entry_traits<name<Name>> {
+  using slots_t = std::tuple<>;
+  using bases_t = std::tuple<>;
+
+  template<typename F, typename T>
+  static constexpr bool bound_v = true;
+
+  template<typename T>
+  static consteval std::tuple<> base_vtables() noexcept {
+    return {};
+  }
+};
+
+// Facade name carried by one entry of a facade's list, empty for every other
+// entry kind.
+template<typename E>
+struct entry_name {
+  static constexpr fixed_string name_v{""};
+  static constexpr bool is_name_v = false;
+};
+template<fixed_string Name>
+struct entry_name<name<Name>> {
+  static constexpr auto name_v = Name;
+  static constexpr bool is_name_v = true;
+};
+
+// Name of a facade with entries `Es`: the single `name` entry's string, or
+// empty. Concatenation acts as selection, because at most one entry
+// contributes a nonempty string.
 template<typename... Es>
-using flat_methods_of_t = decltype(std::tuple_cat(
-    std::declval<typename entry_traits<Es>::methods_t>()...));
+constexpr inline auto facade_name_of_v =
+    (fixed_string{""} + ... + entry_name<Es>::name_v);
+
+// Flattened, deduped slot list and direct-base list of a facade's entry
+// pack.
+template<typename... Es>
+using flat_slots_of_t = dedup_slots_t<decltype(std::tuple_cat(
+    std::declval<typename entry_traits<Es>::slots_t>()...))>;
 
 template<typename... Es>
 using bases_of_t = decltype(std::tuple_cat(
     std::declval<typename entry_traits<Es>::bases_t>()...));
 
-// The flattened core of the builder, over the full method list `Ms` (bases'
-// methods first, in declaration order, then own) and the direct-base facades
-// `Bs`.
-template<typename FlatMethods, typename Bases>
+// The flattened core of the builder, over the full slot list `Ss` (bases'
+// methods first, in declaration order, then own, deduped), the direct-base
+// facades `Bs`, and the facade's own name `OwnName`.
+template<typename FlatSlots, typename Bases, fixed_string OwnName>
 struct vtable_builder_impl;
 
-template<typename... Ms, typename... Bs>
-struct vtable_builder_impl<std::tuple<Ms...>, std::tuple<Bs...>> {
-  static_assert(unique_method_names<Ms...>(),
-      "method names must be unique across the facade and its extends bases");
+template<typename... Ss, typename... Bs, fixed_string OwnName>
+struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
+  static_assert((no_chain_collision_against<Ss, Ss...>() && ...),
+      "a facade cannot declare a method name twice or redeclare an inherited "
+      "one");
+  static_assert((owner_names_unique_against<OwnName, Ss, Ss...>() && ...),
+      "facade names must be unique within a composition");
 
-  using flat_methods_t = std::tuple<Ms...>;
-  static constexpr std::size_t count_v = sizeof...(Ms);
+  using flat_slots_t = std::tuple<Ss...>;
+  static constexpr auto name_v = OwnName;
+  static constexpr std::size_t count_v = sizeof...(Ss);
   static constexpr std::size_t base_count_v = sizeof...(Bs);
+
+  // Flag results of `resolve`, outside the valid index range: no slot
+  // answers to the key, or more than one does and the arguments do not
+  // single one out.
+  static constexpr std::size_t none_v = count_v;
+  static constexpr std::size_t ambiguous_v = count_v + 1;
 
   // Direct-base facade at index `Ndx`.
   template<std::size_t Ndx>
   using base_t = std::tuple_element_t<Ndx, std::tuple<Bs...>>;
 
-  using thunks_t = std::tuple<typename method_traits<Ms>::thunk_ptr_t...>;
+  using thunks_t = std::tuple<
+      typename method_traits<typename Ss::method_t>::thunk_ptr_t...>;
+
+  // Build the thunk tuple for target `T` of facade `F`: one thunk per slot,
+  // each bound through the slot's declaring facade.
+  template<typename F, typename T>
+  static consteval thunks_t make_thunks() noexcept {
+    return {slot_thunk<F, T, Ss>()...};
+  }
 
   // Dispatch table: one thunk slot per flattened method, plus the address of
   // each direct base's table for the same target type.
@@ -764,68 +972,151 @@ struct vtable_builder_impl<std::tuple<Ms...>, std::tuple<Bs...>> {
     return base_count_v;
   }
 
-  // Slot index of the method named `K`, or `count_v` (as an `npos` or `end`
-  // flag) when there is none.
-  template<fixed_string K>
-  static consteval std::size_t index_of() noexcept {
-    return first_index_of<K, Ms...>();
+  // Name that qualifies slot `S`: the declaring facade's name for an
+  // inherited slot, this facade's own name otherwise.
+  template<typename S>
+  static consteval auto owner_name() noexcept {
+    if constexpr (std::is_void_v<typename S::owner_t>)
+      return OwnName;
+    else
+      return vtbuild_t<typename S::owner_t>::name_v;
   }
 
-  // Qualification of the method named `K`. Both are `false` when no method
-  // has that name, since rejecting an unknown name is `index_of`'s job.
+  // Whether slot `S` answers to key `K`. An unqualified key matches the
+  // method name alone; a qualified key ("facade::method") also requires the
+  // qualifying facade's name.
+  template<typename S, fixed_string K>
+  static consteval bool slot_matches() noexcept {
+    constexpr std::string_view k = K.view();
+    constexpr auto pos = k.find("::");
+    constexpr auto qual =
+        pos == std::string_view::npos ? std::string_view{} : k.substr(0, pos);
+    constexpr auto base =
+        pos == std::string_view::npos ? k : k.substr(pos + 2);
+    if (S::name_v.view() != base) return false;
+    if (qual.empty()) return true;
+    constexpr auto owner = owner_name<S>();
+    return owner.view() == qual;
+  }
+
+  // Resolve key `K`, called with `CallArgs`, to a slot index, or to `none_v`
+  // or `ambiguous_v`.
+  //
+  // A qualified key names its slot outright. An unqualified key with a
+  // single candidate resolves to it unconditionally, so a call with
+  // unsuitable arguments still fails directly at the thunk. An unqualified
+  // key over a sibling overload set resolves the way a C++ call would: a
+  // unique exact signature match wins, else a unique viable candidate, and
+  // anything else is ambiguous and needs the qualified spelling. `ConstOnly`
+  // restricts the candidates to const-qualified methods, for dispatch
+  // through const handles.
+  template<fixed_string K, bool ConstOnly, typename... CallArgs>
+  static consteval std::size_t resolve() noexcept {
+    constexpr std::array<bool, count_v> cand{
+        (slot_matches<Ss, K>() && (!ConstOnly || Ss::const_v))...};
+    constexpr std::array<bool, count_v> exact{method_traits<
+        typename Ss::method_t>::template exact_v<CallArgs...>...};
+    constexpr std::array<bool, count_v> viable{method_traits<
+        typename Ss::method_t>::template viable_v<CallArgs...>...};
+    std::size_t cnt{};
+    std::size_t at{none_v};
+    for (std::size_t ndx = 0; ndx != count_v; ++ndx)
+      if (cand[ndx]) {
+        ++cnt;
+        at = ndx;
+      }
+    if (cnt < 2) return cnt ? at : none_v;
+    cnt = 0;
+    for (std::size_t ndx = 0; ndx != count_v; ++ndx)
+      if (cand[ndx] && exact[ndx]) {
+        ++cnt;
+        at = ndx;
+      }
+    if (cnt == 1) return at;
+    if (cnt > 1) return ambiguous_v;
+    for (std::size_t ndx = 0; ndx != count_v; ++ndx)
+      if (cand[ndx] && viable[ndx]) {
+        ++cnt;
+        at = ndx;
+      }
+    if (cnt == 1) return at;
+    return cnt ? ambiguous_v : none_v;
+  }
+
+  // Resolve key `K` to the unique candidate whose declared parameters match
+  // `CallArgs` exactly. This is the validation probe's strictness: a
+  // merely-viable signature does not count.
+  template<fixed_string K, bool ConstOnly, typename... CallArgs>
+  static consteval std::size_t resolve_exact() noexcept {
+    constexpr std::array<bool, count_v> cand{
+        (slot_matches<Ss, K>() && (!ConstOnly || Ss::const_v))...};
+    constexpr std::array<bool, count_v> exact{method_traits<
+        typename Ss::method_t>::template exact_v<CallArgs...>...};
+    std::size_t cnt{};
+    std::size_t at{none_v};
+    for (std::size_t ndx = 0; ndx != count_v; ++ndx)
+      if (cand[ndx] && exact[ndx]) {
+        ++cnt;
+        at = ndx;
+      }
+    if (cnt == 1) return at;
+    return cnt ? ambiguous_v : none_v;
+  }
+
+  // Whether any method answering to `K` is const-qualified: the gate on
+  // dispatching `K` through a const handle. False for an unknown key, since
+  // rejecting one is `resolve`'s job.
   template<fixed_string K>
   static consteval bool is_const() noexcept {
-    constexpr std::array<bool, sizeof...(Ms)> flags{Ms::const_v...};
-    constexpr auto ndx = index_of<K>();
-    return ndx != count_v && flags[ndx];
+    return ((slot_matches<Ss, K>() && Ss::const_v) || ...);
   }
 
-  template<fixed_string K>
+  // Whether the call `K` resolves to, with `CallArgs`, dispatches a noexcept
+  // method. False when the call does not resolve.
+  template<fixed_string K, bool ConstOnly, typename... CallArgs>
   static consteval bool is_noexcept() noexcept {
-    constexpr std::array<bool, sizeof...(Ms)> flags{Ms::noexcept_v...};
-    constexpr auto ndx = index_of<K>();
-    return ndx != count_v && flags[ndx];
+    constexpr std::array<bool, count_v> flags{Ss::noexcept_v...};
+    constexpr auto ndx = resolve<K, ConstOnly, CallArgs...>();
+    return ndx < count_v && flags[ndx];
   }
 
-  // Declared result type of the method named `K`, or `void` when no method has
-  // that name. The permissive fallback keeps return-type substitution in the
-  // `api_probe` from hard-erroring before its constraint can reject the
-  // unknown name.
-  template<fixed_string K>
+  // Declared result type of the exact-match candidate for `K`, or `void`
+  // when there is none. The permissive fallback keeps return-type
+  // substitution in the `api_probe` from hard-erroring before its constraint
+  // can reject the key.
+  template<fixed_string K, bool ConstOnly, typename... CallArgs>
   static consteval auto do_result_of() noexcept {
-    constexpr auto ndx = index_of<K>();
-    if constexpr (ndx != count_v) {
-      using m_t = std::tuple_element_t<ndx, std::tuple<Ms...>>;
-      return std::type_identity<typename m_t::result_t>{};
+    constexpr auto ndx = resolve_exact<K, ConstOnly, CallArgs...>();
+    if constexpr (ndx < count_v) {
+      using s_t = std::tuple_element_t<ndx, std::tuple<Ss...>>;
+      return std::type_identity<typename s_t::result_t>{};
     } else {
       return std::type_identity<void>{};
     }
   }
 
-  template<fixed_string K>
-  using result_of_t = decltype(do_result_of<K>())::type;
+  template<fixed_string K, bool ConstOnly, typename... CallArgs>
+  using result_of_t =
+      decltype(do_result_of<K, ConstOnly, CallArgs...>())::type;
 
-  // Whether `Args` match the declared parameters of the method named `K`
-  // exactly after normalization, rather than by convertibility. False for an
-  // unknown name. This is the `api_probe`'s strictness.
-  template<fixed_string K, typename... Args>
+  // Whether `Args` match the declared parameters of exactly one candidate
+  // for `K`, after normalization, rather than by convertibility. False for
+  // an unknown key. This is the `api_probe`'s constraint.
+  template<fixed_string K, bool ConstOnly, typename... Args>
   static consteval bool exact_args() noexcept {
-    constexpr auto ndx = index_of<K>();
-    if constexpr (ndx != count_v) {
-      using m_t = std::tuple_element_t<ndx, std::tuple<Ms...>>;
-      return std::same_as<std::tuple<std::remove_cvref_t<Args>...>,
-          typename method_traits<m_t>::norm_args_t>;
-    } else {
-      return false;
-    }
+    return resolve_exact<K, ConstOnly, Args...>() < count_v;
   }
 };
 
 template<typename... Es>
 struct vtable_builder<facade<Es...>>
-    : vtable_builder_impl<flat_methods_of_t<Es...>, bases_of_t<Es...>> {
-  using impl_t =
-      vtable_builder_impl<flat_methods_of_t<Es...>, bases_of_t<Es...>>;
+    : vtable_builder_impl<flat_slots_of_t<Es...>, bases_of_t<Es...>,
+          facade_name_of_v<Es...>> {
+  static_assert((0 + ... + entry_name<Es>::is_name_v) == 1,
+      "every facade must carry exactly one name entry");
+
+  using impl_t = vtable_builder_impl<flat_slots_of_t<Es...>, bases_of_t<Es...>,
+      facade_name_of_v<Es...>>;
   using vtable_t = impl_t::vtable_t;
 
   // Whether every method of the facade, inherited and own, has a usable
@@ -838,7 +1129,7 @@ struct vtable_builder<facade<Es...>>
 
   template<typename F, typename T>
   static consteval vtable_t make_vtable() noexcept {
-    return {std::tuple_cat(entry_traits<Es>::template thunks<F, T>()...),
+    return {impl_t::template make_thunks<F, T>(),
         std::tuple_cat(entry_traits<Es>::template base_vtables<T>()...)};
   }
 
@@ -968,6 +1259,17 @@ consteval bool is_handle_for() noexcept {
     return std::same_as<G, F> || Extends<G, F>;
 }
 
+// Key `K` qualified by facade `F`'s name.
+//
+// The library's self-conformance bindings forward through this spelling: `K`
+// there is always one of `F`'s own method names, so the qualified key stays
+// unambiguous on a derived handle even when the derived facade's flattened
+// list collides on `K`.
+template<Facade F, fixed_string K>
+consteval auto qualified_key() noexcept {
+  return vtbuild_t<F>::name_v + fixed_string{"::"} + K;
+}
+
 } // namespace details
 
 #pragma endregion
@@ -1010,17 +1312,18 @@ using strict_return_t = std::conditional_t<std::is_void_v<R>, void,
 template<Facade F>
 struct api_probe: api_base_t<F> {
   template<fixed_string K, typename... Args>
-  requires(vtbuild_t<F>::template exact_args<K, Args...>())
-  strict_return_t<typename vtbuild_t<F>::template result_of_t<K>>
+  requires(vtbuild_t<F>::template exact_args<K, false, Args...>())
+  strict_return_t<
+      typename vtbuild_t<F>::template result_of_t<K, false, Args...>>
   call(Args&&...) {
     std::terminate();
   }
 
   template<fixed_string K, typename... Args>
-  requires(vtbuild_t<F>::template is_const<K>() &&
-           vtbuild_t<F>::template exact_args<K, Args...>())
+  requires(vtbuild_t<F>::template exact_args<K, true, Args...>())
   // NOLINTNEXTLINE(modernize-use-nodiscard): mirrors `call`, never executed.
-  strict_return_t<typename vtbuild_t<F>::template result_of_t<K>>
+  strict_return_t<
+      typename vtbuild_t<F>::template result_of_t<K, true, Args...>>
   call(Args&&...) const {
     std::terminate();
   }
@@ -1071,6 +1374,12 @@ consteval auto corvid_proxy_spec(F*, api_probe<G>*) noexcept {
 // reference-to-value decay of a declared result, and a body dispatching the
 // wrong key with an identical signature.
 //
+// Limitation: a composed facade whose flattened list collides on a
+// same-signature method name cannot validate, because the boilerplates drive
+// the probe by natural name, which is exactly the spelling the collision
+// makes ambiguous. Such a facade registers with `api_check::off`; its base
+// levels still validate normally.
+//
 // Failures are hard compile errors rather than a `false` return, and the
 // facade must have a boilerplate impl (a facade-hosted nested `boilerplate`,
 // or a namespace-scope `proxy_impl` partial gated on `ProxyRegistered`) for
@@ -1116,9 +1425,11 @@ public:
   requires(vtbuild_t<F>::template is_const<K>())
   // NOLINTNEXTLINE(modernize-use-nodiscard)
   constexpr decltype(auto) call(Args&&... args) const
-      noexcept(vtbuild_t<F>::template is_noexcept<K>()) {
-    constexpr auto ndx = vtbuild_t<F>::template index_of<K>();
-    static_assert(ndx != vtbuild_t<F>::count_v, "no matching signature");
+      noexcept(vtbuild_t<F>::template is_noexcept<K, true, Args...>()) {
+    constexpr auto ndx = vtbuild_t<F>::template resolve<K, true, Args...>();
+    static_assert(ndx != vtbuild_t<F>::none_v, "no matching signature");
+    static_assert(ndx != vtbuild_t<F>::ambiguous_v,
+        "ambiguous method name; qualify the key with the facade name");
     return std::get<ndx>(
         vtable_->thunks)(target_, std::forward<Args>(args)...);
   }
@@ -1222,10 +1533,12 @@ public:
   // re-exposed by the using-declaration, is constrained to const-qualified
   // methods, mirroring the owning proxy's deep const.
   template<fixed_string K, typename... Args>
-  constexpr decltype(auto)
-  call(Args&&... args) noexcept(vtbuild_t::template is_noexcept<K>()) {
-    constexpr auto ndx = vtbuild_t::template index_of<K>();
-    static_assert(ndx != vtbuild_t::count_v, "no matching signature");
+  constexpr decltype(auto) call(Args&&... args) noexcept(
+      vtbuild_t::template is_noexcept<K, false, Args...>()) {
+    constexpr auto ndx = vtbuild_t::template resolve<K, false, Args...>();
+    static_assert(ndx != vtbuild_t::none_v, "no matching signature");
+    static_assert(ndx != vtbuild_t::ambiguous_v,
+        "ambiguous method name; qualify the key with the facade name");
     return std::get<ndx>(
         this->vtable_->thunks)(this->target_, std::forward<Args>(args)...);
   }
@@ -1252,17 +1565,23 @@ private:
 template<Facade F, Facade D>
 requires(std::same_as<D, F> || Extends<D, F>)
 struct proxy_impl<F, proxy_view<D>> {
+  // The qualified spelling keeps the forwarded key unambiguous when `D`'s
+  // flattened list collides on `K`; see `qualified_key`.
   template<fixed_string K, typename... Args>
   static constexpr decltype(auto)
   on(method_key<K>, proxy_view<D>& view, Args&&... args) noexcept(
-      noexcept(view.template call<K>(std::forward<Args>(args)...))) {
-    return view.template call<K>(std::forward<Args>(args)...);
+      noexcept(view.template call<details::qualified_key<F, K>()>(
+          std::forward<Args>(args)...))) {
+    return view.template call<details::qualified_key<F, K>()>(
+        std::forward<Args>(args)...);
   }
   template<fixed_string K, typename... Args>
   static constexpr decltype(auto)
   on(method_key<K>, const proxy_view<D>& view, Args&&... args) noexcept(
-      noexcept(view.template call<K>(std::forward<Args>(args)...))) {
-    return view.template call<K>(std::forward<Args>(args)...);
+      noexcept(view.template call<details::qualified_key<F, K>()>(
+          std::forward<Args>(args)...))) {
+    return view.template call<details::qualified_key<F, K>()>(
+        std::forward<Args>(args)...);
   }
 };
 
@@ -1362,8 +1681,10 @@ struct proxy_impl<F, const_proxy_view<D>> {
   requires(details::vtbuild_t<F>::template is_const<K>())
   static constexpr decltype(auto)
   on(method_key<K>, const const_proxy_view<D>& view, Args&&... args) noexcept(
-      noexcept(view.template call<K>(std::forward<Args>(args)...))) {
-    return view.template call<K>(std::forward<Args>(args)...);
+      noexcept(view.template call<details::qualified_key<F, K>()>(
+          std::forward<Args>(args)...))) {
+    return view.template call<details::qualified_key<F, K>()>(
+        std::forward<Args>(args)...);
   }
 };
 
@@ -1465,10 +1786,12 @@ public:
   // is not `[[nodiscard]]`, because discardability belongs to the facade
   // method rather than the dispatcher (the `std::invoke` precedent).
   template<fixed_string K, typename... Args>
-  decltype(auto)
-  call(Args&&... args) noexcept(vtbuild_t::template is_noexcept<K>()) {
-    constexpr auto ndx = vtbuild_t::template index_of<K>();
-    static_assert(ndx != vtbuild_t::count_v, "no matching signature");
+  decltype(auto) call(Args&&... args) noexcept(
+      vtbuild_t::template is_noexcept<K, false, Args...>()) {
+    constexpr auto ndx = vtbuild_t::template resolve<K, false, Args...>();
+    static_assert(ndx != vtbuild_t::none_v, "no matching signature");
+    static_assert(ndx != vtbuild_t::ambiguous_v,
+        "ambiguous method name; qualify the key with the facade name");
     return std::get<ndx>(
         vtable_->vt.thunks)(target(), std::forward<Args>(args)...);
   }
@@ -1477,9 +1800,11 @@ public:
   requires(details::vtbuild_t<F>::template is_const<K>())
   // NOLINTNEXTLINE(modernize-use-nodiscard)
   decltype(auto) call(Args&&... args) const
-      noexcept(vtbuild_t::template is_noexcept<K>()) {
-    constexpr auto ndx = vtbuild_t::template index_of<K>();
-    static_assert(ndx != vtbuild_t::count_v, "no matching signature");
+      noexcept(vtbuild_t::template is_noexcept<K, true, Args...>()) {
+    constexpr auto ndx = vtbuild_t::template resolve<K, true, Args...>();
+    static_assert(ndx != vtbuild_t::none_v, "no matching signature");
+    static_assert(ndx != vtbuild_t::ambiguous_v,
+        "ambiguous method name; qualify the key with the facade name");
     return std::get<ndx>(
         vtable_->vt.thunks)(target(), std::forward<Args>(args)...);
   }
@@ -1543,17 +1868,22 @@ private:
 template<Facade F, Facade D>
 requires(std::same_as<D, F> || Extends<D, F>)
 struct proxy_impl<F, proxy<D>> {
+  // Qualified forwarding, as with the view bindings; see `qualified_key`.
   template<fixed_string K, typename... Args>
   static decltype(auto)
   on(method_key<K>, proxy<D>& p, Args&&... args) noexcept(
-      noexcept(p.template call<K>(std::forward<Args>(args)...))) {
-    return p.template call<K>(std::forward<Args>(args)...);
+      noexcept(p.template call<details::qualified_key<F, K>()>(
+          std::forward<Args>(args)...))) {
+    return p.template call<details::qualified_key<F, K>()>(
+        std::forward<Args>(args)...);
   }
   template<fixed_string K, typename... Args>
   static decltype(auto)
   on(method_key<K>, const proxy<D>& p, Args&&... args) noexcept(
-      noexcept(p.template call<K>(std::forward<Args>(args)...))) {
-    return p.template call<K>(std::forward<Args>(args)...);
+      noexcept(p.template call<details::qualified_key<F, K>()>(
+          std::forward<Args>(args)...))) {
+    return p.template call<details::qualified_key<F, K>()>(
+        std::forward<Args>(args)...);
   }
 };
 

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -437,21 +437,35 @@ concept Proxiable =
 #pragma endregion
 #pragma region proxy_view
 
-// Non-owning erased handle over any `Proxiable` target: Rust's `&dyn Trait`,
-// ngcpp's `proxy_view`.
+// Forward declaration so the mutable view can befriend the const flavor.
+template<Facade F>
+class const_proxy_view;
+
+// Non-owning erased handle over any `Proxiable` target: Rust's `&mut dyn
+// Trait`, ngcpp's `proxy_view`.
 //
-// Two pointers: the target and the per-(facade, type) dispatch table. Copyable
-// and shallow-const like other views: `call` is const and dispatches const and
-// non-const facade methods alike. The target must outlive the view.
+// Two pointers: the target and the per-(facade, type) dispatch table. The
+// target must outlive the view.
+//
+// Deep-const as an instance: only const-qualified facade methods dispatch
+// through a `const proxy_view`. Because views are freely copyable, that is a
+// guardrail rather than a guarantee: copying a `const proxy_view` yields a
+// mutable view onto the same target, much as a `T* const` pointer copies to
+// a plain `T*`. Code that means read-only access should use
+// `const_proxy_view`, where constness is part of the type and survives
+// copying.
 template<Facade F>
 class proxy_view {
+  using vtbuild_t = details::vtbuild_t<F>;
+  using vtable_t = vtbuild_t::vtable_t;
+
 public:
   using facade_t = F;
 
   // Converting constructor from an lvalue target. Intentionally implicit, like
   // `string_view` from `string`. Rvalues do not bind, so construction from a
-  // temporary is rejected at compile time; const targets are rejected until a
-  // const view flavor exists.
+  // temporary is rejected at compile time; const targets take a
+  // `const_proxy_view`.
   template<typename T>
   requires(Proxiable<T, F> && !std::is_const_v<T> &&
               !std::same_as<T, proxy_view>)
@@ -461,9 +475,20 @@ public:
   // Call the facade method named `K`, forwarding `args` through the erased
   // signature. The call is `noexcept` when the method is.
   //
-  // Not `[[nodiscard]]`: discardability belongs to the facade method, not the
-  // dispatcher (the `std::invoke` precedent).
+  // The const overload is constrained to const-qualified methods, mirroring
+  // the owning proxy's deep const. Not `[[nodiscard]]`: discardability
+  // belongs to the facade method, not the dispatcher (the `std::invoke`
+  // precedent).
   template<fixed_string K, typename... Args>
+  constexpr decltype(auto)
+  call(Args&&... args) noexcept(vtbuild_t::template is_noexcept<K>()) {
+    constexpr auto ndx = vtbuild_t::template index_of<K>();
+    static_assert(ndx != vtbuild_t::count_v, "no matching signature");
+    return std::get<ndx>(*vtable_)(target_, std::forward<Args>(args)...);
+  }
+
+  template<fixed_string K, typename... Args>
+  requires(details::vtbuild_t<F>::template is_const<K>())
   // NOLINTNEXTLINE(modernize-use-nodiscard)
   constexpr decltype(auto) call(Args&&... args) const
       noexcept(vtbuild_t::template is_noexcept<K>()) {
@@ -473,8 +498,7 @@ public:
   }
 
 private:
-  using vtbuild_t = details::vtbuild_t<F>;
-  using vtable_t = vtbuild_t::vtable_t;
+  friend const_proxy_view<F>;
 
   void* target_;
   const vtable_t* vtable_;
@@ -484,14 +508,90 @@ private:
 // in Rust, where `dyn Trait` implements `Trait`).
 //
 // Calls forward through the wrapped view, with conditional `noexcept` so the
-// invariant also holds for facades with noexcept methods. This makes
-// facade-constrained generic code accept concrete and erased arguments
-// interchangeably, and allows views of views.
+// invariant also holds for facades with noexcept methods. The const overload
+// serves const-qualified methods, matching the view's instance-level deep
+// const. This makes facade-constrained generic code accept concrete and
+// erased arguments interchangeably, and allows views of views.
 template<Facade F>
 struct proxy_impl<F, proxy_view<F>> {
   template<fixed_string K, typename... Args>
   static constexpr decltype(auto)
+  on(method_key<K>, proxy_view<F>& view, Args&&... args) noexcept(
+      noexcept(view.template call<K>(std::forward<Args>(args)...))) {
+    return view.template call<K>(std::forward<Args>(args)...);
+  }
+  template<fixed_string K, typename... Args>
+  static constexpr decltype(auto)
   on(method_key<K>, const proxy_view<F>& view, Args&&... args) noexcept(
+      noexcept(view.template call<K>(std::forward<Args>(args)...))) {
+    return view.template call<K>(std::forward<Args>(args)...);
+  }
+};
+
+// Non-owning read-only erased handle: Rust's `&dyn Trait`, the
+// `const_iterator` to `proxy_view`'s `iterator`.
+//
+// Constness is part of the type, so unlike a `const proxy_view` it survives
+// copying: a const view only ever copies or converts to another const view.
+// It binds const and mutable targets alike, and dispatches only the
+// const-qualified facade methods, sharing the mutable view's per-(facade,
+// type) dispatch table (the non-const slots are simply unreachable). The
+// target must outlive the view.
+template<Facade F>
+class const_proxy_view {
+  using vtbuild_t = details::vtbuild_t<F>;
+  using vtable_t = vtbuild_t::vtable_t;
+
+public:
+  using facade_t = F;
+
+  // Converting constructor from an lvalue target, const or not. Intentionally
+  // implicit; rvalues do not bind.
+  template<typename T>
+  requires(Proxiable<std::remove_const_t<T>, F> &&
+              !std::same_as<std::remove_const_t<T>, const_proxy_view> &&
+              !std::same_as<std::remove_const_t<T>, proxy_view<F>>)
+  constexpr explicit(false) const_proxy_view(T& target) noexcept
+      : target_{std::addressof(target)},
+        vtable_{&details::vtable_for<F, std::remove_const_t<T>>} {}
+
+  // Converting constructor from the mutable view: dropping mutability is
+  // implicit and safe, like `T*` to `const T*`. There is no path back.
+  constexpr explicit(false)
+      const_proxy_view(const proxy_view<F>& view) noexcept
+      : target_{view.target_}, vtable_{view.vtable_} {}
+
+  // Call the facade method named `K`, which must be const-qualified; the
+  // mutable methods do not exist on this view. The call is `noexcept` when
+  // the method is. Not `[[nodiscard]]`, as on the other handles.
+  template<fixed_string K, typename... Args>
+  requires(details::vtbuild_t<F>::template is_const<K>())
+  // NOLINTNEXTLINE(modernize-use-nodiscard)
+  constexpr decltype(auto) call(Args&&... args) const
+      noexcept(vtbuild_t::template is_noexcept<K>()) {
+    constexpr auto ndx = vtbuild_t::template index_of<K>();
+    static_assert(ndx != vtbuild_t::count_v, "no matching signature");
+    return std::get<ndx>(*vtable_)(target_, std::forward<Args>(args)...);
+  }
+
+private:
+  const void* target_;
+  const vtable_t* vtable_;
+};
+
+// Library-provided binding so that a const view satisfies its own facade
+// where that is possible: it dispatches only const methods, so the invariant
+// holds exactly for all-const facades.
+//
+// The `on` is itself constrained to const methods so that a mixed facade
+// fails conformance cleanly at overload resolution, rather than erroring
+// during return type deduction of a forwarder whose `call` cannot compile.
+template<Facade F>
+struct proxy_impl<F, const_proxy_view<F>> {
+  template<fixed_string K, typename... Args>
+  requires(details::vtbuild_t<F>::template is_const<K>())
+  static constexpr decltype(auto)
+  on(method_key<K>, const const_proxy_view<F>& view, Args&&... args) noexcept(
       noexcept(view.template call<K>(std::forward<Args>(args)...))) {
     return view.template call<K>(std::forward<Args>(args)...);
   }

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -16,6 +16,7 @@
 // limitations under the License.
 #pragma once
 #include <array>
+#include <bit>
 #include <cassert>
 #include <concepts>
 #include <cstddef>
@@ -23,6 +24,7 @@
 #include <exception>
 #include <memory>
 #include <new>
+#include <stdexcept>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -65,6 +67,8 @@
 // - `M`: a `method` descriptor; `Ms` is a pack of them.
 // - `S`: a flattened dispatch slot; `Ss` is a pack of them.
 // - `Owner`: the facade that declared a slot's method.
+// - `Born`: the facade a proxy's target was constructed as, keying its
+//      owning tables and the birth ancestry `try_downcast` searches.
 // - `Name`: a declared name, a facade's or a method's, as a `fixed_string`.
 // - `OwnName`: the name of the facade being built.
 // - `Key`: a `call` lookup key: a method name, optionally facade-qualified.
@@ -75,12 +79,14 @@
 //      passes; `CallArgs` where the two meet and need distinguishing.
 // - `Impl`: a registration-carried binding class.
 // - `Check`: an `api_check` value.
+// - `Policy`: an owning proxy's storage policy, a `proxy_policy` value; `P`
+//      where a second handle's policy varies independently.
 namespace corvid { inline namespace meta {
 namespace prox {
 
 #pragma region Method and key
 
-// Method key.
+// `method_key`.
 //
 // A tag carrying a method name as a compile-time string.
 //
@@ -98,9 +104,11 @@ inline namespace literals {
 //
 // This must be a literal operator template: the literal itself binds as the
 // `fixed_string` template argument, which is what lets it reach NTTP
-// position. The ordinary `(const char*, size_t)` form cannot work, because
-// function parameters are runtime values, never constant expressions, even
-// under `consteval`.
+// position.
+//
+// The ordinary `(const char*, size_t)` form cannot work, because function
+// parameters are runtime values, never constant expressions, even under
+// `consteval`.
 template<fixed_string Name>
 consteval auto operator""_method() noexcept {
   return method_key<Name>{};
@@ -108,7 +116,23 @@ consteval auto operator""_method() noexcept {
 
 } // namespace literals
 
-// Method descriptor: a name plus the erased signature.
+namespace details {
+
+// `method_base`: shared base for the four `method` flavors (`const` crossed
+// with `noexcept`).
+//
+// It carries the qualification flags and the result type, which are the only
+// things that vary, and supplies the `method_key` base.
+template<fixed_string Name, bool Const, bool Noexcept, typename R>
+struct method_base: method_key<Name> {
+  static constexpr bool const_v = Const;
+  static constexpr bool noexcept_v = Noexcept;
+  using result_t = R;
+};
+
+} // namespace details
+
+// `method`: Method descriptor, a name plus the erased signature.
 //
 // The signature is spelled like a member function's definition, using the same
 // syntax that `std::function` takes. So, for example, it would look like
@@ -127,22 +151,6 @@ consteval auto operator""_method() noexcept {
 // `method_key<Key>` from a method argument. This also leaves the door open for
 // bindings that overload on the full method (signature included) if per-name
 // overload sets are ever supported.
-namespace details {
-
-// Shared base for the four `method` flavors (`const` crossed with
-// `noexcept`).
-//
-// It carries the qualification flags and the result type, which are the only
-// things that vary, and supplies the `method_key` base.
-template<fixed_string Name, bool Const, bool Noexcept, typename R>
-struct method_base: method_key<Name> {
-  static constexpr bool const_v = Const;
-  static constexpr bool noexcept_v = Noexcept;
-  using result_t = R;
-};
-
-} // namespace details
-
 template<fixed_string Name, typename Sig>
 struct method;
 
@@ -165,13 +173,14 @@ struct method<Name, R(Args...) const noexcept>
 #pragma endregion
 #pragma region Facade
 
-// Facade base: an interface definition.
+// `facade`: facade base, an interface definition.
 //
 // Derive a named struct from `facade`, listing the facade's `name` and its
 // methods. For example:
 //
 //    struct animal
-//        : facade<name<"animal">, method<"speak", void() const>> {};
+//        : facade<name<"animal">, //
+//            method<"speak", void() const>> {};
 //
 // The derived type, `animal` here, IS the facade: it is the `F` in
 // `proxy_view<F>` and `proxy_impl<F, T>`, and the type registration keys on.
@@ -193,7 +202,7 @@ struct method<Name, R(Args...) const noexcept>
 //        }
 //      };
 //      template<typename T>
-//      struct boilerplate : prox_impl {
+//      struct boilerplate : proxy_impl_base {
 //        static int on(method_key<"speak">, const T& t) {
 //          return t.speak();
 //        }
@@ -201,8 +210,7 @@ struct method<Name, R(Args...) const noexcept>
 //    };
 //
 // With that in place, `handle.speak()` is sugar for `handle.call<"speak">()`,
-// dispatching through the same table. See "proxy.md" for the design and its
-// limits.
+// dispatching through the same table.
 //
 // The facade body is also the normal home of the boilerplate impl; see also
 // `proxy_impl`.
@@ -211,19 +219,19 @@ struct facade {};
 
 namespace details {
 
-// Probe for the unique public `facade` base of `F`. Declared only; used in
-// unevaluated contexts.
+// `probe`: Probe for the unique public `facade` base of `F`.
+// Declared only; used in unevaluated contexts.
 template<typename... Ms>
 auto probe(const facade<Ms...>&) -> facade<Ms...>;
 
 } // namespace details
 
-// Concept for a type derived from a single `facade` base.
+// `Facade`: concept for a type derived from a single `facade` base.
 template<typename F>
 concept Facade = requires(const F& f) { details::probe(f); };
 
-// Facade composition entry: the facade extends `B` (Rust supertrait, ngcpp
-// `add_facade`).
+// `extends`: facade composition entry declaring that the facade extends `B`
+// (Rust supertrait, ngcpp `add_facade`).
 //
 // Listed in the facade's method list alongside the methods, conventionally
 // after the `name`. For example:
@@ -264,8 +272,8 @@ concept Facade = requires(const F& f) { details::probe(f); };
 template<Facade B>
 struct extends {};
 
-// Facade name entry: gives the facade a formal name, which qualifies its
-// methods.
+// `name`: facade name entry, giving the facade a formal name, which qualifies
+// its methods.
 //
 // Listed in the facade's entry list, conventionally first. For example:
 //
@@ -284,10 +292,10 @@ struct name {};
 
 namespace details {
 
-// Stand-in API base for facades that define no member-call sugar.
+// `no_api`: stand-in API base for facades that define no member-call sugar.
 struct no_api {};
 
-// Sugar base for handles of facade `F`.
+// `api_base`: sugar base for handles of facade `F`.
 //
 // Yields the facade's nested `api` when it defines one, and the empty stand-in
 // otherwise. The selection has to be lazy (a specialization rather than a
@@ -310,32 +318,127 @@ using api_base_t = api_base<F>::type;
 } // namespace details
 
 #pragma endregion
+#pragma region Proxy policy
+
+// `proxy_alloc`: allocation strategy for the owning `proxy`.
+//
+// `sbo_or_heap` stores a target inline when it is eligible and efficient (see
+// `proxy_policy`), and on the heap otherwise.
+//
+// `sbo_only` forbids the heap path: constructing a proxy over an ineligible
+// target is a compile error, and a heap target arriving through a
+// converting move is un-boxed into the buffer, throwing `std::length_error`
+// if it does not fit (the one runtime failure, since an erased target's size
+// cannot be checked statically).
+//
+// `heap_only` forbids the inline path, so every target has a stable heap
+// address, and the proxy carries no inline buffer at all; an inline target
+// arriving through a converting move is re-boxed onto the heap.
+enum class proxy_alloc : std::uint8_t {
+  sbo_only = 1 << 0,
+  heap_only = 1 << 1,
+  sbo_or_heap = sbo_only | heap_only
+};
+
+// `proxy_policy`: per-handle storage policy for the owning `proxy`, used as
+// its second template parameter.
+//
+// The default reproduces the baseline proxy: a two-pointer inline buffer at
+// `std::max_align_t` alignment, falling back to the heap. A facade whose
+// typical targets are a little too big for the default buffer can be handled
+// with a larger `sbo_size`.
+//
+// A target is stored inline when it fits `sbo_size` and `sbo_align` and is
+// nothrow-move-constructible (a proxy move relocates an inline target, and
+// proxy moves are unconditionally `noexcept`). The exception is when the
+// source is on the heap and the target allows heap storage, in which case only
+// the pointer is moved.
+//
+// Policies are checked at proxy construction, not at registration.
+// Registration is per (facade, type) and knows nothing about any particular
+// handle's storage. One facade can serve proxies of different policies, and
+// views, simultaneously.
+struct proxy_policy {
+  std::size_t sbo_size{2 * sizeof(void*)};
+  std::size_t sbo_align{alignof(std::max_align_t)};
+  proxy_alloc alloc{proxy_alloc::sbo_or_heap};
+
+  friend constexpr bool
+  operator==(const proxy_policy&, const proxy_policy&) = default;
+};
+
+namespace details {
+
+// `sbo_fits`: whether `T` is eligible for policy `P`'s inline buffer.
+template<typename T>
+consteval bool sbo_fits(proxy_policy p) noexcept {
+  return sizeof(T) <= p.sbo_size && alignof(T) <= p.sbo_align &&
+         std::is_nothrow_move_constructible_v<T>;
+}
+
+// `can_store_inline`: whether policy `P` can store `T` inline.
+//
+// An `sbo_only` policy over an ineligible target is rejected separately, with
+// its own diagnostic.
+template<typename T>
+consteval bool can_store_inline(proxy_policy p) noexcept {
+  return p.alloc != proxy_alloc::heap_only && sbo_fits<T>(p);
+}
+
+// `inline_fit_guaranteed`: whether every inline target the source policy
+// admits is guaranteed to fit the destination's buffer, letting adoption skip
+// the runtime fit check (and, with it, every mode-changing path for inline
+// arrivals).
+consteval bool
+inline_fit_guaranteed(proxy_policy to, proxy_policy from) noexcept {
+  return to.alloc != proxy_alloc::heap_only && to.sbo_size >= from.sbo_size &&
+         to.sbo_align >= from.sbo_align;
+}
+
+// `adopt_may_throw`: whether adopting from policy `from` into policy `to` can
+// throw.
+//
+// Could be an inline arrival that might not stay inline (a re-boxing
+// allocation, or nowhere at all to put it under `sbo_only`), or a heap arrival
+// that must un-box into an `sbo_only` buffer it might not fit.
+consteval bool adopt_may_throw(proxy_policy to, proxy_policy from) noexcept {
+  const bool from_sbo = from.alloc != proxy_alloc::heap_only;
+  const bool from_heap = from.alloc != proxy_alloc::sbo_only;
+  return (from_sbo && !inline_fit_guaranteed(to, from)) ||
+         (from_heap && to.alloc == proxy_alloc::sbo_only);
+}
+
+} // namespace details
+
+#pragma endregion
 #pragma region Registration and binding
 
-// Convenience base for binding classes: a facade's `boilerplate`, or a
-// registration-carried impl.
-//
-// Its sole member is a `method_key` alias, which lets a binding class spell
-// its `on` parameters without qualification. Base-class members participate
-// in unqualified lookup, where the enclosing namespace's names do not.
+// `proxy_impl_base` is a convenience base for binding classes: a facade's
+// `boilerplate`, or a registration-carried impl.
 //
 // Inheriting it is optional, and a binding class that inherits a boilerplate
 // already has it through that base. It also serves as documentation of what
 // the class is for.
-struct prox_impl {
+struct proxy_impl_base {
   template<fixed_string Name>
   using method_key = prox::method_key<Name>;
 };
 
-// Binding point between a facade and a concrete type (Rust's `impl Trait for
-// Type`).
+// `proxy_impl` is a binding point between a facade and a concrete type (Rust's
+// `impl Trait for Type`).
 //
-// Intentionally undefined. A binding provides one static `on` overload per
-// facade method, taking the method's `key`, the target (const-qualified per
-// the method), and the method's arguments. Registration is the sole act of
-// conformance: it either unlocks the facade's boilerplate or carries the
-// pair's impl itself, and library partial specializations of this template
-// install whichever applies.
+// The primary template is a bare forward declaration: it never receives a
+// body, so instantiating it directly yields an incomplete type. Every usable
+// binding is a specialization, and the specializations are gated on
+// registration, the sole act of conformance: the library's partial
+// specializations install the facade's boilerplate or the pair's
+// registration-carried impl, and their constraints match registered pairs
+// only. For an unregistered pair, no specialization applies, and the
+// incomplete primary is what makes conformance fail.
+//
+// A binding provides a single static `on` overload per facade method, taking
+// the method's `key`, the target (const-qualified per the method), and the
+// method's arguments.
 //
 // A facade author typically hosts a boilerplate impl inside the facade
 // itself: a nested class template named `boilerplate`, generic over any
@@ -346,7 +449,9 @@ struct prox_impl {
 // live anywhere a type can: local to the hook itself (a fully self-contained
 // registration, and the only self-contained option for a type you do not
 // own), nested in the type it serves (which additionally grants access to
-// the type's private members), or at namespace scope.
+// the type's private members), or at namespace scope. Note that you can also
+// forward-declare and friend it in the class, giving it private access without
+// nesting.
 //
 // A carried impl outranks the boilerplate, being the more specific
 // declaration. The namespace-scope spelling of the boilerplate, a `proxy_impl`
@@ -355,29 +460,23 @@ struct prox_impl {
 // require `!SpecCarriesImpl<F, T>`); it is the one user-authored
 // specialization of this template in the supported surface.
 //
-// Unregistered per-type full specializations, the original wrong-names tier,
-// are subsumed by carried impls and no longer supported.
-//
 // Because the nested boilerplate is an ordinary inheritable class, it also
 // enables partial overrides: a type whose names line up except for one method
 // registers a carried impl that inherits `F::boilerplate<T>`, re-exposes its
 // `on` overloads with a using-declaration, and declares only the divergent
 // binding.
 //
-// See "proxy.md" for the mechanics and "proxy_test.cpp" for
-// examples (`sheriff`, `turncoat`).
+// See "proxy_test.cpp" for examples (`sheriff`, `turncoat`).
 //
 // For example:
-
+//
 //    // Facade author's boilerplate, written once, serving any registered
-//    // type whose member names line up. The `api` is omitted here for
-//    // brevity. Inheriting `prox_impl` supplies the unqualified `method_key`
-//    // spelling.
+//    // type whose member names line up.
 //    struct animal
 //        : facade<name<"animal">, //
 //            method<"speak", void() const>> {
 //      // Note: API omitted for brevity.
-//      template<typename T> struct boilerplate : prox_impl {
+//      template<typename T> struct boilerplate : proxy_impl_base {
 //        static void on(method_key<"speak">, const T& t) { t.speak(); }
 //      };
 //    };
@@ -390,7 +489,7 @@ struct prox_impl {
 //    // Conforming `cat`, whose names differ: the registration carries the
 //    // impl, here local to the hook itself.
 //    consteval auto corvid_proxy_spec(animal*, cat*) {
-//      struct as_animal : prox_impl {
+//      struct as_animal : proxy_impl_base {
 //        static void on(method_key<"speak">, const cat& c) { c.meow(); }
 //      };
 //      return make_proxy_spec<animal, cat, as_animal>();
@@ -398,7 +497,7 @@ struct prox_impl {
 template<typename F, typename T>
 struct proxy_impl;
 
-// Minimal registration spec.
+// `proxy_spec`: minimal registration spec.
 //
 // The value a registration hook returns. Distinct from `corvid_proxy_spec`,
 // which is the hook itself, provided by the user.
@@ -425,16 +524,19 @@ struct api_probe;
 template<Facade F>
 [[nodiscard]] consteval bool validate_api() noexcept;
 
-// Whether registering a pair also validates the facade's `api` (see
-// `validate_api`). A facade whose `api` deliberately deviates from the method
-// list (say, a widening convenience signature), must register with
-// `api_check::off`.
+// `api_check`: whether registering a pair also validates the facade's `api`
+// (see `validate_api`).
+//
+// A facade whose `api` deliberately deviates from the method list (say, a
+// widening convenience signature), must register with `api_check::off`.
 enum class api_check : std::uint8_t { off, on };
 
 namespace details {
 
-// Registration-time half of `validate_api`: run the check when the facade
-// has an `api` and the registration has not opted out.
+// `maybe_validate_api`: registration-time half of `validate_api`.
+//
+// Run the check when the facade has an `api` and the registration has not
+// opted out.
 template<typename F, api_check Check>
 consteval void maybe_validate_api() noexcept {
   if constexpr (Check == api_check::on && Facade<F> &&
@@ -452,7 +554,7 @@ consteval void maybe_validate_api() noexcept {
 
 } // namespace details
 
-// Make the registration spec for a (facade, type) pair.
+// `make_proxy_spec`: make the registration spec for a (facade, type) pair.
 //
 // Call this from a `corvid_proxy_spec` overload, just as
 // `make_sequence_enum_spec` is returned from `corvid_enum_spec`.
@@ -484,7 +586,7 @@ template<typename F, typename T, typename Impl,
   return {};
 }
 
-// Concept for a (facade, type) pair being registered.
+// `ProxyRegistered`: concept for a (facade, type) pair being registered.
 //
 // To register a pair, declare a `corvid_proxy_spec(F*, T*)` overload returning
 // `make_proxy_spec<F, T>()`, in the namespace of either the facade or the
@@ -504,15 +606,16 @@ concept ProxyRegistered = requires {
   corvid_proxy_spec(static_cast<F*>(nullptr), static_cast<T*>(nullptr));
 };
 
-// Concept for a (facade, type) pair whose registration carries an impl.
+// `SpecCarriesImpl`: concept for a (facade, type) pair whose registration
+// carries an impl.
 //
 // True when the pair is registered through the three-type
 // `make_proxy_spec<F, T, Impl>()`, which names the binding class serving the
 // pair.
 //
 // The library installs the carried impl as the pair's `proxy_impl` (below),
-// outranking the facade's boilerplate: the carried impl is the more specific
-// declaration, closer to the type.
+// outranking the facade's boilerplate because the carried impl is the more
+// specific declaration, closer to the type.
 //
 // A namespace-scope boilerplate partial should include `!SpecCarriesImpl<F,
 // T>` in its gate to preserve that precedence, since partial ordering would
@@ -525,14 +628,14 @@ concept SpecCarriesImpl =
 
 namespace details {
 
-// Impl type carried by the pair's registration.
+// `registered_impl_t`: impl type carried by the pair's registration.
 template<typename F, typename T>
 using registered_impl_t = decltype(corvid_proxy_spec(static_cast<F*>(nullptr),
     static_cast<T*>(nullptr)))::impl_t;
 
 } // namespace details
 
-// Library-provided delegation to a registration-carried impl.
+// `proxy_impl`: library-provided delegation to a registration-carried impl.
 //
 // The registration names the binding class, so the impl is explicitly
 // registered like everything else, and the class itself can be local to the
@@ -542,7 +645,8 @@ template<Facade F, typename T>
 requires SpecCarriesImpl<F, T>
 struct proxy_impl<F, T>: details::registered_impl_t<F, T> {};
 
-// Library-provided delegation to a facade-hosted boilerplate impl.
+// `proxy_impl`: library-provided delegation to a facade-hosted boilerplate
+// impl.
 //
 // When a facade defines a nested `boilerplate` class template and the
 // (facade, type) pair is registered, this serves as the pair's `proxy_impl`,
@@ -557,7 +661,8 @@ requires(ProxyRegistered<F, T> && !SpecCarriesImpl<F, T> &&
          requires { typename F::template boilerplate<T>; })
 struct proxy_impl<F, T>: F::template boilerplate<T> {};
 
-// Central access point for the registered spec, mirroring `enum_spec_v`.
+// `proxy_spec_v`: central access point for the registered spec, mirroring
+// `enum_spec_v`.
 //
 // Each specialization deduces its own type, so richer spec types can be
 // introduced later without touching existing registrations.
@@ -571,8 +676,8 @@ constexpr inline auto proxy_spec_v =
 
 namespace details {
 
-// Per-method dispatch machinery, shared by the four erased-signature flavors
-// (`const` crossed with `noexcept`).
+// `method_traits_base`: per-method dispatch machinery, shared by the four
+// erased-signature flavors (`const` crossed with `noexcept`).
 //
 // Contains the thunk pointer type, the compile-time check that a `proxy_impl`
 // binding exists, and the thunk itself, which is where the concrete type is
@@ -590,15 +695,19 @@ struct method_traits_base {
   using erased_ptr_t = std::conditional_t<Const, const void*, void*>;
   using thunk_ptr_t = R (*)(erased_ptr_t, Args...) noexcept(Noexcept);
 
-  // Parameter list normalized for exact-match probing: top-level cv and
-  // references stripped from each parameter, so value-category spelling is
-  // ignored but a merely-convertible type does not match.
+  // `norm_args_t`: parameter list normalized for exact-match probing.
+  //
+  // Top-level cv and references stripped from each parameter, so
+  // value-category spelling is ignored, but a merely-convertible type does not
+  // match.
   using norm_args_t = std::tuple<std::remove_cvref_t<Args>...>;
 
-  // Whether `CallArgs` match the declared parameters exactly after
-  // normalization, and whether they are merely viable through the ordinary
-  // conversions a call performs. Exactness is the validation probe's
-  // strictness; viability is overload-set resolution's fallback.
+  // `exact_v`, `viable_v`: whether `CallArgs` match the declared parameters
+  // exactly after normalization, and whether they are merely viable through
+  // the ordinary conversions a call performs.
+  //
+  // Exactness is the validation probe's strictness; viability is overload-set
+  // resolution's fallback.
   template<typename... CallArgs>
   static constexpr bool exact_v =
       std::same_as<std::tuple<std::remove_cvref_t<CallArgs>...>, norm_args_t>;
@@ -645,20 +754,8 @@ template<fixed_string Name, typename R, typename... Args>
 struct method_traits<method<Name, R(Args...) const noexcept>>
     : method_traits_base<Name, true, true, R, Args...> {};
 
-// Inline (SBO) storage parameters for the owning `proxy`.
-//
-// A target is stored inline when it fits the buffer, is no more aligned than
-// `std::max_align_t`, and is nothrow-move-constructible (a proxy move
-// relocates an inline target, and proxy moves are unconditionally
-// `noexcept`). Anything else lives in a unique-owned heap allocation.
-inline constexpr std::size_t sbo_size = 2 * sizeof(void*);
-
-template<typename T>
-constexpr inline bool sbo_eligible_v =
-    sizeof(T) <= sbo_size && alignof(T) <= alignof(std::max_align_t) &&
-    std::is_nothrow_move_constructible_v<T>;
-
-// Housekeeping thunks for the owning `proxy`, the analog of Rust's drop glue.
+// `sbo_destroy`, `heap_destroy`, `sbo_relocate`: housekeeping thunks for the
+// owning `proxy`, the analog of Rust's drop glue.
 //
 // `sbo_relocate` move-constructs `*from` into `to` and destroys the source.
 // The heap path has none because a heap target moves by pointer steal.
@@ -679,35 +776,175 @@ void sbo_relocate(void* from, void* to) noexcept {
   source->~T();
 }
 
-// Facade-wide dispatch machinery, specialized on the `facade` base to get at
-// the entry pack: the flattened method list, name-to-slot lookup, the
-// dispatch table type, the all-methods-bound check behind `Proxiable`, and
-// the table builders.
+// `sbo_copy`, `heap_copy`: copy thunks, present in the owning table only for
+// copy-constructible targets.
+//
+// Both return the copy's address. `sbo_copy` copy-constructs `*from` into
+// the buffer at `to` (and the return is that same address); `heap_copy`
+// allocates the copy, ignoring `to`. Either can throw (the target's copy
+// constructor, or the allocation), so unlike the other housekeeping thunks
+// they are not `noexcept`; the caller publishes the result only on success.
+template<typename T>
+void* sbo_copy(const void* from, void* to) {
+  return ::new (to) T(*static_cast<const T*>(from));
+}
+
+template<typename T>
+void* heap_copy(const void* from, void* /*to*/) {
+  return new T(*static_cast<const T*>(from));
+}
+
+// `sbo_to_heap`, `heap_to_sbo`: mode-changing thunks, for adopting a target
+// into a proxy whose policy demands the other storage mode.
+//
+// `sbo_to_heap` re-boxes: it moves an inline target into a fresh heap
+// allocation and destroys the inline source. Inline eligibility guarantees
+// a nothrow move, so only the allocation can throw, and it throws before
+// the source is touched.
+//
+// `heap_to_sbo` un-boxes: it moves a heap target into the buffer at `to` and
+// frees the allocation; nothing can throw, but the caller must first verify
+// the fit through the table's `size` and `align`.
+template<typename T>
+void* sbo_to_heap(void* from) {
+  auto* source = static_cast<T*>(from);
+  auto* target = new T(std::move(*source));
+  source->~T();
+  return target;
+}
+
+template<typename T>
+void heap_to_sbo(void* from, void* to) noexcept {
+  auto* source = static_cast<T*>(from);
+  ::new (to) T(std::move(*source));
+  delete source;
+}
+
+// `type_tag_v`: type identity tag: the address of `type_tag_v<T>` identifies
+// `T` uniquely across the program, without RTTI.
+//
+// The owning table carries it, so typed operations on an erased target can
+// verify the type at runtime.
+template<typename T>
+constexpr inline std::byte type_tag_v{};
+
+// `facade_tag_v`: facade identity tag, the facade analog of `type_tag_v`.
+//
+// Birth-ancestry entries carry it, so `try_downcast` can match a facade at
+// runtime.
+template<Facade F>
+constexpr inline std::byte facade_tag_v{};
+
+// `vtable_builder`: facade-wide dispatch machinery, specialized on the
+// `facade` base to get at the entry pack.
+//
+// Contains the flattened method list, name-to-slot lookup, the dispatch table
+// type, the all-methods-bound check behind `Proxiable`, and the table
+// builders.
 template<typename FB>
 struct vtable_builder;
 
-// Facade-wide machinery for the derived facade type `F`.
+// `vtbuild_t`: facade-wide machinery for the derived facade type `F`.
 template<Facade F>
 using vtbuild_t = vtable_builder<decltype(probe(std::declval<const F&>()))>;
 
-// Per-(facade, type) dispatch table instance. The handle stores a pointer to
-// this; the table pointer lives in the handle, not in the target (a fat
-// handle, like Rust's `&dyn`). A composed facade's table also embeds the
-// address of each direct base's instance for the same target type, which is
-// what makes upcasting a pointer read.
+// `vtable_for`: per-(facade, type) dispatch table instance.
+//
+// The handle stores a pointer to this; the table pointer lives in the handle,
+// not in the target (a fat handle, like Rust's `&dyn`). A composed facade's
+// table also embeds the address of each direct base's instance for the same
+// target type, which is what makes upcasting a pointer read.
 template<Facade F, typename T>
 constexpr inline auto vtable_for = vtbuild_t<F>::template make_vtable<F, T>();
 
-// Per-(facade, type) owning dispatch table instance, for `proxy`.
-template<Facade F, typename T>
-constexpr inline auto owning_vtable_for =
-    vtbuild_t<F>::template make_owning_vtable<F, T>();
+// `owning_vtable_for`: per-(facade, born facade, type, storage mode) owning
+// dispatch table instance, for `proxy`.
+//
+// `Sbo` marks a table whose target is stored inline; whether it is depends on
+// the constructing handle's policy as well as on `T`.
+//
+// `Born` is the facade the target was constructed as. Every pointer a table
+// embeds (the direct-base tables, the other-mode sibling, the birth
+// ancestry) stays within the same born family, so upcasts and mode changes
+// land on born-keyed siblings automatically and `try_downcast` can recover
+// the birth identity from the table alone, at no cost in the handle.
+// Instances are many and tables are few, cold, and deduplicated, so the
+// table is where the memory belongs. The table TYPE is still per facade;
+// `Born` only selects which static object is pointed at.
+//
+// The type is spelled explicitly, not deduced: the two modes' tables
+// reference each other by address, which is fine for initialization but
+// would make `auto` deduction circular.
+template<Facade F, Facade Born, typename T, bool Sbo>
+constexpr inline vtbuild_t<F>::owning_vtable_t owning_vtable_for =
+    vtbuild_t<F>::template make_owning_vtable<F, Born, T, Sbo>();
 
-// Flattened dispatch slot: one facade method plus the facade that declared
-// it.
+// `ancestor_entry`: one entry of a birth ancestry.
+//
+// Contains a facade's identity tag and that facade's owning table for the same
+// birth, target type, and storage mode.
+struct ancestor_entry {
+  const void* tag;
+  const void* table;
+};
+
+// `ancestry_t`: type-erased view of a birth ancestry, the facade the target
+// was born as plus every facade it transitively extends.
+//
+// Every owning table points at its born family's ancestry; the underlying
+// tables are the per-(born facade, type, mode) statics below.
+struct ancestry_t {
+  const ancestor_entry* entries;
+  std::size_t count;
+};
+
+// `find_ancestor`: the owning table of the ancestry member whose tag is `tag`,
+// or null when the facade is not in the ancestry.
+//
+// This is `try_downcast`'s runtime search; the tag match is what proves the
+// cast sound, so the caller can cast the table back to the matched facade's
+// type.
+[[nodiscard]] constexpr const void*
+find_ancestor(const ancestry_t& ancestry, const void* tag) noexcept {
+  for (std::size_t ndx = 0; ndx != ancestry.count; ++ndx)
+    if (ancestry.entries[ndx].tag == tag) return ancestry.entries[ndx].table;
+  return nullptr;
+}
+
+// `make_ancestor_table`: build the ancestor table for a target born as (Born,
+// T, Sbo).
+//
+// Contains `Born` itself first, then every facade it extends, all keyed by the
+// same birth. The tuple pointer parameter carries
+// `vtbuild_t<Born>::ancestors_t` in deducible position.
+template<Facade Born, typename T, bool Sbo, Facade... As>
+consteval std::array<ancestor_entry, 1 + sizeof...(As)>
+make_ancestor_table(std::tuple<As...>*) noexcept {
+  return {{{&facade_tag_v<Born>, &owning_vtable_for<Born, Born, T, Sbo>},
+      {&facade_tag_v<As>, &owning_vtable_for<As, Born, T, Sbo>}...}};
+}
+
+template<Facade Born, typename T, bool Sbo>
+constexpr inline auto ancestor_table_for = make_ancestor_table<Born, T, Sbo>(
+    static_cast<vtbuild_t<Born>::ancestors_t*>(nullptr));
+
+// `ancestry_for`: the birth ancestry for a target born as (Born, T, Sbo), the
+// object every owning table of that born family points at.
+//
+// Each storage mode has its own ancestry, whose entries are that mode's
+// tables; a mode-changing adoption switches the proxy to the table's
+// other-mode sibling, which carries the other mode's ancestry, so the tables
+// an ancestry hands out always match the target's current home.
+template<Facade Born, typename T, bool Sbo>
+constexpr inline ancestry_t ancestry_for{
+    ancestor_table_for<Born, T, Sbo>.data(),
+    ancestor_table_for<Born, T, Sbo>.size()};
+
+// `slot`: flattened dispatch slot, containing one facade method plus the
+// facade that declared it.
 //
 // The owner is `void` while the declaring facade is the one being built,
-// since a facade cannot name itself from inside its own list; an `extends`
+// since a facade cannot name itself from inside its own list. An `extends`
 // entry retags its base's own slots with the base's type as it flattens
 // them, so in any facade's flattened list every inherited slot carries its
 // declaring facade.
@@ -728,8 +965,9 @@ struct slot {
   using result_t = M::result_t;
 };
 
-// Retag base facade `B`'s own slots with `B` itself, leaving inherited slots
-// untouched, as `extends<B>` flattens B's list into the derived facade's.
+// `retagged`: retag base facade `B`'s own slots with `B` itself, leaving
+// inherited slots untouched, as `extends<B>` flattens B's list into the
+// derived facade's.
 template<Facade B, typename S>
 struct retagged {
   using type = S;
@@ -739,6 +977,7 @@ struct retagged<B, slot<void, M>> {
   using type = slot<B, M>;
 };
 
+// `retag_slots`: retag all slots in a tuple with `B`.
 template<Facade B, typename Slots>
 struct retag_slots;
 template<Facade B, typename... Ss>
@@ -748,7 +987,8 @@ struct retag_slots<B, std::tuple<Ss...>> {
 template<Facade B, typename Slots>
 using retag_slots_t = retag_slots<B, Slots>::type;
 
-// First position of type `S` in `Ss`, for dedup's first-occurrence test.
+// `first_index_of_type`: first position of type `S` in `Ss`, for dedup's
+// first-occurrence test.
 template<typename S, typename... Ss>
 consteval std::size_t first_index_of_type() noexcept {
   constexpr std::array<bool, sizeof...(Ss)> matches{std::same_as<S, Ss>...};
@@ -757,7 +997,8 @@ consteval std::size_t first_index_of_type() noexcept {
   return sizeof...(Ss);
 }
 
-// Remove duplicate slot types, keeping first occurrences in order.
+// `dedup_slots`: remove duplicate slot types, keeping first occurrences in
+// order.
 //
 // A slot type recurs exactly when the same ancestor facade is reached
 // through more than one composition path, so this is what collapses a
@@ -777,10 +1018,11 @@ struct dedup_slots<std::tuple<Ss...>> {
 template<typename Slots>
 using dedup_slots_t = dedup_slots<Slots>::type;
 
-// Thunk for one slot: an inherited method binds through its declaring
-// facade, an own method through `F` itself, so per-facade conformance
-// survives flattening verbatim and an upcast handle cannot disagree with the
-// derived one.
+// `slot_thunk`: thunk for one slot.
+//
+// An inherited method binds through its declaring facade, an own method
+// through `F` itself, so per-facade conformance survives flattening verbatim
+// and an upcast handle cannot disagree with the derived one.
 template<typename F, typename T, typename S>
 consteval auto slot_thunk() noexcept {
   using owner_t = std::conditional_t<std::is_void_v<typename S::owner_t>, F,
@@ -789,8 +1031,9 @@ consteval auto slot_thunk() noexcept {
       T>();
 }
 
-// Name that qualifies slot `S`, in a facade whose own name is `OwnName`: the
-// declaring facade's name for an inherited slot, `OwnName` for an own one.
+// `slot_owner_name`: name that qualifies slot `S`, in a facade whose own name
+// is `OwnName`, which is the declaring facade's name for an inherited slot,
+// `OwnName` for an own one.
 template<fixed_string OwnName, typename S>
 consteval auto slot_owner_name() noexcept {
   if constexpr (std::is_void_v<typename S::owner_t>)
@@ -799,9 +1042,9 @@ consteval auto slot_owner_name() noexcept {
     return vtbuild_t<typename S::owner_t>::name_v;
 }
 
-// Whether the declaring facades of two slots lie in one extends chain:
-// identical, or one extends the other, with the facade being built (`void`)
-// counting as extending every inherited owner.
+// `same_chain_owners`: whether the declaring facades of two slots lie in one
+// extends chain: identical, or one extends the other, with the facade being
+// built (`void`) counting as extending every inherited owner.
 template<typename S1, typename S2>
 consteval bool same_chain_owners() noexcept {
   using o1_t = S1::owner_t;
@@ -814,13 +1057,15 @@ consteval bool same_chain_owners() noexcept {
            vtbuild_t<o2_t>::template extends_facade<o1_t>();
 }
 
-// The two collision detonators, each pitting slot `S1` against the whole list.
+// `no_chain_collision_against`, `owner_names_unique_against`: the two
+// collision detonators, each pitting slot `S1` against the whole list.
 // Post-dedup, a repeated slot type is only ever the self-pairing, so same-type
 // pairs are skipped.
 //
 // A method name may not recur within one extends chain (a doubled declaration,
 // or a derived facade redeclaring an inherited name, which is rejected by
 // design: facades carry no implementations, so there is nothing to override).
+//
 // Unrelated sibling facades may collide on a method name freely, since every
 // facade is named and the qualified spelling is always available as the route
 // to a collided slot that the arguments cannot single out. Facade names must
@@ -841,8 +1086,8 @@ consteval bool owner_names_unique_against() noexcept {
       ...);
 }
 
-// Traits over one entry of a facade's declaration list, which mixes `method`
-// descriptors with `extends` composition entries.
+// `entry_traits`: traits over one entry of a facade's declaration list, which
+// mixes `method` descriptors with `extends` composition entries.
 //
 // Each entry contributes slots to the flattened list, base facades to the
 // direct-base list, base-table pointers to the dispatch table, and a
@@ -855,6 +1100,8 @@ template<typename M>
 struct entry_traits {
   using slots_t = std::tuple<slot<void, M>>;
   using bases_t = std::tuple<>;
+  using owning_bases_t = std::tuple<>;
+  using chain_t = std::tuple<>;
 
   template<typename F, typename T>
   static constexpr bool bound_v = method_traits<M>::template bound_v<F, T>;
@@ -869,6 +1116,10 @@ template<Facade B>
 struct entry_traits<extends<B>> {
   using slots_t = retag_slots_t<B, typename vtbuild_t<B>::flat_slots_t>;
   using bases_t = std::tuple<B>;
+  using owning_bases_t =
+      std::tuple<const typename vtbuild_t<B>::owning_vtable_t*>;
+  using chain_t = decltype(std::tuple_cat(std::declval<std::tuple<B>>(),
+      std::declval<typename vtbuild_t<B>::ancestors_t>()));
 
   template<typename F, typename T>
   static constexpr bool bound_v = vtbuild_t<B>::template all_bound_v<B, T>;
@@ -883,6 +1134,8 @@ template<fixed_string Name>
 struct entry_traits<name<Name>> {
   using slots_t = std::tuple<>;
   using bases_t = std::tuple<>;
+  using owning_bases_t = std::tuple<>;
+  using chain_t = std::tuple<>;
 
   template<typename F, typename T>
   static constexpr bool bound_v = true;
@@ -893,8 +1146,8 @@ struct entry_traits<name<Name>> {
   }
 };
 
-// Facade name carried by one entry of a facade's list, empty for every other
-// entry kind.
+// `entry_name`: facade name carried by one entry of a facade's list, empty for
+// every other entry kind.
 template<typename E>
 struct entry_name {
   static constexpr fixed_string name_v{""};
@@ -906,26 +1159,28 @@ struct entry_name<name<Name>> {
   static constexpr bool is_name_v = true;
 };
 
-// Name of a facade with entries `Es`: the single `name` entry's string, or
-// empty. Concatenation acts as selection, because at most one entry
-// contributes a nonempty string.
+// `facade_name_of_v`: name of a facade with entries `Es`.
+//
+// The single `name` entry's string, or empty. Concatenation acts as selection,
+// because at most one entry contributes a nonempty string.
 template<typename... Es>
 constexpr inline auto facade_name_of_v =
     (fixed_string{""} + ... + entry_name<Es>::name_v);
 
-// Flattened, deduped slot list and direct-base list of a facade's entry
-// pack.
+// `flat_slots_of_t`: flattened, deduped slot list and direct-base list of a
+// facade's entry pack.
 template<typename... Es>
 using flat_slots_of_t = dedup_slots_t<decltype(std::tuple_cat(
     std::declval<typename entry_traits<Es>::slots_t>()...))>;
 
+// `bases_of_t`: flattened direct-base list of a facade's entry pack.
 template<typename... Es>
 using bases_of_t = decltype(std::tuple_cat(
     std::declval<typename entry_traits<Es>::bases_t>()...));
 
-// The flattened core of the builder, over the full slot list `Ss` (bases'
-// methods first, in declaration order, then own, deduped), the direct-base
-// facades `Bs`, and the facade's own name `OwnName`.
+// `vtable_builder_impl`: the flattened core of the builder, over the full slot
+// list `Ss` (bases' methods first, in declaration order, then own, deduped),
+// the direct-base facades `Bs`, and the facade's own name `OwnName`.
 template<typename FlatSlots, typename Bases, fixed_string OwnName>
 struct vtable_builder_impl;
 
@@ -942,28 +1197,29 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
   static constexpr std::size_t count_v = sizeof...(Ss);
   static constexpr std::size_t base_count_v = sizeof...(Bs);
 
-  // Flag results of `resolve`, outside the valid index range: no slot
-  // answers to the key, or more than one does and the arguments do not
-  // single one out.
+  // `none_v`, `ambiguous_v`: flag results of `resolve`, outside the valid
+  // index range: no slot answers to the key, or more than one does and the
+  // arguments do not single one out.
   static constexpr std::size_t none_v = count_v;
   static constexpr std::size_t ambiguous_v = count_v + 1;
 
-  // Direct-base facade at index `Ndx`.
+  // `base_t`: direct-base facade at index `Ndx`.
   template<std::size_t Ndx>
   using base_t = std::tuple_element_t<Ndx, std::tuple<Bs...>>;
 
   using thunks_t = std::tuple<
       typename method_traits<typename Ss::method_t>::thunk_ptr_t...>;
 
-  // Build the thunk tuple for target `T` of facade `F`: one thunk per slot,
-  // each bound through the slot's declaring facade.
+  // `make_thunks`: build the thunk tuple for target `T` of facade `F`,
+  // containing one thunk per slot, each bound through the slot's declaring
+  // facade.
   template<typename F, typename T>
   static consteval thunks_t make_thunks() noexcept {
     return {slot_thunk<F, T, Ss>()...};
   }
 
-  // Dispatch table: one thunk slot per flattened method, plus the address of
-  // each direct base's table for the same target type.
+  // `vtable_t`: dispatch table, with one thunk slot per flattened method, plus
+  // the address of each direct base's table for the same target type.
   //
   // Dispatch always uses the flattened thunks, so an inherited call costs the
   // same single indexed load as an own one; the base pointers exist for
@@ -973,9 +1229,9 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
     std::tuple<const typename vtbuild_t<Bs>::vtable_t*...> bases;
   };
 
-  // Whether this facade transitively extends facade `B`. Strict: the search
-  // covers the bases and their bases, never this facade itself, so a
-  // self-match is false.
+  // `extends_facade`: whether this facade transitively extends facade `B`.
+  // Strict: the search covers the bases and their bases, never this facade
+  // itself, so a self-match is false.
   template<typename B>
   static consteval bool extends_facade() noexcept {
     return (
@@ -983,7 +1239,7 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
         ...);
   }
 
-  // Index of the first direct base that is `B` or extends it, or
+  // `base_route`: index of the first direct base that is `B` or extends it, or
   // `base_count_v` when there is none. This is the route `upcast_vtable`
   // descends.
   template<typename B>
@@ -996,8 +1252,10 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
     return base_count_v;
   }
 
-  // Name that qualifies slot `S`: the declaring facade's name for an
-  // inherited slot, this facade's own name otherwise.
+  // `owner_name`: name that qualifies slot `S`.
+  //
+  // The declaring facade's name for an inherited slot, this facade's own name
+  // otherwise.
   template<typename S>
   static consteval auto owner_name() noexcept {
     if constexpr (std::is_void_v<typename S::owner_t>)
@@ -1006,9 +1264,10 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
       return vtbuild_t<typename S::owner_t>::name_v;
   }
 
-  // Whether slot `S` answers to `Key`. An unqualified key matches the
-  // method name alone; a qualified key ("facade::method") also requires the
-  // qualifying facade's name.
+  // `slot_matches`: whether slot `S` answers to `Key`.
+  //
+  // An unqualified key matches the method name alone; a qualified key
+  // ("facade::method") also requires the qualifying facade's name.
   template<typename S, fixed_string Key>
   static consteval bool slot_matches() noexcept {
     constexpr std::string_view k = Key.view();
@@ -1023,35 +1282,42 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
     return owner.view() == qual;
   }
 
-  // Per-slot flags over the whole list: the candidates answering to `Key`
-  // (const-qualified only, when dispatching through a const handle), and the
-  // slots whose declared parameters match `CallArgs` exactly or are viable
-  // through ordinary conversions.
+  // `candidates`: per-slot flags over the whole list, containing the
+  // candidates answering to `Key` (const-qualified only, when dispatching
+  // through a const handle), and the slots whose declared parameters match
+  // `CallArgs` exactly or are viable through ordinary conversions.
   template<fixed_string Key, bool ConstOnly>
   static consteval std::array<bool, count_v> candidates() noexcept {
     return {(slot_matches<Ss, Key>() && (!ConstOnly || Ss::const_v))...};
   }
 
+  // `exact_flags`, `viable_flags`: per-slot flags over the whole list,
+  // containing the slots whose declared parameters match `CallArgs` exactly or
+  // are viable through ordinary conversions.
   template<typename... CallArgs>
   static consteval std::array<bool, count_v> exact_flags() noexcept {
     return {method_traits<typename Ss::method_t>::template exact_v<
         CallArgs...>...};
   }
 
+  // `exact_flags`, `viable_flags`: per-slot flags over the whole list,
+  // containing the slots whose declared parameters match `CallArgs` exactly or
+  // are viable through ordinary conversions.
   template<typename... CallArgs>
   static consteval std::array<bool, count_v> viable_flags() noexcept {
     return {method_traits<typename Ss::method_t>::template viable_v<
         CallArgs...>...};
   }
 
-  // Narrow flag set `a` by flag set `b`, elementwise.
+  // `both`: narrow flag set `a` by flag set `b`, elementwise.
   static consteval std::array<bool, count_v> both(std::array<bool, count_v> a,
       const std::array<bool, count_v>& b) noexcept {
     for (std::size_t ndx = 0; ndx != count_v; ++ndx) a[ndx] = a[ndx] && b[ndx];
     return a;
   }
 
-  // Count of set flags, plus the last set index (`none_v` when none are).
+  // `tally`: count of set flags, plus the last set index (`none_v` when none
+  // are).
   static consteval std::pair<std::size_t, std::size_t> tally(
       const std::array<bool, count_v>& flags) noexcept {
     std::size_t cnt{};
@@ -1064,8 +1330,8 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
     return {cnt, at};
   }
 
-  // Resolve `Key`, called with `CallArgs`, to a slot index, or to `none_v`
-  // or `ambiguous_v`.
+  // `resolve`: resolve `Key`, called with `CallArgs`, to a slot index, or to
+  // `none_v` or `ambiguous_v`.
   //
   // A qualified key names its slot outright. An unqualified key with a
   // single candidate resolves to it unconditionally, so a call with
@@ -1090,9 +1356,11 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
     return viable_cnt ? ambiguous_v : none_v;
   }
 
-  // Resolve `Key` to the unique candidate whose declared parameters match
-  // `CallArgs` exactly. This is the validation probe's strictness: a
-  // merely-viable signature does not count.
+  // `resolve_exact`: resolve `Key` to the unique candidate whose declared
+  // parameters match `CallArgs` exactly.
+  //
+  // This is the validation probe's strictness: a merely-viable signature does
+  // not count.
   template<fixed_string Key, bool ConstOnly, typename... CallArgs>
   static consteval std::size_t resolve_exact() noexcept {
     const auto [cnt, at] =
@@ -1101,16 +1369,19 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
     return cnt ? ambiguous_v : none_v;
   }
 
-  // Whether any method answering to `Key` is const-qualified: the gate on
-  // dispatching `Key` through a const handle. False for an unknown key, since
-  // rejecting one is `resolve`'s job.
+  // `is_const`: whether any method answering to `Key` is const-qualified.
+  //
+  // The gate on dispatching `Key` through a const handle. False for an unknown
+  // key, since rejecting one is `resolve`'s job.
   template<fixed_string Key>
   static consteval bool is_const() noexcept {
     return ((slot_matches<Ss, Key>() && Ss::const_v) || ...);
   }
 
-  // Whether the call `Key` resolves to, with `CallArgs`, dispatches a noexcept
-  // method. False when the call does not resolve.
+  // `is_noexcept`: whether the call `Key` resolves to, with `CallArgs`,
+  // dispatches a noexcept method.
+  //
+  // False when the call does not resolve.
   template<fixed_string Key, bool ConstOnly, typename... CallArgs>
   static consteval bool is_noexcept() noexcept {
     constexpr std::array<bool, count_v> flags{Ss::noexcept_v...};
@@ -1118,10 +1389,11 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
     return ndx < count_v && flags[ndx];
   }
 
-  // Declared result type of the exact-match candidate for `Key`, or `void`
-  // when there is none. The permissive fallback keeps return-type
-  // substitution in the `api_probe` from hard-erroring before its constraint
-  // can reject the key.
+  // `do_result_of`: declared result type of the exact-match candidate for
+  // `Key`, or `void` when there is none.
+  //
+  // The permissive fallback keeps return-type substitution in the `api_probe`
+  // from hard-erroring before its constraint can reject the key.
   template<fixed_string Key, bool ConstOnly, typename... CallArgs>
   static consteval auto do_result_of() noexcept {
     constexpr auto ndx = resolve_exact<Key, ConstOnly, CallArgs...>();
@@ -1133,19 +1405,24 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
     }
   }
 
+  // `result_of_t`: declared result type of the exact-match candidate for
+  // `Key`, or `void` when there is none.
   template<fixed_string Key, bool ConstOnly, typename... CallArgs>
   using result_of_t =
       decltype(do_result_of<Key, ConstOnly, CallArgs...>())::type;
 
-  // Whether `Args` match the declared parameters of exactly one candidate
-  // for `Key`, after normalization, rather than by convertibility. False for
-  // an unknown key. This is the `api_probe`'s constraint.
+  // `exact_args`: whether `Args` match the declared parameters of exactly one
+  // candidate for `Key`, after normalization, rather than by convertibility.
+  //
+  // False for an unknown key. This is the `api_probe`'s constraint.
   template<fixed_string Key, bool ConstOnly, typename... Args>
   static consteval bool exact_args() noexcept {
     return resolve_exact<Key, ConstOnly, Args...>() < count_v;
   }
 };
 
+// `vtable_builder`: facade-wide dispatch machinery, specialized on the
+// `facade` base to get at the entry pack.
 template<typename... Es>
 struct vtable_builder<facade<Es...>>
     : vtable_builder_impl<flat_slots_of_t<Es...>, bases_of_t<Es...>,
@@ -1157,42 +1434,127 @@ struct vtable_builder<facade<Es...>>
       facade_name_of_v<Es...>>;
   using vtable_t = impl_t::vtable_t;
 
-  // Whether every method of the facade, inherited and own, has a usable
-  // binding for `T`. Own methods bind through `proxy_impl<F, T>`; inherited
-  // ones recurse into their declaring facade, so conforming to a composed
-  // facade requires conforming to each of its bases.
+  // `all_bound_v`: whether every method of the facade, inherited and own, has
+  // a usable binding for `T`.
+  //
+  // Own methods bind through `proxy_impl<F, T>`; inherited ones recurse into
+  // their declaring facade, so conforming to a composed facade requires
+  // conforming to each of its bases.
   template<typename F, typename T>
   static constexpr bool all_bound_v =
       (entry_traits<Es>::template bound_v<F, T> && ...);
 
+  // `make_vtable`: build the dispatch table for target `T` of facade `F`.
   template<typename F, typename T>
   static consteval vtable_t make_vtable() noexcept {
     return {impl_t::template make_thunks<F, T>(),
         std::tuple_cat(entry_traits<Es>::template base_vtables<T>()...)};
   }
 
-  // Owning dispatch table, carrying housekeeping slots alongside the facade
-  // methods. A null `relocate` marks a heap-stored target, which moves by
-  // pointer steal rather than relocation.
+  // `owning_bases_t`: direct-base owning-table pointers, mirroring
+  // `vtable_t::bases`.
+  using owning_bases_t = decltype(std::tuple_cat(
+      std::declval<typename entry_traits<Es>::owning_bases_t>()...));
+
+  // `ancestors_t`: every facade this one transitively extends, deduped (a
+  // diamond's shared ancestor appears once), not including this facade itself.
+  //
+  // The birth ancestry `try_downcast` searches is built over it.
+  using ancestors_t = dedup_slots_t<decltype(std::tuple_cat(
+      std::declval<typename entry_traits<Es>::chain_t>()...))>;
+
+  // `owning_vtable_t`: owning dispatch table, carrying housekeeping slots
+  // alongside the facade methods, plus the address of each direct base's
+  // owning table for the same target type, which is what makes owning upcasts
+  // a pointer read (mirroring `vtable_t::bases`).
+  //
+  // A null `relocate` marks a heap-stored target, which moves by pointer
+  // steal rather than relocation. A null `copy` marks a target that is not
+  // copy-constructible. `type_tag` identifies the target type itself (see
+  // `type_tag_v`), letting typed operations on the erased target verify
+  // their `T` at runtime; `size` and `align` describe it, so an adopting
+  // proxy can check the fit of an erased arrival against its own buffer.
+  //
+  // The mode-changing pairs point across to the table's other-mode sibling:
+  // an inline-mode table carries `to_heap` (see `sbo_to_heap`) plus
+  // `heap_table`, which is how a `heap_only` proxy adopts an erased inline
+  // arrival, and a heap-mode table carries `to_sbo` plus `sbo_table` (null
+  // when the target is not nothrow-move-constructible and so can never live
+  // inline), the un-boxing inverse for an `sbo_only` proxy.
+  //
+  // `ancestry` names the born family's birth ancestry for this mode (see
+  // `ancestry_for`): the facade the target was constructed as plus every
+  // facade it extends, which is what `try_downcast` searches.
   struct owning_vtable_t {
     vtable_t vt;
     void (*destroy)(void*) noexcept;
     void (*relocate)(void*, void*) noexcept;
+    void* (*copy)(const void*, void*);
+    void* (*to_heap)(void*);
+    void (*to_sbo)(void*, void*) noexcept;
+    const void* type_tag;
+    const owning_vtable_t* heap_table;
+    const owning_vtable_t* sbo_table;
+    std::size_t size;
+    std::size_t align;
+    const ancestry_t* ancestry;
+    owning_bases_t bases;
   };
 
-  template<typename F, typename T>
+  // `owning_bases_t`: owning-table pointers of the direct bases, for the same
+  // born family, target, and mode, built over the direct-base pack (carried by
+  // the tuple pointer parameter, as in `make_ancestor_table`).
+  //
+  // Deliberately a member rather than an `entry_traits` hook, and with a
+  // spelled-out return type: an entry's helper is shared by every facade
+  // listing that entry, and in a diamond the ancestry's back-references
+  // reach a sibling's table build while the shared helper is still
+  // mid-instantiation, which a deduced return type cannot survive. A member
+  // is unique per (facade, born, type, mode) and so is only ever entered
+  // once.
+  template<typename Born, typename T, bool Sbo, typename... Bs2>
+  static consteval owning_bases_t
+  make_owning_bases(std::tuple<Bs2...>*) noexcept {
+    return {&owning_vtable_for<Bs2, Born, T, Sbo>...};
+  }
+
+  // `make_owning_vtable`: build the owning table for target `T` born as facade
+  // `Born`, stored inline (`Sbo`) or on the heap.
+  //
+  // The mode is decided at proxy construction from the handle's policy, so it
+  // is part of the table's identity rather than a property of the type alone;
+  // the birth is decided there too, as the facade under construction.
+  template<typename F, typename Born, typename T, bool Sbo>
   static consteval owning_vtable_t make_owning_vtable() noexcept {
-    if constexpr (sbo_eligible_v<T>)
-      return {make_vtable<F, T>(), &sbo_destroy<T>, &sbo_relocate<T>};
-    else
-      return {make_vtable<F, T>(), &heap_destroy<T>, nullptr};
+    owning_vtable_t ovt{make_vtable<F, T>(), nullptr, nullptr, nullptr,
+        nullptr, nullptr, &type_tag_v<T>, nullptr, nullptr, sizeof(T),
+        alignof(T), &ancestry_for<Born, T, Sbo>,
+        make_owning_bases<Born, T, Sbo>(
+            static_cast<bases_of_t<Es...>*>(nullptr))};
+    if constexpr (Sbo) {
+      ovt.destroy = &sbo_destroy<T>;
+      ovt.relocate = &sbo_relocate<T>;
+      ovt.to_heap = &sbo_to_heap<T>;
+      ovt.heap_table = &owning_vtable_for<F, Born, T, false>;
+      if constexpr (std::is_copy_constructible_v<T>) ovt.copy = &sbo_copy<T>;
+    } else {
+      ovt.destroy = &heap_destroy<T>;
+      if constexpr (std::is_nothrow_move_constructible_v<T>) {
+        ovt.to_sbo = &heap_to_sbo<T>;
+        ovt.sbo_table = &owning_vtable_for<F, Born, T, true>;
+      }
+      if constexpr (std::is_copy_constructible_v<T>) ovt.copy = &heap_copy<T>;
+    }
+    return ovt;
   }
 };
 
-// Narrow a dispatch-table pointer from facade `D` to `B`, where `B` is `D`
-// itself or a facade it extends, by following the embedded direct-base table
-// pointers. The route is resolved at compile time; the runtime cost is one
-// dependent load per composition level crossed.
+// `upcast_vtable`: narrow a dispatch-table pointer from facade `D` to `B`,
+// where `B` is `D` itself or a facade it extends, by following the embedded
+// direct-base table pointers.
+//
+// The route is resolved at compile time; the runtime cost is one dependent
+// load per composition level crossed.
 template<Facade B, Facade D>
 [[nodiscard]] constexpr auto
 upcast_vtable(const typename vtbuild_t<D>::vtable_t* vt) noexcept
@@ -1208,9 +1570,31 @@ upcast_vtable(const typename vtbuild_t<D>::vtable_t* vt) noexcept
   }
 }
 
-// Shared body of every handle's `call`: resolve `Key` against facade `F`'s
-// slot list, surface the user-facing errors, and invoke the thunk on the
-// erased target. `ConstOnly` marks dispatch through a const handle.
+// `upcast_owning_vtable`: narrow an owning-table pointer from facade `D` to
+// `B`, where `B` is `D` itself or a facade it extends.
+//
+// The owning counterpart of `upcast_vtable`, following the embedded
+// direct-base owning tables along the same compile-time-resolved route.
+template<Facade B, Facade D>
+[[nodiscard]] constexpr auto
+upcast_owning_vtable(const typename vtbuild_t<D>::owning_vtable_t* vt) noexcept
+    -> const vtbuild_t<B>::owning_vtable_t* {
+  if constexpr (std::same_as<B, D>) {
+    return vt;
+  } else {
+    constexpr auto ndx = vtbuild_t<D>::template base_route<B>();
+    static_assert(ndx != vtbuild_t<D>::base_count_v,
+        "the source facade does not extend the target facade");
+    return upcast_owning_vtable<B,
+        typename vtbuild_t<D>::template base_t<ndx>>(std::get<ndx>(vt->bases));
+  }
+}
+
+// `dispatch`: shared body of every handle's `call`.
+//
+// Resolves `Key` against facade `F`'s slot list, surfaces the user-facing
+// errors, and invokes the thunk on the erased target. `ConstOnly` marks
+// dispatch through a const handle.
 template<Facade F, bool ConstOnly, fixed_string Key, typename ErasedPtr,
     typename... Args>
 constexpr decltype(auto)
@@ -1230,7 +1614,7 @@ dispatch(const typename vtbuild_t<F>::thunks_t& tks, ErasedPtr target,
 #pragma endregion
 #pragma region Proxiable
 
-// Concept: `T` can back facade `F`.
+// `Proxiable`: concept for when `T` can back facade `F`.
 //
 // Satisfied when a usable `proxy_impl<F, T>` binding exists for every method
 // of `F`.
@@ -1244,8 +1628,8 @@ template<typename T, typename F>
 concept Proxiable =
     Facade<F> && details::vtbuild_t<F>::template all_bound_v<F, T>;
 
-// Concept: facade `D` (transitively) extends facade `B` through `extends`
-// composition entries.
+// `Extends` concept for  when facade `D` (transitively) extends facade `B`
+// through `extends` composition entries.
 //
 // Strict: false when `D` is `B` itself. Constraints that mean "B or anything
 // extending it" pair this with `std::same_as`.
@@ -1254,7 +1638,8 @@ concept Extends =
     Facade<D> && Facade<B> &&
     details::vtbuild_t<D>::template extends_facade<B>();
 
-// Concept: facade `B` is `D` itself or a facade `D` (transitively) extends.
+// `InChainOf` concept for when facade `B` is `D` itself or a facade `D`
+// (transitively) extends.
 //
 // This is `Extends` made reflexive and argument-flipped, so it can constrain
 // a registration hook's facade parameter. A single template hook
@@ -1271,18 +1656,26 @@ concept Extends =
 template<typename B, typename D>
 concept InChainOf = Facade<B> && (std::same_as<B, D> || Extends<D, B>);
 
-// Forward declarations of the three erased-handle flavors, for the trait
-// below and the cross-handle constructors.
+// `proxy_view`, `const_proxy_view`, `proxy`, `shared_proxy`, `weak_proxy`:
+// forward declarations of the erased-handle flavors, for the trait below and
+// the cross-handle constructors.
+//
+// The owning proxy's storage policy defaults here, on the first declaration.
 template<Facade F>
 class proxy_view;
 template<Facade F>
 class const_proxy_view;
-template<Facade F>
+template<Facade F, proxy_policy Policy = proxy_policy{}>
 class proxy;
+template<Facade F>
+class shared_proxy;
+template<Facade F>
+class weak_proxy;
 
 namespace details {
 
-// Facade of a proxy handle type, or `void` for any other type.
+// `handle_facade`: facade of a proxy handle type, or `void` for any other
+// type.
 template<typename T>
 struct handle_facade {
   using type = void;
@@ -1295,13 +1688,17 @@ template<Facade F>
 struct handle_facade<const_proxy_view<F>> {
   using type = F;
 };
+template<Facade F, proxy_policy P>
+struct handle_facade<proxy<F, P>> {
+  using type = F;
+};
 template<Facade F>
-struct handle_facade<proxy<F>> {
+struct handle_facade<shared_proxy<F>> {
   using type = F;
 };
 
-// Whether `T` is a proxy handle whose facade is `F` or extends it: the set
-// the dedicated viewing and upcasting constructors serve.
+// `is_handle_for`: whether `T` is a proxy handle whose facade is `F` or
+// extends the set the dedicated viewing and upcasting constructors serve.
 //
 // The generic erased-target constructors exclude it, so re-pointing at such a
 // handle's target always wins over wrapping the handle itself as a target.
@@ -1314,7 +1711,7 @@ consteval bool is_handle_for() noexcept {
     return std::same_as<G, F> || Extends<G, F>;
 }
 
-// `Key` qualified by facade `F`'s name.
+// `qualified_key`: `Key` qualified by facade `F`'s name.
 //
 // The library's self-conformance bindings forward through this spelling: `Key`
 // there is always one of `F`'s own method names, so the qualified key stays
@@ -1332,7 +1729,8 @@ consteval auto qualified_key() noexcept {
 
 namespace details {
 
-// Exact-conversion carrier for the `api_probe`'s strict `call`.
+// `strict_result`: exact-conversion carrier for the `api_probe`'s strict
+// `call`.
 //
 // The conversion operator is a template constrained to exactly `R`. Deduction
 // runs against the target type, which in a forwarder's `return` statement is
@@ -1348,8 +1746,10 @@ struct strict_result {
   }
 };
 
-// Result type of the probe's strict `call`: `strict_result` for object types,
-// `void` for `void`, and references passed through unchanged.
+// `strict_return_t`: result type of the probe's strict `call`.
+//
+// This is `strict_result` for object types, `void` for `void`, and references
+// passed through unchanged.
 //
 // A conversion operator cannot distinguish binding a reference from copying
 // out of one, so reference results cannot be exactness-checked; a forwarder
@@ -1358,7 +1758,7 @@ template<typename R>
 using strict_return_t = std::conditional_t<std::is_void_v<R>, void,
     std::conditional_t<std::is_reference_v<R>, R, strict_result<R>>>;
 
-// Synthetic dispatch target for `validate_api`.
+// `api_probe`: synthetic dispatch target for `validate_api`.
 //
 // It inherits the facade's `api` and exposes a deliberately strict `call`.
 // Argument types must match the method's declared parameters exactly (per
@@ -1384,7 +1784,7 @@ struct api_probe: api_base_t<F> {
   }
 };
 
-// Probe registration, covering every facade.
+// `corvid_proxy_spec`: probe registration, covering every facade.
 //
 // This is the only overload of `corvid_proxy_spec` the library itself
 // provides; it is what admits the probe to a facade author's
@@ -1403,8 +1803,8 @@ consteval auto corvid_proxy_spec(F*, api_probe<G>*) noexcept {
 
 } // namespace details
 
-// Validate a facade's `api` against its method list, spelling neither the
-// names nor the signatures again.
+// `validate_api`: validate a facade's `api` against its method list, spelling
+// neither the names nor the signatures again.
 //
 // This runs automatically from `make_proxy_spec` at every registration of an
 // `api`-bearing facade, unless the registration opts out with
@@ -1456,8 +1856,8 @@ template<Facade F>
 
 namespace details {
 
-// Storage and const-method dispatch shared by the two view flavors, which
-// differ only in the constness of the erased target pointer.
+// `view_base`: storage and const-method dispatch shared by the two view
+// flavors, which differ only in the constness of the erased target pointer.
 //
 // The `call` here serves const-qualified methods, the only dispatch a const
 // handle allows. The `proxy_view` class layers the unrestricted non-const
@@ -1470,8 +1870,8 @@ class view_base: public api_base_t<F> {
 public:
   using facade_t = F;
 
-  // Call the const-qualified facade method named `Key`, forwarding `args`
-  // through the erased signature.
+  // `call`: call the const-qualified facade method named `Key`, forwarding
+  // `args` through the erased signature.
   //
   // The call is `noexcept` when the method is. It is not `[[nodiscard]]`,
   // because discardability belongs to the facade method rather than the
@@ -1485,9 +1885,10 @@ public:
         std::forward<Args>(args)...);
   }
 
-  // An empty view (default-constructed) holds no target. It is testable and
-  // rebindable by assignment, but calling through it is undefined behavior,
-  // exactly as with an empty proxy.
+  // `operator bool`: an empty view (default-constructed) holds no target.
+  //
+  // It is testable and rebindable by assignment, but calling through it is
+  // undefined behavior, exactly as with an empty proxy.
   [[nodiscard]] constexpr explicit operator bool() const noexcept {
     return vtable_;
   }
@@ -1513,19 +1914,19 @@ protected:
 // target must outlive the view.
 //
 // A view also converts implicitly from any handle of a facade that extends
-// `F` (Rust trait upcasting), and from an lvalue owning proxy, re-pointing at
-// the handle's target rather than wrapping the handle. An upcast view is
+// `F` (Rust trait upcasting), and from an lvalue owning `proxy`, re-pointing
+// at the handle's target rather than wrapping the handle. An upcast view is
 // indistinguishable from one built directly over the target.
 //
 // Deep-const as an instance, so only const-qualified facade methods dispatch
 // through a `const proxy_view`. Because views are freely copyable, that is a
-// guardrail rather than a guarantee. Copying a `const proxy_view` yields a
-// mutable view onto the same target, much as a `T* const` pointer copies to
-// a plain `T*`. Code that enforces read-only access must use
+// guardrail rather than a guarantee since copying a `const proxy_view`
+// yields a mutable view onto the same target, much as a `T* const` pointer
+// copies to a plain `T*`. Code that enforces read-only access must use
 // `const_proxy_view`, where constness is part of the type and survives
 // copying.
 //
-// A default-constructed view is empty, like a default-constructed proxy:
+// A default-constructed view is empty, like a default-constructed `proxy`:
 // testable via `operator bool` and rebindable by assignment, but calling
 // through it is undefined behavior.
 //
@@ -1537,10 +1938,10 @@ class proxy_view: public details::view_base<F, false> {
   using vtbuild_t = details::vtbuild_t<F>;
 
 public:
-  // An empty view holds no target; see the class comment.
+  // `proxy_view`: An empty view holds no target; see the class comment.
   proxy_view() = default;
 
-  // Converting constructor from an lvalue target.
+  // `proxy_view`: converting constructor from an lvalue target.
   //
   // Intentionally implicit, like `string_view` from `string`. Rvalues do not
   // bind, so construction from a temporary is rejected at compile time. Const
@@ -1553,8 +1954,8 @@ public:
   constexpr explicit(false) proxy_view(T& target) noexcept
       : base{std::addressof(target), &details::vtable_for<F, T>} {}
 
-  // Upcasting constructor from a view over a facade that extends `F` (Rust
-  // trait upcasting).
+  // `proxy_view`: upcasting constructor from a view over a facade that extends
+  // `F` (Rust trait upcasting).
   //
   // Intentionally implicit, like derived-to-base pointer conversion: the
   // target carries over unchanged and the dispatch table narrows to `F`'s by
@@ -1565,24 +1966,34 @@ public:
   constexpr explicit(false) proxy_view(const proxy_view<D>& view) noexcept
       : base{view.target_, details::upcast_vtable<F, D>(view.vtable_)} {}
 
-  // Viewing constructor from an owning proxy of `F`, or of a facade that
-  // extends it.
+  // `proxy_view`: viewing constructor from an owning `proxy` of `F`, or of a
+  // facade that extends it.
   //
   // Intentionally implicit, and lvalue-only, so a view cannot be left dangling
-  // by a temporary proxy. The proxy must be non-empty and must outlive the
-  // view. A const proxy takes a `const_proxy_view` instead, preserving deep
+  // by a temporary `proxy`. The `proxy` must be non-empty and must outlive the
+  // view. A const `proxy` takes a `const_proxy_view` instead, preserving deep
   // const.
-  template<Facade D>
+  template<Facade D, proxy_policy P>
   requires(std::same_as<D, F> || Extends<D, F>)
-  explicit(false) proxy_view(proxy<D>& p) noexcept
+  explicit(false) proxy_view(proxy<D, P>& p) noexcept
       : base{p.target(), details::upcast_vtable<F, D>(&p.vtable_->vt)} {}
 
-  // Call the facade method named `Key`, forwarding `args` through the erased
-  // signature. The call is `noexcept` when the method is.
+  // `proxy_view`: viewing constructor from a shared `proxy` of `F`, or of a
+  // facade that extends it, under the same rules as viewing an owning `proxy`;
+  // the target must outlive the view, meaning at least one shared owner must.
+  template<Facade D>
+  requires(std::same_as<D, F> || Extends<D, F>)
+  explicit(false) proxy_view(shared_proxy<D>& p) noexcept
+      : base{p.target(), details::upcast_vtable<F, D>(p.vtable_)} {}
+
+  // `call`: call the facade method named `Key`, forwarding `args` through the
+  // erased signature.
+  //
+  // The call is `noexcept` when the method is.
   //
   // This overload dispatches every method. The inherited const overload,
   // re-exposed by the using-declaration, is constrained to const-qualified
-  // methods, mirroring the owning proxy's deep const.
+  // methods, mirroring the owning `proxy`'s deep const.
   template<fixed_string Key, typename... Args>
   constexpr decltype(auto) call(Args&&... args) noexcept(
       vtbuild_t::template is_noexcept<Key, false, Args...>()) {
@@ -1599,9 +2010,9 @@ private:
   friend class const_proxy_view;
 };
 
-// Library-provided binding so that a view satisfies its own facade and every
-// facade that facade extends (as in Rust, where `dyn Trait` implements
-// `Trait` and meets its supertrait bounds).
+// `proxy_impl`: library-provided binding so that a view satisfies its own
+// facade and every facade that facade extends (as in Rust, where `dyn Trait`
+// implements `Trait` and meets its supertrait bounds).
 //
 // Calls forward through the wrapped view, with conditional `noexcept` so the
 // invariant also holds for facades with noexcept methods. The const overload
@@ -1612,8 +2023,8 @@ private:
 template<Facade F, Facade D>
 requires(std::same_as<D, F> || Extends<D, F>)
 struct proxy_impl<F, proxy_view<D>> {
-  // The qualified spelling keeps the forwarded key unambiguous when `D`'s
-  // flattened list collides on `Key`; see `qualified_key`.
+  // `on`: the qualified spelling keeps the forwarded key unambiguous when
+  // `D`'s flattened list collides on `Key`; see `qualified_key`.
   template<fixed_string Key, typename... Args>
   static constexpr decltype(auto)
   on(method_key<Key>, proxy_view<D>& view, Args&&... args) noexcept(
@@ -1632,8 +2043,8 @@ struct proxy_impl<F, proxy_view<D>> {
   }
 };
 
-// Non-owning read-only erased handle: Rust's `&dyn Trait`, the
-// `const_iterator` to `proxy_view`'s `iterator`.
+// `const_proxy_view`: non-owning read-only erased handle: Rust's `&dyn Trait`,
+// the `const_iterator` to `proxy_view`'s `iterator`.
 //
 // Constness is part of the type, so unlike a `const proxy_view` it survives
 // copying. A const view only ever copies or converts to another const view.
@@ -1653,10 +2064,11 @@ class const_proxy_view: public details::view_base<F, true> {
   using base = details::view_base<F, true>;
 
 public:
-  // An empty view holds no target; see the class comment.
+  // `const_proxy_view`: an empty view holds no target; see the class comment.
   const_proxy_view() = default;
 
-  // Converting constructor from an lvalue target, const or not.
+  // `const_proxy_view`: converting constructor from an lvalue target, const or
+  // not.
   //
   // Intentionally implicit. Rvalues do not bind. Handles of `F`, or of a
   // facade extending it, take the dedicated constructors below instead of
@@ -1668,14 +2080,16 @@ public:
       : base{std::addressof(target),
             &details::vtable_for<F, std::remove_const_t<T>>} {}
 
-  // Converting constructor from the mutable view. Dropping mutability is
-  // implicit and safe, like `T*` to `const T*`, and there is no path back.
+  // `const_proxy_view`: converting constructor from the mutable view.
+  //
+  // Dropping mutability is implicit and safe, like `T*` to `const T*`, and
+  // there is no path back.
   constexpr explicit(false)
       const_proxy_view(const proxy_view<F>& view) noexcept
       : base{view.target_, view.vtable_} {}
 
-  // Upcasting constructor from a const view over a facade that extends `F`
-  // (Rust trait upcasting).
+  // `const_proxy_view`: upcasting constructor from a const view over a facade
+  // that extends `F` (Rust trait upcasting).
   //
   // Intentionally implicit; see the mutable view's upcasting constructor.
   template<Facade D>
@@ -1684,24 +2098,32 @@ public:
       const_proxy_view(const const_proxy_view<D>& view) noexcept
       : base{view.target_, details::upcast_vtable<F, D>(view.vtable_)} {}
 
-  // Upcasting constructor from the mutable view of a facade that extends
-  // `F`, dropping mutability and upcasting in one implicit step.
+  // `const_proxy_view`: upcasting constructor from the mutable view of a
+  // facade that extends `F`, dropping mutability and upcasting in one implicit
+  // step.
   template<Facade D>
   requires Extends<D, F>
   constexpr explicit(false)
       const_proxy_view(const proxy_view<D>& view) noexcept
       : base{view.target_, details::upcast_vtable<F, D>(view.vtable_)} {}
 
-  // Viewing constructor from an owning proxy of `F`, or of a facade that
-  // extends it.
+  // `const_proxy_view`: viewing constructor from an owning proxy of `F`, or of
+  // a facade that extends it.
   //
   // Intentionally implicit, and lvalue-only. The proxy must be non-empty and
   // must outlive the view. Mutable and const proxies alike yield the const
   // view; there is no path back to mutability.
+  template<Facade D, proxy_policy P>
+  requires(std::same_as<D, F> || Extends<D, F>)
+  explicit(false) const_proxy_view(const proxy<D, P>& p) noexcept
+      : base{p.target(), details::upcast_vtable<F, D>(&p.vtable_->vt)} {}
+
+  // `const_proxy_view`: viewing constructor from a shared proxy of `F`, or of
+  // a facade that extends it; see the owning-proxy constructor above.
   template<Facade D>
   requires(std::same_as<D, F> || Extends<D, F>)
-  explicit(false) const_proxy_view(const proxy<D>& p) noexcept
-      : base{p.target(), details::upcast_vtable<F, D>(&p.vtable_->vt)} {}
+  explicit(false) const_proxy_view(const shared_proxy<D>& p) noexcept
+      : base{p.target(), details::upcast_vtable<F, D>(p.vtable_)} {}
 
   // No need for a `using` because`call` is inherited. The base's const-method
   // dispatch is the entire interface, since the mutable methods do not exist
@@ -1712,8 +2134,8 @@ private:
   friend class const_proxy_view;
 };
 
-// Library-provided binding so that a const view satisfies its own facade,
-// and the facades that facade extends, where that is possible.
+// `proxy_impl`: library-provided binding so that a const view satisfies its
+// own facade, and the facades that facade extends, where that is possible.
 //
 // It dispatches only const methods, so the invariant holds exactly for
 // all-const facades.
@@ -1735,8 +2157,8 @@ struct proxy_impl<F, const_proxy_view<D>> {
   }
 };
 
-// Make a view over `target`: a convenience for spelling the facade at the call
-// site.
+// `make_proxy_view`: make a view over `target`: a convenience for spelling the
+// facade at the call site.
 //
 // When `target` is already a view of `F` it is copied rather than wrapped, so
 // generic facade-constrained code can erase its argument without stacking
@@ -1755,14 +2177,22 @@ requires Proxiable<T, F>
 #pragma endregion
 #pragma region proxy
 
-// Owning erased handle over any `Proxiable` target: Rust's `Box<dyn Trait>`,
-// ngcpp's `proxy`.
+// `proxy`: owning erased handle over any `Proxiable` target: Rust's `Box<dyn
+// Trait>`, ngcpp's `proxy`.
 //
-// Move-only. Small targets (at most `sbo_size` bytes, at most
-// `std::max_align_t` alignment, nothrow-move-constructible) are stored
-// inline. Anything else lives in a unique-owned heap allocation. The owning
-// dispatch table carries destroy and relocate slots alongside the facade
-// methods, so destruction and moves work without knowing the target type.
+// Move-only. Storage follows `Policy` (see `proxy_policy`): by default,
+// eligible targets are stored inline and anything else lives in a
+// unique-owned heap allocation. The owning dispatch table carries destroy
+// and relocate slots alongside the facade methods, so destruction and moves
+// work without knowing the target type.
+//
+// Proxies of different policies interconvert as rvalues, in the same move
+// that upcasts. The source's policy never matters: this proxy accommodates
+// whatever target actually arrives, changing its storage mode when the
+// policy demands it (re-boxing an inline arrival onto the heap under
+// `heap_only`, un-boxing a heap arrival into the buffer under `sbo_only`).
+// Only the conversions that might change the mode can throw; everything
+// else is `noexcept`, including every same-policy move.
 //
 // The proxy is deep-const, so only const-qualified facade methods dispatch
 // through a const proxy. Being move-only, it cannot be copied out of that
@@ -1777,42 +2207,126 @@ requires Proxiable<T, F>
 // extends; the view re-points at the stored target, and the proxy must
 // outlive it. See the view constructors.
 //
+// An rvalue proxy also upcasts: it converts implicitly to a proxy of any
+// facade its facade extends (Rust: `Box<dyn Derived>` to `Box<dyn Base>`).
+// The conversion is a move, transferring ownership of the target and leaving
+// the source empty. The owning tables remember the facade the target was
+// born as, so an upcast is undoable: `try_downcast` recovers a proxy of any
+// facade in the birth ancestry.
+//
 // When the facade defines a nested `api`, the proxy inherits it, so the
 // member-call sugar forwarders dispatch alongside `call`.
-template<Facade F>
+template<Facade F, proxy_policy Policy>
 class proxy: public details::api_base_t<F> {
   using vtbuild_t = details::vtbuild_t<F>;
   using owning_vtable_t = vtbuild_t::owning_vtable_t;
 
+  // The buffer may only grow from its defaults, so any target eligible for
+  // the default buffer stays eligible for every buffer; a `heap_only` proxy
+  // has no buffer for the knobs to apply to.
+  static_assert(
+      Policy.alloc == proxy_alloc::heap_only ||
+          (Policy.sbo_size >= proxy_policy{}.sbo_size &&
+              Policy.sbo_align >= proxy_policy{}.sbo_align),
+      "sbo_size and sbo_align may not shrink below their defaults");
+  static_assert(std::has_single_bit(Policy.sbo_align),
+      "sbo_align must be a power of two");
+
 public:
   using facade_t = F;
 
-  // Inline storage capacity in bytes. See the class comment for the other
-  // inline-eligibility conditions.
-  static constexpr std::size_t sbo_size = details::sbo_size;
+  // `sbo_size`: inline storage capacity in bytes (which a `heap_only` policy
+  // never uses).
+  //
+  // See `proxy_policy` for the inline-eligibility conditions.
+  static constexpr std::size_t sbo_size = Policy.sbo_size;
 
-  // An empty proxy holds no target.
+  // `proxy`: an empty proxy holds no target.
   proxy() = default;
 
   proxy(const proxy&) = delete;
   proxy& operator=(const proxy&) = delete;
 
-  // Construct an owning proxy holding a `T` built in place from `args`.
+  // `proxy`: construct an owning proxy holding a `T` built in place from
+  // `args`.
+  //
   // Usually spelled through `make_proxy`.
+  //
+  // This is the moment the policy meets the concrete type: the storage mode
+  // is chosen here and baked into the owning table, and an `sbo_only` policy
+  // rejects an ineligible target here.
   template<typename T, typename... Args>
   requires(Proxiable<T, F> && std::constructible_from<T, Args...>)
   explicit proxy(std::in_place_type_t<T>, Args&&... args)
-      : vtable_{&details::owning_vtable_for<F, T>} {
-    if constexpr (details::sbo_eligible_v<T>)
+      : vtable_{&details::owning_vtable_for<F, F, T,
+            details::can_store_inline<T>(Policy)>} {
+    static_assert(
+        Policy.alloc != proxy_alloc::sbo_only || details::sbo_fits<T>(Policy),
+        "the target is not eligible for an sbo_only proxy's inline buffer");
+    if constexpr (details::can_store_inline<T>(Policy))
       ::new (static_cast<void*>(storage_.buf)) T(std::forward<Args>(args)...);
     else
       storage_.ptr = new T(std::forward<Args>(args)...);
   }
 
-  // Move construction and assignment leave the source empty. Inline targets
-  // relocate through the table's move slot, while heap targets move by
-  // pointer steal.
+  // `proxy`: construct an owning proxy adopting a heap target already owned by
+  // a `std::unique_ptr` (with the default deleter; the proxy destroys through
+  // `delete` either way).
+  //
+  // Usually spelled through `make_proxy`.
+  //
+  // The allocation is adopted as-is: the proxy takes the heap path even for
+  // a target the policy could store inline, so nothing is copied or moved
+  // and the target's address stays stable.
+  //
+  // The exception is `sbo_only`, which cannot hold a heap target: it un-boxes
+  // the target into its buffer (the type is concrete here, so the fit is
+  // checked at compile time) and frees the allocation.
+  //
+  // A null pointer yields an empty proxy. Ownership arrives from a raw pointer
+  // only by way of a `unique_ptr`; there is deliberately no raw-pointer
+  // constructor.
+  template<typename T>
+  requires Proxiable<T, F>
+  explicit proxy(std::unique_ptr<T> target) {
+    if (!target) return;
+    if constexpr (Policy.alloc == proxy_alloc::sbo_only) {
+      static_assert(details::sbo_fits<T>(Policy),
+          "the target is not eligible for an sbo_only proxy's inline buffer");
+      ::new (static_cast<void*>(storage_.buf)) T(std::move(*target));
+      vtable_ = &details::owning_vtable_for<F, F, T, true>;
+    } else {
+      storage_.ptr = target.release();
+      vtable_ = &details::owning_vtable_for<F, F, T, false>;
+    }
+  }
+
+  // `proxy`: move construction and assignment leave the source empty.
+  //
+  // Inline targets relocate through the table's move slot, while heap targets
+  // move by pointer steal.
   proxy(proxy&& other) noexcept { do_adopt(other); }
+
+  // `proxy`: converting move constructor from an owning proxy of any facade
+  // that extends `F` (an upcast), of any other policy, or both at once.
+  //
+  // Intentionally implicit, like the view upcasts, but consuming: the target
+  // moves into this proxy and the source is left empty, so an upcast is
+  // one-way as a conversion (`try_downcast` is the way back).
+  //
+  // An empty source yields an empty proxy. The source's policy never
+  // constrains the conversion; storage is accommodated per target at runtime
+  // (see `do_adopt`), and a conversion that might have to change the storage
+  // mode is exactly as `noexcept` as that allows.
+  //
+  // A throw leaves the source intact and this proxy empty; `can_adopt` checks
+  // accommodation up front.
+  template<Facade D, proxy_policy P>
+  requires(std::same_as<D, F> || Extends<D, F>)
+  explicit(false) proxy(proxy<D, P>&& other) noexcept(
+      !details::adopt_may_throw(Policy, P)) {
+    do_adopt(other);
+  }
 
   proxy& operator=(proxy&& other) noexcept {
     if (this != &other) {
@@ -1824,8 +2338,8 @@ public:
 
   ~proxy() { do_reset(); }
 
-  // Call the facade method named `Key`, forwarding `args` through the erased
-  // signature.
+  // `call`: call the facade method named `Key`, forwarding `args` through the
+  // erased signature.
   //
   // The call is `noexcept` when the method is. The const overload is
   // constrained to const-qualified methods, enforcing deep const at overload
@@ -1848,69 +2362,505 @@ public:
         std::forward<Args>(args)...);
   }
 
-  // An empty proxy (default-constructed or moved-from) holds no target.
+  // `operator bool`: an empty proxy (default-constructed or moved-from) holds
+  // no target.
   [[nodiscard]] explicit operator bool() const noexcept { return vtable_; }
 
+  // `can_clone`: whether `clone` is callable, meaning that the target is
+  // copy-constructible, or there is no target at all (an empty proxy clones to
+  // an empty proxy).
+  //
+  // The answer is a runtime property of the erased target, not of the proxy
+  // type; a container of proxies can mix cloneable and uncloneable targets.
+  [[nodiscard]] bool can_clone() const noexcept {
+    return !vtable_ || vtable_->copy;
+  }
+
+  // `can_adopt`: whether this `proxy` type can accommodate `source`'s current
+  // target, so that converting (or assigning) from it will not throw
+  // `std::length_error`.
+  //
+  // This is the up-front check that advertises, and lets a caller sidestep,
+  // the one conversion that can fail for reasons other than memory
+  // availability.
+  //
+  // Static, because the answer is a property of this proxy TYPE against the
+  // source's runtime target; it works before any destination instance
+  // exists, and is equally callable through one. Only an `sbo_only`
+  // destination can ever answer no (everything else has the heap to fall
+  // back on), and an empty source is always adoptable, to empty. It does
+  // not promise the allocation a mode-changing adoption may need.
+  template<Facade D, proxy_policy P>
+  requires(std::same_as<D, F> || Extends<D, F>)
+  [[nodiscard]] static bool can_adopt(const proxy<D, P>& source) noexcept {
+    if constexpr (Policy.alloc != proxy_alloc::sbo_only) {
+      return true;
+    } else {
+      const auto* src = source.vtable_;
+      if (!src) return true;
+      return src->size <= buf_size && src->align <= buf_align &&
+             (src->relocate || src->to_sbo);
+    }
+  }
+
+  // `clone`: clone the `proxy`, creating a new instance with the same policy,
+  // owning a copy of the target made through the table's copy slot.
+  //
+  // Requires `can_clone()`; cloning a proxy over a non-copyable target is a
+  // precondition violation, like calling through an empty proxy. The copy
+  // itself can throw (the target's copy constructor, or the allocation), in
+  // which case nothing leaks and no clone is produced.
+  //
+  // This is deliberately a named method rather than a copy constructor: an
+  // unconditional copy constructor would satisfy `std::copyable` for every
+  // proxy while failing at runtime for uncloneable targets, turning a
+  // concept-probed guarantee into a lie.
+  [[nodiscard]] proxy clone() const {
+    proxy result;
+    if (!vtable_ || !vtable_->copy) return result;
+    if (vtable_->relocate)
+      (void)vtable_->copy(target(), result.storage_.buf);
+    else
+      result.storage_.ptr = vtable_->copy(target(), nullptr);
+    result.vtable_ = vtable_;
+    return result;
+  }
+
+  // `extract`: move the target out into a `std::unique_ptr<T>`, leaving the
+  // proxy empty.
+  //
+  // The inverse of the adopting constructor, and the only way ownership leaves
+  // a proxy other than destruction; a raw pointer is never exposed.
+  //
+  // `T` must be the target's exact type, verified at runtime through the
+  // table's type tag: on a mismatch, or an empty proxy, the result is null
+  // and the proxy is untouched. A heap-stored target hands over its
+  // allocation as-is; an inline target moves onto the heap first (the one
+  // case with target activity, and the one case that can throw, again
+  // leaving the proxy untouched).
+  template<typename T>
+  [[nodiscard]] std::unique_ptr<T> extract() {
+    if (!vtable_ || vtable_->type_tag != &details::type_tag_v<T>)
+      return nullptr;
+    if (!vtable_->relocate) {
+      auto* ptr = static_cast<T*>(storage_.ptr);
+      vtable_ = nullptr;
+      return std::unique_ptr<T>{ptr};
+    }
+    if constexpr (std::is_move_constructible_v<T>) {
+      std::unique_ptr<T> result{new T(std::move(*static_cast<T*>(target())))};
+      do_reset();
+      return result;
+    } else {
+      // Unreachable: an immovable target is never stored inline.
+      return nullptr;
+    }
+  }
+
+  // `try_downcast`: attempt to recover a proxy of `D`, a facade extending `F`,
+  // from a proxy that may have been upcast away from it.
+  //
+  // The owning table remembers the facade the target was born as, meaning
+  // the facade it was constructed under, not the concrete type's full
+  // conformance: a target made through `make_proxy<marshal, texas_ranger>`
+  // downcasts to `marshal` but never to `ranger`. Its birth ancestry, the
+  // born facade plus every facade that one extends, is searched at runtime
+  // for `D` itself; a target born as a facade that extends `D` therefore
+  // matches, and through a diamond, the common base can sidecast to either
+  // sibling.
+  //
+  // On success the target moves into the result (whose table carries the
+  // same birth, so further casts in either direction still work) and the
+  // source is left empty. On failure, including an empty source, the result
+  // is empty and the source is untouched. Consuming only on success is why
+  // this is spelled as a method on an rvalue rather than a conversion.
+  template<Facade D>
+  requires Extends<D, F>
+  [[nodiscard]] proxy<D, Policy> try_downcast() && {
+    proxy<D, Policy> result;
+    if (!vtable_) return result;
+    const auto* table =
+        details::find_ancestor(*vtable_->ancestry, &details::facade_tag_v<D>);
+    if (!table) return result;
+    result.vtable_ =
+        static_cast<const details::vtbuild_t<D>::owning_vtable_t*>(table);
+    if (vtable_->relocate)
+      vtable_->relocate(storage_.buf, result.storage_.buf);
+    else
+      // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Assign): see target
+      result.storage_.ptr = storage_.ptr;
+    vtable_ = nullptr;
+    return result;
+  }
+
 private:
+  // `buf_size`, `buf_align`: a `heap_only` proxy shrinks the buffer to the
+  // pointer it overlays, so the whole handle is two words, like a view.
+  static constexpr std::size_t buf_size =
+      Policy.alloc == proxy_alloc::heap_only ? sizeof(void*) : Policy.sbo_size;
+  static constexpr std::size_t buf_align =
+      Policy.alloc == proxy_alloc::heap_only
+          ? alignof(void*)
+          : Policy.sbo_align;
+
   union storage_t {
-    alignas(std::max_align_t) std::byte buf[sbo_size];
+    alignas(buf_align) std::byte buf[buf_size];
     void* ptr;
   };
 
-  // Target address, inline or heap. Meaningless when empty.
+  // `target`: the target address, inline or heap, which is meaningless when
+  // empty.
+  //
+  // The active union member is keyed by the table's `relocate` slot (null
+  // means heap), an invariant every write site maintains but the static
+  // analyzer cannot see, so the union reads here and in `do_adopt` and
+  // `try_downcast` suppress its uninitialized-value checks.
   [[nodiscard]] void* target() noexcept {
     assert(vtable_);
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
     return vtable_->relocate ? static_cast<void*>(storage_.buf) : storage_.ptr;
   }
   [[nodiscard]] const void* target() const noexcept {
     assert(vtable_);
+    // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.UndefReturn)
     return vtable_->relocate
                ? static_cast<const void*>(storage_.buf)
                : storage_.ptr;
   }
 
-  // Destroy the target, if any, leaving the proxy empty.
+  // `do_reset`: destroy the target, if any, leaving the proxy empty.
   void do_reset() noexcept {
     if (!vtable_) return;
     vtable_->destroy(target());
     vtable_ = nullptr;
   }
 
-  // Take over `other`'s target, leaving `other` empty. Assumes `*this` holds
-  // no target (freshly constructed or just reset). Note that we don't need to
-  // clear `buf` or `ptr` on `other.storage_` because `other.vtable_` defines
-  // whether it's empty.
-  void do_adopt(proxy& other) noexcept {
-    vtable_ = std::exchange(other.vtable_, nullptr);
-    if (!vtable_) return;
-    if (vtable_->relocate)
-      vtable_->relocate(other.storage_.buf, storage_.buf);
+  // `do_adopt`: take over `other`'s target, upcasting its table when `other`'s
+  // facade extends `F`, and leaving `other` empty.
+  //
+  // Assumes `*this` holds no target (freshly constructed or just reset). Note
+  // that we don't need to clear `buf` or `ptr` on `other.storage_` because
+  // `other.vtable_` defines whether it's empty.
+  //
+  // The source's policy does not matter here: this proxy accommodates
+  // whatever target actually arrives, per target, at runtime.
+  //
+  // An inline arrival relocates into the buffer when it fits (guaranteed, and
+  // checked only at compile time, when this buffer dominates the source's) and
+  // otherwise re-boxes onto the heap. A heap arrival moves by pointer
+  // steal, or un-boxes into an `sbo_only` proxy's buffer.
+  //
+  // A mode change switches to the table's other-mode sibling, which carries
+  // its own mode's birth ancestry. Only the mode-changing paths can throw (the
+  // re-boxing allocation, or `std::length_error` when an erased target
+  // cannot be stored inline and the policy forbids the heap), and a throw
+  // happens before anything moves, leaving `other` intact and `*this`
+  // empty.
+  template<Facade D, proxy_policy P>
+  void
+  do_adopt(proxy<D, P>& other) noexcept(!details::adopt_may_throw(Policy, P)) {
+    const auto* src = other.vtable_;
+    if (!src) return;
+    const auto* vt = details::upcast_owning_vtable<F, D>(src);
+    if (src->relocate)
+      do_take_inline(other, vt);
     else
+      do_take_heap(other, vt);
+    other.vtable_ = nullptr;
+  }
+
+  // `do_take_inline`: the inline-arrival half of `do_adopt`, which relocates
+  // into the buffer when the target fits, else re-boxes onto the heap (or
+  // throws, under `sbo_only`).
+  //
+  // Statically impossible paths are pruned rather than left dynamically
+  // unreachable, so a `noexcept` adoption contains no throw at all.
+  template<Facade D, proxy_policy P>
+  void do_take_inline(proxy<D, P>& other, const owning_vtable_t* vt) {
+    if constexpr (P.alloc == proxy_alloc::heap_only) {
+      // Unreachable: a heap_only source never carries an inline target.
+    } else if constexpr (details::inline_fit_guaranteed(Policy, P)) {
+      vt->relocate(other.storage_.buf, storage_.buf);
+      vtable_ = vt;
+    } else {
+      const bool inline_ok =
+          Policy.alloc != proxy_alloc::heap_only && vt->size <= buf_size &&
+          vt->align <= buf_align;
+      if (inline_ok) {
+        vt->relocate(other.storage_.buf, storage_.buf);
+        vtable_ = vt;
+        return;
+      }
+      if constexpr (Policy.alloc != proxy_alloc::sbo_only) {
+        storage_.ptr = vt->to_heap(other.storage_.buf);
+        vtable_ = vt->heap_table;
+      } else {
+        throw std::length_error(
+            "the target cannot be stored in an sbo_only proxy's buffer");
+      }
+    }
+  }
+
+  // `do_take_heap`: the heap-arrival half of `do_adopt`, which steals the
+  // pointer, or un-boxes into an `sbo_only` `proxy`'s buffer (or throws, when
+  // the erased target does not fit it or cannot move).
+  template<Facade D, proxy_policy P>
+  void do_take_heap(proxy<D, P>& other, const owning_vtable_t* vt) {
+    if constexpr (P.alloc == proxy_alloc::sbo_only) {
+      // Unreachable: an sbo_only source never carries a heap target.
+    } else if constexpr (Policy.alloc != proxy_alloc::sbo_only) {
+      // NOLINTNEXTLINE(clang-analyzer-core.uninitialized.Assign): see target
       storage_.ptr = other.storage_.ptr;
+      vtable_ = vt;
+    } else {
+      if (!vt->to_sbo || vt->size > buf_size || vt->align > buf_align)
+        throw std::length_error(
+            "the target cannot be stored in an sbo_only proxy's buffer");
+      // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage): see target
+      vt->to_sbo(other.storage_.ptr, storage_.buf);
+      vtable_ = vt->sbo_table;
+    }
   }
 
   storage_t storage_;
   const owning_vtable_t* vtable_{};
 
+  template<Facade G, proxy_policy P>
+  friend class proxy;
+  template<Facade G>
+  friend class proxy_view;
+  template<Facade G>
+  friend class const_proxy_view;
+  template<Facade G>
+  friend class shared_proxy;
+};
+
+// `proxy_impl`: library-provided binding so that an owning `proxy` satisfies
+// its own facade and every facade that facade extends, like the view.
+//
+// Calls forward through the proxy, with conditional `noexcept`. The const
+// overload serves const-qualified methods, matching the proxy's deep const,
+// and the non-const overload serves the rest.
+template<Facade F, Facade D, proxy_policy P>
+requires(std::same_as<D, F> || Extends<D, F>)
+struct proxy_impl<F, proxy<D, P>> {
+  // Qualified forwarding, as with the view bindings; see `qualified_key`.
+  template<fixed_string Key, typename... Args>
+  static decltype(auto)
+  on(method_key<Key>, proxy<D, P>& p, Args&&... args) noexcept(
+      noexcept(p.template call<details::qualified_key<F, Key>()>(
+          std::forward<Args>(args)...))) {
+    return p.template call<details::qualified_key<F, Key>()>(
+        std::forward<Args>(args)...);
+  }
+  template<fixed_string Key, typename... Args>
+  static decltype(auto)
+  on(method_key<Key>, const proxy<D, P>& p, Args&&... args) noexcept(
+      noexcept(p.template call<details::qualified_key<F, Key>()>(
+          std::forward<Args>(args)...))) {
+    return p.template call<details::qualified_key<F, Key>()>(
+        std::forward<Args>(args)...);
+  }
+};
+
+// `make_proxy`: make an owning `proxy` of facade `F` holding a `T` constructed
+// in place from `args`.
+//
+// To move an existing object in, pass it as the constructor argument:
+// `make_proxy<F, T>(std::move(obj))`. A non-default storage policy is the
+// optional third argument: `make_proxy<F, T, proxy_policy{...}>(...)`.
+template<Facade F, typename T, proxy_policy Policy = proxy_policy{},
+    typename... Args>
+requires Proxiable<T, F>
+[[nodiscard]] proxy<F, Policy> make_proxy(Args&&... args) {
+  return proxy<F, Policy>{std::in_place_type<T>, std::forward<Args>(args)...};
+}
+
+// `make_proxy`: make an owning `proxy` of facade `F`, adopting a heap target
+// already owned by a `std::unique_ptr`; see the adopting constructor.
+template<Facade F, proxy_policy Policy = proxy_policy{}, typename T>
+requires Proxiable<T, F>
+[[nodiscard]] proxy<F, Policy> make_proxy(std::unique_ptr<T> target) {
+  return proxy<F, Policy>{std::move(target)};
+}
+
+#pragma endregion
+#pragma region Shared ownership
+
+// `shared_proxy`: shared-owning erased handle, like Rust's `Rc<dyn Trait>`,
+// backed by a `std::shared_ptr<void>`.
+//
+// Copyable, and a copy shares the one target rather than cloning it; the
+// target dies with its last owner. The control block already type-erases
+// destruction, so no owning table is needed: the handle is the shared
+// pointer plus the same per-(facade, type) dispatch table the views use.
+// There is no inline-storage mode, so the target's address is always stable.
+//
+// Ownership interoperates with `std`: construct from a `std::shared_ptr<T>`
+// (sharing with any outside holders) or a `std::unique_ptr<T>` (which
+// converts), or build target and control block in one allocation with
+// `make_shared_proxy`. Reference counting is `std::shared_ptr`'s, with its
+// usual thread-safety: the count is atomic, the target's own state is the
+// user's business.
+//
+// Deep-const as an instance, like the views: only const-qualified methods
+// dispatch through a const handle, and copying escapes it (a copy of a
+// `const shared_proxy` is mutable). A `weak_proxy` observes without owning.
+//
+// A default-constructed or moved-from handle is empty: testable via
+// `operator bool`, but calling through it is undefined behavior. Handles
+// upcast implicitly, by copy or by move, to any facade theirs extends.
+template<Facade F>
+class shared_proxy: public details::api_base_t<F> {
+  using vtbuild_t = details::vtbuild_t<F>;
+  using vtable_t = vtbuild_t::vtable_t;
+
+public:
+  using facade_t = F;
+
+  // `shared_proxy`: an empty handle holds no target.
+  shared_proxy() = default;
+
+  // `shared_proxy`: adopting constructor from shared ownership of a concrete
+  // target. A null pointer yields an empty handle.
+  //
+  //  Usually spelled through `make_shared_proxy`; there is deliberately no
+  //  raw-pointer constructor.
+  template<typename T>
+  requires Proxiable<T, F>
+  explicit shared_proxy(std::shared_ptr<T> target) noexcept
+      : target_{std::move(target)} {
+    if (target_) vtable_ = &details::vtable_for<F, T>;
+  }
+
+  // `shared_proxy`: adopting constructor from unique ownership, which becomes
+  // shared (this allocates the control block, so unlike the shared flavor it
+  // can throw).
+  template<typename T>
+  requires Proxiable<T, F>
+  explicit shared_proxy(std::unique_ptr<T> target)
+      : shared_proxy{std::shared_ptr<T>{std::move(target)}} {}
+
+  // `shared_proxy`: adopting constructor from an owning proxy of `F`, or of a
+  // facade that extends it.
+  //
+  // The unique ownership becomes shared (Rust: `Box<dyn T>` into `Rc<dyn T>`),
+  // consuming the source.
+  //
+  // A heap-stored target is adopted as-is, the owning table's destroy slot
+  // becoming the control block's deleter, so only the control block
+  // allocates; an inline target moves onto the heap first. On a throw from
+  // the control-block allocation the target is destroyed rather than
+  // leaked, and the source is left empty (the same contract as
+  // `std::shared_ptr`'s constructor from a `unique_ptr`); a throw from the
+  // re-boxing leaves the source intact.
+  //
+  // The reverse conversion deliberately does not exist: unique ownership
+  // cannot be recovered from a shared target, even at a use count of one,
+  // without racing the other owners, which is also why `std::shared_ptr`
+  // has no `release`.
+  template<Facade D, proxy_policy P>
+  requires(std::same_as<D, F> || Extends<D, F>)
+  explicit shared_proxy(proxy<D, P>&& source) {
+    const auto* src = source.vtable_;
+    if (!src) return;
+    const auto* ovt = details::upcast_owning_vtable<F, D>(src);
+    void* ptr = nullptr;
+    void (*destroy)(void*) noexcept = nullptr;
+    if (src->relocate) {
+      ptr = ovt->to_heap(source.storage_.buf);
+      destroy = ovt->heap_table->destroy;
+    } else {
+      ptr = source.storage_.ptr;
+      destroy = ovt->destroy;
+    }
+    source.vtable_ = nullptr;
+    target_ = std::shared_ptr<void>{ptr, destroy};
+    vtable_ = &ovt->vt;
+  }
+
+  // `shared_proxy`: upcasting converting constructors from a shared proxy of a
+  // facade that extends `F`, sharing (copy) or transferring (move) ownership.
+  // Intentionally implicit, like every handle upcast.
+  template<Facade D>
+  requires Extends<D, F>
+  explicit(false) shared_proxy(const shared_proxy<D>& other) noexcept
+      : target_{other.target_},
+        vtable_{
+            other ? details::upcast_vtable<F, D>(other.vtable_) : nullptr} {}
+
+  template<Facade D>
+  requires Extends<D, F>
+  explicit(false) shared_proxy(shared_proxy<D>&& other) noexcept
+      : vtable_{
+            other ? details::upcast_vtable<F, D>(other.vtable_) : nullptr} {
+    target_ = std::move(other.target_);
+  }
+
+  // `call`: call the facade method named `Key`, forwarding `args` through the
+  // erased signature; the same dispatch as the other handles, deep const
+  // included.
+  template<fixed_string Key, typename... Args>
+  decltype(auto) call(Args&&... args) noexcept(
+      vtbuild_t::template is_noexcept<Key, false, Args...>()) {
+    return details::dispatch<F, false, Key>(vtable_->thunks, target(),
+        std::forward<Args>(args)...);
+  }
+
+  template<fixed_string Key, typename... Args>
+  requires(details::vtbuild_t<F>::template is_const<Key>())
+  // NOLINTNEXTLINE(modernize-use-nodiscard)
+  decltype(auto) call(Args&&... args) const
+      noexcept(vtbuild_t::template is_noexcept<Key, true, Args...>()) {
+    return details::dispatch<F, true, Key>(vtable_->thunks, target(),
+        std::forward<Args>(args)...);
+  }
+
+  // `operator bool`: an empty handle (default-constructed or moved-from) holds
+  // no target.
+  [[nodiscard]] explicit operator bool() const noexcept {
+    return static_cast<bool>(target_);
+  }
+
+private:
+  // `target`: the target address; meaningless when empty.
+  [[nodiscard]] void* target() noexcept {
+    assert(target_);
+    return target_.get();
+  }
+  [[nodiscard]] const void* target() const noexcept {
+    assert(target_);
+    return target_.get();
+  }
+
+  // `shared_proxy`: for `weak_proxy::lock`, whose vtable pointer is already
+  // upcast; an expired weak pointer arrives here null, yielding an empty
+  // handle.
+  shared_proxy(std::shared_ptr<void> target, const vtable_t* vtable) noexcept
+      : target_{std::move(target)}, vtable_{vtable} {}
+
+  std::shared_ptr<void> target_;
+  const vtable_t* vtable_{};
+
+  template<Facade G>
+  friend class shared_proxy;
+  template<Facade G>
+  friend class weak_proxy;
   template<Facade G>
   friend class proxy_view;
   template<Facade G>
   friend class const_proxy_view;
 };
 
-// Library-provided binding so that an owning proxy satisfies its own facade
-// and every facade that facade extends, like the view.
-//
-// Calls forward through the proxy, with conditional `noexcept`. The const
-// overload serves const-qualified methods, matching the proxy's deep const,
-// and the non-const overload serves the rest.
+// `proxy_impl`: library-provided binding so that a shared proxy satisfies its
+// own facade and every facade that facade extends, like the other handles; see
+// the owning proxy's binding.
 template<Facade F, Facade D>
 requires(std::same_as<D, F> || Extends<D, F>)
-struct proxy_impl<F, proxy<D>> {
-  // Qualified forwarding, as with the view bindings; see `qualified_key`.
+struct proxy_impl<F, shared_proxy<D>> {
   template<fixed_string Key, typename... Args>
   static decltype(auto)
-  on(method_key<Key>, proxy<D>& p, Args&&... args) noexcept(
+  on(method_key<Key>, shared_proxy<D>& p, Args&&... args) noexcept(
       noexcept(p.template call<details::qualified_key<F, Key>()>(
           std::forward<Args>(args)...))) {
     return p.template call<details::qualified_key<F, Key>()>(
@@ -1918,7 +2868,7 @@ struct proxy_impl<F, proxy<D>> {
   }
   template<fixed_string Key, typename... Args>
   static decltype(auto)
-  on(method_key<Key>, const proxy<D>& p, Args&&... args) noexcept(
+  on(method_key<Key>, const shared_proxy<D>& p, Args&&... args) noexcept(
       noexcept(p.template call<details::qualified_key<F, Key>()>(
           std::forward<Args>(args)...))) {
     return p.template call<details::qualified_key<F, Key>()>(
@@ -1926,15 +2876,79 @@ struct proxy_impl<F, proxy<D>> {
   }
 };
 
-// Make an owning proxy of facade `F` holding a `T` constructed in place from
-// `args`.
+// `weak_proxy`: weak counterpart to `shared_proxy`, which observes the target
+// without owning it, via a `std::weak_ptr<void>`.
 //
-// To move an existing object in, pass it as the constructor argument:
-// `make_proxy<F, T>(std::move(obj))`.
+// It carries no dispatch at all; regaining access always goes through
+// `lock`, which returns a shared proxy (empty if every owner is gone), so
+// there is no way to call through a target that might be dying.
+template<Facade F>
+class weak_proxy {
+  using vtable_t = details::vtbuild_t<F>::vtable_t;
+
+public:
+  // `weak_proxy`:an empty weak proxy observes nothing; `lock` yields an empty
+  // handle.
+  weak_proxy() = default;
+
+  // `weak_proxy`: observe a shared proxy of `F`, or of a facade that extends
+  // it (the upcast happens here, so `lock` is cheap).
+  //
+  // Intentionally implicit.
+  template<Facade D>
+  requires(std::same_as<D, F> || Extends<D, F>)
+  explicit(false) weak_proxy(const shared_proxy<D>& p) noexcept
+      : target_{p.target_},
+        vtable_{p ? details::upcast_vtable<F, D>(p.vtable_) : nullptr} {}
+
+  // `weak_proxy`: upcasting converting constructors from a weak proxy of a
+  // facade that extends `F`, by copy or by move, mirroring the shared proxy's.
+  //
+  // Intentionally implicit, like every handle upcast. An expired source
+  // upcasts like a live one, still observing the same target; expiry stays
+  // `lock`'s business.
+  template<Facade D>
+  requires Extends<D, F>
+  explicit(false) weak_proxy(const weak_proxy<D>& other) noexcept
+      : target_{other.target_},
+        vtable_{other.vtable_ ? details::upcast_vtable<F, D>(other.vtable_)
+                              : nullptr} {}
+
+  template<Facade D>
+  requires Extends<D, F>
+  explicit(false) weak_proxy(weak_proxy<D>&& other) noexcept
+      : vtable_{other.vtable_ ? details::upcast_vtable<F, D>(other.vtable_)
+                              : nullptr} {
+    target_ = std::move(other.target_);
+  }
+
+  // `expired`: whether the target is already gone.
+  //
+  // As with `std::weak_ptr`, a false answer is stale the moment it is read;
+  // `lock` is the reliable gate.
+  [[nodiscard]] bool expired() const noexcept { return target_.expired(); }
+
+  // `lock`: regain shared ownership by creating a `shared_proxy` over the
+  // target, or an empty one when every owner is gone.
+  [[nodiscard]] shared_proxy<F> lock() const noexcept {
+    return shared_proxy<F>{target_.lock(), vtable_};
+  }
+
+private:
+  std::weak_ptr<void> target_;
+  const vtable_t* vtable_{};
+
+  template<Facade G>
+  friend class weak_proxy;
+};
+
+// `make_shared_proxy`: make a shared proxy of facade `F` holding a `T`
+// constructed in place from `args`, with target and control block in one
+// allocation (`std::make_shared`).
 template<Facade F, typename T, typename... Args>
 requires Proxiable<T, F>
-[[nodiscard]] proxy<F> make_proxy(Args&&... args) {
-  return proxy<F>{std::in_place_type<T>, std::forward<Args>(args)...};
+[[nodiscard]] shared_proxy<F> make_shared_proxy(Args&&... args) {
+  return shared_proxy<F>{std::make_shared<T>(std::forward<Args>(args)...)};
 }
 
 #pragma endregion
@@ -1947,17 +2961,23 @@ requires Proxiable<T, F>
 //
 // Consuming an erased handle is ordinary type usage, as in
 // `do_stuff(proxy_view<foo_like>)`, so these names belong in the wider
-// namespace. The authoring vocabulary (`facade`, `method`, `proxy_impl`, and
-// the registration machinery) stays inside `prox`, since those names are too
-// generic to export and facade and impl authors are already working in that
-// domain.
+// namespace.
+//
+// The authoring vocabulary generally stays inside `prox`, since those names
+// are too generic to export and facade and impl authors are already working in
+// that domain.
 using prox::const_proxy_view;
 using prox::make_proxy;
 using prox::make_proxy_view;
+using prox::make_shared_proxy;
 using prox::proxy;
+using prox::proxy_alloc;
 using prox::Proxiable;
+using prox::proxy_policy;
 using prox::proxy_view;
-using prox::prox_impl;
+using prox::proxy_impl_base;
+using prox::shared_proxy;
+using prox::weak_proxy;
 
 #pragma endregion
 

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -51,6 +51,30 @@
 // implicitly to handles of any facade theirs extends (Rust trait upcasting).
 //
 // See "proxy.md" for the design.
+//
+// Template parameter conventions, used consistently throughout this header:
+//
+// - `F`: the facade being dispatched, bound, or validated.
+// - `B`: a base facade, one that `F` or `D` extends.
+// - `D`: a derived facade, one that extends `F` or `B`.
+// - `G`: a second facade, where two vary independently.
+// - `T`: the concrete target type behind a handle.
+// - `E`: one entry of a facade's list; `Es` is the whole pack (`name`,
+//     `extends`, and `method` entries).
+// - `Bs`: a facade's direct-base facades.
+// - `M`: a `method` descriptor; `Ms` is a pack of them.
+// - `S`: a flattened dispatch slot; `Ss` is a pack of them.
+// - `Owner`: the facade that declared a slot's method.
+// - `Name`: a declared name, a facade's or a method's, as a `fixed_string`.
+// - `OwnName`: the name of the facade being built.
+// - `Key`: a `call` lookup key: a method name, optionally facade-qualified.
+//      Distinct from `Name` because a key can be qualified; a name never is.
+// - `Sig`: a method's erased signature.
+// - `R`: a method's declared result type.
+// - `Args`: a method's declared parameters, or the arguments a call site
+//      passes; `CallArgs` where the two meet and need distinguishing.
+// - `Impl`: a registration-carried binding class.
+// - `Check`: an `api_check` value.
 namespace corvid { inline namespace meta {
 namespace prox {
 
@@ -100,7 +124,7 @@ consteval auto operator""_method() noexcept {
 //
 // A method derives from its `method_key`, so a method tag is usable anywhere
 // its key is, including `on` overload selection and deduction of
-// `method_key<K>` from a method argument. This also leaves the door open for
+// `method_key<Key>` from a method argument. This also leaves the door open for
 // bindings that overload on the full method (signature included) if per-name
 // overload sets are ever supported.
 namespace details {
@@ -982,12 +1006,12 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
       return vtbuild_t<typename S::owner_t>::name_v;
   }
 
-  // Whether slot `S` answers to key `K`. An unqualified key matches the
+  // Whether slot `S` answers to `Key`. An unqualified key matches the
   // method name alone; a qualified key ("facade::method") also requires the
   // qualifying facade's name.
-  template<typename S, fixed_string K>
+  template<typename S, fixed_string Key>
   static consteval bool slot_matches() noexcept {
-    constexpr std::string_view k = K.view();
+    constexpr std::string_view k = Key.view();
     constexpr auto pos = k.find("::");
     constexpr auto qual =
         pos == std::string_view::npos ? std::string_view{} : k.substr(0, pos);
@@ -999,7 +1023,48 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
     return owner.view() == qual;
   }
 
-  // Resolve key `K`, called with `CallArgs`, to a slot index, or to `none_v`
+  // Per-slot flags over the whole list: the candidates answering to `Key`
+  // (const-qualified only, when dispatching through a const handle), and the
+  // slots whose declared parameters match `CallArgs` exactly or are viable
+  // through ordinary conversions.
+  template<fixed_string Key, bool ConstOnly>
+  static consteval std::array<bool, count_v> candidates() noexcept {
+    return {(slot_matches<Ss, Key>() && (!ConstOnly || Ss::const_v))...};
+  }
+
+  template<typename... CallArgs>
+  static consteval std::array<bool, count_v> exact_flags() noexcept {
+    return {method_traits<typename Ss::method_t>::template exact_v<
+        CallArgs...>...};
+  }
+
+  template<typename... CallArgs>
+  static consteval std::array<bool, count_v> viable_flags() noexcept {
+    return {method_traits<typename Ss::method_t>::template viable_v<
+        CallArgs...>...};
+  }
+
+  // Narrow flag set `a` by flag set `b`, elementwise.
+  static consteval std::array<bool, count_v> both(std::array<bool, count_v> a,
+      const std::array<bool, count_v>& b) noexcept {
+    for (std::size_t ndx = 0; ndx != count_v; ++ndx) a[ndx] = a[ndx] && b[ndx];
+    return a;
+  }
+
+  // Count of set flags, plus the last set index (`none_v` when none are).
+  static consteval std::pair<std::size_t, std::size_t> tally(
+      const std::array<bool, count_v>& flags) noexcept {
+    std::size_t cnt{};
+    std::size_t at{none_v};
+    for (std::size_t ndx = 0; ndx != count_v; ++ndx)
+      if (flags[ndx]) {
+        ++cnt;
+        at = ndx;
+      }
+    return {cnt, at};
+  }
+
+  // Resolve `Key`, called with `CallArgs`, to a slot index, or to `none_v`
   // or `ambiguous_v`.
   //
   // A qualified key names its slot outright. An unqualified key with a
@@ -1010,83 +1075,56 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
   // anything else is ambiguous and needs the qualified spelling. `ConstOnly`
   // restricts the candidates to const-qualified methods, for dispatch
   // through const handles.
-  template<fixed_string K, bool ConstOnly, typename... CallArgs>
+  template<fixed_string Key, bool ConstOnly, typename... CallArgs>
   static consteval std::size_t resolve() noexcept {
-    constexpr std::array<bool, count_v> cand{
-        (slot_matches<Ss, K>() && (!ConstOnly || Ss::const_v))...};
-    constexpr std::array<bool, count_v> exact{method_traits<
-        typename Ss::method_t>::template exact_v<CallArgs...>...};
-    constexpr std::array<bool, count_v> viable{method_traits<
-        typename Ss::method_t>::template viable_v<CallArgs...>...};
-    std::size_t cnt{};
-    std::size_t at{none_v};
-    for (std::size_t ndx = 0; ndx != count_v; ++ndx)
-      if (cand[ndx]) {
-        ++cnt;
-        at = ndx;
-      }
+    constexpr auto cand = candidates<Key, ConstOnly>();
+    const auto [cnt, at] = tally(cand);
     if (cnt < 2) return cnt ? at : none_v;
-    cnt = 0;
-    for (std::size_t ndx = 0; ndx != count_v; ++ndx)
-      if (cand[ndx] && exact[ndx]) {
-        ++cnt;
-        at = ndx;
-      }
-    if (cnt == 1) return at;
-    if (cnt > 1) return ambiguous_v;
-    for (std::size_t ndx = 0; ndx != count_v; ++ndx)
-      if (cand[ndx] && viable[ndx]) {
-        ++cnt;
-        at = ndx;
-      }
-    if (cnt == 1) return at;
-    return cnt ? ambiguous_v : none_v;
+    const auto [exact_cnt, exact_at] =
+        tally(both(cand, exact_flags<CallArgs...>()));
+    if (exact_cnt == 1) return exact_at;
+    if (exact_cnt > 1) return ambiguous_v;
+    const auto [viable_cnt, viable_at] =
+        tally(both(cand, viable_flags<CallArgs...>()));
+    if (viable_cnt == 1) return viable_at;
+    return viable_cnt ? ambiguous_v : none_v;
   }
 
-  // Resolve key `K` to the unique candidate whose declared parameters match
+  // Resolve `Key` to the unique candidate whose declared parameters match
   // `CallArgs` exactly. This is the validation probe's strictness: a
   // merely-viable signature does not count.
-  template<fixed_string K, bool ConstOnly, typename... CallArgs>
+  template<fixed_string Key, bool ConstOnly, typename... CallArgs>
   static consteval std::size_t resolve_exact() noexcept {
-    constexpr std::array<bool, count_v> cand{
-        (slot_matches<Ss, K>() && (!ConstOnly || Ss::const_v))...};
-    constexpr std::array<bool, count_v> exact{method_traits<
-        typename Ss::method_t>::template exact_v<CallArgs...>...};
-    std::size_t cnt{};
-    std::size_t at{none_v};
-    for (std::size_t ndx = 0; ndx != count_v; ++ndx)
-      if (cand[ndx] && exact[ndx]) {
-        ++cnt;
-        at = ndx;
-      }
+    const auto [cnt, at] =
+        tally(both(candidates<Key, ConstOnly>(), exact_flags<CallArgs...>()));
     if (cnt == 1) return at;
     return cnt ? ambiguous_v : none_v;
   }
 
-  // Whether any method answering to `K` is const-qualified: the gate on
-  // dispatching `K` through a const handle. False for an unknown key, since
+  // Whether any method answering to `Key` is const-qualified: the gate on
+  // dispatching `Key` through a const handle. False for an unknown key, since
   // rejecting one is `resolve`'s job.
-  template<fixed_string K>
+  template<fixed_string Key>
   static consteval bool is_const() noexcept {
-    return ((slot_matches<Ss, K>() && Ss::const_v) || ...);
+    return ((slot_matches<Ss, Key>() && Ss::const_v) || ...);
   }
 
-  // Whether the call `K` resolves to, with `CallArgs`, dispatches a noexcept
+  // Whether the call `Key` resolves to, with `CallArgs`, dispatches a noexcept
   // method. False when the call does not resolve.
-  template<fixed_string K, bool ConstOnly, typename... CallArgs>
+  template<fixed_string Key, bool ConstOnly, typename... CallArgs>
   static consteval bool is_noexcept() noexcept {
     constexpr std::array<bool, count_v> flags{Ss::noexcept_v...};
-    constexpr auto ndx = resolve<K, ConstOnly, CallArgs...>();
+    constexpr auto ndx = resolve<Key, ConstOnly, CallArgs...>();
     return ndx < count_v && flags[ndx];
   }
 
-  // Declared result type of the exact-match candidate for `K`, or `void`
+  // Declared result type of the exact-match candidate for `Key`, or `void`
   // when there is none. The permissive fallback keeps return-type
   // substitution in the `api_probe` from hard-erroring before its constraint
   // can reject the key.
-  template<fixed_string K, bool ConstOnly, typename... CallArgs>
+  template<fixed_string Key, bool ConstOnly, typename... CallArgs>
   static consteval auto do_result_of() noexcept {
-    constexpr auto ndx = resolve_exact<K, ConstOnly, CallArgs...>();
+    constexpr auto ndx = resolve_exact<Key, ConstOnly, CallArgs...>();
     if constexpr (ndx < count_v) {
       using s_t = std::tuple_element_t<ndx, std::tuple<Ss...>>;
       return std::type_identity<typename s_t::result_t>{};
@@ -1095,16 +1133,16 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
     }
   }
 
-  template<fixed_string K, bool ConstOnly, typename... CallArgs>
+  template<fixed_string Key, bool ConstOnly, typename... CallArgs>
   using result_of_t =
-      decltype(do_result_of<K, ConstOnly, CallArgs...>())::type;
+      decltype(do_result_of<Key, ConstOnly, CallArgs...>())::type;
 
   // Whether `Args` match the declared parameters of exactly one candidate
-  // for `K`, after normalization, rather than by convertibility. False for
+  // for `Key`, after normalization, rather than by convertibility. False for
   // an unknown key. This is the `api_probe`'s constraint.
-  template<fixed_string K, bool ConstOnly, typename... Args>
+  template<fixed_string Key, bool ConstOnly, typename... Args>
   static consteval bool exact_args() noexcept {
-    return resolve_exact<K, ConstOnly, Args...>() < count_v;
+    return resolve_exact<Key, ConstOnly, Args...>() < count_v;
   }
 };
 
@@ -1168,6 +1206,23 @@ upcast_vtable(const typename vtbuild_t<D>::vtable_t* vt) noexcept
     return upcast_vtable<B, typename vtbuild_t<D>::template base_t<ndx>>(
         std::get<ndx>(vt->bases));
   }
+}
+
+// Shared body of every handle's `call`: resolve `Key` against facade `F`'s
+// slot list, surface the user-facing errors, and invoke the thunk on the
+// erased target. `ConstOnly` marks dispatch through a const handle.
+template<Facade F, bool ConstOnly, fixed_string Key, typename ErasedPtr,
+    typename... Args>
+constexpr decltype(auto)
+dispatch(const typename vtbuild_t<F>::thunks_t& tks, ErasedPtr target,
+    Args&&... args) noexcept(vtbuild_t<F>::template is_noexcept<Key, ConstOnly,
+    Args...>()) {
+  constexpr auto ndx =
+      vtbuild_t<F>::template resolve<Key, ConstOnly, Args...>();
+  static_assert(ndx != vtbuild_t<F>::none_v, "no matching signature");
+  static_assert(ndx != vtbuild_t<F>::ambiguous_v,
+      "ambiguous method name; qualify the key with the facade name");
+  return std::get<ndx>(tks)(target, std::forward<Args>(args)...);
 }
 
 } // namespace details
@@ -1259,15 +1314,15 @@ consteval bool is_handle_for() noexcept {
     return std::same_as<G, F> || Extends<G, F>;
 }
 
-// Key `K` qualified by facade `F`'s name.
+// `Key` qualified by facade `F`'s name.
 //
-// The library's self-conformance bindings forward through this spelling: `K`
+// The library's self-conformance bindings forward through this spelling: `Key`
 // there is always one of `F`'s own method names, so the qualified key stays
 // unambiguous on a derived handle even when the derived facade's flattened
-// list collides on `K`.
-template<Facade F, fixed_string K>
+// list collides on `Key`.
+template<Facade F, fixed_string Key>
 consteval auto qualified_key() noexcept {
-  return vtbuild_t<F>::name_v + fixed_string{"::"} + K;
+  return vtbuild_t<F>::name_v + fixed_string{"::"} + Key;
 }
 
 } // namespace details
@@ -1311,19 +1366,19 @@ using strict_return_t = std::conditional_t<std::is_void_v<R>, void,
 // type. Never constructed or executed; it exists to be type-checked.
 template<Facade F>
 struct api_probe: api_base_t<F> {
-  template<fixed_string K, typename... Args>
-  requires(vtbuild_t<F>::template exact_args<K, false, Args...>())
+  template<fixed_string Key, typename... Args>
+  requires(vtbuild_t<F>::template exact_args<Key, false, Args...>())
   strict_return_t<
-      typename vtbuild_t<F>::template result_of_t<K, false, Args...>>
+      typename vtbuild_t<F>::template result_of_t<Key, false, Args...>>
   call(Args&&...) {
     std::terminate();
   }
 
-  template<fixed_string K, typename... Args>
-  requires(vtbuild_t<F>::template exact_args<K, true, Args...>())
+  template<fixed_string Key, typename... Args>
+  requires(vtbuild_t<F>::template exact_args<Key, true, Args...>())
   // NOLINTNEXTLINE(modernize-use-nodiscard): mirrors `call`, never executed.
   strict_return_t<
-      typename vtbuild_t<F>::template result_of_t<K, true, Args...>>
+      typename vtbuild_t<F>::template result_of_t<Key, true, Args...>>
   call(Args&&...) const {
     std::terminate();
   }
@@ -1415,23 +1470,19 @@ class view_base: public api_base_t<F> {
 public:
   using facade_t = F;
 
-  // Call the const-qualified facade method named `K`, forwarding `args`
+  // Call the const-qualified facade method named `Key`, forwarding `args`
   // through the erased signature.
   //
   // The call is `noexcept` when the method is. It is not `[[nodiscard]]`,
   // because discardability belongs to the facade method rather than the
   // dispatcher (the `std::invoke` precedent).
-  template<fixed_string K, typename... Args>
-  requires(vtbuild_t<F>::template is_const<K>())
+  template<fixed_string Key, typename... Args>
+  requires(vtbuild_t<F>::template is_const<Key>())
   // NOLINTNEXTLINE(modernize-use-nodiscard)
   constexpr decltype(auto) call(Args&&... args) const
-      noexcept(vtbuild_t<F>::template is_noexcept<K, true, Args...>()) {
-    constexpr auto ndx = vtbuild_t<F>::template resolve<K, true, Args...>();
-    static_assert(ndx != vtbuild_t<F>::none_v, "no matching signature");
-    static_assert(ndx != vtbuild_t<F>::ambiguous_v,
-        "ambiguous method name; qualify the key with the facade name");
-    return std::get<ndx>(
-        vtable_->thunks)(target_, std::forward<Args>(args)...);
+      noexcept(vtbuild_t<F>::template is_noexcept<Key, true, Args...>()) {
+    return dispatch<F, true, Key>(vtable_->thunks, target_,
+        std::forward<Args>(args)...);
   }
 
   // An empty view (default-constructed) holds no target. It is testable and
@@ -1526,21 +1577,17 @@ public:
   explicit(false) proxy_view(proxy<D>& p) noexcept
       : base{p.target(), details::upcast_vtable<F, D>(&p.vtable_->vt)} {}
 
-  // Call the facade method named `K`, forwarding `args` through the erased
+  // Call the facade method named `Key`, forwarding `args` through the erased
   // signature. The call is `noexcept` when the method is.
   //
   // This overload dispatches every method. The inherited const overload,
   // re-exposed by the using-declaration, is constrained to const-qualified
   // methods, mirroring the owning proxy's deep const.
-  template<fixed_string K, typename... Args>
+  template<fixed_string Key, typename... Args>
   constexpr decltype(auto) call(Args&&... args) noexcept(
-      vtbuild_t::template is_noexcept<K, false, Args...>()) {
-    constexpr auto ndx = vtbuild_t::template resolve<K, false, Args...>();
-    static_assert(ndx != vtbuild_t::none_v, "no matching signature");
-    static_assert(ndx != vtbuild_t::ambiguous_v,
-        "ambiguous method name; qualify the key with the facade name");
-    return std::get<ndx>(
-        this->vtable_->thunks)(this->target_, std::forward<Args>(args)...);
+      vtbuild_t::template is_noexcept<Key, false, Args...>()) {
+    return details::dispatch<F, false, Key>(this->vtable_->thunks,
+        this->target_, std::forward<Args>(args)...);
   }
 
   using base::call;
@@ -1566,21 +1613,21 @@ template<Facade F, Facade D>
 requires(std::same_as<D, F> || Extends<D, F>)
 struct proxy_impl<F, proxy_view<D>> {
   // The qualified spelling keeps the forwarded key unambiguous when `D`'s
-  // flattened list collides on `K`; see `qualified_key`.
-  template<fixed_string K, typename... Args>
+  // flattened list collides on `Key`; see `qualified_key`.
+  template<fixed_string Key, typename... Args>
   static constexpr decltype(auto)
-  on(method_key<K>, proxy_view<D>& view, Args&&... args) noexcept(
-      noexcept(view.template call<details::qualified_key<F, K>()>(
+  on(method_key<Key>, proxy_view<D>& view, Args&&... args) noexcept(
+      noexcept(view.template call<details::qualified_key<F, Key>()>(
           std::forward<Args>(args)...))) {
-    return view.template call<details::qualified_key<F, K>()>(
+    return view.template call<details::qualified_key<F, Key>()>(
         std::forward<Args>(args)...);
   }
-  template<fixed_string K, typename... Args>
+  template<fixed_string Key, typename... Args>
   static constexpr decltype(auto)
-  on(method_key<K>, const proxy_view<D>& view, Args&&... args) noexcept(
-      noexcept(view.template call<details::qualified_key<F, K>()>(
+  on(method_key<Key>, const proxy_view<D>& view, Args&&... args) noexcept(
+      noexcept(view.template call<details::qualified_key<F, Key>()>(
           std::forward<Args>(args)...))) {
-    return view.template call<details::qualified_key<F, K>()>(
+    return view.template call<details::qualified_key<F, Key>()>(
         std::forward<Args>(args)...);
   }
 };
@@ -1677,13 +1724,13 @@ private:
 template<Facade F, Facade D>
 requires(std::same_as<D, F> || Extends<D, F>)
 struct proxy_impl<F, const_proxy_view<D>> {
-  template<fixed_string K, typename... Args>
-  requires(details::vtbuild_t<F>::template is_const<K>())
-  static constexpr decltype(auto)
-  on(method_key<K>, const const_proxy_view<D>& view, Args&&... args) noexcept(
-      noexcept(view.template call<details::qualified_key<F, K>()>(
-          std::forward<Args>(args)...))) {
-    return view.template call<details::qualified_key<F, K>()>(
+  template<fixed_string Key, typename... Args>
+  requires(details::vtbuild_t<F>::template is_const<Key>())
+  static constexpr decltype(auto) on(method_key<Key>,
+      const const_proxy_view<D>& view, Args&&... args) noexcept(noexcept(view
+          .template call<details::qualified_key<F, Key>()>(
+              std::forward<Args>(args)...))) {
+    return view.template call<details::qualified_key<F, Key>()>(
         std::forward<Args>(args)...);
   }
 };
@@ -1777,7 +1824,7 @@ public:
 
   ~proxy() { do_reset(); }
 
-  // Call the facade method named `K`, forwarding `args` through the erased
+  // Call the facade method named `Key`, forwarding `args` through the erased
   // signature.
   //
   // The call is `noexcept` when the method is. The const overload is
@@ -1785,28 +1832,20 @@ public:
   // resolution so the rejection is visible to `requires` probes as well. It
   // is not `[[nodiscard]]`, because discardability belongs to the facade
   // method rather than the dispatcher (the `std::invoke` precedent).
-  template<fixed_string K, typename... Args>
+  template<fixed_string Key, typename... Args>
   decltype(auto) call(Args&&... args) noexcept(
-      vtbuild_t::template is_noexcept<K, false, Args...>()) {
-    constexpr auto ndx = vtbuild_t::template resolve<K, false, Args...>();
-    static_assert(ndx != vtbuild_t::none_v, "no matching signature");
-    static_assert(ndx != vtbuild_t::ambiguous_v,
-        "ambiguous method name; qualify the key with the facade name");
-    return std::get<ndx>(
-        vtable_->vt.thunks)(target(), std::forward<Args>(args)...);
+      vtbuild_t::template is_noexcept<Key, false, Args...>()) {
+    return details::dispatch<F, false, Key>(vtable_->vt.thunks, target(),
+        std::forward<Args>(args)...);
   }
 
-  template<fixed_string K, typename... Args>
-  requires(details::vtbuild_t<F>::template is_const<K>())
+  template<fixed_string Key, typename... Args>
+  requires(details::vtbuild_t<F>::template is_const<Key>())
   // NOLINTNEXTLINE(modernize-use-nodiscard)
   decltype(auto) call(Args&&... args) const
-      noexcept(vtbuild_t::template is_noexcept<K, true, Args...>()) {
-    constexpr auto ndx = vtbuild_t::template resolve<K, true, Args...>();
-    static_assert(ndx != vtbuild_t::none_v, "no matching signature");
-    static_assert(ndx != vtbuild_t::ambiguous_v,
-        "ambiguous method name; qualify the key with the facade name");
-    return std::get<ndx>(
-        vtable_->vt.thunks)(target(), std::forward<Args>(args)...);
+      noexcept(vtbuild_t::template is_noexcept<Key, true, Args...>()) {
+    return details::dispatch<F, true, Key>(vtable_->vt.thunks, target(),
+        std::forward<Args>(args)...);
   }
 
   // An empty proxy (default-constructed or moved-from) holds no target.
@@ -1869,20 +1908,20 @@ template<Facade F, Facade D>
 requires(std::same_as<D, F> || Extends<D, F>)
 struct proxy_impl<F, proxy<D>> {
   // Qualified forwarding, as with the view bindings; see `qualified_key`.
-  template<fixed_string K, typename... Args>
+  template<fixed_string Key, typename... Args>
   static decltype(auto)
-  on(method_key<K>, proxy<D>& p, Args&&... args) noexcept(
-      noexcept(p.template call<details::qualified_key<F, K>()>(
+  on(method_key<Key>, proxy<D>& p, Args&&... args) noexcept(
+      noexcept(p.template call<details::qualified_key<F, Key>()>(
           std::forward<Args>(args)...))) {
-    return p.template call<details::qualified_key<F, K>()>(
+    return p.template call<details::qualified_key<F, Key>()>(
         std::forward<Args>(args)...);
   }
-  template<fixed_string K, typename... Args>
+  template<fixed_string Key, typename... Args>
   static decltype(auto)
-  on(method_key<K>, const proxy<D>& p, Args&&... args) noexcept(
-      noexcept(p.template call<details::qualified_key<F, K>()>(
+  on(method_key<Key>, const proxy<D>& p, Args&&... args) noexcept(
+      noexcept(p.template call<details::qualified_key<F, Key>()>(
           std::forward<Args>(args)...))) {
-    return p.template call<details::qualified_key<F, K>()>(
+    return p.template call<details::qualified_key<F, Key>()>(
         std::forward<Args>(args)...);
   }
 };

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -67,8 +67,9 @@
 // - `M`: a `method` descriptor; `Ms` is a pack of them.
 // - `S`: a flattened dispatch slot; `Ss` is a pack of them.
 // - `Owner`: the facade that declared a slot's method.
-// - `Born`: the facade a proxy's target was constructed as, keying its
-//      owning tables and the birth ancestry `try_downcast` searches.
+// - `Born`: the facade a handle's target was constructed as, keying its
+//      owning and view tables and the birth ancestries `try_downcast`
+//      searches.
 // - `Name`: a declared name, a facade's or a method's, as a `fixed_string`.
 // - `OwnName`: the name of the facade being built.
 // - `Key`: a `call` lookup key: a method name, optionally facade-qualified.
@@ -846,14 +847,23 @@ struct vtable_builder;
 template<Facade F>
 using vtbuild_t = vtable_builder<decltype(probe(std::declval<const F&>()))>;
 
-// `vtable_for`: per-(facade, type) dispatch table instance.
+// `vtable_for`: per-(facade, type, born facade) dispatch table instance.
 //
 // The handle stores a pointer to this; the table pointer lives in the handle,
 // not in the target (a fat handle, like Rust's `&dyn`). A composed facade's
 // table also embeds the address of each direct base's instance for the same
-// target type, which is what makes upcasting a pointer read.
-template<Facade F, typename T>
-constexpr inline auto vtable_for = vtbuild_t<F>::template make_vtable<F, T>();
+// target type and birth, which is what makes upcasting a pointer read.
+//
+// `Born` plays the same role as on the owning tables: it defaults to the
+// facade itself, which is the birth of every directly built view, and stays
+// out of the table's type; a view lent from an owning handle points at the
+// born family its owner's table embeds, so the owner's birth carries over
+// without the handle doing anything. The type is spelled explicitly for the
+// same reason as `owning_vtable_for`: the born family's tables and its
+// ancestry reference each other by address.
+template<Facade F, typename T, Facade Born = F>
+constexpr inline vtbuild_t<F>::vtable_t vtable_for =
+    vtbuild_t<F>::template make_vtable<F, T, Born>();
 
 // `owning_vtable_for`: per-(facade, born facade, type, storage mode) owning
 // dispatch table instance, for `proxy`.
@@ -879,8 +889,9 @@ constexpr inline vtbuild_t<F>::owning_vtable_t owning_vtable_for =
 
 // `ancestor_entry`: one entry of a birth ancestry.
 //
-// Contains a facade's identity tag and that facade's owning table for the same
-// birth, target type, and storage mode.
+// Contains a facade's identity tag and that facade's table for the same birth
+// and target: an owning table in an owning ancestry (which is also per
+// storage mode), a view table in a view ancestry.
 struct ancestor_entry {
   const void* tag;
   const void* table;
@@ -889,15 +900,16 @@ struct ancestor_entry {
 // `ancestry_t`: type-erased view of a birth ancestry, the facade the target
 // was born as plus every facade it transitively extends.
 //
-// Every owning table points at its born family's ancestry; the underlying
-// tables are the per-(born facade, type, mode) statics below.
+// Every table points at its born family's ancestry of its own kind: owning
+// tables at an owning ancestry, view tables at a view ancestry; the
+// underlying tables are the statics below.
 struct ancestry_t {
   const ancestor_entry* entries;
   std::size_t count;
 };
 
-// `find_ancestor`: the owning table of the ancestry member whose tag is `tag`,
-// or null when the facade is not in the ancestry.
+// `find_ancestor`: the table of the ancestry member whose tag is `tag`, or
+// null when the facade is not in the ancestry.
 //
 // This is `try_downcast`'s runtime search; the tag match is what proves the
 // cast sound, so the caller can cast the table back to the matched facade's
@@ -937,6 +949,34 @@ template<Facade Born, typename T, bool Sbo>
 constexpr inline ancestry_t ancestry_for{
     ancestor_table_for<Born, T, Sbo>.data(),
     ancestor_table_for<Born, T, Sbo>.size()};
+
+// `make_view_ancestor_table`: build the view-table ancestor table for a
+// target born as (Born, T), mirroring `make_ancestor_table`.
+//
+// A parallel family over the view tables, rather than entries into the
+// owning tables: a view's downcast only ever needs dispatch, and routing it
+// through owning tables would drag their destroy, relocate, and copy thunks
+// into code that never owns anything.
+template<Facade Born, typename T, Facade... As>
+consteval std::array<ancestor_entry, 1 + sizeof...(As)>
+make_view_ancestor_table(std::tuple<As...>*) noexcept {
+  return {{{&facade_tag_v<Born>, &vtable_for<Born, T, Born>},
+      {&facade_tag_v<As>, &vtable_for<As, T, Born>}...}};
+}
+
+template<Facade Born, typename T>
+constexpr inline auto view_ancestor_table_for =
+    make_view_ancestor_table<Born, T>(
+        static_cast<vtbuild_t<Born>::ancestors_t*>(nullptr));
+
+// `view_ancestry_for`: the birth ancestry for a view over a target born as
+// (Born, T), the object every view table of that born family points at.
+//
+// There is no storage-mode axis here; a view has no storage.
+template<Facade Born, typename T>
+constexpr inline ancestry_t view_ancestry_for{
+    view_ancestor_table_for<Born, T>.data(),
+    view_ancestor_table_for<Born, T>.size()};
 
 // `slot`: flattened dispatch slot, containing one facade method plus the
 // facade that declared it.
@@ -1103,11 +1143,6 @@ struct entry_traits {
 
   template<typename F, typename T>
   static constexpr bool bound_v = method_traits<M>::template bound_v<F, T>;
-
-  template<typename T>
-  static consteval std::tuple<> base_vtables() noexcept {
-    return {};
-  }
 };
 
 template<Facade B>
@@ -1121,11 +1156,6 @@ struct entry_traits<extends<B>> {
 
   template<typename F, typename T>
   static constexpr bool bound_v = vtbuild_t<B>::template all_bound_v<B, T>;
-
-  template<typename T>
-  static consteval auto base_vtables() noexcept {
-    return std::tuple{&vtable_for<B, T>};
-  }
 };
 
 template<fixed_string Name>
@@ -1137,11 +1167,6 @@ struct entry_traits<name<Name>> {
 
   template<typename F, typename T>
   static constexpr bool bound_v = true;
-
-  template<typename T>
-  static consteval std::tuple<> base_vtables() noexcept {
-    return {};
-  }
 };
 
 // `entry_name`: facade name carried by one entry of a facade's list, empty for
@@ -1222,8 +1247,14 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
   // Dispatch always uses the flattened thunks, so an inherited call costs the
   // same single indexed load as an own one; the base pointers exist for
   // upcasting to follow (Rust's embedded supertrait vtables).
+  //
+  // `ancestry` names the born family's view ancestry (see
+  // `view_ancestry_for`), which is what `try_downcast` on the views and on
+  // `shared_proxy` searches; it is the table's only slot beyond dispatch, so
+  // views still carry no lifetime machinery.
   struct vtable_t {
     thunks_t thunks;
+    const ancestry_t* ancestry;
     std::tuple<const typename vtbuild_t<Bs>::vtable_t*...> bases;
   };
 
@@ -1439,11 +1470,26 @@ struct vtable_builder<facade<Es...>>
   static constexpr bool all_bound_v =
       (entry_traits<Es>::template bound_v<F, T> && ...);
 
-  // `make_vtable`: build the dispatch table for target `T` of facade `F`.
-  template<typename F, typename T>
+  // `make_view_bases`: view-table pointers of the direct bases, for the same
+  // born family and target, built over the direct-base pack (carried by the
+  // tuple pointer parameter, as in `make_ancestor_table`).
+  //
+  // A member with a spelled-out return type for the same reason as
+  // `make_owning_bases`: the view ancestry's back-references reach a
+  // sibling's table build mid-instantiation in a diamond, which the shared
+  // per-entry hook this replaced could not survive.
+  template<typename T, typename Born, typename... Bs2>
+  static consteval std::tuple<const typename vtbuild_t<Bs2>::vtable_t*...>
+  make_view_bases(std::tuple<Bs2...>*) noexcept {
+    return {&vtable_for<Bs2, T, Born>...};
+  }
+
+  // `make_vtable`: build the dispatch table for target `T` of facade `F`, born
+  // as facade `Born`.
+  template<typename F, typename T, typename Born>
   static consteval vtable_t make_vtable() noexcept {
-    return {impl_t::template make_thunks<F, T>(),
-        std::tuple_cat(entry_traits<Es>::template base_vtables<T>()...)};
+    return {impl_t::template make_thunks<F, T>(), &view_ancestry_for<Born, T>,
+        make_view_bases<T, Born>(static_cast<bases_of_t<Es...>*>(nullptr))};
   }
 
   // `owning_bases_t`: direct-base owning-table pointers, mirroring
@@ -1521,9 +1567,16 @@ struct vtable_builder<facade<Es...>>
   // The mode is decided at proxy construction from the handle's policy, so it
   // is part of the table's identity rather than a property of the type alone;
   // the birth is decided there too, as the facade under construction.
+  //
+  // The embedded `vt` is a copy of the standalone view-table instance rather
+  // than a second `make_vtable` call: both spellings would share one function
+  // specialization, and the view ancestry's back-references re-enter it while
+  // it is mid-instantiation from here, the same diamond hazard as
+  // `make_owning_bases`. Reading the completed variable keeps `make_vtable`
+  // entered from exactly one place, its own `vtable_for`.
   template<typename F, typename Born, typename T, bool Sbo>
   static consteval owning_vtable_t make_owning_vtable() noexcept {
-    owning_vtable_t ovt{make_vtable<F, T>(), nullptr, nullptr, nullptr,
+    owning_vtable_t ovt{vtable_for<F, T, Born>, nullptr, nullptr, nullptr,
         nullptr, nullptr, &type_tag_v<T>, nullptr, nullptr, sizeof(T),
         alignof(T), &ancestry_for<Born, T, Sbo>,
         make_owning_bases<Born, T, Sbo>(
@@ -1909,8 +1962,8 @@ protected:
 // `proxy_view` is a non-owning erased handle over any `Proxiable` target:
 // Rust's `&mut dyn Trait`, ngcpp's `proxy_view`.
 //
-// Two pointers: the target and the per-(facade, type) dispatch table. The
-// target must outlive the view.
+// Two pointers: the target and the per-(facade, type, born facade) dispatch
+// table. The target must outlive the view.
 //
 // A view also converts implicitly from any handle of a facade that extends
 // `F` (Rust trait upcasting), and from an lvalue owning `proxy`, re-pointing
@@ -2002,7 +2055,36 @@ public:
 
   using base::call;
 
+  // `try_downcast`: attempt a view of `D`, a facade extending `F`, over a
+  // target that may have been upcast away from it.
+  //
+  // The view table remembers the facade the target was born as: the view's
+  // own facade for a view built directly over a target, and the owning
+  // handle's birth for a view lent from a `proxy` or `shared_proxy`, so a
+  // lent view recovers exactly what its owner could. On success the result
+  // is a new view over the same target; the source is copied from, never
+  // consumed, which is why this is const where the owning flavor is an
+  // rvalue method. On failure, including an empty source, the result is
+  // empty. Like copying, this escapes the instance-level deep-const
+  // guardrail; the guarantee tier is `const_proxy_view`, whose downcast
+  // stays const.
+  template<Facade D>
+  requires Extends<D, F>
+  [[nodiscard]] constexpr proxy_view<D> try_downcast() const noexcept {
+    if (!this->vtable_) return {};
+    const auto* table = details::find_ancestor(*this->vtable_->ancestry,
+        &details::facade_tag_v<D>);
+    if (!table) return {};
+    return proxy_view<D>{this->target_,
+        static_cast<const details::vtbuild_t<D>::vtable_t*>(table)};
+  }
+
 private:
+  // `proxy_view`: for `try_downcast`, whose target and table are already
+  // resolved.
+  constexpr proxy_view(void* target, const base::vtable_t* vtable) noexcept
+      : base{target, vtable} {}
+
   template<Facade G>
   friend class proxy_view;
   template<Facade G>
@@ -2048,9 +2130,9 @@ struct proxy_impl<F, proxy_view<D>> {
 // Constness is part of the type, so unlike a `const proxy_view` it survives
 // copying. A const view only ever copies or converts to another const view.
 // It binds const and mutable targets alike, and dispatches only the
-// const-qualified facade methods, sharing the mutable view's per-(facade,
-// type) dispatch table (the non-const slots are simply unreachable). The
-// target must outlive the view.
+// const-qualified facade methods, sharing the mutable view's dispatch table
+// (the non-const slots are simply unreachable). The target must outlive the
+// view.
 //
 // A default-constructed view is empty: testable via `operator bool` and
 // rebindable by assignment, but calling through it is undefined behavior.
@@ -2128,7 +2210,30 @@ public:
   // dispatch is the entire interface, since the mutable methods do not exist
   // on this view.
 
+  // `try_downcast`: attempt a const view of `D`, a facade extending `F`, over
+  // a target that may have been upcast away from it; see
+  // `proxy_view::try_downcast`.
+  //
+  // The result is another const view, so downcasting never reopens
+  // mutability.
+  template<Facade D>
+  requires Extends<D, F>
+  [[nodiscard]] constexpr const_proxy_view<D> try_downcast() const noexcept {
+    if (!this->vtable_) return {};
+    const auto* table = details::find_ancestor(*this->vtable_->ancestry,
+        &details::facade_tag_v<D>);
+    if (!table) return {};
+    return const_proxy_view<D>{this->target_,
+        static_cast<const details::vtbuild_t<D>::vtable_t*>(table)};
+  }
+
 private:
+  // `const_proxy_view`: for `try_downcast`, whose target and table are already
+  // resolved.
+  constexpr const_proxy_view(const void* target,
+      const base::vtable_t* vtable) noexcept
+      : base{target, vtable} {}
+
   template<Facade G>
   friend class const_proxy_view;
 };
@@ -2702,8 +2807,8 @@ requires Proxiable<T, F>
 //
 // The control block therefore type-erases destruction on its own, which is why
 // no owning table is needed: the handle is the shared pointer plus the same
-// per-(facade, type) dispatch table the views use. There is no inline-storage
-// mode, so the target's address is always stable.
+// dispatch table the views use, born-keyed the same way. There is no
+// inline-storage mode, so the target's address is always stable.
 //
 // Ownership interoperates with `std`: construct from a `std::shared_ptr<T>`
 // (sharing with any outside holders) or a `std::unique_ptr<T>` (which
@@ -2831,6 +2936,33 @@ public:
     return static_cast<bool>(target_);
   }
 
+  // `try_downcast`: attempt to recover a `shared_proxy` of `D`, a facade
+  // extending `F`, from a handle that may have been upcast away from it.
+  //
+  // The table remembers the facade the target was born as, exactly as with
+  // the owning proxy (see `proxy::try_downcast`), including a birth adopted
+  // from a consumed `proxy`. Because shared ownership is copyable, the
+  // lvalue flavor shares: on success the result is another owner of the one
+  // target and the source keeps its own share. The rvalue flavor transfers
+  // instead, consuming the source only on success. On failure, including an
+  // empty source, the result is empty and the source is untouched.
+  template<Facade D>
+  requires Extends<D, F>
+  [[nodiscard]] shared_proxy<D> try_downcast() const& noexcept {
+    const auto* table = do_find_downcast<D>();
+    if (!table) return {};
+    return shared_proxy<D>{target_, table};
+  }
+  template<Facade D>
+  requires Extends<D, F>
+  [[nodiscard]] shared_proxy<D> try_downcast() && noexcept {
+    const auto* table = do_find_downcast<D>();
+    if (!table) return {};
+    shared_proxy<D> result{std::move(target_), table};
+    vtable_ = nullptr;
+    return result;
+  }
+
 private:
   // `target`: the target address; meaningless when empty.
   [[nodiscard]] void* target() noexcept {
@@ -2842,9 +2974,19 @@ private:
     return target_.get();
   }
 
-  // `shared_proxy`: for `weak_proxy::lock`, whose vtable pointer is already
-  // upcast; an expired weak pointer arrives here null, yielding an empty
-  // handle.
+  // `do_find_downcast`: `D`'s view table from the birth ancestry, or null when
+  // the handle is empty or was not born as `D` or a facade extending it.
+  template<Facade D>
+  [[nodiscard]] const details::vtbuild_t<D>::vtable_t*
+  do_find_downcast() const noexcept {
+    if (!vtable_) return nullptr;
+    return static_cast<const details::vtbuild_t<D>::vtable_t*>(
+        details::find_ancestor(*vtable_->ancestry, &details::facade_tag_v<D>));
+  }
+
+  // `shared_proxy`: for `weak_proxy::lock` and `try_downcast`, whose vtable
+  // pointer is already resolved; a null target (an expired weak pointer)
+  // yields an empty handle.
   shared_proxy(std::shared_ptr<void> target, const vtable_t* vtable) noexcept
       : target_{std::move(target)}, vtable_{vtable} {}
 

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -31,12 +31,25 @@
 
 // Registration-based runtime polymorphism ("proxy") system.
 //
-// Type-erased handles over an interface definition (a facade), without
-// inheritance, vtable pointers in the target type, or macros.
+// Type-erased handles (`proxy`, `proxy_view`, `const_proxy_view`) over an
+// interface definition (a facade), without inheritance, vtable pointers in the
+// target type, or macros.
 //
-// Conformance is based on name, not shape. A (facade, type) pair is bound by
-// an explicit `proxy_impl` specialization or by registering the pair to a
-// facade author's boilerplate impl, in the same spirit as registered enums.
+// Opting a class into a facade does not require modifying it, so you can
+// retrofit a facade onto an existing type (even one in `std`), or have
+// multiple facades over the same type.
+
+// Some duplication currently exists in the facade definition, but it will
+// collapse once reflection is available.
+//
+// A class's conformance to a facade is based on name, not shape, and
+// registration is the act of conformance. This is in the same spirit as
+// registered enums: registering a (facade, type) pair unlocks the facade's
+// boilerplate impl, or carries a custom impl of its own.
+//
+// Facades compose through `extends<Base>` entries, and handles convert
+// implicitly to handles of any facade theirs extends (Rust trait upcasting).
+//
 // See "proxy.md" for the design.
 namespace corvid { inline namespace meta {
 namespace prox {
@@ -130,8 +143,7 @@ struct method<Name, R(Args...) const noexcept>
 
 // Facade base: an interface definition.
 //
-// Derive a named, empty struct from `facade`, listing the methods. For
-// example:
+// Derive a named struct from `facade`, listing the methods. For example:
 //
 //    struct animal : facade<method<"speak", void() const>> {};
 //
@@ -142,7 +154,7 @@ struct method<Name, R(Args...) const noexcept>
 // methods in unrelated facades cannot cross-contaminate. This is also why we
 // inherit from `facade` instead of just aliasing it.
 //
-// The facade body is also where the optional member-call sugar is authored: a
+// The facade body is where the optional member-call sugar is authored: a
 // nested `api` type holding one deducing-this forwarder per method, which
 // every handle of the facade inherits. For example:
 //
@@ -152,11 +164,20 @@ struct method<Name, R(Args...) const noexcept>
 //          self.template call<"speak">();
 //        }
 //      };
+//      template<typename T>
+//      struct boilerplate {
+//        static int on(method_key<"speak">, const T& t) {
+//          return t.speak();
+//        }
+//      };
 //    };
 //
 // With that in place, `handle.speak()` is sugar for `handle.call<"speak">()`,
 // dispatching through the same table. See "proxy.md" for the design and its
 // limits.
+//
+// The facade body is also the normal home of the boilerplate impl; see also
+// `proxy_impl`.
 template<typename... Methods>
 struct facade {};
 
@@ -172,6 +193,33 @@ auto probe(const facade<Ms...>&) -> facade<Ms...>;
 // Concept for a type derived from a single `facade` base.
 template<typename F>
 concept Facade = requires(const F& f) { details::probe(f); };
+
+// Facade composition entry: the facade extends `B` (Rust supertrait, ngcpp
+// `add_facade`).
+//
+// Listed in the facade's method list alongside the methods, conventionally
+// first. For example:
+//
+//    struct pet : facade<extends<animal>, method<"play", void()>> {};
+//
+// The derived facade's effective method list is the flattening of its bases'
+// lists, in declaration order, followed by its own; handles of the derived
+// facade dispatch inherited and own methods alike. Names must be unique
+// across the flattened list, so a facade cannot redeclare (or override) an
+// inherited method, and diamond composition is rejected.
+//
+// Conformance is per facade, as with Rust supertraits: a type conforms to
+// `pet` by binding `pet`'s own methods through `proxy_impl<pet, T>` and
+// conforming to `animal` in the usual way. An inherited method's behavior is
+// therefore defined once, by the base facade's impl, and an upcast handle
+// cannot disagree with the derived one. A type relying on boilerplate impls
+// registers once per facade in the chain, normally with a single chain hook
+// (see `InChainOf`).
+//
+// Handles convert implicitly to handles of any facade theirs extends (Rust
+// trait upcasting); see the view constructors.
+template<Facade B>
+struct extends {};
 
 namespace details {
 
@@ -206,31 +254,52 @@ using api_base_t = api_base<F>::type;
 // Binding point between a facade and a concrete type (Rust's `impl Trait for
 // Type`).
 //
-// Intentionally undefined. A specialization provides one static `on` overload
-// per facade method, taking the method's `key`, the target (const-qualified
-// per the method), and the method's arguments.
+// Intentionally undefined. A binding provides one static `on` overload per
+// facade method, taking the method's `key`, the target (const-qualified per
+// the method), and the method's arguments. Registration is the sole act of
+// conformance: it either unlocks the facade's boilerplate or carries the
+// pair's impl itself, and library partial specializations of this template
+// install whichever applies.
 //
-// A facade author typically also provides a boilerplate partial
-// specialization, generic over any registered `T` whose member names line up.
-// An explicit full specialization for one type outranks the boilerplate and
-// needs no registration.
+// A facade author typically hosts a boilerplate impl inside the facade
+// itself: a nested class template named `boilerplate`, generic over any
+// registered `T` whose member names line up.
 //
-// A facade author who factors the boilerplate bindings into a plain
-// inheritable class (with the partial specialization deriving from it) also
+// A type whose names do not line up carries its own impl in the registration
+// instead: `make_proxy_spec<F, T, Impl>()` names a binding class, which can
+// live anywhere a type can: local to the hook itself (a fully self-contained
+// registration, and the only self-contained option for a type you do not
+// own), nested in the type it serves (which additionally grants access to
+// the type's private members), or at namespace scope.
+//
+// A carried impl outranks the boilerplate, being the more specific
+// declaration. The namespace-scope spelling of the boilerplate, a `proxy_impl`
+// partial specialization gated on `ProxyRegistered`, remains equivalent and
+// supported (to preserve carried-impl precedence, its gate should also
+// require `!SpecCarriesImpl<F, T>`); it is the one user-authored
+// specialization of this template in the supported surface.
+//
+// Unregistered per-type full specializations, the original wrong-names tier,
+// are subsumed by carried impls and no longer supported.
+//
+// Because the nested boilerplate is an ordinary inheritable class, it also
 // enables partial overrides: a type whose names line up except for one method
-// writes a full specialization that inherits that class, re-exposes its `on`
-// overloads with a using-declaration, and declares only the divergent
-// binding. See "proxy.md" for the mechanics and "proxy_test.cpp" for an
-// example in `proxy_impl_gunslinger`.
+// registers a carried impl that inherits `F::boilerplate<T>`, re-exposes its
+// `on` overloads with a using-declaration, and declares only the divergent
+// binding.
 //
-// For example, given `struct animal : facade<method<"speak", void() const>>`:
+// See "proxy.md" for the mechanics and "proxy_test.cpp" for
+// examples (`sheriff`, `turncoat`).
 //
+// For example:
+
 //    // Facade author's boilerplate, written once, serving any registered
-//    // type whose member names line up:
-//    template<typename T>
-//    requires ProxyRegistered<animal, T>
-//    struct proxy_impl<animal, T> {
-//      static void on(method_key<"speak">, const T& t) { t.speak(); }
+//    // type whose member names line up. The `api` is omitted here for
+//    //  brevity.
+//    struct animal : facade<method<"speak", void() const>> {
+//    template<typename T> struct boilerplate {
+//        static void on(method_key<"speak">, const T& t) { t.speak(); }
+//      };
 //    };
 //
 //    // Conforming `dog`, whose names line up: pure registration.
@@ -238,22 +307,31 @@ using api_base_t = api_base<F>::type;
 //      return make_proxy_spec<animal, dog>();
 //    }
 //
-//    // Conforming `cat`, whose names differ: a custom impl, not registration.
-//    template<>
-//    struct proxy_impl<animal, cat> {
-//      static void on(method_key<"speak">, const cat& c) { c.meow(); }
-//    };
+//    // Conforming `cat`, whose names differ: the registration carries the
+//    // impl, here local to the hook itself.
+//    consteval auto corvid_proxy_spec(animal*, cat*) {
+//      struct as_animal {
+//        static void on(method_key<"speak">, const cat& c) { c.meow(); }
+//      };
+//      return make_proxy_spec<animal, cat, as_animal>();
+//    }
 template<typename F, typename T>
 struct proxy_impl;
 
 // Minimal registration spec.
 //
-// The value a registration hook returns, currently carrying no knobs. Distinct
-// from `corvid_proxy_spec`, which is the hook itself, provided by the user.
-// Because each hook's return type is deduced independently, richer spec types
-// can be added later without touching existing registrations.
-template<typename F, typename T>
-struct proxy_spec {};
+// The value a registration hook returns. Distinct from `corvid_proxy_spec`,
+// which is the hook itself, provided by the user.
+//
+// `Impl`, when not `void`, is a registration-carried impl: a binding class the
+// registration names, which the library installs as the pair's `proxy_impl`
+// (see `SpecCarriesImpl`). Because each hook's return type is deduced
+// independently, richer spec types can be added later without touching
+// existing registrations.
+template<typename F, typename T, typename Impl = void>
+struct proxy_spec {
+  using impl_t = Impl;
+};
 
 namespace details {
 
@@ -269,34 +347,60 @@ template<Facade F>
 
 // Whether registering a pair also validates the facade's `api` (see
 // `validate_api`). A facade whose `api` deliberately deviates from the method
-// list (say, a widening convenience signature), should register with
+// list (say, a widening convenience signature), must register with
 // `api_check::off`.
 enum class api_check : std::uint8_t { off, on };
 
-// Make the registration spec for a (facade, type) pair.
-//
-// Call this from a `corvid_proxy_spec` overload, just as
-// `make_sequence_enum_spec` is returned from `corvid_enum_spec`.
-//
-// When the facade defines an `api`, registration is also the moment that `api`
-// is validated against the method list (see `validate_api`), because the
-// boilerplate impl the registration exists to unlock must be visible here,
-// along with the facade and its `api`. Correctness is opt-out rather than
-// opt-in: pass `api_check::off` to skip. A registration hook that is itself a
-// template defers the check to its own instantiation.
-template<typename F, typename T, api_check Check = api_check::on>
-[[nodiscard]] consteval proxy_spec<F, T> make_proxy_spec() noexcept {
+namespace details {
+
+// Registration-time half of `validate_api`: run the check when the facade
+// has an `api` and the registration has not opted out.
+template<typename F, api_check Check>
+consteval void maybe_validate_api() noexcept {
   if constexpr (Check == api_check::on && Facade<F> &&
                 requires { typename F::api; })
   {
     constexpr bool has_boilerplate = requires {
-      sizeof(proxy_impl<F, details::api_probe<F>>);
+      sizeof(proxy_impl<F, api_probe<F>>);
     };
     static_assert(has_boilerplate,
         "validating the api needs the facade's boilerplate impl visible at "
         "the registration; pass api_check::off to skip");
     if constexpr (has_boilerplate) (void)validate_api<F>();
   }
+}
+
+} // namespace details
+
+// Make the registration spec for a (facade, type) pair.
+//
+// Call this from a `corvid_proxy_spec` overload, just as
+// `make_sequence_enum_spec` is returned from `corvid_enum_spec`.
+//
+// The three-type overload carries an impl: `make_proxy_spec<F, T, Impl>()`
+// names the binding class serving the pair, typically a local class in the
+// hook itself or a class nested in `T`; see `proxy_impl` and
+// `SpecCarriesImpl`. `api_check` is the trailing, defaulted parameter of both
+// overloads.
+//
+// When the facade defines an `api`, registration is also the moment that the
+// `api` is validated against the method list (see `validate_api`), because the
+// boilerplate impl the registration exists to unlock must be visible here,
+// along with the facade and its `api`.
+//
+// Correctness checking is opt-out rather than opt-in: pass `api_check::off` to
+// skip. A registration hook that is itself a template defers the check to its
+// own instantiation.
+template<typename F, typename T, api_check Check = api_check::on>
+[[nodiscard]] consteval proxy_spec<F, T> make_proxy_spec() noexcept {
+  details::maybe_validate_api<F, Check>();
+  return {};
+}
+
+template<typename F, typename T, typename Impl,
+    api_check Check = api_check::on>
+[[nodiscard]] consteval proxy_spec<F, T, Impl> make_proxy_spec() noexcept {
+  details::maybe_validate_api<F, Check>();
   return {};
 }
 
@@ -306,16 +410,72 @@ template<typename F, typename T, api_check Check = api_check::on>
 // `make_proxy_spec<F, T>()`, in the namespace of either the facade or the
 // type; it is found here by ADL.
 //
+// To register a type for a composed facade and its whole chain, one
+// constrained template hook serves every level; see `InChainOf`.
+//
 // The library never defines this function: declaring an overload IS the act of
 // registration. The single exception is the overload the library provides for
 // its own API-validation probe; see `validate_api`.
 //
-// Registration gates a facade author's boilerplate impl; an explicit
-// `proxy_impl` specialization does not need it.
+// Registration is the sole act of conformance: it unlocks the facade's
+// boilerplate, or carries the pair's impl itself.
 template<typename F, typename T>
 concept ProxyRegistered = requires {
   corvid_proxy_spec(static_cast<F*>(nullptr), static_cast<T*>(nullptr));
 };
+
+// Concept for a (facade, type) pair whose registration carries an impl.
+//
+// True when the pair is registered through the three-type
+// `make_proxy_spec<F, T, Impl>()`, which names the binding class serving the
+// pair.
+//
+// The library installs the carried impl as the pair's `proxy_impl` (below),
+// outranking the facade's boilerplate: the carried impl is the more specific
+// declaration, closer to the type.
+//
+// A namespace-scope boilerplate partial should include `!SpecCarriesImpl<F,
+// T>` in its gate to preserve that precedence, since partial ordering would
+// otherwise prefer it.
+template<typename F, typename T>
+concept SpecCarriesImpl =
+    ProxyRegistered<F, T> &&
+    !std::is_void_v<typename decltype(corvid_proxy_spec(
+        static_cast<F*>(nullptr), static_cast<T*>(nullptr)))::impl_t>;
+
+namespace details {
+
+// Impl type carried by the pair's registration.
+template<typename F, typename T>
+using registered_impl_t = decltype(corvid_proxy_spec(static_cast<F*>(nullptr),
+    static_cast<T*>(nullptr)))::impl_t;
+
+} // namespace details
+
+// Library-provided delegation to a registration-carried impl.
+//
+// The registration names the binding class, so the impl is explicitly
+// registered like everything else, and the class itself can be local to the
+// hook or nest inside the type it serves (a hook is implicitly inline, so a
+// hook-local class is ODR-consistent across translation units).
+template<Facade F, typename T>
+requires SpecCarriesImpl<F, T>
+struct proxy_impl<F, T>: details::registered_impl_t<F, T> {};
+
+// Library-provided delegation to a facade-hosted boilerplate impl.
+//
+// When a facade defines a nested `boilerplate` class template and the
+// (facade, type) pair is registered, this serves as the pair's `proxy_impl`,
+// so the boilerplate lives next to the method list and `api` it mirrors and
+// the facade needs no namespace-scope impl at all.
+//
+// A registration-carried impl outranks it (the exclusion below is what
+// arbitrates), and a facade author's own namespace-scope partial outranks both
+// by the ordinary specialization-ordering rules.
+template<Facade F, typename T>
+requires(ProxyRegistered<F, T> && !SpecCarriesImpl<F, T> &&
+         requires { typename F::template boilerplate<T>; })
+struct proxy_impl<F, T>: F::template boilerplate<T> {};
 
 // Central access point for the registered spec, mirroring `enum_spec_v`.
 //
@@ -429,25 +589,166 @@ void sbo_relocate(void* from, void* to) noexcept {
 }
 
 // Facade-wide dispatch machinery, specialized on the `facade` base to get at
-// the method pack: method count, name-to-slot lookup, the dispatch table type,
-// the all-methods-bound check behind `Proxiable`, and the table builder.
+// the entry pack: the flattened method list, name-to-slot lookup, the
+// dispatch table type, the all-methods-bound check behind `Proxiable`, and
+// the table builders.
 template<typename FB>
 struct vtable_builder;
 
-template<typename... Ms>
-struct vtable_builder<facade<Ms...>> {
-  static constexpr std::size_t count_v = sizeof...(Ms);
+// Facade-wide machinery for the derived facade type `F`.
+template<Facade F>
+using vtbuild_t = vtable_builder<decltype(probe(std::declval<const F&>()))>;
 
-  using vtable_t = std::tuple<typename method_traits<Ms>::thunk_ptr_t...>;
+// Per-(facade, type) dispatch table instance. The handle stores a pointer to
+// this; the table pointer lives in the handle, not in the target (a fat
+// handle, like Rust's `&dyn`). A composed facade's table also embeds the
+// address of each direct base's instance for the same target type, which is
+// what makes upcasting a pointer read.
+template<Facade F, typename T>
+constexpr inline auto vtable_for = vtbuild_t<F>::template make_vtable<F, T>();
+
+// Per-(facade, type) owning dispatch table instance, for `proxy`.
+template<Facade F, typename T>
+constexpr inline auto owning_vtable_for =
+    vtbuild_t<F>::template make_owning_vtable<F, T>();
+
+// Slot index of the first method in `Ms` named `K`, or `sizeof...(Ms)` (as
+// an `npos` or `end` flag) when there is none.
+template<fixed_string K, typename... Ms>
+consteval std::size_t first_index_of() noexcept {
+  constexpr std::array<bool, sizeof...(Ms)> matches{(Ms::name_v == K)...};
+  for (std::size_t ndx = 0; ndx != matches.size(); ++ndx)
+    if (matches[ndx]) return ndx;
+  return sizeof...(Ms);
+}
+
+// Whether every method name in `Ms` is unique: each name's first occurrence
+// must be its own slot. Duplicates arise from composition (an inherited name
+// redeclared, or a diamond) as well as from a doubled declaration.
+template<typename... Ms>
+consteval bool unique_method_names() noexcept {
+  std::size_t ndx = 0;
+  return (... && (first_index_of<Ms::name_v, Ms...>() == ndx++));
+}
+
+// Traits over one entry of a facade's declaration list, which mixes `method`
+// descriptors with `extends` composition entries.
+//
+// Each entry contributes methods to the flattened method list, base facades
+// to the direct-base list, thunk slots and base-table pointers to the
+// dispatch table, and a conformance term to `all_bound_v`.
+//
+// A `method` contributes itself, bound through `proxy_impl<F, T>`. An
+// `extends<B>` contributes B's already-flattened methods, with the thunks
+// copied from B's own table and conformance delegated to `B`, so an inherited
+// method's binding always comes from the facade that declared it and an upcast
+// handle cannot disagree with the derived one.
+template<typename M>
+struct entry_traits {
+  using methods_t = std::tuple<M>;
+  using bases_t = std::tuple<>;
+
+  template<typename F, typename T>
+  static constexpr bool bound_v = method_traits<M>::template bound_v<F, T>;
+
+  template<typename F, typename T>
+  static consteval auto thunks() noexcept {
+    return std::tuple{method_traits<M>::template make_thunk<F, T>()};
+  }
+
+  template<typename T>
+  static consteval std::tuple<> base_vtables() noexcept {
+    return {};
+  }
+};
+
+template<Facade B>
+struct entry_traits<extends<B>> {
+  using methods_t = vtbuild_t<B>::flat_methods_t;
+  using bases_t = std::tuple<B>;
+
+  template<typename F, typename T>
+  static constexpr bool bound_v = vtbuild_t<B>::template all_bound_v<B, T>;
+
+  template<typename F, typename T>
+  static consteval auto thunks() noexcept {
+    return vtable_for<B, T>.thunks;
+  }
+
+  template<typename T>
+  static consteval auto base_vtables() noexcept {
+    return std::tuple{&vtable_for<B, T>};
+  }
+};
+
+// Flattened method list and direct-base list of a facade's entry pack.
+template<typename... Es>
+using flat_methods_of_t = decltype(std::tuple_cat(
+    std::declval<typename entry_traits<Es>::methods_t>()...));
+
+template<typename... Es>
+using bases_of_t = decltype(std::tuple_cat(
+    std::declval<typename entry_traits<Es>::bases_t>()...));
+
+// The flattened core of the builder, over the full method list `Ms` (bases'
+// methods first, in declaration order, then own) and the direct-base facades
+// `Bs`.
+template<typename FlatMethods, typename Bases>
+struct vtable_builder_impl;
+
+template<typename... Ms, typename... Bs>
+struct vtable_builder_impl<std::tuple<Ms...>, std::tuple<Bs...>> {
+  static_assert(unique_method_names<Ms...>(),
+      "method names must be unique across the facade and its extends bases");
+
+  using flat_methods_t = std::tuple<Ms...>;
+  static constexpr std::size_t count_v = sizeof...(Ms);
+  static constexpr std::size_t base_count_v = sizeof...(Bs);
+
+  // Direct-base facade at index `Ndx`.
+  template<std::size_t Ndx>
+  using base_t = std::tuple_element_t<Ndx, std::tuple<Bs...>>;
+
+  using thunks_t = std::tuple<typename method_traits<Ms>::thunk_ptr_t...>;
+
+  // Dispatch table: one thunk slot per flattened method, plus the address of
+  // each direct base's table for the same target type.
+  //
+  // Dispatch always uses the flattened thunks, so an inherited call costs the
+  // same single indexed load as an own one; the base pointers exist for
+  // upcasting to follow (Rust's embedded supertrait vtables).
+  struct vtable_t {
+    thunks_t thunks;
+    std::tuple<const typename vtbuild_t<Bs>::vtable_t*...> bases;
+  };
+
+  // Whether this facade transitively extends facade `B`. Strict: false when
+  // `B` is this facade itself.
+  template<typename B>
+  static consteval bool extends_facade() noexcept {
+    return (
+        (std::same_as<B, Bs> || vtbuild_t<Bs>::template extends_facade<B>()) ||
+        ...);
+  }
+
+  // Index of the first direct base that is `B` or extends it, or
+  // `base_count_v` when there is none. This is the route `upcast_vtable`
+  // descends.
+  template<typename B>
+  static consteval std::size_t base_route() noexcept {
+    constexpr std::array<bool, sizeof...(Bs)> matches{(
+        std::same_as<B, Bs> ||
+        vtbuild_t<Bs>::template extends_facade<B>())...};
+    for (std::size_t ndx = 0; ndx != matches.size(); ++ndx)
+      if (matches[ndx]) return ndx;
+    return base_count_v;
+  }
 
   // Slot index of the method named `K`, or `count_v` (as an `npos` or `end`
   // flag) when there is none.
   template<fixed_string K>
   static consteval std::size_t index_of() noexcept {
-    constexpr std::array<bool, sizeof...(Ms)> matches{(Ms::name_v == K)...};
-    for (std::size_t ndx = 0; ndx != matches.size(); ++ndx)
-      if (matches[ndx]) return ndx;
-    return count_v;
+    return first_index_of<K, Ms...>();
   }
 
   // Qualification of the method named `K`. Both are `false` when no method
@@ -498,21 +799,34 @@ struct vtable_builder<facade<Ms...>> {
       return false;
     }
   }
+};
 
+template<typename... Es>
+struct vtable_builder<facade<Es...>>
+    : vtable_builder_impl<flat_methods_of_t<Es...>, bases_of_t<Es...>> {
+  using impl_t =
+      vtable_builder_impl<flat_methods_of_t<Es...>, bases_of_t<Es...>>;
+  using vtable_t = impl_t::vtable_t;
+
+  // Whether every method of the facade, inherited and own, has a usable
+  // binding for `T`. Own methods bind through `proxy_impl<F, T>`; inherited
+  // ones recurse into their declaring facade, so conforming to a composed
+  // facade requires conforming to each of its bases.
   template<typename F, typename T>
   static constexpr bool all_bound_v =
-      (method_traits<Ms>::template bound_v<F, T> && ...);
+      (entry_traits<Es>::template bound_v<F, T> && ...);
 
   template<typename F, typename T>
   static consteval vtable_t make_vtable() noexcept {
-    return {method_traits<Ms>::template make_thunk<F, T>()...};
+    return {std::tuple_cat(entry_traits<Es>::template thunks<F, T>()...),
+        std::tuple_cat(entry_traits<Es>::template base_vtables<T>()...)};
   }
 
   // Owning dispatch table, carrying housekeeping slots alongside the facade
   // methods. A null `relocate` marks a heap-stored target, which moves by
   // pointer steal rather than relocation.
   struct owning_vtable_t {
-    vtable_t methods;
+    vtable_t vt;
     void (*destroy)(void*) noexcept;
     void (*relocate)(void*, void*) noexcept;
   };
@@ -526,20 +840,24 @@ struct vtable_builder<facade<Ms...>> {
   }
 };
 
-// Facade-wide machinery for the derived facade type `F`.
-template<Facade F>
-using vtbuild_t = vtable_builder<decltype(probe(std::declval<const F&>()))>;
-
-// Per-(facade, type) dispatch table instance. The handle stores a pointer to
-// this; the table pointer lives in the handle, not in the target (a fat
-// handle, like Rust's `&dyn`).
-template<Facade F, typename T>
-constexpr inline auto vtable_for = vtbuild_t<F>::template make_vtable<F, T>();
-
-// Per-(facade, type) owning dispatch table instance, for `proxy`.
-template<Facade F, typename T>
-constexpr inline auto owning_vtable_for =
-    vtbuild_t<F>::template make_owning_vtable<F, T>();
+// Narrow a dispatch-table pointer from facade `D` to `B`, where `B` is `D`
+// itself or a facade it extends, by following the embedded direct-base table
+// pointers. The route is resolved at compile time; the runtime cost is one
+// dependent load per composition level crossed.
+template<Facade B, Facade D>
+[[nodiscard]] constexpr auto
+upcast_vtable(const typename vtbuild_t<D>::vtable_t* vt) noexcept
+    -> const vtbuild_t<B>::vtable_t* {
+  if constexpr (std::same_as<B, D>) {
+    return vt;
+  } else {
+    constexpr auto ndx = vtbuild_t<D>::template base_route<B>();
+    static_assert(ndx != vtbuild_t<D>::base_count_v,
+        "the source facade does not extend the target facade");
+    return upcast_vtable<B, typename vtbuild_t<D>::template base_t<ndx>>(
+        std::get<ndx>(vt->bases));
+  }
+}
 
 } // namespace details
 
@@ -549,13 +867,88 @@ constexpr inline auto owning_vtable_for =
 // Concept: `T` can back facade `F`.
 //
 // Satisfied when a usable `proxy_impl<F, T>` binding exists for every method
-// of `F`. An explicit specialization satisfies it directly; a facade author's
-// boilerplate satisfies it exactly when the pair is registered. This is the
-// gate on proxy construction and doubles as the trait bound for
+// of `F`.
+//
+// An explicit specialization satisfies it directly; a facade author's
+// boilerplate satisfies it exactly when the pair is registered.
+//
+// This is the gate on proxy construction and doubles as the trait bound for
 // static-dispatch templates.
 template<typename T, typename F>
 concept Proxiable =
     Facade<F> && details::vtbuild_t<F>::template all_bound_v<F, T>;
+
+// Concept: facade `D` (transitively) extends facade `B` through `extends`
+// composition entries.
+//
+// Strict: false when `D` is `B` itself. Constraints that mean "B or anything
+// extending it" pair this with `std::same_as`.
+template<typename D, typename B>
+concept Extends =
+    Facade<D> && Facade<B> &&
+    details::vtbuild_t<D>::template extends_facade<B>();
+
+// Concept: facade `B` is `D` itself or a facade `D` (transitively) extends.
+//
+// This is `Extends` made reflexive and argument-flipped, so it can constrain
+// a registration hook's facade parameter. A single template hook
+//
+//    template<prox::InChainOf<pet> F>
+//    consteval auto corvid_proxy_spec(F*, dog*) {
+//      return prox::make_proxy_spec<F, dog>();
+//    }
+//
+// registers `dog` for `pet` and every facade it extends in one declaration,
+// the idiomatic spelling for conforming a type to a whole composition chain.
+// The bindings stay per facade either way; the chain hook only collapses the
+// opt-in ceremony.
+template<typename B, typename D>
+concept InChainOf = Facade<B> && (std::same_as<B, D> || Extends<D, B>);
+
+// Forward declarations of the three erased-handle flavors, for the trait
+// below and the cross-handle constructors.
+template<Facade F>
+class proxy_view;
+template<Facade F>
+class const_proxy_view;
+template<Facade F>
+class proxy;
+
+namespace details {
+
+// Facade of a proxy handle type, or `void` for any other type.
+template<typename T>
+struct handle_facade {
+  using type = void;
+};
+template<Facade F>
+struct handle_facade<proxy_view<F>> {
+  using type = F;
+};
+template<Facade F>
+struct handle_facade<const_proxy_view<F>> {
+  using type = F;
+};
+template<Facade F>
+struct handle_facade<proxy<F>> {
+  using type = F;
+};
+
+// Whether `T` is a proxy handle whose facade is `F` or extends it: the set
+// the dedicated viewing and upcasting constructors serve.
+//
+// The generic erased-target constructors exclude it, so re-pointing at such a
+// handle's target always wins over wrapping the handle itself as a target.
+template<typename T, typename F>
+consteval bool is_handle_for() noexcept {
+  using G = handle_facade<T>::type;
+  if constexpr (std::is_void_v<G>)
+    return false;
+  else
+    return std::same_as<G, F> || Extends<G, F>;
+}
+
+} // namespace details
 
 #pragma endregion
 #pragma region API validation
@@ -613,15 +1006,21 @@ struct api_probe: api_base_t<F> {
   }
 };
 
-// Probe registration, covering every facade. This is the single
-// `corvid_proxy_spec` overload the library itself provides; it is what admits
-// the probe to a facade author's registration-gated boilerplate impl. It must
-// opt out of validation: a validating registration would recurse into itself
-// through the boilerplate-visibility check, whose `ProxyRegistered` probe
-// deduces this hook's return type.
-template<Facade F>
-consteval auto corvid_proxy_spec(F*, api_probe<F>*) noexcept {
-  return make_proxy_spec<F, api_probe<F>, api_check::off>();
+// Probe registration, covering every facade.
+//
+// This is the only overload of `corvid_proxy_spec` the library itself
+// provides; it is what admits the probe to a facade author's
+// registration-gated boilerplate impl.
+//
+// The probe of a facade also registers for every facade its facade extends,
+// because validating a composed facade drives each base's boilerplate at the
+// derived probe. It must opt out of validation: a validating registration
+// would recurse into itself through the boilerplate-visibility check, whose
+// `ProxyRegistered` probe deduces this hook's return type.
+template<Facade F, Facade G>
+requires(std::same_as<F, G> || Extends<G, F>)
+consteval auto corvid_proxy_spec(F*, api_probe<G>*) noexcept {
+  return make_proxy_spec<F, api_probe<G>, api_check::off>();
 }
 
 } // namespace details
@@ -632,17 +1031,17 @@ consteval auto corvid_proxy_spec(F*, api_probe<F>*) noexcept {
 // This runs automatically from `make_proxy_spec` at every registration of an
 // `api`-bearing facade, unless the registration opts out with
 // `api_check::off`.
+//
 // The standalone spelling, `static_assert(validate_api<my_facade>());`,
 // remains for a facade author to assert at the definition site, before any
 // registration exists.
 //
-// It works by dispatching
-// the facade author's boilerplate impl at a probe target that inherits the
-// `api`, chaining thunk -> boilerplate `on` -> `api` forwarder -> strict probe
-// `call`. The chain is anchored to the facade's exact declared types at both
-// ends, so convertibility drift anywhere in the middle, in the `api` or in the
-// boilerplate itself, fails to compile with the error pointing at the drifting
-// line.
+// It works by dispatching the facade author's boilerplate impl at a probe
+// target that inherits the `api`, chaining thunk -> boilerplate `on` -> `api`
+// forwarder -> strict probe `call`. The chain is anchored to the facade's
+// exact declared types at both ends, so convertibility drift anywhere in the
+// middle, in the `api` or in the boilerplate itself, fails to compile with the
+// error pointing at the drifting line.
 //
 // Caught: a missing or misspelled forwarder, wrong arity, wrong const flavor
 // of `self`, a parameter or declared result type that is merely convertible to
@@ -653,8 +1052,14 @@ consteval auto corvid_proxy_spec(F*, api_probe<F>*) noexcept {
 // wrong key with an identical signature.
 //
 // Failures are hard compile errors rather than a `false` return, and the
-// facade must have a boilerplate `proxy_impl` partial specialization gated on
-// `ProxyRegistered` for the chain to exist.
+// facade must have a boilerplate impl (a facade-hosted nested `boilerplate`,
+// or a namespace-scope `proxy_impl` partial gated on `ProxyRegistered`) for
+// the chain to exist.
+//
+// For a facade with `extends` bases, the chain also runs through each base's
+// boilerplate, so the inherited forwarders (typically brought in by deriving
+// the `api` from the base facade's) are validated against the flattened
+// method list as well.
 template<Facade F>
 [[nodiscard]] consteval bool validate_api() noexcept {
   const auto vt = details::vtable_for<F, details::api_probe<F>>;
@@ -671,8 +1076,8 @@ namespace details {
 // differ only in the constness of the erased target pointer.
 //
 // The `call` here serves const-qualified methods, the only dispatch a const
-// handle allows. `proxy_view` layers the unrestricted non-const overload on
-// top.
+// handle allows. The `proxy_view` class layers the unrestricted non-const
+// overload on top.
 //
 // This is also where the views pick up the facade's `api` base, keeping each
 // view a single-inheritance chain.
@@ -694,7 +1099,8 @@ public:
       noexcept(vtbuild_t<F>::template is_noexcept<K>()) {
     constexpr auto ndx = vtbuild_t<F>::template index_of<K>();
     static_assert(ndx != vtbuild_t<F>::count_v, "no matching signature");
-    return std::get<ndx>(*vtable_)(target_, std::forward<Args>(args)...);
+    return std::get<ndx>(
+        vtable_->thunks)(target_, std::forward<Args>(args)...);
   }
 
 protected:
@@ -710,21 +1116,22 @@ protected:
 
 } // namespace details
 
-// Forward declaration so the mutable view can befriend the const flavor.
-template<Facade F>
-class const_proxy_view;
-
-// Non-owning erased handle over any `Proxiable` target: Rust's `&mut dyn
-// Trait`, ngcpp's `proxy_view`.
+// `proxy_view` is a non-owning erased handle over any `Proxiable` target:
+// Rust's `&mut dyn Trait`, ngcpp's `proxy_view`.
 //
 // Two pointers: the target and the per-(facade, type) dispatch table. The
 // target must outlive the view.
+//
+// A view also converts implicitly from any handle of a facade that extends
+// `F` (Rust trait upcasting), and from an lvalue owning proxy, re-pointing at
+// the handle's target rather than wrapping the handle. An upcast view is
+// indistinguishable from one built directly over the target.
 //
 // Deep-const as an instance, so only const-qualified facade methods dispatch
 // through a `const proxy_view`. Because views are freely copyable, that is a
 // guardrail rather than a guarantee. Copying a `const proxy_view` yields a
 // mutable view onto the same target, much as a `T* const` pointer copies to
-// a plain `T*`. Code that means read-only access should use
+// a plain `T*`. Code that enforces read-only access must use
 // `const_proxy_view`, where constness is part of the type and survives
 // copying.
 //
@@ -736,15 +1143,42 @@ class proxy_view: public details::view_base<F, false> {
   using vtbuild_t = details::vtbuild_t<F>;
 
 public:
-  // Converting constructor from an lvalue target. Intentionally implicit, like
-  // `string_view` from `string`. Rvalues do not bind, so construction from a
-  // temporary is rejected at compile time. Const targets take a
-  // `const_proxy_view`.
+  // Converting constructor from an lvalue target.
+  //
+  // Intentionally implicit, like `string_view` from `string`. Rvalues do not
+  // bind, so construction from a temporary is rejected at compile time. Const
+  // targets take a `const_proxy_view`. Handles of `F`, or of a facade
+  // extending it, take the dedicated constructors below instead of being
+  // wrapped as targets.
   template<typename T>
-  requires(
-      Proxiable<T, F> && !std::is_const_v<T> && !std::same_as<T, proxy_view>)
+  requires(Proxiable<T, F> && !std::is_const_v<T> &&
+           !details::is_handle_for<T, F>())
   constexpr explicit(false) proxy_view(T& target) noexcept
       : base{std::addressof(target), &details::vtable_for<F, T>} {}
+
+  // Upcasting constructor from a view over a facade that extends `F` (Rust
+  // trait upcasting).
+  //
+  // Intentionally implicit, like derived-to-base pointer conversion: the
+  // target carries over unchanged and the dispatch table narrows to `F`'s by
+  // following the embedded base-table pointers, so the upcast view dispatches
+  // exactly what a directly-built `F` view of the target would.
+  template<Facade D>
+  requires Extends<D, F>
+  constexpr explicit(false) proxy_view(const proxy_view<D>& view) noexcept
+      : base{view.target_, details::upcast_vtable<F, D>(view.vtable_)} {}
+
+  // Viewing constructor from an owning proxy of `F`, or of a facade that
+  // extends it.
+  //
+  // Intentionally implicit, and lvalue-only, so a view cannot be left dangling
+  // by a temporary proxy. The proxy must be non-empty and must outlive the
+  // view. A const proxy takes a `const_proxy_view` instead, preserving deep
+  // const.
+  template<Facade D>
+  requires(std::same_as<D, F> || Extends<D, F>)
+  explicit(false) proxy_view(proxy<D>& p) noexcept
+      : base{p.target(), details::upcast_vtable<F, D>(&p.vtable_->vt)} {}
 
   // Call the facade method named `K`, forwarding `args` through the erased
   // signature. The call is `noexcept` when the method is.
@@ -758,34 +1192,40 @@ public:
     constexpr auto ndx = vtbuild_t::template index_of<K>();
     static_assert(ndx != vtbuild_t::count_v, "no matching signature");
     return std::get<ndx>(
-        *this->vtable_)(this->target_, std::forward<Args>(args)...);
+        this->vtable_->thunks)(this->target_, std::forward<Args>(args)...);
   }
 
   using base::call;
 
 private:
-  friend const_proxy_view<F>;
+  template<Facade G>
+  friend class proxy_view;
+  template<Facade G>
+  friend class const_proxy_view;
 };
 
-// Library-provided binding so that a view itself satisfies its own facade (as
-// in Rust, where `dyn Trait` implements `Trait`).
+// Library-provided binding so that a view satisfies its own facade and every
+// facade that facade extends (as in Rust, where `dyn Trait` implements
+// `Trait` and meets its supertrait bounds).
 //
 // Calls forward through the wrapped view, with conditional `noexcept` so the
 // invariant also holds for facades with noexcept methods. The const overload
 // serves const-qualified methods, matching the view's instance-level deep
 // const. This makes facade-constrained generic code accept concrete and
-// erased arguments interchangeably, and allows views of views.
-template<Facade F>
-struct proxy_impl<F, proxy_view<F>> {
+// erased arguments interchangeably, including derived-facade handles under a
+// base-facade bound, and allows views of views.
+template<Facade F, Facade D>
+requires(std::same_as<D, F> || Extends<D, F>)
+struct proxy_impl<F, proxy_view<D>> {
   template<fixed_string K, typename... Args>
   static constexpr decltype(auto)
-  on(method_key<K>, proxy_view<F>& view, Args&&... args) noexcept(
+  on(method_key<K>, proxy_view<D>& view, Args&&... args) noexcept(
       noexcept(view.template call<K>(std::forward<Args>(args)...))) {
     return view.template call<K>(std::forward<Args>(args)...);
   }
   template<fixed_string K, typename... Args>
   static constexpr decltype(auto)
-  on(method_key<K>, const proxy_view<F>& view, Args&&... args) noexcept(
+  on(method_key<K>, const proxy_view<D>& view, Args&&... args) noexcept(
       noexcept(view.template call<K>(std::forward<Args>(args)...))) {
     return view.template call<K>(std::forward<Args>(args)...);
   }
@@ -809,13 +1249,14 @@ class const_proxy_view: public details::view_base<F, true> {
   using base = details::view_base<F, true>;
 
 public:
-  // Converting constructor from an lvalue target, const or not. Intentionally
-  // implicit. Rvalues do not bind.
+  // Converting constructor from an lvalue target, const or not.
+  //
+  // Intentionally implicit. Rvalues do not bind. Handles of `F`, or of a
+  // facade extending it, take the dedicated constructors below instead of
+  // being wrapped as targets.
   template<typename T>
-  requires(
-      Proxiable<std::remove_const_t<T>, F> &&
-      !std::same_as<std::remove_const_t<T>, const_proxy_view> &&
-      !std::same_as<std::remove_const_t<T>, proxy_view<F>>)
+  requires(Proxiable<std::remove_const_t<T>, F> &&
+           !details::is_handle_for<std::remove_const_t<T>, F>())
   constexpr explicit(false) const_proxy_view(T& target) noexcept
       : base{std::addressof(target),
             &details::vtable_for<F, std::remove_const_t<T>>} {}
@@ -826,34 +1267,73 @@ public:
       const_proxy_view(const proxy_view<F>& view) noexcept
       : base{view.target_, view.vtable_} {}
 
-  // `call` is inherited. The base's const-method dispatch is the entire
-  // interface, since the mutable methods do not exist on this view.
+  // Upcasting constructor from a const view over a facade that extends `F`
+  // (Rust trait upcasting).
+  //
+  // Intentionally implicit; see the mutable view's upcasting constructor.
+  template<Facade D>
+  requires Extends<D, F>
+  constexpr explicit(false)
+      const_proxy_view(const const_proxy_view<D>& view) noexcept
+      : base{view.target_, details::upcast_vtable<F, D>(view.vtable_)} {}
+
+  // Upcasting constructor from the mutable view of a facade that extends
+  // `F`, dropping mutability and upcasting in one implicit step.
+  template<Facade D>
+  requires Extends<D, F>
+  constexpr explicit(false)
+      const_proxy_view(const proxy_view<D>& view) noexcept
+      : base{view.target_, details::upcast_vtable<F, D>(view.vtable_)} {}
+
+  // Viewing constructor from an owning proxy of `F`, or of a facade that
+  // extends it.
+  //
+  // Intentionally implicit, and lvalue-only. The proxy must be non-empty and
+  // must outlive the view. Mutable and const proxies alike yield the const
+  // view; there is no path back to mutability.
+  template<Facade D>
+  requires(std::same_as<D, F> || Extends<D, F>)
+  explicit(false) const_proxy_view(const proxy<D>& p) noexcept
+      : base{p.target(), details::upcast_vtable<F, D>(&p.vtable_->vt)} {}
+
+  // No need for a `using` because`call` is inherited. The base's const-method
+  // dispatch is the entire interface, since the mutable methods do not exist
+  // on this view.
+
+private:
+  template<Facade G>
+  friend class const_proxy_view;
 };
 
-// Library-provided binding so that a const view satisfies its own facade
-// where that is possible. It dispatches only const methods, so the invariant
-// holds exactly for all-const facades.
+// Library-provided binding so that a const view satisfies its own facade,
+// and the facades that facade extends, where that is possible.
+//
+// It dispatches only const methods, so the invariant holds exactly for
+// all-const facades.
 //
 // The `on` is itself constrained to const methods so that a mixed facade
 // fails conformance cleanly at overload resolution, rather than erroring
 // during return type deduction of a forwarder whose `call` cannot compile.
-template<Facade F>
-struct proxy_impl<F, const_proxy_view<F>> {
+template<Facade F, Facade D>
+requires(std::same_as<D, F> || Extends<D, F>)
+struct proxy_impl<F, const_proxy_view<D>> {
   template<fixed_string K, typename... Args>
   requires(details::vtbuild_t<F>::template is_const<K>())
   static constexpr decltype(auto)
-  on(method_key<K>, const const_proxy_view<F>& view, Args&&... args) noexcept(
+  on(method_key<K>, const const_proxy_view<D>& view, Args&&... args) noexcept(
       noexcept(view.template call<K>(std::forward<Args>(args)...))) {
     return view.template call<K>(std::forward<Args>(args)...);
   }
 };
 
-// Make a view over `target`.
+// Make a view over `target`: a convenience for spelling the facade at the call
+// site.
 //
-// A convenience for spelling the facade at the call site. When `target` is
-// already a view of `F` it is copied rather than wrapped, so generic
-// facade-constrained code can erase its argument without stacking
-// indirections.
+// When `target` is already a view of `F` it is copied rather than wrapped, so
+// generic facade-constrained code can erase its argument without stacking
+// indirections. A handle of a facade extending `F`, or an owning proxy,
+// likewise re-points at its target (upcasting as needed) through the
+// dedicated view constructors.
 template<Facade F, typename T>
 requires Proxiable<T, F>
 [[nodiscard]] constexpr proxy_view<F> make_proxy_view(T& target) noexcept {
@@ -882,6 +1362,11 @@ requires Proxiable<T, F>
 // A default-constructed or moved-from proxy is empty. It is destructible,
 // assignable, and testable via `operator bool`, but calling through it is
 // undefined behavior.
+//
+// A non-empty lvalue proxy converts implicitly to `proxy_view` (mutable
+// proxies only) and `const_proxy_view`, of its own facade or of any facade it
+// extends; the view re-points at the stored target, and the proxy must
+// outlive it. See the view constructors.
 //
 // When the facade defines a nested `api`, the proxy inherits it, so the
 // member-call sugar forwarders dispatch alongside `call`.
@@ -944,7 +1429,7 @@ public:
     constexpr auto ndx = vtbuild_t::template index_of<K>();
     static_assert(ndx != vtbuild_t::count_v, "no matching signature");
     return std::get<ndx>(
-        vtable_->methods)(target(), std::forward<Args>(args)...);
+        vtable_->vt.thunks)(target(), std::forward<Args>(args)...);
   }
 
   template<fixed_string K, typename... Args>
@@ -955,7 +1440,7 @@ public:
     constexpr auto ndx = vtbuild_t::template index_of<K>();
     static_assert(ndx != vtbuild_t::count_v, "no matching signature");
     return std::get<ndx>(
-        vtable_->methods)(target(), std::forward<Args>(args)...);
+        vtable_->vt.thunks)(target(), std::forward<Args>(args)...);
   }
 
   // An empty proxy (default-constructed or moved-from) holds no target.
@@ -1001,25 +1486,31 @@ private:
 
   storage_t storage_;
   const owning_vtable_t* vtable_{};
+
+  template<Facade G>
+  friend class proxy_view;
+  template<Facade G>
+  friend class const_proxy_view;
 };
 
-// Library-provided binding so that an owning proxy satisfies its own facade,
-// like the view.
+// Library-provided binding so that an owning proxy satisfies its own facade
+// and every facade that facade extends, like the view.
 //
 // Calls forward through the proxy, with conditional `noexcept`. The const
 // overload serves const-qualified methods, matching the proxy's deep const,
 // and the non-const overload serves the rest.
-template<Facade F>
-struct proxy_impl<F, proxy<F>> {
+template<Facade F, Facade D>
+requires(std::same_as<D, F> || Extends<D, F>)
+struct proxy_impl<F, proxy<D>> {
   template<fixed_string K, typename... Args>
   static decltype(auto)
-  on(method_key<K>, proxy<F>& p, Args&&... args) noexcept(
+  on(method_key<K>, proxy<D>& p, Args&&... args) noexcept(
       noexcept(p.template call<K>(std::forward<Args>(args)...))) {
     return p.template call<K>(std::forward<Args>(args)...);
   }
   template<fixed_string K, typename... Args>
   static decltype(auto)
-  on(method_key<K>, const proxy<F>& p, Args&&... args) noexcept(
+  on(method_key<K>, const proxy<D>& p, Args&&... args) noexcept(
       noexcept(p.template call<K>(std::forward<Args>(args)...))) {
     return p.template call<K>(std::forward<Args>(args)...);
   }

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -1675,6 +1675,10 @@ struct vtable_builder<facade<Es...>>
   // Own methods bind through `proxy_impl<F, T>`; inherited ones recurse into
   // their declaring facade, so conforming to a composed facade requires
   // conforming to each of its bases.
+  //
+  // This is binding-existence only, vacuously true when the facade contributes
+  // no methods; the per-pair opt-in that keeps vacuity from conforming lives
+  // in `Proxiable`.
   template<typename F, typename T>
   static constexpr bool all_bound_v =
       (entry_traits<Es>::template bound_v<F, T> && ...);
@@ -1878,21 +1882,6 @@ dispatch(const typename vtbuild_t<F>::thunks_t& tks, ErasedPtr target,
 #pragma endregion
 #pragma region Proxiable
 
-// `Proxiable`: concept for when `T` can back facade `F`.
-//
-// Satisfied when a usable `proxy_impl<F, T>` binding exists for every method
-// of `F`.
-//
-// Both binding routes, the facade's boilerplate and the registration-carried
-// impl, are registration-gated, so the concept is satisfied exactly when the
-// pair is registered with a usable binding.
-//
-// This is the gate on proxy construction and doubles as the trait bound for
-// static-dispatch templates.
-template<typename T, typename F>
-concept Proxiable =
-    Facade<F> && details::vtbuild_t<F>::template all_bound_v<F, T>;
-
 // `Extends`: concept for when facade `D` (transitively) extends facade `B`
 // through `extends` composition entries.
 //
@@ -1989,6 +1978,24 @@ consteval auto qualified_key() noexcept {
 }
 
 } // namespace details
+
+// `Proxiable`: concept for when `T` can back facade `F`.
+//
+// Satisfied when a usable `proxy_impl<F, T>` binding exists for every method
+// of `F`, and the pair itself has opted in: it is registered, or `T` is a
+// proxy handle of `F` or of a facade extending it (the library's
+// self-conformance bindings).
+//
+// The explicit opt-in term is what keeps a facade with no own methods, a
+// name-only marker or a pure aggregation level, from being backed by every
+// type in the program: binding-existence alone is vacuously true there.
+//
+// This is the gate on proxy construction and doubles as the trait bound for
+// static-dispatch templates.
+template<typename T, typename F>
+concept Proxiable =
+    Facade<F> && details::vtbuild_t<F>::template all_bound_v<F, T> &&
+    (ProxyRegistered<F, T> || details::is_handle_for<T, F>());
 
 #pragma endregion
 #pragma region API validation

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -16,9 +16,11 @@
 // limitations under the License.
 #pragma once
 #include <array>
+#include <cassert>
 #include <concepts>
 #include <cstddef>
 #include <memory>
+#include <new>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -76,6 +78,10 @@ consteval auto operator""_method() noexcept {
 // The signature fixes the erased ABI; a binding may return the declared result
 // type or anything convertible to it.
 //
+// A `noexcept` qualifier is likewise honored: conformance then requires the
+// binding itself to be noexcept-invocable, and the erased call (`call` through
+// a handle) is itself `noexcept`.
+//
 // A method derives from its `method_key`, so a method tag is usable anywhere
 // its key is, including `on` overload selection and deduction of
 // `method_key<K>` from a method argument. This also leaves the door open for
@@ -87,12 +93,28 @@ struct method;
 template<fixed_string Name, typename R, typename... Args>
 struct method<Name, R(Args...)>: method_key<Name> {
   static constexpr bool const_v = false;
+  static constexpr bool noexcept_v = false;
   using result_t = R;
 };
 
 template<fixed_string Name, typename R, typename... Args>
 struct method<Name, R(Args...) const>: method_key<Name> {
   static constexpr bool const_v = true;
+  static constexpr bool noexcept_v = false;
+  using result_t = R;
+};
+
+template<fixed_string Name, typename R, typename... Args>
+struct method<Name, R(Args...) noexcept>: method_key<Name> {
+  static constexpr bool const_v = false;
+  static constexpr bool noexcept_v = true;
+  using result_t = R;
+};
+
+template<fixed_string Name, typename R, typename... Args>
+struct method<Name, R(Args...) const noexcept>: method_key<Name> {
+  static constexpr bool const_v = true;
+  static constexpr bool noexcept_v = true;
   using result_t = R;
 };
 
@@ -222,52 +244,97 @@ constexpr inline auto proxy_spec_v =
 
 namespace details {
 
-// Per-method dispatch machinery, split on the const qualification of the
-// erased signature: the thunk pointer type, the compile-time check that a
-// `proxy_impl` binding exists, and the thunk itself, which is where the
-// concrete type is seen for the last time before erasure.
+// Per-method dispatch machinery, shared by the four erased-signature flavors
+// (`const` crossed with `noexcept`).
+//
+// Contains the thunk pointer type, the compile-time check that a `proxy_impl`
+// binding exists, and the thunk itself, which is where the concrete type is
+// seen for the last time before erasure.
+//
+// A const method sees the target as `const T&` and erases it as `const
+// void*`. A noexcept method additionally requires the binding to be
+// noexcept-invocable, and its thunk pointer type carries `noexcept` through
+// the erased ABI.
+template<fixed_string Name, bool Const, bool Noexcept, typename R,
+    typename... Args>
+struct method_traits_base {
+  template<typename T>
+  using target_t = std::conditional_t<Const, const T, T>;
+  using erased_ptr_t = std::conditional_t<Const, const void*, void*>;
+  using thunk_ptr_t = R (*)(erased_ptr_t, Args...) noexcept(Noexcept);
+
+  template<typename F, typename T>
+  static constexpr bool bound_v = requires(target_t<T>& t, Args... args) {
+    {
+      proxy_impl<F, T>::on(method_key<Name>{}, t, std::forward<Args>(args)...)
+    } -> std::convertible_to<R>;
+  } && (!Noexcept || requires(target_t<T>& t, Args... args) {
+    {
+      proxy_impl<F, T>::on(method_key<Name>{}, t, std::forward<Args>(args)...)
+    } noexcept;
+  });
+
+  template<typename F, typename T>
+  static consteval thunk_ptr_t make_thunk() noexcept {
+    return [](erased_ptr_t target, Args... args) noexcept(Noexcept) -> R {
+      return proxy_impl<F, T>::on(method_key<Name>{},
+          *static_cast<target_t<T>*>(target), std::forward<Args>(args)...);
+    };
+  }
+};
+
 template<typename M>
 struct method_traits;
 
 template<fixed_string Name, typename R, typename... Args>
-struct method_traits<method<Name, R(Args...)>> {
-  using thunk_ptr_t = R (*)(void*, Args...);
-
-  template<typename F, typename T>
-  static constexpr bool bound_v = requires(T& t, Args... args) {
-    {
-      proxy_impl<F, T>::on(method_key<Name>{}, t, std::forward<Args>(args)...)
-    } -> std::convertible_to<R>;
-  };
-
-  template<typename F, typename T>
-  static consteval thunk_ptr_t make_thunk() noexcept {
-    return [](void* target, Args... args) -> R {
-      return proxy_impl<F, T>::on(method_key<Name>{}, *static_cast<T*>(target),
-          std::forward<Args>(args)...);
-    };
-  }
-};
+struct method_traits<method<Name, R(Args...)>>
+    : method_traits_base<Name, false, false, R, Args...> {};
 
 template<fixed_string Name, typename R, typename... Args>
-struct method_traits<method<Name, R(Args...) const>> {
-  using thunk_ptr_t = R (*)(const void*, Args...);
+struct method_traits<method<Name, R(Args...) const>>
+    : method_traits_base<Name, true, false, R, Args...> {};
 
-  template<typename F, typename T>
-  static constexpr bool bound_v = requires(const T& t, Args... args) {
-    {
-      proxy_impl<F, T>::on(method_key<Name>{}, t, std::forward<Args>(args)...)
-    } -> std::convertible_to<R>;
-  };
+template<fixed_string Name, typename R, typename... Args>
+struct method_traits<method<Name, R(Args...) noexcept>>
+    : method_traits_base<Name, false, true, R, Args...> {};
 
-  template<typename F, typename T>
-  static consteval thunk_ptr_t make_thunk() noexcept {
-    return [](const void* target, Args... args) -> R {
-      return proxy_impl<F, T>::on(method_key<Name>{},
-          *static_cast<const T*>(target), std::forward<Args>(args)...);
-    };
-  }
-};
+template<fixed_string Name, typename R, typename... Args>
+struct method_traits<method<Name, R(Args...) const noexcept>>
+    : method_traits_base<Name, true, true, R, Args...> {};
+
+// Inline (SBO) storage parameters for the owning `proxy`.
+//
+// A target is stored inline when it fits the buffer, is no more aligned than
+// `std::max_align_t`, and is nothrow-move-constructible (a proxy move
+// relocates an inline target, and proxy moves are unconditionally
+// `noexcept`); anything else lives in a unique-owned heap allocation.
+inline constexpr std::size_t sbo_size = 2 * sizeof(void*);
+
+template<typename T>
+constexpr inline bool sbo_eligible_v =
+    sizeof(T) <= sbo_size && alignof(T) <= alignof(std::max_align_t) &&
+    std::is_nothrow_move_constructible_v<T>;
+
+// Housekeeping thunks for the owning `proxy`: the analog of Rust's drop glue.
+//
+// `sbo_relocate` move-constructs `*from` into `to` and destroys the source;
+// the heap path has none because a heap target moves by pointer steal.
+template<typename T>
+void sbo_destroy(void* target) noexcept {
+  static_cast<T*>(target)->~T();
+}
+
+template<typename T>
+void heap_destroy(void* target) noexcept {
+  delete static_cast<T*>(target);
+}
+
+template<typename T>
+void sbo_relocate(void* from, void* to) noexcept {
+  auto* source = static_cast<T*>(from);
+  ::new (to) T(std::move(*source));
+  source->~T();
+}
 
 // Facade-wide dispatch machinery, specialized on the `facade` base to get at
 // the method pack: method count, name-to-slot lookup, the dispatch table type,
@@ -291,6 +358,22 @@ struct vtable_builder<facade<Ms...>> {
     return count_v;
   }
 
+  // Qualification of the method named `K`. Both are `false` when no method
+  // has that name; rejecting an unknown name is `index_of`'s job.
+  template<fixed_string K>
+  static consteval bool is_const() noexcept {
+    constexpr std::array<bool, sizeof...(Ms)> flags{Ms::const_v...};
+    constexpr auto ndx = index_of<K>();
+    return ndx != count_v && flags[ndx];
+  }
+
+  template<fixed_string K>
+  static consteval bool is_noexcept() noexcept {
+    constexpr std::array<bool, sizeof...(Ms)> flags{Ms::noexcept_v...};
+    constexpr auto ndx = index_of<K>();
+    return ndx != count_v && flags[ndx];
+  }
+
   template<typename F, typename T>
   static constexpr bool all_bound_v =
       (method_traits<Ms>::template bound_v<F, T> && ...);
@@ -298,6 +381,23 @@ struct vtable_builder<facade<Ms...>> {
   template<typename F, typename T>
   static consteval vtable_t make_vtable() noexcept {
     return {method_traits<Ms>::template make_thunk<F, T>()...};
+  }
+
+  // Owning dispatch table: the facade methods plus housekeeping slots. A null
+  // `relocate` marks a heap-stored target, which moves by pointer steal
+  // rather than relocation.
+  struct owning_vtable_t {
+    vtable_t methods;
+    void (*destroy)(void*) noexcept;
+    void (*relocate)(void*, void*) noexcept;
+  };
+
+  template<typename F, typename T>
+  static consteval owning_vtable_t make_owning_vtable() noexcept {
+    if constexpr (sbo_eligible_v<T>)
+      return {make_vtable<F, T>(), &sbo_destroy<T>, &sbo_relocate<T>};
+    else
+      return {make_vtable<F, T>(), &heap_destroy<T>, nullptr};
   }
 };
 
@@ -310,6 +410,11 @@ using vtbuild_t = vtable_builder<decltype(probe(std::declval<const F&>()))>;
 // handle, like Rust's `&dyn`).
 template<Facade F, typename T>
 constexpr inline auto vtable_for = vtbuild_t<F>::template make_vtable<F, T>();
+
+// Per-(facade, type) owning dispatch table instance, for `proxy`.
+template<Facade F, typename T>
+constexpr inline auto owning_vtable_for =
+    vtbuild_t<F>::template make_owning_vtable<F, T>();
 
 } // namespace details
 
@@ -352,18 +457,22 @@ public:
       : target_{std::addressof(target)}, vtable_{&details::vtable_for<F, T>} {}
 
   // Call the facade method named `K`, forwarding `args` through the erased
-  // signature.
+  // signature. The call is `noexcept` when the method is.
+  //
+  // Not `[[nodiscard]]`: discardability belongs to the facade method, not the
+  // dispatcher (the `std::invoke` precedent).
   template<fixed_string K, typename... Args>
-  constexpr decltype(auto) call(Args&&... args) const {
+  // NOLINTNEXTLINE(modernize-use-nodiscard)
+  constexpr decltype(auto) call(Args&&... args) const
+      noexcept(vtbuild_t::template is_noexcept<K>()) {
     constexpr auto ndx = vtbuild_t::template index_of<K>();
-    static_assert(ndx != vtbuild_t::count_v,
-        "facade has no method with this name");
+    static_assert(ndx != vtbuild_t::count_v, "no matching signature");
     return std::get<ndx>(*vtable_)(target_, std::forward<Args>(args)...);
   }
 
 private:
   using vtbuild_t = details::vtbuild_t<F>;
-  using vtable_t = typename vtbuild_t::vtable_t;
+  using vtable_t = vtbuild_t::vtable_t;
 
   void* target_;
   const vtable_t* vtable_;
@@ -372,14 +481,16 @@ private:
 // Library-provided binding so that a view itself satisfies its own facade (as
 // in Rust, where `dyn Trait` implements `Trait`).
 //
-// Calls forward through the wrapped view. This makes facade-constrained
-// generic code accept concrete and erased arguments interchangeably, and
-// allows views of views.
+// Calls forward through the wrapped view, with conditional `noexcept` so the
+// invariant also holds for facades with noexcept methods. This makes
+// facade-constrained generic code accept concrete and erased arguments
+// interchangeably, and allows views of views.
 template<Facade F>
 struct proxy_impl<F, proxy_view<F>> {
   template<fixed_string K, typename... As>
   static constexpr decltype(auto)
-  on(method_key<K>, const proxy_view<F>& view, As&&... args) {
+  on(method_key<K>, const proxy_view<F>& view, As&&... args) noexcept(
+      noexcept(view.template call<K>(std::forward<As>(args)...))) {
     return view.template call<K>(std::forward<As>(args)...);
   }
 };
@@ -397,6 +508,174 @@ requires Proxiable<T, F>
     return target;
   else
     return proxy_view<F>{target};
+}
+
+#pragma endregion
+#pragma region proxy
+
+// Owning erased handle over any `Proxiable` target: Rust's `Box<dyn Trait>`,
+// ngcpp's `proxy`.
+//
+// Move-only. Small targets (at most `sbo_size` bytes, at most
+// `std::max_align_t` alignment, nothrow-move-constructible) are stored
+// inline; anything else lives in a unique-owned heap allocation. The owning
+// dispatch table carries destroy and relocate slots alongside the facade
+// methods, so destruction and moves work without knowing the target type.
+//
+// Unlike the shallow-const view, the proxy owns its target and is deep-const:
+// only const-qualified facade methods dispatch through a const proxy.
+//
+// A default-constructed or moved-from proxy is empty: destructible,
+// assignable, and testable via `operator bool`, but calling through it is
+// undefined behavior.
+template<Facade F>
+class proxy {
+  using vtbuild_t = details::vtbuild_t<F>;
+  using owning_vtable_t = vtbuild_t::owning_vtable_t;
+
+public:
+  using facade_t = F;
+
+  // Inline storage capacity in bytes; see the class comment for the other
+  // inline-eligibility conditions.
+  static constexpr std::size_t sbo_size = details::sbo_size;
+
+  // An empty proxy holds no target.
+  proxy() = default;
+
+  proxy(const proxy&) = delete;
+  proxy& operator=(const proxy&) = delete;
+
+  // Construct an owning proxy holding a `T` built in place from `args`.
+  // Usually spelled through `make_proxy`.
+  template<typename T, typename... Args>
+  requires(Proxiable<T, F> && std::constructible_from<T, Args...>)
+  explicit proxy(std::in_place_type_t<T>, Args&&... args)
+      : vtable_{&details::owning_vtable_for<F, T>} {
+    if constexpr (details::sbo_eligible_v<T>)
+      ::new (static_cast<void*>(storage_.buf)) T(std::forward<Args>(args)...);
+    else
+      storage_.ptr = new T(std::forward<Args>(args)...);
+  }
+
+  // Move construction and assignment leave the source empty. Inline targets
+  // relocate through the table's move slot; heap targets move by pointer
+  // steal.
+  proxy(proxy&& other) noexcept { do_adopt(other); }
+
+  proxy& operator=(proxy&& other) noexcept {
+    if (this != &other) {
+      do_reset();
+      do_adopt(other);
+    }
+    return *this;
+  }
+
+  ~proxy() { do_reset(); }
+
+  // Call the facade method named `K`, forwarding `args` through the erased
+  // signature. The call is `noexcept` when the method is.
+  //
+  // The const overload is constrained to const-qualified methods: deep const,
+  // enforced at overload resolution so the rejection is visible to `requires`
+  // probes as well. Not `[[nodiscard]]`: discardability belongs to the facade
+  // method, not the dispatcher (the `std::invoke` precedent).
+  template<fixed_string K, typename... Args>
+  decltype(auto)
+  call(Args&&... args) noexcept(vtbuild_t::template is_noexcept<K>()) {
+    constexpr auto ndx = vtbuild_t::template index_of<K>();
+    static_assert(ndx != vtbuild_t::count_v, "no matching signature");
+    return std::get<ndx>(
+        vtable_->methods)(target(), std::forward<Args>(args)...);
+  }
+
+  template<fixed_string K, typename... Args>
+  requires(details::vtbuild_t<F>::template is_const<K>())
+  // NOLINTNEXTLINE(modernize-use-nodiscard)
+  decltype(auto) call(Args&&... args) const
+      noexcept(vtbuild_t::template is_noexcept<K>()) {
+    constexpr auto ndx = vtbuild_t::template index_of<K>();
+    static_assert(ndx != vtbuild_t::count_v, "no matching signature");
+    return std::get<ndx>(
+        vtable_->methods)(target(), std::forward<Args>(args)...);
+  }
+
+  // An empty proxy (default-constructed or moved-from) holds no target.
+  [[nodiscard]] explicit operator bool() const noexcept { return vtable_; }
+
+private:
+  union storage_t {
+    alignas(std::max_align_t) std::byte buf[sbo_size];
+    void* ptr;
+  };
+
+  // Target address, inline or heap. Meaningless when empty.
+  [[nodiscard]] void* target() noexcept {
+    assert(vtable_);
+    return vtable_->relocate ? static_cast<void*>(storage_.buf) : storage_.ptr;
+  }
+  [[nodiscard]] const void* target() const noexcept {
+    assert(vtable_);
+    return vtable_->relocate
+               ? static_cast<const void*>(storage_.buf)
+               : storage_.ptr;
+  }
+
+  // Destroy the target, if any, leaving the proxy empty.
+  void do_reset() noexcept {
+    if (!vtable_) return;
+    vtable_->destroy(target());
+    vtable_ = nullptr;
+  }
+
+  // Take over `other`'s target, leaving `other` empty. Assumes `*this` holds
+  // no target (freshly constructed or just reset). Note that we don't need to
+  // clear `buf` or `ptr` on `other.storage_` because `other.vtable_` defines
+  // whether it's empty.
+  void do_adopt(proxy& other) noexcept {
+    vtable_ = std::exchange(other.vtable_, nullptr);
+    if (!vtable_) return;
+    if (vtable_->relocate)
+      vtable_->relocate(other.storage_.buf, storage_.buf);
+    else
+      storage_.ptr = other.storage_.ptr;
+  }
+
+  storage_t storage_;
+  const owning_vtable_t* vtable_{};
+};
+
+// Library-provided binding so that an owning proxy satisfies its own facade,
+// like the view.
+//
+// Calls forward through the proxy, with conditional `noexcept`. The const
+// overload serves const-qualified methods, matching the proxy's deep const;
+// the non-const overload serves the rest.
+template<Facade F>
+struct proxy_impl<F, proxy<F>> {
+  template<fixed_string K, typename... Args>
+  static decltype(auto)
+  on(method_key<K>, proxy<F>& p, Args&&... args) noexcept(
+      noexcept(p.template call<K>(std::forward<Args>(args)...))) {
+    return p.template call<K>(std::forward<Args>(args)...);
+  }
+  template<fixed_string K, typename... Args>
+  static decltype(auto)
+  on(method_key<K>, const proxy<F>& p, Args&&... args) noexcept(
+      noexcept(p.template call<K>(std::forward<Args>(args)...))) {
+    return p.template call<K>(std::forward<Args>(args)...);
+  }
+};
+
+// Make an owning proxy of facade `F` holding a `T` constructed in place from
+// `args`.
+//
+// To move an existing object in, pass it as the constructor argument:
+// `make_proxy<F, T>(std::move(obj))`.
+template<Facade F, typename T, typename... Args>
+requires Proxiable<T, F>
+[[nodiscard]] proxy<F> make_proxy(Args&&... args) {
+  return proxy<F>{std::in_place_type<T>, std::forward<Args>(args)...};
 }
 
 #pragma endregion

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -264,10 +264,11 @@ concept Facade = requires(const F& f) { details::probe(f); };
 // lists, in declaration order, followed by its own; handles of the derived
 // facade dispatch inherited and own methods alike.
 //
-// A method name may not recur within one extends chain: a facade cannot
-// declare a name twice or redeclare (or override) an inherited one, which is
-// by design, because facades carry no implementations and there is nothing to
-// override.
+// Within one extends chain, a recurring method name forms an overload set,
+// legal when every pair differs in arguments or constness, whether the
+// declarations share a facade or span levels. A same-signature recurrence is
+// rejected eagerly, because that would be redeclaration (or overriding), and
+// facades carry no implementations, so there is nothing to override.
 //
 // Unrelated sibling bases MAY collide on a method name: distinct signatures
 // form an overload set that unqualified calls resolve by argument, and a

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -1,0 +1,384 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+#include <array>
+#include <concepts>
+#include <cstddef>
+#include <memory>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include "fixed_string.h"
+
+// Registration-based runtime polymorphism ("proxy") system.
+//
+// Type-erased handles over an interface definition (a facade), without
+// inheritance, vtable pointers in the target type, or macros.
+//
+// Conformance is based on name, not shape. A (facade, type) pair is bound by
+// an explicit `proxy_impl` specialization or by registering the pair to a
+// facade author's boilerplate impl, in the same spirit as registered enums.
+// See "proxy.md" for the design.
+namespace corvid { inline namespace meta { namespace prox {
+
+#pragma region Method and key
+
+// Method key.
+//
+// A tag carrying a method name as a compile-time string.
+//
+// `proxy_impl` bindings overload their `on` hook on it; it is how code
+// canonically names a method, given that a library cannot mint a member with a
+// caller-chosen name.
+template<fixed_string Name>
+struct key {
+  static constexpr auto name_v = Name;
+};
+
+// Method descriptor: a name plus the erased signature.
+//
+// The signature is spelled like a member function's definition, using the same
+// syntax that `std::function` takes. So, for example, it would look like
+// `std::string(int)`. Or, for `const this`, it would be `std::string(int)
+// const`.
+//
+// The signature fixes the erased ABI; a binding may return the declared result
+// type or anything convertible to it.
+//
+// A method derives from its `key`, so a method tag is usable anywhere its key
+// is, including `on` overload selection and deduction of `key<K>` from a
+// method argument. This also leaves the door open for bindings that overload
+// on the full method (signature included) if per-name overload sets are ever
+// supported.
+template<fixed_string Name, typename Sig>
+struct method;
+
+template<fixed_string Name, typename R, typename... Args>
+struct method<Name, R(Args...)>: key<Name> {
+  static constexpr bool const_v = false;
+  using result_t = R;
+};
+
+template<fixed_string Name, typename R, typename... Args>
+struct method<Name, R(Args...) const>: key<Name> {
+  static constexpr bool const_v = true;
+  using result_t = R;
+};
+
+#pragma endregion
+#pragma region Facade
+
+// Facade base: an interface definition.
+//
+// Derive a named, empty struct from `facade`, listing the methods. For
+// example:
+//
+//    struct animal : facade<method<"speak", void() const>> {};
+//
+// The derived type, `animal` here, IS the facade: it is the `F` in
+// `proxy_view<F>` and `proxy_impl<F, T>`, and the type registration keys on.
+//
+// Because identity is this named type rather than the method list, same-named
+// methods in unrelated facades cannot cross-contaminate. This is also why we
+// inherit from `facade` instead of just aliasing it.
+template<typename... Methods>
+struct facade {};
+
+namespace details {
+
+// Probe for the unique public `facade` base of `F`. Declared only; used in
+// unevaluated contexts.
+template<typename... Ms>
+auto facade_probe(const facade<Ms...>&) -> facade<Ms...>;
+
+} // namespace details
+
+// Concept for a type derived from a single `facade` base.
+template<typename F>
+concept Facade = requires(const F& f) { details::facade_probe(f); };
+
+#pragma endregion
+#pragma region Registration and binding
+
+// Binding point between a facade and a concrete type (Rust's `impl Trait for
+// Type`).
+//
+// Intentionally undefined. A specialization provides one static `on` overload
+// per facade method, taking the method's `key`, the target (const-qualified
+// per the method), and the method's arguments.
+//
+// A facade author typically also provides a boilerplate partial
+// specialization, generic over any registered `T` whose member names line up.
+// An explicit full specialization for one type outranks the boilerplate and
+// needs no registration.
+//
+// For example, given `struct animal : facade<method<"speak", void() const>>`:
+//
+//    // Facade author's boilerplate, written once, serving any registered
+//    // type whose member names line up:
+//    template<typename T>
+//    requires ProxyRegistered<animal, T>
+//    struct proxy_impl<animal, T> {
+//      static void on(key<"speak">, const T& t) { t.speak(); }
+//    };
+//
+//    // Conforming `dog`, whose names line up: pure registration.
+//    consteval auto corvid_proxy_spec(animal*, dog*) {
+//      return make_proxy_spec<animal, dog>();
+//    }
+//
+//    // Conforming `cat`, whose names differ: a custom impl, not registration.
+//    template<>
+//    struct proxy_impl<animal, cat> {
+//      static void on(key<"speak">, const cat& c) { c.meow(); }
+//    };
+template<typename F, typename T>
+struct proxy_impl;
+
+// Minimal registration spec.
+//
+// The value a registration hook returns, currently carrying no knobs. Distinct
+// from `corvid_proxy_spec`, which is the hook itself, provided by the user.
+// Because each hook's return type is deduced independently, richer spec types
+// can be added later without touching existing registrations.
+template<typename F, typename T>
+struct proxy_spec {};
+
+// Make the registration spec for a (facade, type) pair.
+//
+// Call this from a `corvid_proxy_spec` overload, just as
+// `make_sequence_enum_spec` is returned from `corvid_enum_spec`.
+template<typename F, typename T>
+[[nodiscard]] consteval proxy_spec<F, T> make_proxy_spec() noexcept {
+  return {};
+}
+
+// Concept for a (facade, type) pair being registered.
+//
+// To register a pair, declare a `corvid_proxy_spec(F*, T*)` overload returning
+// `make_proxy_spec<F, T>()`, in the namespace of either the facade or the
+// type; it is found here by ADL. The library never defines this function:
+// declaring an overload IS the act of registration. The `corvid_` prefix
+// marks it as a cross-namespace protocol name, the same convention as
+// `corvid_enum_spec`; a plain verb like `register_proxy` would risk collision
+// in user namespaces and would not read as a Corvid hook. The pointer
+// parameters are never dereferenced; they only carry the types.
+//
+// Registration gates a facade author's boilerplate impl; an explicit
+// `proxy_impl` specialization does not need it.
+template<typename F, typename T>
+concept ProxyRegistered = requires {
+  corvid_proxy_spec(static_cast<F*>(nullptr), static_cast<T*>(nullptr));
+};
+
+// Central access point for the registered spec, mirroring `enum_spec_v`. Each
+// specialization deduces its own type, so richer spec types can be introduced
+// later without touching existing registrations.
+template<typename F, typename T>
+requires ProxyRegistered<F, T>
+constexpr inline auto proxy_spec_v =
+    corvid_proxy_spec(static_cast<F*>(nullptr), static_cast<T*>(nullptr));
+
+#pragma endregion
+#pragma region Dispatch details
+
+namespace details {
+
+// Per-method dispatch machinery, split on the const qualification of the
+// erased signature: the thunk pointer type, the compile-time check that a
+// `proxy_impl` binding exists, and the thunk itself, which is where the
+// concrete type is seen for the last time before erasure.
+template<typename M>
+struct method_traits;
+
+template<fixed_string Name, typename R, typename... Args>
+struct method_traits<method<Name, R(Args...)>> {
+  using thunk_ptr_t = R (*)(void*, Args...);
+
+  template<typename F, typename T>
+  static constexpr bool bound_v = requires(T& t, Args... args) {
+    {
+      proxy_impl<F, T>::on(key<Name>{}, t, std::forward<Args>(args)...)
+    } -> std::convertible_to<R>;
+  };
+
+  template<typename F, typename T>
+  static consteval thunk_ptr_t make_thunk() noexcept {
+    return [](void* target, Args... args) -> R {
+      return proxy_impl<F, T>::on(key<Name>{}, *static_cast<T*>(target),
+          std::forward<Args>(args)...);
+    };
+  }
+};
+
+template<fixed_string Name, typename R, typename... Args>
+struct method_traits<method<Name, R(Args...) const>> {
+  using thunk_ptr_t = R (*)(const void*, Args...);
+
+  template<typename F, typename T>
+  static constexpr bool bound_v = requires(const T& t, Args... args) {
+    {
+      proxy_impl<F, T>::on(key<Name>{}, t, std::forward<Args>(args)...)
+    } -> std::convertible_to<R>;
+  };
+
+  template<typename F, typename T>
+  static consteval thunk_ptr_t make_thunk() noexcept {
+    return [](const void* target, Args... args) -> R {
+      return proxy_impl<F, T>::on(key<Name>{}, *static_cast<const T*>(target),
+          std::forward<Args>(args)...);
+    };
+  }
+};
+
+// Facade-wide dispatch machinery, specialized on the `facade` base to get at
+// the method pack: method count, name-to-slot lookup, the dispatch table type,
+// the all-methods-bound check behind `Proxiable`, and the table builder.
+template<typename FB>
+struct vtable_builder;
+
+template<typename... Ms>
+struct vtable_builder<facade<Ms...>> {
+  static constexpr std::size_t count_v = sizeof...(Ms);
+
+  using vtable_t = std::tuple<typename method_traits<Ms>::thunk_ptr_t...>;
+
+  // Slot index of the method named `K`, or `count_v` (as an `npos` or `end`
+  // flag) when there is none.
+  template<fixed_string K>
+  static consteval std::size_t index_of() noexcept {
+    constexpr std::array<bool, sizeof...(Ms)> matches{(Ms::name_v == K)...};
+    for (std::size_t ndx = 0; ndx != matches.size(); ++ndx)
+      if (matches[ndx]) return ndx;
+    return count_v;
+  }
+
+  template<typename F, typename T>
+  static constexpr bool all_bound_v =
+      (method_traits<Ms>::template bound_v<F, T> && ...);
+
+  template<typename F, typename T>
+  static consteval vtable_t make_vtable() noexcept {
+    return {method_traits<Ms>::template make_thunk<F, T>()...};
+  }
+};
+
+// Facade-wide machinery for the derived facade type `F`.
+template<Facade F>
+using vtbuild_t =
+    vtable_builder<decltype(facade_probe(std::declval<const F&>()))>;
+
+// Per-(facade, type) dispatch table instance. The handle stores a pointer to
+// this; the table pointer lives in the handle, not in the target (a fat
+// handle, like Rust's `&dyn`).
+template<Facade F, typename T>
+constexpr inline auto vtable_for = vtbuild_t<F>::template make_vtable<F, T>();
+
+} // namespace details
+
+#pragma endregion
+#pragma region Proxiable
+
+// Concept: `T` can back facade `F`.
+//
+// Satisfied when a usable `proxy_impl<F, T>` binding exists for every method
+// of `F`. An explicit specialization satisfies it directly; a facade author's
+// boilerplate satisfies it exactly when the pair is registered. This is the
+// gate on proxy construction and doubles as the trait bound for
+// static-dispatch templates.
+template<typename T, typename F>
+concept Proxiable =
+    Facade<F> && details::vtbuild_t<F>::template all_bound_v<F, T>;
+
+#pragma endregion
+#pragma region proxy_view
+
+// Non-owning erased handle over any `Proxiable` target: Rust's `&dyn Trait`,
+// ngcpp's `proxy_view`.
+//
+// Two pointers: the target and the per-(facade, type) dispatch table. Copyable
+// and shallow-const like other views: `call` is const and dispatches const and
+// non-const facade methods alike. The target must outlive the view.
+template<Facade F>
+class proxy_view {
+public:
+  using facade_t = F;
+
+  // Converting constructor from an lvalue target. Intentionally implicit, like
+  // `string_view` from `string`. Rvalues do not bind, so construction from a
+  // temporary is rejected at compile time; const targets are rejected until a
+  // const view flavor exists.
+  template<typename T>
+  requires(Proxiable<T, F> && !std::is_const_v<T> &&
+              !std::same_as<T, proxy_view>)
+  constexpr explicit(false) proxy_view(T& target) noexcept
+      : target_{std::addressof(target)}, vtable_{&details::vtable_for<F, T>} {}
+
+  // Call the facade method named `K`, forwarding `args` through the erased
+  // signature. Fails to compile when no method has that name; the `if
+  // constexpr` discards the dispatch on that path so the `static_assert` is
+  // the only error emitted.
+  template<fixed_string K, typename... Args>
+  constexpr decltype(auto) call(Args&&... args) const {
+    constexpr auto ndx = vtbuild_t::template index_of<K>();
+    static_assert(ndx != vtbuild_t::count_v,
+        "facade has no method with this name");
+    return std::get<ndx>(*vtable_)(target_, std::forward<Args>(args)...);
+  }
+
+private:
+  using vtbuild_t = details::vtbuild_t<F>;
+  using vtable_t = typename vtbuild_t::vtable_t;
+
+  void* target_;
+  const vtable_t* vtable_;
+};
+
+// Library-provided binding so that a view itself satisfies its own facade (as
+// in Rust, where `dyn Trait` implements `Trait`).
+//
+// Calls forward through the wrapped view. This makes facade-constrained
+// generic code accept concrete and erased arguments interchangeably, and
+// allows views of views.
+template<Facade F>
+struct proxy_impl<F, proxy_view<F>> {
+  template<fixed_string K, typename... As>
+  static constexpr decltype(auto)
+  on(key<K>, const proxy_view<F>& view, As&&... args) {
+    return view.template call<K>(std::forward<As>(args)...);
+  }
+};
+
+// Make a view over `target`.
+//
+// A convenience for spelling the facade at the call site. When `target` is
+// already a view of `F` it is copied rather than wrapped, so generic
+// facade-constrained code can erase its argument without stacking
+// indirections.
+template<Facade F, typename T>
+requires Proxiable<T, F>
+[[nodiscard]] constexpr proxy_view<F> make_proxy_view(T& target) noexcept {
+  if constexpr (std::same_as<std::remove_cv_t<T>, proxy_view<F>>)
+    return target;
+  else
+    return proxy_view<F>{target};
+}
+
+#pragma endregion
+
+}}} // namespace corvid::meta::prox

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -268,8 +268,8 @@ concept Facade = requires(const F& f) { details::probe(f); };
 // declarations share a facade or span levels. A same-signature recurrence is
 // rejected eagerly, because that would be redeclaration (or overriding), and
 // facades carry no implementations, so there is nothing to override. The
-// degenerate case, the identical method listed twice, collapses to a single
-// slot instead of erroring (see `dedup_slots`).
+// degenerate case, the identical entry listed twice, is rejected as a
+// duplicate entry.
 //
 // Unrelated sibling bases MAY collide on a method name: distinct signatures
 // form an overload set that unqualified calls resolve by argument, and a
@@ -1108,10 +1108,10 @@ consteval std::size_t first_index_of_type() noexcept {
 //
 // A slot type recurs when the same ancestor facade is reached through more
 // than one composition path, so this is what collapses a diamond to a single
-// set of slots; it also swallows the degenerate case of one facade listing the
-// identical method twice. Per-facade conformance already yields one
-// `proxy_impl<Ancestor, T>` regardless of path (the effect of Rust's coherence
-// rule); dedup makes the flattened table agree.
+// set of slots (a literal duplicate entry would also collapse here, but
+// `entry_listed_once` rejects it instead). Per-facade conformance already
+// yields one `proxy_impl<Ancestor, T>` regardless of path (the effect of
+// Rust's coherence rule); dedup makes the flattened table agree.
 template<typename Slots>
 struct dedup_slots;
 template<typename... Ss>
@@ -1190,8 +1190,8 @@ consteval bool legal_overload_pair() noexcept {
 // functions that happen to share a spelling, exactly as within one facade.
 // A same-signature recurrence stays an error, since that is redeclaration (or
 // overriding), and facades carry no implementations, so there is nothing to
-// override. The identical declaration listed twice is the exception: dedup
-// collapses it to one slot before this check sees it.
+// override. A literal duplicate entry never reaches this check: dedup
+// collapses it away, and `entry_listed_once` rejects it instead.
 //
 // Unrelated sibling facades may collide on a method name freely, including
 // on the full signature, since every facade is named and the qualified
@@ -1272,6 +1272,19 @@ struct entry_name<name<Name>> {
   static constexpr auto name_v = Name;
   static constexpr bool is_name_v = true;
 };
+
+// `entry_listed_once`: whether entry `E` appears exactly once in the facade's
+// declaration list.
+//
+// A literal duplicate entry, the identical `method` or `extends` spelled
+// twice, is a copy-paste slip with no meaning: dedup would silently collapse
+// the duplicate's slots, so the entry list is checked before flattening can
+// hide it. A diamond is different, two DISTINCT entries whose chains share an
+// ancestor, and stays legal.
+template<typename E, typename... Es>
+consteval bool entry_listed_once() noexcept {
+  return (0 + ... + std::same_as<E, Es>) == 1;
+}
 
 // `facade_name_of_v`: name of a facade with entries `Es`.
 //
@@ -1649,6 +1662,8 @@ struct vtable_builder<facade<Es...>>
           facade_name_of_v<Es...>> {
   static_assert((0 + ... + entry_name<Es>::is_name_v) == 1,
       "every facade must carry exactly one name entry");
+  static_assert((entry_listed_once<Es, Es...>() && ...),
+      "a facade may not list the identical method or extends entry twice");
 
   using impl_t = vtable_builder_impl<flat_slots_of_t<Es...>, bases_of_t<Es...>,
       facade_name_of_v<Es...>>;

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -86,9 +86,7 @@ namespace prox {
 
 #pragma region Method and key
 
-// `method_key`.
-//
-// A tag carrying a method name as a compile-time string.
+// `method_key`: a tag carrying a method name as a compile-time string.
 //
 // `proxy_impl` bindings overload their `on` hook on it; it is how code
 // canonically names a method, given that a library cannot mint a member with a
@@ -1282,27 +1280,24 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
     return owner.view() == qual;
   }
 
-  // `candidates`: per-slot flags over the whole list, containing the
-  // candidates answering to `Key` (const-qualified only, when dispatching
-  // through a const handle), and the slots whose declared parameters match
-  // `CallArgs` exactly or are viable through ordinary conversions.
+  // `candidates`: per-slot flags over the whole list, marking the slots that
+  // answer to `Key` (const-qualified only, when dispatching through a const
+  // handle).
   template<fixed_string Key, bool ConstOnly>
   static consteval std::array<bool, count_v> candidates() noexcept {
     return {(slot_matches<Ss, Key>() && (!ConstOnly || Ss::const_v))...};
   }
 
-  // `exact_flags`, `viable_flags`: per-slot flags over the whole list,
-  // containing the slots whose declared parameters match `CallArgs` exactly or
-  // are viable through ordinary conversions.
+  // `exact_flags`, `viable_flags`: per-slot flags over the whole list, marking
+  // the slots whose declared parameters match `CallArgs` exactly (after
+  // normalization) or are viable through the ordinary conversions a call
+  // performs.
   template<typename... CallArgs>
   static consteval std::array<bool, count_v> exact_flags() noexcept {
     return {method_traits<typename Ss::method_t>::template exact_v<
         CallArgs...>...};
   }
 
-  // `exact_flags`, `viable_flags`: per-slot flags over the whole list,
-  // containing the slots whose declared parameters match `CallArgs` exactly or
-  // are viable through ordinary conversions.
   template<typename... CallArgs>
   static consteval std::array<bool, count_v> viable_flags() noexcept {
     return {method_traits<typename Ss::method_t>::template viable_v<
@@ -1463,10 +1458,12 @@ struct vtable_builder<facade<Es...>>
   using ancestors_t = dedup_slots_t<decltype(std::tuple_cat(
       std::declval<typename entry_traits<Es>::chain_t>()...))>;
 
-  // `owning_vtable_t`: owning dispatch table, carrying housekeeping slots
-  // alongside the facade methods, plus the address of each direct base's
-  // owning table for the same target type, which is what makes owning upcasts
-  // a pointer read (mirroring `vtable_t::bases`).
+  // `owning_vtable_t`: owning dispatch table.
+  //
+  // Carries housekeeping slots alongside the facade methods, plus the address
+  // of each direct base's owning table for the same birth, target type, and
+  // storage mode, which is what makes owning upcasts a pointer read (mirroring
+  // `vtable_t::bases`).
   //
   // A null `relocate` marks a heap-stored target, which moves by pointer
   // steal rather than relocation. A null `copy` marks a target that is not
@@ -1501,9 +1498,9 @@ struct vtable_builder<facade<Es...>>
     owning_bases_t bases;
   };
 
-  // `owning_bases_t`: owning-table pointers of the direct bases, for the same
-  // born family, target, and mode, built over the direct-base pack (carried by
-  // the tuple pointer parameter, as in `make_ancestor_table`).
+  // `make_owning_bases`: owning-table pointers of the direct bases, for the
+  // same born family, target, and mode, built over the direct-base pack
+  // (carried by the tuple pointer parameter, as in `make_ancestor_table`).
   //
   // Deliberately a member rather than an `entry_traits` hook, and with a
   // spelled-out return type: an entry's helper is shared by every facade
@@ -1619,8 +1616,9 @@ dispatch(const typename vtbuild_t<F>::thunks_t& tks, ErasedPtr target,
 // Satisfied when a usable `proxy_impl<F, T>` binding exists for every method
 // of `F`.
 //
-// An explicit specialization satisfies it directly; a facade author's
-// boilerplate satisfies it exactly when the pair is registered.
+// Both binding routes, the facade's boilerplate and the registration-carried
+// impl, are registration-gated, so the concept is satisfied exactly when the
+// pair is registered with a usable binding.
 //
 // This is the gate on proxy construction and doubles as the trait bound for
 // static-dispatch templates.
@@ -1628,7 +1626,7 @@ template<typename T, typename F>
 concept Proxiable =
     Facade<F> && details::vtbuild_t<F>::template all_bound_v<F, T>;
 
-// `Extends` concept for  when facade `D` (transitively) extends facade `B`
+// `Extends`: concept for when facade `D` (transitively) extends facade `B`
 // through `extends` composition entries.
 //
 // Strict: false when `D` is `B` itself. Constraints that mean "B or anything
@@ -1638,7 +1636,7 @@ concept Extends =
     Facade<D> && Facade<B> &&
     details::vtbuild_t<D>::template extends_facade<B>();
 
-// `InChainOf` concept for when facade `B` is `D` itself or a facade `D`
+// `InChainOf`: concept for when facade `B` is `D` itself or a facade `D`
 // (transitively) extends.
 //
 // This is `Extends` made reflexive and argument-flipped, so it can constrain
@@ -1698,7 +1696,8 @@ struct handle_facade<shared_proxy<F>> {
 };
 
 // `is_handle_for`: whether `T` is a proxy handle whose facade is `F` or
-// extends the set the dedicated viewing and upcasting constructors serve.
+// extends it, the set served by the dedicated viewing and upcasting
+// constructors.
 //
 // The generic erased-target constructors exclude it, so re-pointing at such a
 // handle's target always wins over wrapping the handle itself as a target.
@@ -1938,7 +1937,7 @@ class proxy_view: public details::view_base<F, false> {
   using vtbuild_t = details::vtbuild_t<F>;
 
 public:
-  // `proxy_view`: An empty view holds no target; see the class comment.
+  // `proxy_view`: an empty view holds no target; see the class comment.
   proxy_view() = default;
 
   // `proxy_view`: converting constructor from an lvalue target.
@@ -1978,7 +1977,7 @@ public:
   explicit(false) proxy_view(proxy<D, P>& p) noexcept
       : base{p.target(), details::upcast_vtable<F, D>(&p.vtable_->vt)} {}
 
-  // `proxy_view`: viewing constructor from a shared `proxy` of `F`, or of a
+  // `proxy_view`: viewing constructor from a `shared_proxy` of `F`, or of a
   // facade that extends it, under the same rules as viewing an owning `proxy`;
   // the target must outlive the view, meaning at least one shared owner must.
   template<Facade D>
@@ -2107,8 +2106,8 @@ public:
       const_proxy_view(const proxy_view<D>& view) noexcept
       : base{view.target_, details::upcast_vtable<F, D>(view.vtable_)} {}
 
-  // `const_proxy_view`: viewing constructor from an owning proxy of `F`, or of
-  // a facade that extends it.
+  // `const_proxy_view`: viewing constructor from an owning `proxy` of `F`, or
+  // of a facade that extends it.
   //
   // Intentionally implicit, and lvalue-only. The proxy must be non-empty and
   // must outlive the view. Mutable and const proxies alike yield the const
@@ -2118,14 +2117,14 @@ public:
   explicit(false) const_proxy_view(const proxy<D, P>& p) noexcept
       : base{p.target(), details::upcast_vtable<F, D>(&p.vtable_->vt)} {}
 
-  // `const_proxy_view`: viewing constructor from a shared proxy of `F`, or of
-  // a facade that extends it; see the owning-proxy constructor above.
+  // `const_proxy_view`: viewing constructor from a `shared_proxy` of `F`, or
+  // of a facade that extends it; see the owning-proxy constructor above.
   template<Facade D>
   requires(std::same_as<D, F> || Extends<D, F>)
   explicit(false) const_proxy_view(const shared_proxy<D>& p) noexcept
       : base{p.target(), details::upcast_vtable<F, D>(p.vtable_)} {}
 
-  // No need for a `using` because`call` is inherited. The base's const-method
+  // No need for a `using` because `call` is inherited. The base's const-method
   // dispatch is the entire interface, since the mutable methods do not exist
   // on this view.
 
@@ -2366,9 +2365,9 @@ public:
   // no target.
   [[nodiscard]] explicit operator bool() const noexcept { return vtable_; }
 
-  // `can_clone`: whether `clone` is callable, meaning that the target is
-  // copy-constructible, or there is no target at all (an empty proxy clones to
-  // an empty proxy).
+  // `can_clone`: whether `clone` would produce a faithful copy, meaning that
+  // the target is copy-constructible, or there is no target at all (an empty
+  // proxy clones to an empty proxy).
   //
   // The answer is a runtime property of the erased target, not of the proxy
   // type; a container of proxies can mix cloneable and uncloneable targets.
@@ -2406,10 +2405,11 @@ public:
   // `clone`: clone the `proxy`, creating a new instance with the same policy,
   // owning a copy of the target made through the table's copy slot.
   //
-  // Requires `can_clone()`; cloning a proxy over a non-copyable target is a
-  // precondition violation, like calling through an empty proxy. The copy
-  // itself can throw (the target's copy constructor, or the allocation), in
-  // which case nothing leaks and no clone is produced.
+  // Cloning an empty proxy yields an empty one, and so does cloning a proxy
+  // whose target is not copy-constructible; `can_clone` is the up-front check
+  // that tells those apart. The copy itself can throw (the target's copy
+  // constructor, or the allocation), in which case nothing leaks and no clone
+  // is produced.
   //
   // This is deliberately a named method rather than a copy constructor: an
   // unconditional copy constructor would satisfy `std::copyable` for every
@@ -2691,10 +2691,19 @@ requires Proxiable<T, F>
 // backed by a `std::shared_ptr<void>`.
 //
 // Copyable, and a copy shares the one target rather than cloning it; the
-// target dies with its last owner. The control block already type-erases
-// destruction, so no owning table is needed: the handle is the shared
-// pointer plus the same per-(facade, type) dispatch table the views use.
-// There is no inline-storage mode, so the target's address is always stable.
+// target dies with its last owner.
+//
+// Storing the pointer as `shared_ptr<void>` does not lose destruction: a
+// `shared_ptr`'s deleter lives in its control block, fixed when the first
+// owner was created, and converting a `shared_ptr<T>` to `shared_ptr<void>`
+// hands over that control block untouched, so the target is still destroyed as
+// a `T`. (Adoption from an owning `proxy` has no typed pointer to start from;
+// it supplies the owning table's destroy thunk as the deleter instead.)
+//
+// The control block therefore type-erases destruction on its own, which is why
+// no owning table is needed: the handle is the shared pointer plus the same
+// per-(facade, type) dispatch table the views use. There is no inline-storage
+// mode, so the target's address is always stable.
 //
 // Ownership interoperates with `std`: construct from a `std::shared_ptr<T>`
 // (sharing with any outside holders) or a `std::unique_ptr<T>` (which
@@ -2724,8 +2733,8 @@ public:
   // `shared_proxy`: adopting constructor from shared ownership of a concrete
   // target. A null pointer yields an empty handle.
   //
-  //  Usually spelled through `make_shared_proxy`; there is deliberately no
-  //  raw-pointer constructor.
+  // Usually spelled through `make_shared_proxy`; there is deliberately no
+  // raw-pointer constructor.
   template<typename T>
   requires Proxiable<T, F>
   explicit shared_proxy(std::shared_ptr<T> target) noexcept
@@ -2741,8 +2750,8 @@ public:
   explicit shared_proxy(std::unique_ptr<T> target)
       : shared_proxy{std::shared_ptr<T>{std::move(target)}} {}
 
-  // `shared_proxy`: adopting constructor from an owning proxy of `F`, or of a
-  // facade that extends it.
+  // `shared_proxy`: adopting constructor from an owning `proxy` of `F`, or of
+  // a facade that extends it.
   //
   // The unique ownership becomes shared (Rust: `Box<dyn T>` into `Rc<dyn T>`),
   // consuming the source.
@@ -2779,9 +2788,9 @@ public:
     vtable_ = &ovt->vt;
   }
 
-  // `shared_proxy`: upcasting converting constructors from a shared proxy of a
-  // facade that extends `F`, sharing (copy) or transferring (move) ownership.
-  // Intentionally implicit, like every handle upcast.
+  // `shared_proxy`: upcasting converting constructors from a `shared_proxy`
+  // of a facade that extends `F`, sharing (copy) or transferring (move)
+  // ownership. Intentionally implicit, like every handle upcast.
   template<Facade D>
   requires Extends<D, F>
   explicit(false) shared_proxy(const shared_proxy<D>& other) noexcept
@@ -2887,12 +2896,12 @@ class weak_proxy {
   using vtable_t = details::vtbuild_t<F>::vtable_t;
 
 public:
-  // `weak_proxy`:an empty weak proxy observes nothing; `lock` yields an empty
-  // handle.
+  // `weak_proxy`: an empty weak proxy observes nothing; `lock` yields an
+  // empty handle.
   weak_proxy() = default;
 
-  // `weak_proxy`: observe a shared proxy of `F`, or of a facade that extends
-  // it (the upcast happens here, so `lock` is cheap).
+  // `weak_proxy`: observe a `shared_proxy` of `F`, or of a facade that
+  // extends it (the upcast happens here, so `lock` is cheap).
   //
   // Intentionally implicit.
   template<Facade D>
@@ -2901,8 +2910,9 @@ public:
       : target_{p.target_},
         vtable_{p ? details::upcast_vtable<F, D>(p.vtable_) : nullptr} {}
 
-  // `weak_proxy`: upcasting converting constructors from a weak proxy of a
-  // facade that extends `F`, by copy or by move, mirroring the shared proxy's.
+  // `weak_proxy`: upcasting converting constructors from a `weak_proxy` of a
+  // facade that extends `F`, by copy or by move, mirroring the
+  // `shared_proxy`'s.
   //
   // Intentionally implicit, like every handle upcast. An expired source
   // upcasts like a live one, still observing the same target; expiry stays

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -147,27 +147,38 @@ struct method_base: method_key<Name> {
 //
 // A method derives from its `method_key`, so a method tag is usable anywhere
 // its key is, including `on` overload selection and deduction of
-// `method_key<Key>` from a method argument. This also leaves the door open for
-// bindings that overload on the full method (signature included) if per-name
-// overload sets are ever supported.
+// `method_key<Key>` from a method argument. This also leaves the door open
+// for bindings that overload on the full method (signature included);
+// per-name overload sets themselves are supported by listing the name
+// repeatedly, and the bindings overload on the trailing parameters.
+//
+// Each specialization exposes `args_t`, the declared parameter list, for
+// introspection (`codegen` walks it).
 template<fixed_string Name, typename Sig>
 struct method;
 
 template<fixed_string Name, typename R, typename... Args>
 struct method<Name, R(Args...)>: details::method_base<Name, false, false, R> {
+  using args_t = std::tuple<Args...>;
 };
 
 template<fixed_string Name, typename R, typename... Args>
 struct method<Name, R(Args...) const>
-    : details::method_base<Name, true, false, R> {};
+    : details::method_base<Name, true, false, R> {
+  using args_t = std::tuple<Args...>;
+};
 
 template<fixed_string Name, typename R, typename... Args>
 struct method<Name, R(Args...) noexcept>
-    : details::method_base<Name, false, true, R> {};
+    : details::method_base<Name, false, true, R> {
+  using args_t = std::tuple<Args...>;
+};
 
 template<fixed_string Name, typename R, typename... Args>
 struct method<Name, R(Args...) const noexcept>
-    : details::method_base<Name, true, true, R> {};
+    : details::method_base<Name, true, true, R> {
+  using args_t = std::tuple<Args...>;
+};
 
 #pragma endregion
 #pragma region Facade
@@ -213,8 +224,16 @@ struct method<Name, R(Args...) const noexcept>
 //
 // The facade body is also the normal home of the boilerplate impl; see also
 // `proxy_impl`.
+//
+// A facade is an interface descriptor, never a value: declare a handle over
+// it (`proxy<F>`, `proxy_view<F>`, ...) rather than an instance of it. The
+// deleted default constructor propagates to derived facades, so a stray
+// `gunslinger g;` fails at the declaration instead of compiling into a
+// useless empty object.
 template<typename... Methods>
-struct facade {};
+struct facade {
+  facade() = delete;
+};
 
 namespace details {
 

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -33,9 +33,9 @@
 
 // Registration-based runtime polymorphism ("proxy") system.
 //
-// Type-erased handles (`proxy`, `proxy_view`, `const_proxy_view`) over an
-// interface definition (a facade), without inheritance, vtable pointers in the
-// target type, or macros.
+// Type-erased handles (`proxy`, `proxy_view`, `const_proxy_view`,
+// `shared_proxy`, `weak_proxy`) over an interface definition (a facade),
+// without inheritance, vtable pointers in the target type, or macros.
 //
 // Opting a class into a facade does not require modifying it, so you can
 // retrofit a facade onto an existing type (even one in `std`), or have
@@ -53,7 +53,7 @@
 // implicitly to handles of any facade theirs extends (Rust trait upcasting).
 //
 // See "proxy.md" for the design.
-//
+
 // Template parameter conventions, used consistently throughout this header:
 //
 // - `F`: the facade being dispatched, bound, or validated.
@@ -135,10 +135,9 @@ struct method_base: method_key<Name> {
 
 // `method`: Method descriptor, a name plus the erased signature.
 //
-// The signature is spelled like a member function's definition, using the same
-// syntax that `std::function` takes. So, for example, it would look like
-// `std::string(int)`. Or, for `const this`, it would be `std::string(int)
-// const`.
+// The signature is spelled like a member function's definition. So, for
+// example, it would look like `std::string(int)`. Or, for `const this`, it
+// would be `std::string(int) const`.
 //
 // The signature fixes the erased ABI; a binding may return the declared result
 // type or anything convertible to it.
@@ -268,7 +267,9 @@ concept Facade = requires(const F& f) { details::probe(f); };
 // legal when every pair differs in arguments or constness, whether the
 // declarations share a facade or span levels. A same-signature recurrence is
 // rejected eagerly, because that would be redeclaration (or overriding), and
-// facades carry no implementations, so there is nothing to override.
+// facades carry no implementations, so there is nothing to override. The
+// degenerate case, the identical method listed twice, collapses to a single
+// slot instead of erroring (see `dedup_slots`).
 //
 // Unrelated sibling bases MAY collide on a method name: distinct signatures
 // form an overload set that unqualified calls resolve by argument, and a
@@ -347,10 +348,11 @@ using api_base_t = api_base<F>::type;
 // `proxy_policy`), and on the heap otherwise.
 //
 // `sbo_only` forbids the heap path: constructing a proxy over an ineligible
-// target is a compile error, and a heap target arriving through a
-// converting move is un-boxed into the buffer, throwing `std::length_error`
-// if it does not fit (the one runtime failure, since an erased target's size
-// cannot be checked statically).
+// target is a compile error. An erased target arriving through a converting
+// move must end up in the buffer (a heap arrival is un-boxed into it), and the
+// adoption throws `std::length_error` when the target does not fit or cannot
+// move inline at all, the one runtime failure, since an erased arrival cannot
+// be checked statically.
 //
 // `heap_only` forbids the inline path, so every target has a stable heap
 // address, and the proxy carries no inline buffer at all; an inline target
@@ -372,7 +374,7 @@ enum class proxy_alloc : std::uint8_t {
 // A target is stored inline when it fits `sbo_size` and `sbo_align` and is
 // nothrow-move-constructible (a proxy move relocates an inline target, and
 // proxy moves are unconditionally `noexcept`). The exception is when the
-// source is on the heap and the target allows heap storage, in which case only
+// source is on the heap and the policy allows heap storage, in which case only
 // the pointer is moved.
 //
 // Policies are checked at proxy construction, not at registration.
@@ -1076,11 +1078,12 @@ consteval std::size_t first_index_of_type() noexcept {
 // `dedup_slots`: remove duplicate slot types, keeping first occurrences in
 // order.
 //
-// A slot type recurs exactly when the same ancestor facade is reached
-// through more than one composition path, so this is what collapses a
-// diamond to a single set of slots. Per-facade conformance already yields
-// one `proxy_impl<Ancestor, T>` regardless of path (the effect of Rust's
-// coherence rule); dedup makes the flattened table agree.
+// A slot type recurs when the same ancestor facade is reached through more
+// than one composition path, so this is what collapses a diamond to a single
+// set of slots; it also swallows the degenerate case of one facade listing the
+// identical method twice. Per-facade conformance already yields one
+// `proxy_impl<Ancestor, T>` regardless of path (the effect of Rust's coherence
+// rule); dedup makes the flattened table agree.
 template<typename Slots>
 struct dedup_slots;
 template<typename... Ss>
@@ -1157,9 +1160,10 @@ consteval bool legal_overload_pair() noexcept {
 // `legal_overload_pair`), whether the declarations share a facade or span
 // levels: a base's `foo()` and a derived facade's `foo(int)` are different
 // functions that happen to share a spelling, exactly as within one facade.
-// A same-signature recurrence stays an error, since that is redeclaration
-// (or overriding), and facades carry no implementations, so there is
-// nothing to override.
+// A same-signature recurrence stays an error, since that is redeclaration (or
+// overriding), and facades carry no implementations, so there is nothing to
+// override. The identical declaration listed twice is the exception: dedup
+// collapses it to one slot before this check sees it.
 //
 // Unrelated sibling facades may collide on a method name freely, including
 // on the full signature, since every facade is named and the qualified
@@ -2804,7 +2808,7 @@ private:
   //
   // The active union member is keyed by the table's `relocate` slot (null
   // means heap), an invariant every write site maintains but the static
-  // analyzer cannot see, so the union reads here and in `do_adopt` and
+  // analyzer cannot see, so the union reads here and in `do_take_heap` and
   // `try_downcast` suppress its uninitialized-value checks.
   [[nodiscard]] void* target() noexcept {
     assert(vtable_);

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -206,10 +206,11 @@ concept Facade = requires(const F& f) { details::probe(f); };
 // lists, in declaration order, followed by its own; handles of the derived
 // facade dispatch inherited and own methods alike.
 //
-// Names must be unique across the flattened list, so for now a facade cannot
-// redeclare (or override) an inherited method, and diamond composition is
-// rejected. Both are limits of the current implementation rather than the
-// model, with relaxation paths recorded under Future in "proxy.md".
+// Names must be unique across the flattened list. A facade cannot redeclare
+// (or override) an inherited method, which is by design, because facades carry
+// no implementations and there is nothing to override. Diamond composition is
+// also rejected, but that is a limit of the current implementation rather than
+// the model, with the dedup path recorded under Future in "proxy.md".
 //
 // Conformance is per facade, as with Rust supertraits: a type conforms to
 // `pet` by binding `pet`'s own methods through `proxy_impl<pet, T>` and

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -1095,14 +1095,31 @@ consteval bool same_chain_owners() noexcept {
            vtbuild_t<o2_t>::template extends_facade<o1_t>();
 }
 
+// `legal_overload_pair`: whether two same-name slots declared by the same
+// facade form a legal overload pair: distinct normalized argument lists, or
+// the same arguments with different constness (the const-pair idiom, a
+// mutable accessor and a read-only query sharing a name).
+//
+// The C++ member rules apply: the result type and `noexcept` do not
+// overload, so a pair distinguished by nothing else is a collision.
+template<typename S1, typename S2>
+consteval bool legal_overload_pair() noexcept {
+  using args1_t = method_traits<typename S1::method_t>::norm_args_t;
+  using args2_t = method_traits<typename S2::method_t>::norm_args_t;
+  return !std::same_as<args1_t, args2_t> || S1::const_v != S2::const_v;
+}
+
 // `no_chain_collision_against`, `owner_names_unique_against`: the two
 // collision detonators, each pitting slot `S1` against the whole list.
 // Post-dedup, a repeated slot type is only ever the self-pairing, so same-type
 // pairs are skipped.
 //
-// A method name may not recur within one extends chain (a doubled declaration,
-// or a derived facade redeclaring an inherited name, which is rejected by
-// design: facades carry no implementations, so there is nothing to override).
+// Within one declaring facade, a recurring method name is an overload set,
+// legal when every pair differs in arguments or constness (see
+// `legal_overload_pair`). Across an extends chain a name may not recur at
+// all: a derived facade cannot redeclare (or overload, or override) an
+// inherited name, by design, because facades carry no implementations and
+// there is nothing to override.
 //
 // Unrelated sibling facades may collide on a method name freely, since every
 // facade is named and the qualified spelling is always available as the route
@@ -1111,9 +1128,12 @@ consteval bool same_chain_owners() noexcept {
 // collide.
 template<typename S1, typename... Ss>
 consteval bool no_chain_collision_against() noexcept {
-  return ((std::same_as<S1, Ss> || S1::name_v != Ss::name_v ||
-              !same_chain_owners<S1, Ss>()) &&
-          ...);
+  return (
+      (std::same_as<S1, Ss> || S1::name_v != Ss::name_v ||
+          (std::same_as<typename S1::owner_t, typename Ss::owner_t>
+                  ? legal_overload_pair<S1, Ss>()
+                  : !same_chain_owners<S1, Ss>())) &&
+      ...);
 }
 
 template<fixed_string OwnName, typename S1, typename... Ss>
@@ -1210,8 +1230,8 @@ struct vtable_builder_impl;
 template<typename... Ss, typename... Bs, fixed_string OwnName>
 struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
   static_assert((no_chain_collision_against<Ss, Ss...>() && ...),
-      "a facade cannot declare a method name twice or redeclare an inherited "
-      "one");
+      "a method name may recur within one facade only as overloads differing "
+      "in arguments or constness, and never across an extends chain");
   static_assert((owner_names_unique_against<OwnName, Ss, Ss...>() && ...),
       "facade names must be unique within a composition");
 
@@ -1356,41 +1376,82 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
     return {cnt, at};
   }
 
+  // `nonconst_flags`: per-slot flags marking the non-const methods, the
+  // tiebreak preference for dispatch through a mutable handle.
+  static consteval std::array<bool, count_v> nonconst_flags() noexcept {
+    return {!Ss::const_v...};
+  }
+
+  // `tally_preferring_nonconst`: tally `flags`, breaking a tie in favor of a
+  // unique non-const candidate.
+  //
+  // This is C++ overload resolution's object-parameter preference, applied
+  // as a tiebreak: through a mutable handle (`ConstOnly` false), a name
+  // overloaded on constness alone resolves to its non-const member, as a
+  // call on a non-const object would. Through a const handle the candidate
+  // set was already const-filtered, so there is nothing to prefer. The
+  // preference is uniform across a candidate set, so a sibling collision
+  // differing only in constness resolves the same way, matching the stated
+  // using-merge model.
+  template<bool ConstOnly>
+  static consteval std::pair<std::size_t, std::size_t>
+  tally_preferring_nonconst(const std::array<bool, count_v>& flags) noexcept {
+    const auto whole = tally(flags);
+    if constexpr (!ConstOnly) {
+      if (whole.first > 1) {
+        const auto preferred = tally(both(flags, nonconst_flags()));
+        if (preferred.first == 1) return preferred;
+      }
+    }
+    return whole;
+  }
+
   // `resolve`: resolve `Key`, called with `CallArgs`, to a slot index, or to
   // `none_v` or `ambiguous_v`.
   //
-  // A qualified key names its slot outright. An unqualified key with a
-  // single candidate resolves to it unconditionally, so a call with
-  // unsuitable arguments still fails directly at the thunk. An unqualified
-  // key over a sibling overload set resolves the way a C++ call would: a
-  // unique exact signature match wins, else a unique viable candidate, and
-  // anything else is ambiguous and needs the qualified spelling. `ConstOnly`
-  // restricts the candidates to const-qualified methods, for dispatch
-  // through const handles.
+  // An unqualified key with a single candidate resolves to it
+  // unconditionally, so a call with unsuitable arguments still fails
+  // directly at the thunk; a qualified key narrows the candidates to one
+  // facade's before the same rules run. A key over an overload set (per-name
+  // overloads within a facade, or a sibling collision) resolves the way a
+  // C++ call would after a using-merge: a unique exact signature match
+  // wins, else a unique viable candidate, with constness as the tiebreak
+  // within each tier (see `tally_preferring_nonconst`), and anything else
+  // is ambiguous. `ConstOnly` restricts the candidates to const-qualified
+  // methods, for dispatch through const handles.
+  //
+  // The two tiers plus the tiebreak are deliberately not full C++
+  // implicit-conversion ranking: within the viable tier no candidate
+  // outranks another by conversion quality (a promotion does not beat a
+  // conversion), and an exact argument match on a const method outranks the
+  // object-parameter preference where real member overloading would weigh
+  // them together. Arguments first, constness second, predictably.
   template<fixed_string Key, bool ConstOnly, typename... CallArgs>
   static consteval std::size_t resolve() noexcept {
     constexpr auto cand = candidates<Key, ConstOnly>();
     const auto [cnt, at] = tally(cand);
     if (cnt < 2) return cnt ? at : none_v;
-    const auto [exact_cnt, exact_at] =
-        tally(both(cand, exact_flags<CallArgs...>()));
+    const auto [exact_cnt, exact_at] = tally_preferring_nonconst<ConstOnly>(
+        both(cand, exact_flags<CallArgs...>()));
     if (exact_cnt == 1) return exact_at;
     if (exact_cnt > 1) return ambiguous_v;
-    const auto [viable_cnt, viable_at] =
-        tally(both(cand, viable_flags<CallArgs...>()));
+    const auto [viable_cnt, viable_at] = tally_preferring_nonconst<ConstOnly>(
+        both(cand, viable_flags<CallArgs...>()));
     if (viable_cnt == 1) return viable_at;
     return viable_cnt ? ambiguous_v : none_v;
   }
 
   // `resolve_exact`: resolve `Key` to the unique candidate whose declared
-  // parameters match `CallArgs` exactly.
+  // parameters match `CallArgs` exactly, with the same constness tiebreak as
+  // `resolve`.
   //
   // This is the validation probe's strictness: a merely-viable signature does
-  // not count.
+  // not count. The tiebreak is what lets the probe's mutable strict call
+  // single out the non-const member of a const pair.
   template<fixed_string Key, bool ConstOnly, typename... CallArgs>
   static consteval std::size_t resolve_exact() noexcept {
-    const auto [cnt, at] =
-        tally(both(candidates<Key, ConstOnly>(), exact_flags<CallArgs...>()));
+    const auto [cnt, at] = tally_preferring_nonconst<ConstOnly>(
+        both(candidates<Key, ConstOnly>(), exact_flags<CallArgs...>()));
     if (cnt == 1) return at;
     return cnt ? ambiguous_v : none_v;
   }
@@ -1655,7 +1716,8 @@ dispatch(const typename vtbuild_t<F>::thunks_t& tks, ErasedPtr target,
       vtbuild_t<F>::template resolve<Key, ConstOnly, Args...>();
   static_assert(ndx != vtbuild_t<F>::none_v, "no matching signature");
   static_assert(ndx != vtbuild_t<F>::ambiguous_v,
-      "ambiguous method name; qualify the key with the facade name");
+      "ambiguous method call; qualify the key with the facade name, or match "
+      "one overload's arguments exactly");
   return std::get<ndx>(tks)(target, std::forward<Args>(args)...);
 }
 

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -19,6 +19,8 @@
 #include <cassert>
 #include <concepts>
 #include <cstddef>
+#include <cstdint>
+#include <exception>
 #include <memory>
 #include <new>
 #include <tuple>
@@ -173,7 +175,7 @@ concept Facade = requires(const F& f) { details::probe(f); };
 
 namespace details {
 
-// Stand-in api base for facades that define no member-call sugar.
+// Stand-in API base for facades that define no member-call sugar.
 struct no_api {};
 
 // Sugar base for handles of facade `F`.
@@ -253,12 +255,48 @@ struct proxy_impl;
 template<typename F, typename T>
 struct proxy_spec {};
 
+namespace details {
+
+// Forward declaration; defined under "API validation".
+template<Facade F>
+struct api_probe;
+
+} // namespace details
+
+// Forward declaration; defined under "API validation".
+template<Facade F>
+[[nodiscard]] consteval bool validate_api() noexcept;
+
+// Whether registering a pair also validates the facade's `api` (see
+// `validate_api`). A facade whose `api` deliberately deviates from the method
+// list (say, a widening convenience signature), should register with
+// `api_check::off`.
+enum class api_check : std::uint8_t { off, on };
+
 // Make the registration spec for a (facade, type) pair.
 //
 // Call this from a `corvid_proxy_spec` overload, just as
 // `make_sequence_enum_spec` is returned from `corvid_enum_spec`.
-template<typename F, typename T>
+//
+// When the facade defines an `api`, registration is also the moment that `api`
+// is validated against the method list (see `validate_api`), because the
+// boilerplate impl the registration exists to unlock must be visible here,
+// along with the facade and its `api`. Correctness is opt-out rather than
+// opt-in: pass `api_check::off` to skip. A registration hook that is itself a
+// template defers the check to its own instantiation.
+template<typename F, typename T, api_check Check = api_check::on>
 [[nodiscard]] consteval proxy_spec<F, T> make_proxy_spec() noexcept {
+  if constexpr (Check == api_check::on && Facade<F> &&
+                requires { typename F::api; })
+  {
+    constexpr bool has_boilerplate = requires {
+      sizeof(proxy_impl<F, details::api_probe<F>>);
+    };
+    static_assert(has_boilerplate,
+        "validating the api needs the facade's boilerplate impl visible at "
+        "the registration; pass api_check::off to skip");
+    if constexpr (has_boilerplate) (void)validate_api<F>();
+  }
   return {};
 }
 
@@ -269,7 +307,8 @@ template<typename F, typename T>
 // type; it is found here by ADL.
 //
 // The library never defines this function: declaring an overload IS the act of
-// registration.
+// registration. The single exception is the overload the library provides for
+// its own API-validation probe; see `validate_api`.
 //
 // Registration gates a facade author's boilerplate impl; an explicit
 // `proxy_impl` specialization does not need it.
@@ -310,6 +349,11 @@ struct method_traits_base {
   using target_t = std::conditional_t<Const, const T, T>;
   using erased_ptr_t = std::conditional_t<Const, const void*, void*>;
   using thunk_ptr_t = R (*)(erased_ptr_t, Args...) noexcept(Noexcept);
+
+  // Parameter list normalized for exact-match probing: top-level cv and
+  // references stripped from each parameter, so value-category spelling is
+  // ignored but a merely-convertible type does not match.
+  using norm_args_t = std::tuple<std::remove_cvref_t<Args>...>;
 
   template<typename F, typename T>
   static constexpr bool bound_v = requires(target_t<T>& t, Args... args) {
@@ -422,6 +466,39 @@ struct vtable_builder<facade<Ms...>> {
     return ndx != count_v && flags[ndx];
   }
 
+  // Declared result type of the method named `K`, or `void` when no method has
+  // that name. The permissive fallback keeps return-type substitution in the
+  // `api_probe` from hard-erroring before its constraint can reject the
+  // unknown name.
+  template<fixed_string K>
+  static consteval auto do_result_of() noexcept {
+    constexpr auto ndx = index_of<K>();
+    if constexpr (ndx != count_v) {
+      using m_t = std::tuple_element_t<ndx, std::tuple<Ms...>>;
+      return std::type_identity<typename m_t::result_t>{};
+    } else {
+      return std::type_identity<void>{};
+    }
+  }
+
+  template<fixed_string K>
+  using result_of_t = decltype(do_result_of<K>())::type;
+
+  // Whether `Args` match the declared parameters of the method named `K`
+  // exactly after normalization, rather than by convertibility. False for an
+  // unknown name. This is the `api_probe`'s strictness.
+  template<fixed_string K, typename... Args>
+  static consteval bool exact_args() noexcept {
+    constexpr auto ndx = index_of<K>();
+    if constexpr (ndx != count_v) {
+      using m_t = std::tuple_element_t<ndx, std::tuple<Ms...>>;
+      return std::same_as<std::tuple<std::remove_cvref_t<Args>...>,
+          typename method_traits<m_t>::norm_args_t>;
+    } else {
+      return false;
+    }
+  }
+
   template<typename F, typename T>
   static constexpr bool all_bound_v =
       (method_traits<Ms>::template bound_v<F, T> && ...);
@@ -479,6 +556,111 @@ constexpr inline auto owning_vtable_for =
 template<typename T, typename F>
 concept Proxiable =
     Facade<F> && details::vtbuild_t<F>::template all_bound_v<F, T>;
+
+#pragma endregion
+#pragma region API validation
+
+namespace details {
+
+// Exact-conversion carrier for the `api_probe`'s strict `call`.
+//
+// The conversion operator is a template constrained to exactly `R`. Deduction
+// runs against the target type, which in a forwarder's `return` statement is
+// the forwarder's declared result type, so a declared type that is merely
+// convertible to `R` leaves no viable conversion and fails to compile. Probe
+// machinery is only ever type-checked, never executed.
+template<typename R>
+struct strict_result {
+  template<typename U>
+  requires std::same_as<U, R>
+  operator U() {
+    std::terminate();
+  }
+};
+
+// Result type of the probe's strict `call`: `strict_result` for object types,
+// `void` for `void`, and references passed through unchanged.
+//
+// A conversion operator cannot distinguish binding a reference from copying
+// out of one, so reference results cannot be exactness-checked; a forwarder
+// that decays a declared reference result to a value goes undetected here.
+template<typename R>
+using strict_return_t = std::conditional_t<std::is_void_v<R>, void,
+    std::conditional_t<std::is_reference_v<R>, R, strict_result<R>>>;
+
+// Synthetic dispatch target for `validate_api`.
+//
+// It inherits the facade's `api` and exposes a deliberately strict `call`.
+// Argument types must match the method's declared parameters exactly (per
+// `exact_args`), and the result converts only to exactly the declared result
+// type. Never constructed or executed; it exists to be type-checked.
+template<Facade F>
+struct api_probe: api_base_t<F> {
+  template<fixed_string K, typename... Args>
+  requires(vtbuild_t<F>::template exact_args<K, Args...>())
+  strict_return_t<typename vtbuild_t<F>::template result_of_t<K>>
+  call(Args&&...) {
+    std::terminate();
+  }
+
+  template<fixed_string K, typename... Args>
+  requires(vtbuild_t<F>::template is_const<K>() &&
+           vtbuild_t<F>::template exact_args<K, Args...>())
+  // NOLINTNEXTLINE(modernize-use-nodiscard): mirrors `call`, never executed.
+  strict_return_t<typename vtbuild_t<F>::template result_of_t<K>>
+  call(Args&&...) const {
+    std::terminate();
+  }
+};
+
+// Probe registration, covering every facade. This is the single
+// `corvid_proxy_spec` overload the library itself provides; it is what admits
+// the probe to a facade author's registration-gated boilerplate impl. It must
+// opt out of validation: a validating registration would recurse into itself
+// through the boilerplate-visibility check, whose `ProxyRegistered` probe
+// deduces this hook's return type.
+template<Facade F>
+consteval auto corvid_proxy_spec(F*, api_probe<F>*) noexcept {
+  return make_proxy_spec<F, api_probe<F>, api_check::off>();
+}
+
+} // namespace details
+
+// Validate a facade's `api` against its method list, spelling neither the
+// names nor the signatures again.
+//
+// This runs automatically from `make_proxy_spec` at every registration of an
+// `api`-bearing facade, unless the registration opts out with
+// `api_check::off`.
+// The standalone spelling, `static_assert(validate_api<my_facade>());`,
+// remains for a facade author to assert at the definition site, before any
+// registration exists.
+//
+// It works by dispatching
+// the facade author's boilerplate impl at a probe target that inherits the
+// `api`, chaining thunk -> boilerplate `on` -> `api` forwarder -> strict probe
+// `call`. The chain is anchored to the facade's exact declared types at both
+// ends, so convertibility drift anywhere in the middle, in the `api` or in the
+// boilerplate itself, fails to compile with the error pointing at the drifting
+// line.
+//
+// Caught: a missing or misspelled forwarder, wrong arity, wrong const flavor
+// of `self`, a parameter or declared result type that is merely convertible to
+// the facade's (including the silently-truncating kind), and a forwarder body
+// dispatching a key with a different signature. Not caught: a missing
+// `noexcept` on a forwarder, by-value versus by-reference parameter spellings,
+// reference-to-value decay of a declared result, and a body dispatching the
+// wrong key with an identical signature.
+//
+// Failures are hard compile errors rather than a `false` return, and the
+// facade must have a boilerplate `proxy_impl` partial specialization gated on
+// `ProxyRegistered` for the chain to exist.
+template<Facade F>
+[[nodiscard]] consteval bool validate_api() noexcept {
+  const auto vt = details::vtable_for<F, details::api_probe<F>>;
+  (void)vt;
+  return true;
+}
 
 #pragma endregion
 #pragma region proxy_view

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -530,8 +530,17 @@ struct proxy_impl;
 // (see `SpecCarriesImpl`). Because each hook's return type is deduced
 // independently, richer spec types can be added later without touching
 // existing registrations.
+//
+// The spec re-exposes its pair as `facade_t` and `target_t`, which
+// `ProxyRegistered` verifies against the queried pair: the facade exactly, the
+// target as the queried type or a public base of it (the conversion that lets
+// a base-class hook serve every derived type). A hook whose spec names an
+// unrelated pair (a copy-paste slip) therefore fails registration instead of
+// silently registering the pair it was found for.
 template<typename F, typename T, typename Impl = void>
 struct proxy_spec {
+  using facade_t = F;
+  using target_t = T;
   using impl_t = Impl;
 };
 
@@ -609,6 +618,16 @@ template<typename F, typename T, typename Impl,
   return {};
 }
 
+namespace details {
+
+// `registered_spec_t`: return type of the pair's registration hook, found by
+// ADL exactly as `ProxyRegistered` finds it.
+template<typename F, typename T>
+using registered_spec_t = decltype(corvid_proxy_spec(static_cast<F*>(nullptr),
+    static_cast<T*>(nullptr)));
+
+} // namespace details
+
 // `ProxyRegistered`: concept for a (facade, type) pair being registered.
 //
 // To register a pair, declare a `corvid_proxy_spec(F*, T*)` overload returning
@@ -624,9 +643,20 @@ template<typename F, typename T, typename Impl,
 //
 // Registration is the sole act of conformance: it unlocks the facade's
 // boilerplate, or carries the pair's impl itself.
+//
+// The hook's returned spec must agree with the queried pair: the facade
+// exactly, and the target as the queried type or a public base of it, which is
+// the same derived-to-base conversion that lets a base type's hook register
+// every type derived from it. A hook returning `make_proxy_spec` for an
+// unrelated pair (a copy-paste slip) fails this concept rather than silently
+// registering the pair it was found for.
 template<typename F, typename T>
 concept ProxyRegistered = requires {
   corvid_proxy_spec(static_cast<F*>(nullptr), static_cast<T*>(nullptr));
+  requires std::same_as<typename details::registered_spec_t<F, T>::facade_t,
+      F>;
+  requires std::derived_from<T,
+      typename details::registered_spec_t<F, T>::target_t>;
 };
 
 // `SpecCarriesImpl`: concept for a (facade, type) pair whose registration
@@ -646,15 +676,13 @@ concept ProxyRegistered = requires {
 template<typename F, typename T>
 concept SpecCarriesImpl =
     ProxyRegistered<F, T> &&
-    !std::is_void_v<typename decltype(corvid_proxy_spec(
-        static_cast<F*>(nullptr), static_cast<T*>(nullptr)))::impl_t>;
+    !std::is_void_v<typename details::registered_spec_t<F, T>::impl_t>;
 
 namespace details {
 
 // `registered_impl_t`: impl type carried by the pair's registration.
 template<typename F, typename T>
-using registered_impl_t = decltype(corvid_proxy_spec(static_cast<F*>(nullptr),
-    static_cast<T*>(nullptr)))::impl_t;
+using registered_impl_t = registered_spec_t<F, T>::impl_t;
 
 } // namespace details
 

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -6,8 +6,9 @@ Status: phases 1 through 6 built and tested ([proxy.h](proxy.h),
 facade-qualified names with sibling collisions and diamonds, the
 ownership round (storage policies, owning upcast, cloning, `unique_ptr`
 interop, vtable-carried downcasting, and the shared/weak tier), downcasting
-extended to the views and `shared_proxy`, and per-name overload sets within
-a facade.
+extended to the views and `shared_proxy`, per-name overload sets within a
+facade and across extends levels, and `codegen` (generated `api` and
+boilerplate source, with facades made non-constructible).
 Plan for `corvid/meta/proxy.h`, a
 registration-based runtime-polymorphism ("proxy") system: type-erased handles
 over an interface definition, without inheritance, vtable pointers in the
@@ -352,6 +353,40 @@ artifact that invokes the members by name. A registration that cannot see
 such a boilerplate fails a friendly `static_assert` that names the opt-out;
 a nested boilerplate is visible wherever the facade is, so only the
 namespace-scope spelling can trip it.
+
+### Codegen (`prox::codegen`, built)
+
+`prox::codegen<F>(os)` writes the canonical `api` and `boilerplate` for a
+facade to a stream, ready to paste into the facade body: define the facade's
+method list, add the one-liner to a scratch `main`, paste the output, delete
+the one-liner. It lives in its own header,
+[proxy_codegen.h](proxy_codegen.h), so `proxy.h` stays free of streams and
+RTTI. This is the closest thing to reflection available today; the real
+value is that it spells the conventions' edge cases correctly every time:
+`noexcept` propagated onto forwarders and bindings (a plain binding for a
+noexcept method fails conformance), `this const auto&` for const methods,
+the const pair's trailing requires-clause, overload sets sharing one
+`method_key`, base `api` inheritance with the using-declarations that merge
+the names a new forwarder would otherwise hide, redeclared forwarders for
+methods the inherited path does not cover, and the single-path diamond
+shape (inherit the heaviest chain's `api`, redeclare the rest).
+
+Method signatures carry no parameter names, so codegen mints them:
+one `arg_N` sequence spanning the whole facade, deliberately arbitrary and
+unique across the output, so renaming a parameter after pasting is a single
+search-and-replace that hits the `api` forwarder and the `boilerplate`
+binding together. Base facades are spelled by their demangled C++ type
+names (`naming::friendly_type_name`), not their formal `name<>` entries,
+which need not match (`war_correspondent`'s formal name is
+"correspondent"); type spellings are the demangler's, best-effort
+normalized, and may want touch-up after pasting. Tested against golden
+masters covering each shape above; the generated `posse_leader` and
+`armory` bodies match the hand-written fixtures exactly, modulo the minted
+parameter names.
+
+Relatedly, a facade is never a value: `facade`'s default constructor is
+deleted and propagates to derived facades, so a stray `gunslinger g;`,
+where a handle was meant, fails at the declaration.
 
 ### Composition (`extends`, built)
 
@@ -1117,6 +1152,25 @@ architecture.
    arguments or constness") and for a forgotten api using-declaration,
    which fails at the validating registration inside the base boilerplate's
    natural-name calls.
+8. DONE. Codegen and never-a-value facades (described under "Codegen").
+   `facade`'s default constructor deleted (diagnostic on record: a single
+   clean error at the stray declaration, with notes walking to the deleted
+   base constructor); `method` grew `args_t` for introspection;
+   `naming::friendly_type_name` added (demangled names normalized: MSVC
+   elaborated-type keywords, inline-namespace segments, the expanded
+   `std::string` spelling, west-const); `prox::codegen<F>(os)` in the new
+   [proxy_codegen.h](proxy_codegen.h). Verified: golden masters for the
+   plain facade, noexcept flavors, overload sets with the const-pair
+   requires-clause, extends with the cross-level using and gap-preserving
+   parameter numbering, two-base composition with sibling usings and
+   redeclared forwarders, and the single-path diamond; the generated
+   `posse_leader` and `armory` bodies match the hand-written fixtures.
+   Notes from the build: emission walks the flattened slot tuple with a
+   per-slot compile-time branch, membership against the inherited path is
+   by (declaring facade, method) pair rather than slot type, since a base's
+   own slots retag when flattened; and parameter numbering spans the whole
+   flattened list, so covered slots consume numbers, keeping the `api` and
+   `boilerplate` spellings of one parameter identical.
 
 Header: `corvid/meta/proxy.h`, namespace `corvid::meta::prox`, deliberately
 NOT inline: `facade`, `method`, and `key` are too generic to dump into
@@ -1143,7 +1197,8 @@ the facade-level `try_downcast`).
 - C++26 reflection plus annotations (P2996/P3394) enables deriving the
   boilerplate impl itself from the facade's method list, removing even the
   facade author's forwarding lines. Registration-first is what makes this
-  additive rather than a rewrite.
+  additive rather than a rewrite. Until then, `prox::codegen` generates the
+  same artifacts as source to paste; reflection deletes the paste step.
 - `std::formatter` bridge once the formatter forwarding helper exists (see
   [../strings/roadmap.md](../strings/roadmap.md) stage 2); the ngcpp analog
   is `skills::format`.

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -352,9 +352,11 @@ The derived facade's effective method list is the flattening of its bases'
 lists, in declaration order, followed by its own, and every handle of the
 derived facade dispatches inherited and own methods alike. Names must be
 unique across the flattened list, enforced by a `static_assert` detonator at
-first use of the facade's machinery: a facade cannot redeclare (or override)
-an inherited method, and diamonds are rejected. Both restrictions have
-relaxation paths recorded under Future.
+first use of the facade's machinery. A facade cannot redeclare (or override)
+an inherited method, which is by design, because facades carry no
+implementations and there is nothing to override. Diamonds are rejected as a
+limit of the current implementation, with the dedup path recorded under
+Future.
 
 Conformance is per facade, as with Rust supertraits: `Proxiable<T, marshal>`
 requires `marshal`'s own methods bound through `proxy_impl<marshal, T>` plus
@@ -665,40 +667,60 @@ dispatch, allocator plumbing, RTTI, per-name overload sets.
   (RTTI-adjacent, a non-goal), the same permanence as Rust's
   `Box<dyn Derived>` -> `Box<dyn Base>`, and part of why ngcpp gates upward
   conversion behind an explicit opt-in flag.
-- Diamond composition: wanted, deferred. The semantic half is already
-  collapsed, because per-facade conformance yields one `proxy_impl<Base, T>`
-  no matter how many paths reach `Base` (the same effect as Rust's
-  coherence rule). The blocker is mechanical: flattening duplicates the
-  shared ancestor's methods, tripping the unique-name check. The fix is
-  deduplicating repeated ancestor facades during flattening; the shared
-  ancestor's table pointer is the same object along every path.
-- Per-name overload sets via distinct keys sharing an `api` spelling:
-  `method<"foo-0", void()>` and `method<"foo-1", void(int)>` with two `foo`
-  forwarders overloading on the arguments, the same move as C++ name
-  mangling. Nothing in the machinery forbids it today, and on inspection
-  `validate_api` is compatible (it drives each key's slot independently; the
-  boilerplate's natural-name call resolves against the `api` overload set,
-  and convertibility drift in the selection still fails the strict probe),
-  but it is unsupported until a test exercises it. ngcpp supports overloads
-  natively by listing several signatures in one convention.
-- Facade-qualified method names: keys are opaque strings, so a
-  "gunslinger::shoot" spelling convention is available at any time. Making
-  it meaningful (unqualified lookup that searches own methods then bases,
-  with the qualified spelling as the collision-breaker) would relax the
-  unique-name rule from a definition-time error to a call-site ambiguity,
-  which is Rust's model (same-named methods across traits, disambiguated by
-  fully-qualified syntax). Upcasting already provides the other
-  disambiguation route, since a `proxy_view<gunslinger>` only sees the base
-  list. The qualifier itself is best deferred to C++26 reflection, where
-  `identifier_of` recovers the facade type's own name with no extra
-  spelling; a `name<"gunslinger">` facade-list entry (parallel to `extends`)
-  is the pre-reflection fallback shape, at the cost of naming the facade a
-  third time.
-- Overriding an inherited method in a derived facade conflicts with the
-  upcast-consistency invariant (a derived handle and an upcast base handle
-  would disagree about one method), so if it ever happens it has to be
-  shadowing plus qualified access, not a binding-level override. Recorded as
-  a tension to resolve, not a plan.
+- Facade-qualified method names and sibling collisions: SCOPED, pending
+  review before implementation. Every method's formal name is qualified by
+  its facade, "gunslinger::shoot", so qualified keys are unique by
+  construction. The qualifier source is a `name<"gunslinger">` facade-list
+  entry (parallel to `extends`), with a new definition-time detonator
+  requiring facade names to be unique across a composition graph. C++26
+  reflection (`identifier_of`) later deletes the extra spelling without
+  changing the model. The unqualified-name rules below all follow from one
+  structural fact: handles are type-erased, so visibility and ambiguity are
+  facade-level decisions, and whether the concrete type happens to serve
+  two colliding slots from one member is invisible at the call site.
+  - Chain redeclaration (a derived facade redeclaring an inherited name)
+    stays a definition-time error. Facades carry no implementations, so
+    there is nothing to override, and dispatch already reaches the
+    concrete type's binding through any handle. This closes the override
+    tension formerly recorded here. The shadowing-plus-qualified-access
+    escape hatch answered a question no one asks.
+  - Sibling collision with distinct signatures (facade `C` extends `A` and
+    `B`, both declaring `shoot` with different arguments): merged into an
+    overload set, mirroring `using A::shoot; using B::shoot;` in plain
+    C++. Unqualified `call<"shoot">` resolves by argument match over all
+    visible candidates, taking an exact match first, else a unique viable
+    candidate, else failing with an error naming the qualified
+    alternatives. The `api` sugar needs one documented convention: the
+    derived facade's `api` spells a using-declaration per base to merge
+    the forwarders, because C++ member lookup finds sibling-base names
+    ambiguous before overload resolution ever runs.
+  - Sibling collision with the same signature: unqualified use is a
+    call-site error, while the method stays reachable through the
+    qualified key or an upcast view. The sugar agrees at no cost, since
+    same-signature forwarders merged by the using-declarations form an
+    overload set that C++ diagnoses lazily, only at an actual unqualified
+    call. This matches Rust, where cross-trait collisions are legal until
+    an unqualified call and fully-qualified syntax then disambiguates.
+  - Diamond composition: collapses automatically, and better than C++,
+    whose diamond ambiguity comes from duplicated base subobjects. Proxies
+    have no subobjects, and conformance is per facade-type pair, so
+    exactly one `proxy_impl<D, T>` exists no matter how many paths reach
+    `D` (the effect of Rust's coherence rule). The remaining work is
+    mechanical: flattening dedups repeated ancestors by facade identity
+    (the same facade reached twice contributes the same methods, one slot
+    each, the same table pointer along every path), reserving the
+    ambiguity error for distinct facades colliding on an unqualified name.
+- Per-name overload sets within a single facade, via distinct keys sharing
+  an `api` spelling: `method<"foo-0", void()>` and
+  `method<"foo-1", void(int)>` with two `foo` forwarders overloading on the
+  arguments, the same move as C++ name mangling. (Cross-facade collisions
+  no longer need this, since qualification gives them distinct keys
+  naturally.) Nothing in the machinery forbids it today, and on inspection
+  `validate_api` is compatible (it drives each key's slot independently;
+  the boilerplate's natural-name call resolves against the `api` overload
+  set, and convertibility drift in the selection still fails the strict
+  probe), but it is unsupported until a test exercises it. ngcpp supports
+  overloads natively by listing several signatures in one convention.
 
 ## Open questions
 

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -369,13 +369,14 @@ derived facade dispatches inherited and own methods alike. Flattening keeps
 each method's declaring facade (a slot is a method plus its owner), which is
 what the collision rules, qualified keys, and diamond dedup below all read.
 
-A method name may recur within one facade only as an overload set (see
-"Per-name overload sets"), and never elsewhere in an extends chain,
-enforced by a `static_assert` detonator at first use of the facade's
-machinery: a derived facade cannot redeclare (or overload, or override) an
-inherited name, which is by design, because facades carry no
-implementations and there is nothing to override. Unrelated sibling bases
-MAY collide on a method name (see "Facade names and sibling collisions"). Diamonds are supported: a
+A method name may recur within one extends chain only as an overload set
+(see "Per-name overload sets"): a derived facade may overload an inherited
+name with a different signature, but a same-signature recurrence is
+rejected by a `static_assert` detonator at first use of the facade's
+machinery, because that is redeclaration (or overriding), and facades carry
+no implementations, so there is nothing to override. Unrelated sibling
+bases MAY collide on a method name (see "Facade names and sibling
+collisions"). Diamonds are supported: a
 shared ancestor reached through more than one path
 dedups to a single set of slots by facade identity, and since conformance is
 per facade there is only one `proxy_impl<Ancestor, T>` to reach no matter
@@ -535,9 +536,21 @@ A facade may declare one method name several times, forming an overload
 set: `method<"issue", int(int)>` alongside `method<"issue", int()>`. A
 same-name pair must differ in its argument lists or in constness; the C++
 member rules apply, so the result type and `noexcept` do not overload, and
-a pair distinguished by nothing else stays a collision. The chain rules are
-untouched (a derived facade cannot redeclare, overload, or override an
-inherited name), and sibling collisions keep their own rules above.
+a pair distinguished by nothing else stays a collision.
+
+Overloads span extends levels under the same rule: a derived facade may add
+`issue(int, int)` to a base's `issue` pair, since a base's `foo()` and a
+derived `foo(int)` are different functions that happen to share a spelling,
+exactly as within one facade (what C++'s mangling hides). A same-signature
+recurrence in a chain stays an error, because that is redeclaration, and
+there is nothing to override. Sibling collisions keep their own rules
+above, including the legal same-signature collision; the asymmetry is
+deliberate, since sibling composers cannot coordinate names and
+qualification bails them out, while a chain author can see the base, so a
+chain duplicate is rejected eagerly. Unlike C++, where a derived class's
+`foo(int)` silently hides the base's `foo()` until a using-declaration
+merges them, the erased candidate set merges automatically; an upcast
+handle sees only its own level's overloads.
 
 An unqualified call resolves over the whole candidate set the way a C++
 call would after a using-merge: a unique exact argument match wins, else a
@@ -570,11 +583,18 @@ overloads too, with one wrinkle for the const pair: the mutable member's
 forwarder must repeat its call in a trailing requires-clause (the caveat
 under "Member-call sugar" made load-bearing), because a `const_proxy_view`
 is a mutable object whose deep const lives in the type, and object
-constness alone would select the mutable forwarder for it. `validate_api`
-drives each overload's slot independently, so overloaded facades validate
-at registration like any other; the only machinery it needed was the
+constness alone would select the mutable forwarder for it. The C++ hiding
+that the dispatch layer escapes does surface in a cross-level `api`: a
+derived forwarder overloading an inherited name hides the base's forwarders
+until a using-declaration merges them (`using arsenal::api::issue;`), the
+same convention as sibling collisions. `validate_api` drives each
+overload's slot independently, so overloaded facades validate at
+registration like any other; the only machinery it needed was the
 constness tiebreak reaching `resolve_exact`, which is how the probe's
-mutable strict call singles out the non-const member of a const pair.
+mutable strict call singles out the non-const member of a const pair. It
+also catches a forgotten using-declaration, because the probe drives the
+base slots by natural name through the base boilerplate, where the hidden
+forwarders fail to resolve.
 
 An earlier sketch of this feature used mangled keys (`method<"foo-0", ...>`
 and `method<"foo-1", ...>` sharing one `api` spelling). That remains
@@ -1082,7 +1102,21 @@ architecture.
    type, so object constness alone would route it to the mutable forwarder;
    and the ambiguity static_assert's advice was reworded ("qualify the key
    with the facade name, or match one overload's arguments exactly"), since
-   qualification alone cannot split a within-facade overload set.
+   qualification alone cannot split a within-facade overload set. A
+   follow-up round extended overloads across extends levels: once same-name
+   distinct-signature declarations are admitted as different functions,
+   the level boundary stops mattering, so the detonator simplified to one
+   rule (same chain -> must be a legal overload pair) and resolution needed
+   no changes at all, the flattened candidate set already carrying
+   owner-distinct same-name slots from the sibling machinery. Verified:
+   cross-level dispatch by argument count, upcast narrowing to the base's
+   set, both levels' qualified spellings, the `api` using-merge convention
+   (`armory` overloading `arsenal`'s `issue`), and captured diagnostics for
+   the same-signature redeclaration (still an error, message now "a method
+   name may recur within one extends chain only as overloads differing in
+   arguments or constness") and for a forgotten api using-declaration,
+   which fails at the validating registration inside the base boilerplate's
+   natural-name calls.
 
 Header: `corvid/meta/proxy.h`, namespace `corvid::meta::prox`, deliberately
 NOT inline: `facade`, `method`, and `key` are too generic to dump into

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -81,14 +81,15 @@ the two styles cannot collide).
 
 ```cpp
 // The facade: the interface definition, carrying its own boilerplate.
-struct gunslinger : facade<method<"fire", void(int)>,
+struct gunslinger : facade<name<"gunslinger">,
+                       method<"fire", void(int)>,
                        method<"reload", bool()>> {
   // Written once by the facade author. `on` is the fixed hook name,
   // overloaded on the method key; a fixed name is what keeps the mechanism
-  // spellable without macros. Inheriting `impl_base` is optional sugar,
+  // spellable without macros. Inheriting `prox_impl` is optional sugar,
   // supplying the `method_key` alias so the bindings spell it unqualified.
   template<typename T>
-  struct boilerplate : impl_base {
+  struct boilerplate : prox_impl {
     static void on(method_key<"fire">, T& t, int rounds) { t.fire(rounds); }
     static bool on(method_key<"reload">, T& t) { return t.reload(); }
   };
@@ -209,7 +210,8 @@ forwarding line per method, using deducing `this`; all three handles
 present:
 
 ```cpp
-struct gunslinger : facade<method<"fire", void(int)>,
+struct gunslinger : facade<name<"gunslinger">,
+                       method<"fire", void(int)>,
                        method<"reload", bool()>> {
   struct api {
     void fire(this auto&& self, int n) { self.template call<"fire">(n); }
@@ -344,19 +346,27 @@ A facade extends others by listing `extends<Base>` entries alongside its
 methods, conventionally first:
 
 ```cpp
-struct marshal : facade<extends<gunslinger>,
+struct marshal : facade<name<"marshal">, extends<gunslinger>,
                      method<"arrest", bool(int)>> {};
 ```
 
 The derived facade's effective method list is the flattening of its bases'
 lists, in declaration order, followed by its own, and every handle of the
-derived facade dispatches inherited and own methods alike. Names must be
-unique across the flattened list, enforced by a `static_assert` detonator at
-first use of the facade's machinery. A facade cannot redeclare (or override)
-an inherited method, which is by design, because facades carry no
-implementations and there is nothing to override. Diamonds are rejected as a
-limit of the current implementation, with the dedup path recorded under
-Future.
+derived facade dispatches inherited and own methods alike. Flattening keeps
+each method's declaring facade (a slot is a method plus its owner), which is
+what the collision rules, qualified keys, and diamond dedup below all read.
+
+A method name may not recur within one extends chain, enforced by a
+`static_assert` detonator at first use of the facade's machinery: a facade
+cannot declare a name twice or redeclare (or override) an inherited one,
+which is by design, because facades carry no implementations and there is
+nothing to override. Unrelated sibling bases MAY collide on a method name
+(see "Facade names and sibling collisions"). Diamonds are supported: a
+shared ancestor reached through more than one path
+dedups to a single set of slots by facade identity, and since conformance is
+per facade there is only one `proxy_impl<Ancestor, T>` to reach no matter
+the path (the effect of Rust's coherence rule), so the collapse is virtual
+inheritance semantics with no opt-in and no duplicated subobjects.
 
 Conformance is per facade, as with Rust supertraits: `Proxiable<T, marshal>`
 requires `marshal`'s own methods bound through `proxy_impl<marshal, T>` plus
@@ -393,11 +403,13 @@ hooks; it produces a type that is not proxiable at the derived facade at
 all, failing loudly at first use (exercised by `vigilante` in the test).
 
 The dispatch table of a composed facade carries the flattened thunks (bases'
-first), with the inherited entries copied verbatim from each base's table,
-plus the address of each direct base's table for the same target type. An
-inherited call is therefore the same single indexed load as an own one, and
-upcasting is reading an embedded pointer (walked transitively for
-grandparents), which is Rust's dyn-upcast vtable layout. ngcpp reaches the
+first), each built through its slot's declaring facade (identical to the
+thunk in that base's own table), plus the address of each direct base's
+table for the same target type. An inherited call is therefore the same
+single indexed load as an own one, and upcasting is reading an embedded
+pointer (walked transitively for grandparents), which is Rust's dyn-upcast
+vtable layout. In a diamond, the shared ancestor's table pointer is the same
+object along every path, so upcast routes cannot disagree. ngcpp reaches the
 same user-visible feature differently: upward conversion is opt-in per
 composition (`add_facade<F, true>`) and works as a dispatched conversion,
 where the per-type thunk manufactures the target handle.
@@ -429,6 +441,73 @@ through composition: the probe of a facade registers for every facade it
 extends, each base's boilerplate drives the inherited forwarders at the
 derived probe, and the whole flattened list is checked at the derived
 facade's registration.
+
+An `api` diamond needs two touches from the composing facade's author. The
+shared ancestor's forwarder names arrive through both base `api`s, so plain
+member lookup is ambiguous until one using-declaration per shared method
+pulls in a path (either one; they forward identically). And because the two
+empty ancestor-`api` subobjects are the same type, the ABI must give them
+distinct addresses, so the handle picks up one padding word that empty-base
+optimization cannot remove; an author who cares can inherit one base's `api`
+only and redeclare the other's own forwarders.
+
+### Facade names and sibling collisions (`name`, built)
+
+Every facade carries a formal name through a `name` entry, listed
+conventionally first:
+
+```cpp
+struct camera : facade<name<"camera">,
+                    method<"fire", std::string() const>,
+                    method<"reload", void()>> {};
+```
+
+Every method then answers to its facade-qualified name as well as its plain
+one: a `call` key containing "::" matches the declaring facade's name plus
+the method name, so `call<"camera::fire">()` names its slot outright, even
+through a derived handle. The entry is required, exactly once per facade,
+enforced by a detonator at first use of the facade's machinery. It was
+briefly optional; requiring it was the user's call, and the right one: a
+downstream composer cannot add a name to a facade it does not own, so an
+optional name would foreclose legal collisions in every composition that
+ever included an unnamed facade, the per-facade overhead is one short entry,
+and mandatory names delete every nameless special case from the machinery
+(the sibling-collisions-need-names detonator, the empty-name skips in
+matching and uniqueness checking, and `qualified_key`'s fallback branch all
+went away). Facade names must be unique within a composition (a detonator
+enforces it), and C++26 reflection is expected to supply the name from the
+facade type itself, retiring the entry.
+
+Names are what make sibling collisions legal outright: two unrelated bases
+declaring the same method name may always be composed, because the qualified
+spelling is always available as the disambiguator. The rules all follow from
+one structural fact, that handles are type-erased, so visibility and
+ambiguity are facade-level decisions, and whether the concrete type happens
+to serve two colliding slots from one member is invisible at the call site:
+
+- Distinct signatures form an overload set. An unqualified call resolves the
+  way C++ would after `using A::f; using B::f;`: a unique exact signature
+  match wins, else a unique viable candidate, else a `static_assert` naming
+  the ambiguity. The `api` convention is one using-declaration per base,
+  because C++ member lookup finds sibling-base names ambiguous before
+  overload resolution ever runs; with the using-declarations in place the
+  forwarders form the same overload set.
+- A same-signature collision is a lazy call-site error, through `call<>` (a
+  `static_assert`) and through the sugar (an ambiguous overload set) alike.
+  The slots stay reachable through their qualified keys and through upcast
+  handles, where each level's list has no collision. Per-facade conformance
+  means the two slots can carry genuinely different bindings for the same
+  concrete type (the test's `photographer` reloads its gun at the
+  `gunslinger` level and winds its film at the `camera` level).
+- A same-signature collision also blocks `validate_api` for the composed
+  facade, because boilerplates drive the probe by natural name, exactly the
+  spelling the collision makes ambiguous. Such a facade registers with
+  `api_check::off`; the base levels validate normally.
+
+The library's self-conformance bindings (`proxy_impl<B, handle<D>>`) forward
+through the qualified spelling of `B`'s method names, so a derived handle
+keeps satisfying a base-facade bound even when the derived list collides on
+the method's plain name.
 
 ## Mechanism
 
@@ -612,11 +691,37 @@ architecture.
    "User-facing shape"; precedence pinned by `turncoat` in the test),
    dropped the unregistered full-specialization tier in their favor, and
    restyled the tests to prefer the `api` sugar over `call<>` wherever a
-   facade defines one. A second pass added `proxy_impl` (the unqualified
+   facade defines one. A second pass added `prox_impl` (the unqualified
    `method_key` spelling in binding classes), made both views
    default-constructible as empty with `operator bool`, matching the owning
    proxy, and pinned mid-chain anchoring of chain hooks (`constable` in the
    test).
+
+4. DONE. Facade-qualified method names, sibling collisions, and diamond
+   composition (described under "Composition" and "Facade names and sibling
+   collisions"). Built as: flattening reworked onto provenance-carrying
+   slots (a method plus its declaring facade) with dedup by facade
+   identity; the `name<"...">` entry, required exactly once per facade
+   (initially optional; made mandatory on review, which deleted the
+   nameless special cases) plus the unique-within-composition detonator;
+   the strict unique-name detonator replaced by the collision rules (chain
+   redeclaration stays an error, sibling collisions freely legal, facade
+   names unique);
+   `call<>` resolution reworked to qualified-aware candidate sets with
+   exact-then-unique-viable argument matching and a distinct "ambiguous"
+   static_assert; and the validation probe made argument-aware to match.
+   Verified: diamond dispatch and upcast-path identity
+   (`posse_leader`/`trail_boss` in the test), qualified keys through plain,
+   derived, const, and owning handles, the overload set and the
+   same-signature collision (`war_correspondent`/`photographer`), deep
+   const for qualified keys, and re-captured diagnostics for all three
+   detonators plus the ambiguity assert. Discoveries along the way: the
+   library self-conformance bindings must forward through qualified keys,
+   since a plain key forwarded through a derived view is ambiguous under a
+   collision; an `api` diamond costs one padding word (same-type empty
+   subobjects need distinct addresses) plus one using-declaration per
+   shared method; and a same-signature collision blocks `validate_api` for
+   the composed facade, which registers with `api_check::off`.
 
 Header: `corvid/meta/proxy.h`, namespace `corvid::meta::prox`, deliberately
 NOT inline: `facade`, `method`, and `key` are too generic to dump into
@@ -667,49 +772,6 @@ dispatch, allocator plumbing, RTTI, per-name overload sets.
   (RTTI-adjacent, a non-goal), the same permanence as Rust's
   `Box<dyn Derived>` -> `Box<dyn Base>`, and part of why ngcpp gates upward
   conversion behind an explicit opt-in flag.
-- Facade-qualified method names and sibling collisions: SCOPED, pending
-  review before implementation. Every method's formal name is qualified by
-  its facade, "gunslinger::shoot", so qualified keys are unique by
-  construction. The qualifier source is a `name<"gunslinger">` facade-list
-  entry (parallel to `extends`), with a new definition-time detonator
-  requiring facade names to be unique across a composition graph. C++26
-  reflection (`identifier_of`) later deletes the extra spelling without
-  changing the model. The unqualified-name rules below all follow from one
-  structural fact: handles are type-erased, so visibility and ambiguity are
-  facade-level decisions, and whether the concrete type happens to serve
-  two colliding slots from one member is invisible at the call site.
-  - Chain redeclaration (a derived facade redeclaring an inherited name)
-    stays a definition-time error. Facades carry no implementations, so
-    there is nothing to override, and dispatch already reaches the
-    concrete type's binding through any handle. This closes the override
-    tension formerly recorded here. The shadowing-plus-qualified-access
-    escape hatch answered a question no one asks.
-  - Sibling collision with distinct signatures (facade `C` extends `A` and
-    `B`, both declaring `shoot` with different arguments): merged into an
-    overload set, mirroring `using A::shoot; using B::shoot;` in plain
-    C++. Unqualified `call<"shoot">` resolves by argument match over all
-    visible candidates, taking an exact match first, else a unique viable
-    candidate, else failing with an error naming the qualified
-    alternatives. The `api` sugar needs one documented convention: the
-    derived facade's `api` spells a using-declaration per base to merge
-    the forwarders, because C++ member lookup finds sibling-base names
-    ambiguous before overload resolution ever runs.
-  - Sibling collision with the same signature: unqualified use is a
-    call-site error, while the method stays reachable through the
-    qualified key or an upcast view. The sugar agrees at no cost, since
-    same-signature forwarders merged by the using-declarations form an
-    overload set that C++ diagnoses lazily, only at an actual unqualified
-    call. This matches Rust, where cross-trait collisions are legal until
-    an unqualified call and fully-qualified syntax then disambiguates.
-  - Diamond composition: collapses automatically, and better than C++,
-    whose diamond ambiguity comes from duplicated base subobjects. Proxies
-    have no subobjects, and conformance is per facade-type pair, so
-    exactly one `proxy_impl<D, T>` exists no matter how many paths reach
-    `D` (the effect of Rust's coherence rule). The remaining work is
-    mechanical: flattening dedups repeated ancestors by facade identity
-    (the same facade reached twice contributes the same methods, one slot
-    each, the same table pointer along every path), reserving the
-    ambiguity error for distinct facades colliding on an unqualified name.
 - Per-name overload sets within a single facade, via distinct keys sharing
   an `api` spelling: `method<"foo-0", void()>` and
   `method<"foo-1", void(int)>` with two `foo` forwarders overloading on the

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -1,8 +1,8 @@
 # Proxy design
 
 Status: phases 1 and 2 built and tested ([proxy.h](proxy.h),
-[proxy_test.cpp](../../tests/portable/proxy_test.cpp)); phase 3
-pending. Plan for `corvid/meta/proxy.h`, a
+[proxy_test.cpp](../../tests/portable/proxy_test.cpp)); phase 3 in
+progress: the `api` mixin is built and tested, `extends<Base>` is pending. Plan for `corvid/meta/proxy.h`, a
 registration-based runtime-polymorphism ("proxy") system: type-erased handles
 over an interface definition, without inheritance, vtable pointers in the
 target type, or macros.
@@ -157,12 +157,13 @@ specialization. It overlaps in purpose with the spec-carried member-pointer
 binding sketched under Future; the two can coexist. Exercised by `sheriff`
 in the test.
 
-### Member-call sugar (pinned, leading candidate)
+### Member-call sugar (the `api` mixin, built)
 
 `p->fire(3)` spelling cannot be minted by a C++23 library without macros.
-The leading candidate is an optional hand-written `api` mixin on the facade,
-one forwarding line per method, using deducing `this`; `proxy<F>` and
-`proxy_view<F>` inherit `F::api` when present:
+The answer is an optional hand-written `api` mixin on the facade, one
+forwarding line per method, using deducing `this`; all three handles
+(`proxy<F>`, `proxy_view<F>`, `const_proxy_view<F>`) inherit `F::api` when
+present:
 
 ```cpp
 struct gunslinger : facade<method<"fire", void(int)>,
@@ -186,6 +187,32 @@ parses as chained relational operators). A nearby legal family exists via a
 string-literal UDL operator template producing a key object,
 `p("fire"_k, 3)` or `p["fire"_k](3)`; recorded as alternates in case the
 mixin disappoints.
+
+Mechanics of the built form: `details::api_base_t<F>` yields `F::api` when
+the facade defines one and an empty `no_api` stand-in otherwise. The
+selection is a lazy specialization rather than a `std::conditional_t`,
+because naming `F::api` when it does not exist is ill-formed. The views pick
+the base up through their shared `details::view_base`, keeping each view a
+single-inheritance chain; the owning `proxy`, which has no other base,
+inherits it directly. Deducing `this` still sees the complete handle type
+regardless of where in the hierarchy the forwarders sit. The mixin is
+stateless, so empty-base optimization keeps the views at two pointers.
+
+Caveats, all on the facade author's side of the contract:
+
+- Forwarders should declare concrete return types, not `decltype(auto)`: a
+  deduced return type forces body instantiation during mere overload
+  resolution, which turns misuse into errors in contexts that only probe.
+- Plain forwarders are unconstrained declarations, so deep const is enforced
+  inside the forwarder's `call` (a clear hard error at the point of use)
+  rather than at overload resolution. A `requires` probe of the sugar on a
+  const handle therefore succeeds where the same probe of `call<>` fails. A
+  facade author who wants probe-visible sugar can add a trailing
+  requires-clause repeating the `call` expression.
+- The `noexcept` qualifier does not propagate through an unmarked forwarder;
+  the author marks the forwarders of noexcept methods `noexcept` themselves
+  (see `hair_trigger` in the test). Nothing checks the forwarders against
+  the method flavors; the sugar is by-hand by design.
 
 Hosting the `api` inside `proxy_impl` (grouping the sugar next to the `on`
 bindings) was considered and rejected. The erased handle knows only `F`, so
@@ -349,10 +376,17 @@ architecture.
    noexcept conformance both ways (a binding lacking `noexcept` fails the
    facade), `noexcept(call)` propagation, and heterogeneous ownership in a
    container.
-3. `api` mixin support and `extends<Base>` composition, including
-   `proxy<derived>` -> `proxy_view<base>` conversion (Rust trait
-   upcasting). Verify: mixin call parity with `call<>`, upcast dispatch
-   correctness.
+3. IN PROGRESS. The `api` mixin is DONE: `details::api_base_t<F>` selects
+   the facade's nested `api` (lazy specialization, empty `no_api` stand-in),
+   and all three handles inherit it. Verified: forwarder parity with
+   `call<>` through the mutable view, the const view, and the owning proxy
+   (const and mutable), reference returns through the sugar, no
+   dependent-name `template` keyword needed in generic code, `noexcept`
+   propagation when the facade author marks the forwarders, and empty-base
+   optimization keeping the views at two pointers. See the caveats under
+   "Member-call sugar". Remaining: `extends<Base>` composition, including
+   `proxy<derived>` -> `proxy_view<base>` conversion (Rust trait upcasting).
+   Verify: upcast dispatch correctness.
 
 Header: `corvid/meta/proxy.h`, namespace `corvid::meta::prox`, deliberately
 NOT inline: `facade`, `method`, and `key` are too generic to dump into
@@ -398,8 +432,9 @@ dispatch, allocator plumbing, RTTI, per-name overload sets.
 
 ## Open questions
 
-- The member-call sugar pin: the `api` mixin is the leading candidate
-  (judged plausible); confirm once real call sites exist.
+- The member-call sugar pin was resolved in favor of the `api` mixin, now
+  built. Confirm the ergonomics (including the constraint-visibility caveat)
+  once real call sites exist outside the test.
 
 The const flavor of views was an open question until phase 2. It was
 resolved as the `&T` vs `&mut T` split (`const_proxy_view` alongside a

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -652,10 +652,15 @@ one forwarder.)
 Inheriting every base `api` also works, but costs two things. It needs one
 using-declaration per shared-ancestor method, because the ancestor's
 forwarder names arrive through both bases, and plain member lookup is
-ambiguous until a using-declaration pulls in a path. It also pads every
-handle by one word, because the two empty ancestor-`api` subobjects are
-the same type, and the ABI must give them distinct addresses, which
-empty-base optimization cannot remove.
+ambiguous until a using-declaration pulls in a path. It can also pad the
+handle by one word: the two empty ancestor-`api` subobjects are the same
+type, so the language requires them to have distinct addresses that
+empty-base optimization cannot merge.
+
+The Itanium ABI satisfies that by hiding the second subobject inside the
+first pointer's bytes, so the handle stays two words on Linux; the MS ABI
+never overlaps empty bases with data members, so the handle grows to three
+words there (measured under this project's Windows build).
 
 There is no automatic merge available before reflection.
 Using-declarations cannot be pack-expanded over arbitrary names (the
@@ -1258,7 +1263,7 @@ What worked:
   opened.
 - The handles stay lean: views are two pointers, a `heap_only` proxy is
   two words, and the `api` mixin is stateless, so the sugar costs no
-  storage anywhere (except the diamond padding word noted under
+  storage anywhere (except the MS-ABI diamond padding word noted under
   "Composition").
 - Composition reached the full trait-object feature set (implicit upcasts,
   birth-keyed downcasts, per-facade conformance with its coherence-like

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -1791,9 +1791,64 @@ conformance.
 
 ## Non-goals
 
-Operator dispatch, conversion dispatch, allocator plumbing, RTTI (beyond
-the facade-level `try_downcast`). All were scoped out at the start and
-never turned out to be missed.
+Operator dispatch, conversion dispatch, allocator plumbing, and RTTI
+beyond the facade-level `try_downcast` were scoped out at the start and
+never turned out to be missed. All four exist in ngcpp, so each is a
+deliberate divergence rather than an oversight, and they share a shape:
+each would buy a spelling at the call site, not a capability, because
+the binding layer already reaches everything involved.
+
+Operator dispatch would let the handle spell the target's operators
+(`p(x)`, `p1 == p2`; ngcpp's `operator_dispatch`). Everything here is
+keyed by a `fixed_string` name, and operators have no identifier to key,
+but only the blessed convention is missing. A binding can reach a
+target's operator today (`on(method_key<"invoke">, T& t, int x)` may
+return `t(x)`), and the `api` is an ordinary class, so a hand-written
+`operator()` forwarder works, though outside the name-driven tooling
+(`prox::codegen` mints only named forwarders, and `validate_api` drives
+the probe by natural name, so an operator-only `api` registers with
+`api_check::off`). Named methods also dodge a real ambiguity: handles
+have operators of their own, and `p1 == p2` should not have to choose
+between comparing handles and comparing targets.
+
+Conversion dispatch would let the handle convert to another type by
+delegating to the target (ngcpp's `conversion_dispatch`); here a facade
+cannot declare `operator T()`, and the spelling is a named method
+(`to_string()`). This one was dodged rather than deferred. The handle
+family already carries a delicate web of converting constructors
+(upcasts, lending, adoption), all with settled rules, and
+target-delegated conversions would join that overload-resolution
+surface, for a feature whose named replacement is clearer at the call
+site rather than merely equivalent.
+
+Allocator plumbing would thread a user allocator through the owning tier
+(ngcpp's `allocate_proxy`): allocate the target through it, remember it,
+free through it, use it for clones and re-boxing. The heap mode here is
+plain `new`/`delete`, and an allocator would infect the whole
+owning-table ABI. `destroy`, `copy`, `to_heap`, and `to_sbo` would all
+need to reach it, meaning per-instance storage or per-allocator table
+families, plus an allocator-compatibility axis on every adoption. The
+allocation story runs through policy instead: hot targets live inline
+under SBO, `sbo_only` outlaws the heap outright, `make_shared_proxy`
+already gets the one-allocation layout, and a target that must live in
+an arena can stay there and be viewed, since views do not own.
+
+RTTI is capped at two narrow identities, both address compares of empty
+statics: `type_tag_v<T>` lets `extract<T>` verify the exact concrete
+type it names, and `facade_tag_v` plus the birth ancestry lets
+`try_downcast` recover the born facade chain. Scoped out is everything
+open-ended: `typeid` access, type names, `dynamic_cast`-style queries
+against arbitrary types (ngcpp's `proxy_typeid`). The two probes cover
+the legitimate questions, and anything broader invites switch-on-type
+code, the anti-pattern erasure exists to remove. The cap also keeps
+`proxy.h` free of `<typeinfo>` (the RTTI demangling lives only in
+`proxy_codegen.h`, a dev-time tool in its own header for exactly this
+reason).
+
+That the four were never missed is less about restraint than
+redundancy: operators and conversions were always reachable through
+bindings under a name, allocation policy is handled by storage policy
+and views, and identity is handled by the two tags.
 
 ## Future work
 

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -1,11 +1,12 @@
 # Proxy design
 
-Status: phases 1 through 5 built and tested ([proxy.h](proxy.h),
+Status: phases 1 through 6 built and tested ([proxy.h](proxy.h),
 [proxy_test.cpp](../../tests/portable/proxy_test.cpp)): the `api` mixin, its
 `validate_api` drift check, `extends<Base>` composition with upcasting,
-facade-qualified names with sibling collisions and diamonds, and the
+facade-qualified names with sibling collisions and diamonds, the
 ownership round (storage policies, owning upcast, cloning, `unique_ptr`
-interop, vtable-carried downcasting, and the shared/weak tier).
+interop, vtable-carried downcasting, and the shared/weak tier), and
+downcasting extended to the views and `shared_proxy`.
 Plan for `corvid/meta/proxy.h`, a
 registration-based runtime-polymorphism ("proxy") system: type-erased handles
 over an interface definition, without inheritance, vtable pointers in the
@@ -661,6 +662,27 @@ common base can sidecast to either sibling, since both are in the birth
 ancestry. This is the RTTI the library otherwise does without, reinvented
 on the reinvented vtable.
 
+Downcasting spans the views and the shared tier the same way. The view
+tables took the same born key, defaulting to the facade itself, which is
+the birth of every directly built view and keeps the plain spellings
+untouched, and grew exactly one slot: a pointer to a parallel view
+ancestry whose entries reference view tables rather than owning ones, so
+view-only code never instantiates destroy, relocate, or copy thunks. The
+owning table's embedded view table is built with the owner's birth, and a
+view lent from a `proxy` or `shared_proxy` points into that born family,
+so a lent view recovers exactly what its owner could, while a directly
+built view is born as its own facade.
+
+On the copyable handles the operation is non-consuming. `try_downcast` on
+a view is const and returns a new view over the same target (escaping the
+instance-level deep-const guardrail exactly as copying does;
+`const_proxy_view` downcasts only to another const view, so the guarantee
+tier stays closed). `shared_proxy` has an lvalue flavor that shares,
+minting another owner of the one target, and an rvalue flavor that
+transfers, consuming the source only on success; a birth adopted from a
+consumed `proxy` carries over. `weak_proxy` deliberately has no downcast,
+as it has no dispatch: `lock()` first.
+
 ### Shared and weak ownership
 
 `shared_proxy<F>` is Rust's `Rc<dyn Trait>`: a `std::shared_ptr<void>` plus
@@ -673,7 +695,9 @@ their typed view of the same object) or `std::unique_ptr<T>`, or via
 `make_shared_proxy<F, T>(...)` (target and control block in one
 allocation). Handles upcast implicitly by copy or move; views lend from a
 shared proxy exactly as from an owning one. Deep const is the same guardrail
-it is on the views: copying escapes it. ngcpp built this bespoke
+it is on the views: copying escapes it. Upcasts are undoable through
+`try_downcast`, in a sharing lvalue flavor and a transferring rvalue one
+(see "Downcasting"). ngcpp built this bespoke
 (`make_proxy_shared`, compact internal refcounts) to beat `shared_ptr`
 overhead; reusing std is our accepted trade.
 
@@ -742,8 +766,9 @@ upcasts as well as a live one; expiry stays `lock()`'s business.
   the heap mode), copy (null marking an uncloneable target), a type identity
   tag for typed extraction, the birth ancestry for `try_downcast`, and the
   direct bases' owning tables for the
-  owning upcast. `proxy_view` carries none of this, which is why the view
-  was built first.
+  owning upcast. The view table carries none of the lifetime machinery,
+  which is why the view was built first; its one slot beyond dispatch is
+  the view-ancestry pointer for its own `try_downcast`.
 - Const is handled on two axes. Every handle is deep-const as an instance,
   meaning only const-qualified methods dispatch through a const handle,
   enforced by a constraint on the const `call` overload. For the copyable
@@ -937,7 +962,9 @@ architecture.
    target activity, the throwing un-box leaving its source intact, the
    noexcept partition of the converting constructor, inline and heap
    clones with
-   independence and lifetime balance, `unique_ptr` round-trips preserving
+   independence and lifetime balance, the graceful empty clone of an
+   uncloneable target with the source intact, `unique_ptr` round-trips
+   preserving
    the exact allocation, typed extraction rejecting the wrong type,
    downcasts down a chain, past the birth level (failing with the source
    intact), sideways across a diamond, through storage-mode changes
@@ -956,6 +983,29 @@ architecture.
    sibling's table build, which a deduced return type cannot survive; and an
    `sbo_only` violation detonates as a single clean `static_assert` at
    construction (diagnostic on record in the test).
+6. DONE. Downcasting for the views and `shared_proxy` (described under
+   "Downcasting"): the born key on the view tables, defaulted to the facade
+   so plain spellings were untouched; the parallel view-ancestry family;
+   birth inheritance through the owning table's embedded view table; const
+   non-consuming `try_downcast` on both views; the sharing and transferring
+   flavors on `shared_proxy`; `weak_proxy` stays downcast-free. Verified:
+   view downcast dispatch and target identity, the birth limit on directly
+   built views, lent views recovering the owner's birth from a `proxy` and
+   from a `shared_proxy`, the const view downcasting only to a const view,
+   diamond sidecasts through a view, shared copy-downcasts leaving two
+   owners on one target with balanced lifetimes, the transferring flavor
+   consuming only on success, birth surviving unique-into-shared adoption,
+   empty handles, and the concept probes (views and shared positive,
+   `weak_proxy` negative). Notes from the build: the per-entry view-bases
+   hook was replaced by a per-builder `make_view_bases` with a spelled-out
+   return type, the owning round's diamond re-entrancy rule applied
+   preemptively; and the owning table's embedded view table had to become a
+   copy of the standalone born-keyed instance, because initializing it with
+   a second `make_vtable` call would share one function specialization
+   between two variables, and the view ancestry's back-references re-enter
+   it while it is mid-instantiation (the same hazard, one level up:
+   functions must be entered from exactly one variable, where addresses of
+   mid-instantiation variables are fine).
 
 Header: `corvid/meta/proxy.h`, namespace `corvid::meta::prox`, deliberately
 NOT inline: `facade`, `method`, and `key` are too generic to dump into
@@ -1000,12 +1050,6 @@ were later built in phase 5.
   `std::copyable` with no runtime condition (the shape of ngcpp's
   `support_copy`). `clone()`/`can_clone()` cover the need at runtime, so
   this waits for a use case that wants the compile-time guarantee.
-- Downcasting for `shared_proxy` and the views. The vtable-carried birth
-  generalizes: their tables would take the same born key and ancestry hook.
-  Open decision before building: ancestry entries referencing owning tables
-  would drag destroy-thunk instantiation into view-only code, so a parallel
-  ancestry family over view tables is probably wanted. Deferred as the
-  follow-up to the owning-proxy redesign.
 - Per-name overload sets within a single facade, via distinct keys sharing
   an `api` spelling: `method<"foo-0", void()>` and
   `method<"foo-1", void(int)>` with two `foo` forwarders overloading on the

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -5,8 +5,9 @@ Status: phases 1 through 6 built and tested ([proxy.h](proxy.h),
 `validate_api` drift check, `extends<Base>` composition with upcasting,
 facade-qualified names with sibling collisions and diamonds, the
 ownership round (storage policies, owning upcast, cloning, `unique_ptr`
-interop, vtable-carried downcasting, and the shared/weak tier), and
-downcasting extended to the views and `shared_proxy`.
+interop, vtable-carried downcasting, and the shared/weak tier), downcasting
+extended to the views and `shared_proxy`, and per-name overload sets within
+a facade.
 Plan for `corvid/meta/proxy.h`, a
 registration-based runtime-polymorphism ("proxy") system: type-erased handles
 over an interface definition, without inheritance, vtable pointers in the
@@ -62,8 +63,9 @@ Naming notes:
 - `facade` over `trait`: matches ngcpp, and "trait(s)" is irreversibly
   loaded in C++ (`std::char_traits`, type traits).
 - `method` collapses ngcpp's dispatch (the what) and convention (the
-  signature) into one entity; we do not support overload sets per name in
-  the MVP.
+  signature) into one entity; a per-name overload set is spelled by listing
+  the name repeatedly (ngcpp instead lists several signatures in one
+  convention).
 - Nominal identity lives at the facade level: `proxy_impl<F, T>` is keyed on
   the pair, so declaring `method<"draw", ...>` inline in two unrelated
   facades cannot cross-contaminate. Conforming to a `weapon` facade says
@@ -367,12 +369,13 @@ derived facade dispatches inherited and own methods alike. Flattening keeps
 each method's declaring facade (a slot is a method plus its owner), which is
 what the collision rules, qualified keys, and diamond dedup below all read.
 
-A method name may not recur within one extends chain, enforced by a
-`static_assert` detonator at first use of the facade's machinery: a facade
-cannot declare a name twice or redeclare (or override) an inherited one,
-which is by design, because facades carry no implementations and there is
-nothing to override. Unrelated sibling bases MAY collide on a method name
-(see "Facade names and sibling collisions"). Diamonds are supported: a
+A method name may recur within one facade only as an overload set (see
+"Per-name overload sets"), and never elsewhere in an extends chain,
+enforced by a `static_assert` detonator at first use of the facade's
+machinery: a derived facade cannot redeclare (or overload, or override) an
+inherited name, which is by design, because facades carry no
+implementations and there is nothing to override. Unrelated sibling bases
+MAY collide on a method name (see "Facade names and sibling collisions"). Diamonds are supported: a
 shared ancestor reached through more than one path
 dedups to a single set of slots by facade identity, and since conformance is
 per facade there is only one `proxy_impl<Ancestor, T>` to reach no matter
@@ -525,6 +528,57 @@ The library's self-conformance bindings (`proxy_impl<B, handle<D>>`) forward
 through the qualified spelling of `B`'s method names, so a derived handle
 keeps satisfying a base-facade bound even when the derived list collides on
 the method's plain name.
+
+### Per-name overload sets (built)
+
+A facade may declare one method name several times, forming an overload
+set: `method<"issue", int(int)>` alongside `method<"issue", int()>`. A
+same-name pair must differ in its argument lists or in constness; the C++
+member rules apply, so the result type and `noexcept` do not overload, and
+a pair distinguished by nothing else stays a collision. The chain rules are
+untouched (a derived facade cannot redeclare, overload, or override an
+inherited name), and sibling collisions keep their own rules above.
+
+An unqualified call resolves over the whole candidate set the way a C++
+call would after a using-merge: a unique exact argument match wins, else a
+unique viable candidate, with C++'s object-parameter preference applied as
+a tiebreak within each tier, so a mutable handle resolves a const pair
+(`method<"count", int&()>` with `method<"count", int() const>`) to its
+non-const member while const handles and `const_proxy_view` dispatch the
+const one. The tiebreak is uniform over a candidate set, so a sibling
+collision differing only in constness resolves the same way. Qualified
+keys narrow the candidates to one facade's and then resolve identically,
+which is also how the library's self-conformance bindings keep working
+over overloaded names.
+
+The two tiers plus the tiebreak are deliberately not full C++
+implicit-conversion ranking. Within the viable tier no candidate outranks
+another by conversion quality (a promotion does not beat a conversion:
+`call<"aim">(short{})` over `aim(int)`/`aim(double)` is ambiguous where
+real overload resolution would promote), and an exact argument match on a
+const method outranks the object-parameter preference where real member
+overloading would weigh the two together. Arguments first, constness
+second, predictably; the `api` sugar, being a genuine C++ overload set,
+follows the full rules, and the two models agree everywhere except these
+edges.
+
+Bindings overload naturally, sharing one `method_key` and differing in the
+trailing parameters, or in target constness for a const pair:
+`static int on(method_key<"issue">, T& t, int n)` beside
+`static int on(method_key<"issue">, T& t)`. The `api` forwarders are plain
+overloads too, with one wrinkle for the const pair: the mutable member's
+forwarder must repeat its call in a trailing requires-clause (the caveat
+under "Member-call sugar" made load-bearing), because a `const_proxy_view`
+is a mutable object whose deep const lives in the type, and object
+constness alone would select the mutable forwarder for it. `validate_api`
+drives each overload's slot independently, so overloaded facades validate
+at registration like any other; the only machinery it needed was the
+constness tiebreak reaching `resolve_exact`, which is how the probe's
+mutable strict call singles out the non-const member of a const pair.
+
+An earlier sketch of this feature used mangled keys (`method<"foo-0", ...>`
+and `method<"foo-1", ...>` sharing one `api` spelling). That remains
+expressible, but same-name declarations subsume it.
 
 ## Ownership and storage (built)
 
@@ -1006,6 +1060,29 @@ architecture.
    it while it is mid-instantiation (the same hazard, one level up:
    functions must be entered from exactly one variable, where addresses of
    mid-instantiation variables are fine).
+7. DONE. Per-name overload sets within a single facade (described under
+   "Per-name overload sets"): the chain-collision detonator relaxed so
+   same-owner same-name slots are legal when they differ in arguments or
+   constness (`legal_overload_pair`), and resolution gained C++'s
+   object-parameter preference as a tiebreak within each tier
+   (`tally_preferring_nonconst`, reaching `resolve` and `resolve_exact`
+   alike, the latter being what lets the validation probe single out the
+   members of a const pair). Verified: arity and argument-type overloads
+   through the sugar and `call<>`, the const pair's result types through
+   mutable, const, and `const_proxy_view` handles, overload sets inherited
+   through `extends` and reached through qualified keys, owning and shared
+   dispatch, self-conformance over overloaded names, sugar-level ambiguity
+   probes with the core-model divergence pinned (a `short` promotes at the
+   sugar, stays ambiguous in the viable tier), `api` validation of an
+   overloaded facade at a default-checked registration, and re-captured
+   diagnostics for the detonator and the ambiguity assert. Notes from the
+   build: the const-pair `api` convention requires the mutable forwarder to
+   carry a trailing requires-clause repeating its call, because a
+   `const_proxy_view` is a mutable object whose deep const lives in the
+   type, so object constness alone would route it to the mutable forwarder;
+   and the ambiguity static_assert's advice was reworded ("qualify the key
+   with the facade name, or match one overload's arguments exactly"), since
+   qualification alone cannot split a within-facade overload set.
 
 Header: `corvid/meta/proxy.h`, namespace `corvid::meta::prox`, deliberately
 NOT inline: `facade`, `method`, and `key` are too generic to dump into
@@ -1025,9 +1102,7 @@ happen).
 ## Non-goals (MVP)
 
 Operator dispatch, conversion dispatch, allocator plumbing, RTTI (beyond
-the facade-level `try_downcast`), per-name overload sets.
-Copyability and shared/weak ownership were non-goals here originally and
-were later built in phase 5.
+the facade-level `try_downcast`).
 
 ## Future
 
@@ -1050,17 +1125,6 @@ were later built in phase 5.
   `std::copyable` with no runtime condition (the shape of ngcpp's
   `support_copy`). `clone()`/`can_clone()` cover the need at runtime, so
   this waits for a use case that wants the compile-time guarantee.
-- Per-name overload sets within a single facade, via distinct keys sharing
-  an `api` spelling: `method<"foo-0", void()>` and
-  `method<"foo-1", void(int)>` with two `foo` forwarders overloading on the
-  arguments, the same move as C++ name mangling. (Cross-facade collisions
-  no longer need this, since qualification gives them distinct keys
-  naturally.) Nothing in the machinery forbids it today, and on inspection
-  `validate_api` is compatible (it drives each key's slot independently;
-  the boilerplate's natural-name call resolves against the `api` overload
-  set, and convertibility drift in the selection still fails the strict
-  probe), but it is unsupported until a test exercises it. ngcpp supports
-  overloads natively by listing several signatures in one convention.
 
 ## Open questions
 

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -251,7 +251,10 @@ through `call<>` and the same dispatch table.
   converts implicitly from `proxy_view` with no path back, and dispatches
   only const methods while sharing the mutable view's per-(facade, type)
   dispatch table (the non-const slots are simply unreachable, so no
-  const-sliced table or index remapping is needed).
+  const-sliced table or index remapping is needed). The two views share
+  storage and the const-method `call` through `details::view_base<F,
+  Const>`; the mutable view layers the unrestricted non-const overload on
+  top and re-exposes the inherited one with a using-declaration.
 - Invariant: `proxy<F>` and `proxy_view<F>` themselves satisfy
   `proxiable<_, F>`, so generic code constrained on the facade accepts
   concrete and erased arguments interchangeably (Rust: `dyn Trait`
@@ -352,7 +355,12 @@ architecture.
 
 Header: `corvid/meta/proxy.h`, namespace `corvid::meta::prox`, deliberately
 NOT inline: `facade`, `method`, and `key` are too generic to dump into
-`corvid`. Promote to a `corvid/proxy/` family only if it sprawls. Tests:
+`corvid`. The call-site vocabulary (`proxy`, `proxy_view`,
+`const_proxy_view`, `make_proxy`, `make_proxy_view`, `Proxiable`) is
+exported into `corvid::meta` by using-declarations, so consuming code spells
+`proxy_view<foo_like>` unqualified; only authoring (facades, impls,
+registration) needs `prox::`, the domain those authors already work in.
+Promote to a `corvid/proxy/` family only if it sprawls. Tests:
 `tests/portable/proxy_test.cpp`. `method` derives from its `key`
 (subsumption: a method tag is usable anywhere its key is; also the hook for
 overloading bindings on the full method if per-name overload sets ever

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -442,14 +442,20 @@ extends, each base's boilerplate drives the inherited forwarders at the
 derived probe, and the whole flattened list is checked at the derived
 facade's registration.
 
-An `api` diamond needs two touches from the composing facade's author. The
-shared ancestor's forwarder names arrive through both base `api`s, so plain
-member lookup is ambiguous until one using-declaration per shared method
-pulls in a path (either one; they forward identically). And because the two
-empty ancestor-`api` subobjects are the same type, the ABI must give them
-distinct addresses, so the handle picks up one padding word that empty-base
-optimization cannot remove; an author who cares can inherit one base's `api`
-only and redeclare the other's own forwarders.
+An `api` diamond is best built along one path: inherit the heavier chain's
+`api` and redeclare the lighter siblings' own forwarders (the test's
+`posse_leader` inherits `marshal::api` and redeclares `bounty_hunter`'s one
+forwarder). Inheriting every base `api` also works, but costs one
+using-declaration per shared-ancestor method, because the ancestor's
+forwarder names arrive through both bases and plain member lookup is
+ambiguous until a using-declaration pulls in a path, plus one padding word
+in every handle, because the two empty ancestor-`api` subobjects are the
+same type and the ABI must give them distinct addresses, which empty-base
+optimization cannot remove. There is no automatic merge available before
+reflection: using-declarations cannot be pack-expanded over arbitrary names
+(the `overloaded` trick works only for a known name like `operator()`), and
+virtual inheritance would put a vbptr in every handle, costing more than it
+saves.
 
 ### Facade names and sibling collisions (`name`, built)
 

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -31,7 +31,8 @@ buffer plus dispatch pointer).
 | Corvid                        | ngcpp/proxy              | Rust                 |
 | ----------------------------- | ------------------------ | -------------------- |
 | `proxy<F>`                    | `pro::proxy<F>`          | `Box<dyn T>`         |
-| `proxy_view<F>`               | `pro::proxy_view<F>`     | `&dyn T`             |
+| `proxy_view<F>`               | `pro::proxy_view<F>`     | `&mut dyn T`         |
+| `const_proxy_view<F>`         | (none)                   | `&dyn T`             |
 | `facade`                      | facade (`facade_builder`)| `trait`              |
 | `method<"fire", void(int)>`   | dispatch + convention    | trait method         |
 | `proxy_impl<F, T>`            | (none; structural)       | `impl Trait for Type`|
@@ -240,13 +241,29 @@ through `call<>` and the same dispatch table.
 - The owning table carries housekeeping slots (destroy, relocate/move) in
   addition to the facade methods, the analog of Rust's drop glue.
   `proxy_view` carries none, which is why the view is built first.
+- Const is handled on two axes. Every handle is deep-const as an instance:
+  only const-qualified methods dispatch through a const handle, enforced by a
+  constraint on the const `call` overload. For the copyable views this is a
+  guardrail, not a guarantee (copying a `const proxy_view` yields a mutable
+  view, like copying a `T* const` to a `T*`); the guarantee lives in
+  `const_proxy_view`, the `&dyn` to `proxy_view`'s `&mut dyn`, where
+  constness is part of the type. It binds const and mutable targets alike,
+  converts implicitly from `proxy_view` with no path back, and dispatches
+  only const methods while sharing the mutable view's per-(facade, type)
+  dispatch table (the non-const slots are simply unreachable, so no
+  const-sliced table or index remapping is needed).
 - Invariant: `proxy<F>` and `proxy_view<F>` themselves satisfy
   `proxiable<_, F>`, so generic code constrained on the facade accepts
   concrete and erased arguments interchangeably (Rust: `dyn Trait`
   implements `Trait`). Implemented as library-provided `proxy_impl`
   bindings whose `on` forwards through `call` with conditional `noexcept`
-  (so the invariant survives noexcept methods); the owning proxy's binding
-  has const and non-const overloads to respect its deep const.
+  (so the invariant survives noexcept methods); the deep-const handles'
+  bindings have const and non-const overloads to match. For
+  `const_proxy_view` the invariant holds exactly for all-const facades (as
+  with Rust `&dyn`, whose `&mut self` methods are uncallable); its binding's
+  `on` is constrained to const methods so a mixed facade fails conformance
+  cleanly at overload resolution rather than erroring during return type
+  deduction.
 
 ## Alternative considered: virtual-model erasure
 
@@ -319,8 +336,9 @@ architecture.
    and relocate slots; a null relocate slot marks the heap path, which
    moves by pointer steal with no target activity. Default-constructed and
    moved-from proxies are empty (`operator bool`); calling through one is
-   undefined behavior. Also in this phase: `noexcept` method flavors and
-   the self-conformance invariant, both described under Mechanism.
+   undefined behavior. Also in this phase: `noexcept` method flavors, the
+   self-conformance invariant, deep-const `proxy_view`, and
+   `const_proxy_view`, all described under Mechanism.
    Verified: lifetime-counting fixtures balancing construct/destroy/move
    on both the SBO and heap paths, move-assignment over a live target,
    emptiness after move, deep-const positive and negative probes,
@@ -373,7 +391,7 @@ dispatch, allocator plumbing, RTTI, per-name overload sets.
 
 - The member-call sugar pin: the `api` mixin is the leading candidate
   (judged plausible); confirm once real call sites exist.
-- Const flavor of views: whether `proxy_view<F>` needs a distinct
-  const-view type (the `&T` vs `&mut T` split) or const-qualified methods
-  suffice. The owning proxy answered its half of the question (deep const,
-  in phase 2); the view remains shallow-const pending this.
+
+The const flavor of views was an open question until phase 2: resolved as
+the `&T` vs `&mut T` split (`const_proxy_view` alongside a deep-const
+`proxy_view`), described under Mechanism.

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -1,9 +1,9 @@
 # Proxy design
 
-Status: phases 1 and 2 built and tested ([proxy.h](proxy.h),
-[proxy_test.cpp](../../tests/portable/proxy_test.cpp)); phase 3 in
-progress: the `api` mixin and its `validate_api` drift check are built and
-tested, `extends<Base>` is pending. Plan for `corvid/meta/proxy.h`, a
+Status: phases 1 through 3 built and tested ([proxy.h](proxy.h),
+[proxy_test.cpp](../../tests/portable/proxy_test.cpp)): the `api` mixin, its
+`validate_api` drift check, and `extends<Base>` composition with upcasting.
+Plan for `corvid/meta/proxy.h`, a
 registration-based runtime-polymorphism ("proxy") system: type-erased handles
 over an interface definition, without inheritance, vtable pointers in the
 target type, or macros.
@@ -62,28 +62,35 @@ Naming notes:
 
 ## User-facing shape
 
-Conformance is two-layered. The facade author writes a boilerplate impl
-once: a partial specialization of `proxy_impl`, generic over any registered
-`T`, forwarding each method to the natural member name. Only the facade
-author can write it, because only code written with the names in view can
-spell `t.fire`. A conforming type whose method names line up then costs one
-registration line; a type whose names do not line up writes its own impl,
-and a full specialization beats the boilerplate partial by the ordinary
-specialization-ordering rules, with no extra machinery.
+Conformance is tiered. The facade author writes a boilerplate impl
+once: a class template named `boilerplate`, nested in the facade body,
+generic over any registered `T`, forwarding each method to the natural
+member name. Only the facade author can write it, because only code written
+with the names in view can spell `t.fire`. A library-provided constrained
+partial specialization of `proxy_impl` (a C++20 partial specialization with
+the primary's own argument list, legal because it is more constrained)
+delegates every registered pair to the nested boilerplate, so the facade
+needs no namespace-scope impl at all and the boilerplate sits next to the
+method list and `api` it mirrors. A conforming type whose method names line
+up then costs one registration line; a type whose names do not line up
+carries its own impl in the registration. The namespace-scope spelling of
+the boilerplate, a `proxy_impl` partial specialization gated on
+`ProxyRegistered`, predates the nested form and remains equivalent and
+supported (it also outranks the library's delegation by partial ordering, so
+the two styles cannot collide).
 
 ```cpp
-// The facade: the interface definition.
+// The facade: the interface definition, carrying its own boilerplate.
 struct gunslinger : facade<method<"fire", void(int)>,
-                       method<"reload", bool()>> {};
-
-// Boilerplate impl, written once by the facade author. `on` is the fixed
-// hook name, overloaded on the method key; a fixed name is what keeps the
-// mechanism spellable without macros.
-template<typename T>
-requires ProxyRegistered<gunslinger, T>
-struct proxy_impl<gunslinger, T> {
-  static void on(method_key<"fire">, T& t, int rounds) { t.fire(rounds); }
-  static bool on(method_key<"reload">, T& t) { return t.reload(); }
+                       method<"reload", bool()>> {
+  // Written once by the facade author. `on` is the fixed hook name,
+  // overloaded on the method key; a fixed name is what keeps the mechanism
+  // spellable without macros.
+  template<typename T>
+  struct boilerplate {
+    static void on(method_key<"fire">, T& t, int rounds) { t.fire(rounds); }
+    static bool on(method_key<"reload">, T& t) { return t.reload(); }
+  };
 };
 
 // Conforming a type whose methods line up: pure registration. The ADL
@@ -93,18 +100,56 @@ consteval auto corvid_proxy_spec(gunslinger*, lawman*) {
   return make_proxy_spec<gunslinger, lawman>();
 }
 
-// Conforming a type whose methods do not line up: write the impl.
-template<>
-struct proxy_impl<gunslinger, robber> {
-  static void on(method_key<"fire">, robber& r, int rounds) {
-    r.shoot(rounds);
-  }
-  static bool on(method_key<"reload">, robber& r) { return r.rearm(); }
-};
+// Conforming a type whose methods do not line up: the registration carries
+// the impl, here local to the hook itself, so the whole conformance is one
+// self-contained declaration.
+consteval auto corvid_proxy_spec(gunslinger*, robber*) {
+  struct as_gunslinger {
+    static void on(method_key<"fire">, robber& r, int rounds) {
+      r.shoot(rounds);
+    }
+    static bool on(method_key<"reload">, robber& r) { return r.rearm(); }
+  };
+  return make_proxy_spec<gunslinger, robber, as_gunslinger>();
+}
 
 proxy<gunslinger> p = make_proxy<gunslinger, lawman>(/*ctor args*/);
 p.call<"fire">(3); // Core spelling: compile-time name -> slot lookup.
 ```
+
+The registration-carried impl is the spec's first knob: the three-type
+`make_proxy_spec<F, T, Impl>()` returns a `proxy_spec` whose `impl_t` names
+the binding class, a library partial specialization of `proxy_impl` installs
+it for the pair (`SpecCarriesImpl` is the detecting concept), and it
+outranks the facade's boilerplate as the closer declaration. Registration is
+therefore the sole act of conformance, with fewer distinctions between the
+routes: every binding is either the facade's boilerplate or a carried impl,
+and both are opt-in. The unregistered per-type full specialization of
+`proxy_impl`, which was the original wrong-names tier, is subsumed by
+carried impls and dropped from the supported surface: it offered nothing the
+carried impl does not (foreign types take a hook in the facade's namespace;
+generic families take a constrained template hook, like `strongbox` in the
+test), while uniquely enabling conformance with no opt-in declaration and
+inviting ODR mischief, since any TU could silently override another's
+binding. The language cannot forbid such specializations, and `proxy_impl`
+necessarily stays a public name for the namespace-scope boilerplate
+spelling, so this is a contract boundary rather than a mechanical one. A
+namespace-scope boilerplate partial should add `!SpecCarriesImpl<F, T>` to
+its gate to preserve carried-impl precedence, since raw partial ordering
+would prefer it (the nested boilerplate gets this arbitration from the
+library).
+
+The binding class can live anywhere a type can. Local to the hook, as
+above, the registration is fully self-contained, which is also the only
+self-contained way to conform a type you do not own; this is sound because
+local classes are ordinary template arguments, their static member
+functions are ordinary runtime functions even inside a consteval hook, and
+a consteval function is implicitly inline, so the local type is
+ODR-consistent across translation units (local classes do forgo static data
+members and member templates, which bindings do not need). Nested in the
+type it serves, the impl additionally reaches the type's private members
+(`turncoat` in the test). Namespace scope works too, but buys nothing over
+the other placements.
 
 The string NTTP rides on the existing
 [fixed_string.h](fixed_string.h). `call<"fire">` resolves at
@@ -114,33 +159,23 @@ lookup exists anywhere.
 ### Partial override of the boilerplate
 
 When a type's names line up except for one method, a full custom impl
-re-spells every binding just to change one. The facade author can enable a
-cheaper middle tier by factoring the boilerplate's bindings into a plain,
-inheritable class template, with the partial specialization deriving from
-it. A near-conforming type then writes a full specialization that inherits
-the factored class, re-exposes its `on` overloads with a using-declaration,
+re-spells every binding just to change one. The nested boilerplate, being an
+ordinary inheritable class template, provides a cheaper middle tier for
+free: a near-conforming type registers a carried impl that inherits
+`F::boilerplate<T>`, re-exposes its `on` overloads with a using-declaration,
 and declares only the divergent binding:
 
 ```cpp
-// Facade author: factor the bindings so they are inheritable.
-template<typename T>
-struct proxy_impl_gunslinger {
-  static void on(method_key<"fire">, T& t, int rounds) { t.fire(rounds); }
-  static bool on(method_key<"reload">, T& t) { return t.reload(); }
-};
-
-template<typename T>
-requires ProxyRegistered<gunslinger, T>
-struct proxy_impl<gunslinger, T>: proxy_impl_gunslinger<T> {};
-
 // `sheriff` lines up except that `fire` is spelled `shoot`.
-template<>
-struct proxy_impl<gunslinger, sheriff>: proxy_impl_gunslinger<sheriff> {
-  using proxy_impl_gunslinger<sheriff>::on;
-  static void on(method_key<"fire">, sheriff& s, int rounds) {
-    s.shoot(rounds);
-  }
-};
+consteval auto corvid_proxy_spec(gunslinger*, sheriff*) {
+  struct as_gunslinger : gunslinger::boilerplate<sheriff> {
+    using gunslinger::boilerplate<sheriff>::on;
+    static void on(method_key<"fire">, sheriff& s, int rounds) {
+      s.shoot(rounds);
+    }
+  };
+  return make_proxy_spec<gunslinger, sheriff, as_gunslinger>();
+}
 ```
 
 Mechanics: a derived `on` with the identical parameter list excludes the
@@ -149,14 +184,13 @@ override wins with no ambiguity. The using-declaration is load-bearing:
 without it, the derived `on` hides all the inherited overloads and
 conformance fails on the rest. The hidden base binding is never
 instantiated (class-template members instantiate only on use), so its body
-naming the absent member is harmless. As with any full specialization, no
-registration is involved.
+naming the absent member is harmless.
 
-The trade is that the tier exists only if the facade author exposes the
-bindings as a named class rather than writing them inline in the partial
-specialization. It overlaps in purpose with the spec-carried member-pointer
-binding sketched under Future; the two can coexist. Exercised by `sheriff`
-in the test.
+Before the boilerplate moved into the facade, this tier required the facade
+author to factor the bindings into a separately-named class for the
+namespace-scope partial to derive from; with the nested form it is inherent.
+It overlaps in purpose with the spec-carried member-pointer binding sketched
+under Future; the two can coexist. Exercised by `sheriff` in the test.
 
 ### Member-call sugar (the `api` mixin, built)
 
@@ -288,11 +322,100 @@ deletes the whole problem by generating the `api` from the facade.
 Two structural limits: failures are hard compile errors rather than a
 `false` (a fully generic `FulfillsApi<H, F>` concept is impossible in
 C++23, since no mechanism turns a `fixed_string` into an identifier to
-probe `h.fire(...)`), and the facade must have a boilerplate `proxy_impl`
-partial gated on `ProxyRegistered` for the chain to exist, since that impl
-is the only artifact that invokes the members by name. A registration that
-cannot see such a boilerplate fails a friendly `static_assert` that names
-the opt-out.
+probe `h.fire(...)`), and the facade must have a boilerplate impl (a nested
+`boilerplate`, or a namespace-scope `proxy_impl` partial gated on
+`ProxyRegistered`) for the chain to exist, since that impl is the only
+artifact that invokes the members by name. A registration that cannot see
+such a boilerplate fails a friendly `static_assert` that names the opt-out;
+a nested boilerplate is visible wherever the facade is, so only the
+namespace-scope spelling can trip it.
+
+### Composition (`extends`, built)
+
+A facade extends others by listing `extends<Base>` entries alongside its
+methods, conventionally first:
+
+```cpp
+struct marshal : facade<extends<gunslinger>,
+                     method<"arrest", bool(int)>> {};
+```
+
+The derived facade's effective method list is the flattening of its bases'
+lists, in declaration order, followed by its own, and every handle of the
+derived facade dispatches inherited and own methods alike. Names must be
+unique across the flattened list, enforced by a `static_assert` detonator at
+first use of the facade's machinery: a facade cannot redeclare (or override)
+an inherited method, and diamonds are rejected. Both restrictions have
+relaxation paths recorded under Future.
+
+Conformance is per facade, as with Rust supertraits: `Proxiable<T, marshal>`
+requires `marshal`'s own methods bound through `proxy_impl<marshal, T>` plus
+`Proxiable<T, gunslinger>`, and the derived boilerplate spells only the new
+methods. The alternative, one derived impl covering the whole flattened
+list, was rejected because it lets a directly-built `proxy_view<gunslinger>`
+and an upcast one dispatch different bindings for the same method. Per-facade
+binding defines each inherited method's behavior exactly once, so the two
+are identical by construction.
+
+Registration does not multiply with the chain, though: the idiomatic
+spelling is a single template hook constrained on `InChainOf` (`Extends`
+made reflexive and argument-flipped), which registers a type for the derived
+facade and every facade it extends in one declaration:
+
+```cpp
+template<prox::InChainOf<texas_ranger> F>
+consteval auto corvid_proxy_spec(F*, ranger*) {
+  return prox::make_proxy_spec<F, ranger>();
+}
+```
+
+The hook collapses only the opt-in ceremony; the bindings stay per facade.
+Chain registration is always semantically safe, because conformance to the
+derived facade requires base conformance anyway. A base level that needs a
+carried impl (its names diverge at that level only) takes its own plain hook
+alongside the chain hook; overload resolution prefers the non-template hook
+for that level, and the carried impl outranks the boilerplate. A
+deliberately partial registration remains expressible with plain per-facade
+hooks; it produces a type that is not proxiable at the derived facade at
+all, failing loudly at first use (exercised by `vigilante` in the test).
+
+The dispatch table of a composed facade carries the flattened thunks (bases'
+first), with the inherited entries copied verbatim from each base's table,
+plus the address of each direct base's table for the same target type. An
+inherited call is therefore the same single indexed load as an own one, and
+upcasting is reading an embedded pointer (walked transitively for
+grandparents), which is Rust's dyn-upcast vtable layout. ngcpp reaches the
+same user-visible feature differently: upward conversion is opt-in per
+composition (`add_facade<F, true>`) and works as a dispatched conversion,
+where the per-type thunk manufactures the target handle.
+
+Handles upcast implicitly, like derived-to-base pointers: `proxy_view<D>`
+and `const_proxy_view<D>` convert to their `B` counterparts (and mutable to
+const, never back), and an lvalue owning proxy converts to a view of its own
+facade or any base, re-pointing at the stored target rather than wrapping
+the handle. The proxy-to-view constructors are lvalue-only so a temporary
+proxy cannot leave a dangling view, and a const proxy yields only the const
+view. Viewing an empty proxy is a precondition violation, like calling
+through one. The generic target constructors exclude handles of the same or
+an extending facade (`details::is_handle_for`), so the re-pointing
+constructors always win over wrapping a handle as a target; wrapping a
+handle of an unrelated facade that conforms via a custom impl still works.
+
+The self-conformance invariant stretches across composition: the library
+bindings generalize from `proxy_impl<F, handle<F>>` to
+`proxy_impl<B, handle<D>>` for any `D` extending `B`, so a derived handle
+satisfies a base-facade bound (Rust: `dyn Derived` meets a `Base` bound) and
+`make_proxy_view<B>` accepts and upcasts derived handles.
+
+A derived facade does not inherit the base's `api` automatically (facade
+types are unrelated as C++ types); the convention is
+`struct api : gunslinger::api { ... };`, adding only the new forwarders.
+Deducing `this` sees the complete handle either way, so inherited forwarders
+dispatch through the derived handle's flattened table. `validate_api` runs
+through composition: the probe of a facade registers for every facade it
+extends, each base's boilerplate drives the inherited forwarders at the
+derived probe, and the whole flattened list is checked at the derived
+facade's registration.
 
 ## Mechanism
 
@@ -301,10 +424,10 @@ the opt-out.
   invocable and returns the right type. Concepts gate (the converting
   constructor, static-dispatch template bounds); they cannot generate, since
   C++ has no introspection over requires-expressions. The facade is the
-  source of truth and the concept is derived from it, never the reverse. An
-  explicit `proxy_impl` specialization satisfies the concept directly; the
-  boilerplate partial satisfies it exactly when the pair is registered, so
-  registration is required precisely when relying on the boilerplate.
+  source of truth and the concept is derived from it, never the reverse.
+  Both binding routes are registration-gated, so the concept is satisfied
+  exactly when the pair is registered with a usable binding (the facade's
+  boilerplate or a carried impl).
 - The registration slot mirrors the enum registry idiom: an ADL-found
   `corvid_proxy_spec(F*, T*)` hook returns a spec object created by
   `make_proxy_spec<F, T>()` (as `make_sequence_enum_spec` is returned from
@@ -314,12 +437,13 @@ the opt-out.
   declared in user namespaces; the maker keeps the spec type's name out of
   user code, resolving the hook-vs-type name confusion. Because either
   namespace can host the hook, a type you do not own can be conformed to a
-  facade you do not own (the case Rust's orphan rule forbids). The MVP spec
-  type carries no knobs; since each specialization of an `auto` variable
-  template deduces its own type and readers detect capabilities via
-  concepts on the spec (precedent: `NamedSequentialEnum` detecting
-  `intern_name` on the enum spec), richer spec types are additive later,
-  with no change to existing registrations. Maximal slot, minimal values.
+  facade you do not own (the case Rust's orphan rule forbids). Each
+  specialization of an `auto` variable template deduces its own type and
+  readers detect capabilities via concepts on the spec (precedent:
+  `NamedSequentialEnum` detecting `intern_name` on the enum spec), so richer
+  spec types are additive, with no change to existing registrations. Maximal
+  slot, minimal values. The first knob to use this is the carried impl
+  (`SpecCarriesImpl`), described under "User-facing shape".
 - Conversion to a proxy instantiates one thunk per method
   (`+[](void* p, args...) { return proxy_impl<F, T>::on(...); }`) and
   stores a pointer to the resulting per-`(F, T)` `static constexpr` table.
@@ -458,9 +582,24 @@ architecture.
    `int`-to-`long long` parameter drift in a forwarder compiled silently
    before the check existed and now fails through `lawman`'s registration
    alone, at the forwarder's own line, with the diagnostic on record in the
-   test. Remaining: `extends<Base>` composition, including
-   `proxy<derived>` -> `proxy_view<base>` conversion (Rust trait upcasting).
-   Verify: upcast dispatch correctness.
+   test. `extends<Base>` composition is DONE (see "Composition"): flattened
+   dispatch, per-facade conformance, implicit upcasting of views and of
+   lvalue owning proxies (including `proxy<derived>` ->
+   `proxy_view<base>`), cross-facade self-conformance, `api` inheritance by
+   convention, and validation through the chain. Verified: inherited and own
+   dispatch through all three handles, upcast target identity (mutations
+   through the derived handle visible through the upcast view, and
+   reference-return address equality against a directly-built view),
+   two-level chains, deep-const preservation across upcasts, negative
+   conformance with a missing base registration, and the duplicate-name
+   detonator; diagnostics on record in the test. A follow-up ergonomics
+   round, driven by reading the test as an end user, added chain
+   registration (`InChainOf`), moved the boilerplate into the facade body,
+   added registration-carried impls (the delegations described under
+   "User-facing shape"; precedence pinned by `turncoat` in the test),
+   dropped the unregistered full-specialization tier in their favor, and
+   restyled the tests to prefer the `api` sugar over `call<>` wherever a
+   facade defines one.
 
 Header: `corvid/meta/proxy.h`, namespace `corvid::meta::prox`, deliberately
 NOT inline: `facade`, `method`, and `key` are too generic to dump into
@@ -503,6 +642,48 @@ dispatch, allocator plumbing, RTTI, per-name overload sets.
   (`make_proxy_shared`, compact internal refcounts) to beat `shared_ptr`
   overhead; reusing std is our accepted trade. The plain heap fallback in
   phase 2 stays unique-owned (destroy slot, move-only, cheaper).
+- Owning upcast, `proxy<D>` -> `proxy<B>`: wanted, deferred. Needs the
+  base's owning table (destroy and relocate slots) reachable for an erased
+  target, either embedded like the view tables or via ngcpp's
+  dispatched-conversion approach. The conversion is one-way: the D-ness of
+  the stored target is unrecoverable without a downcast mechanism
+  (RTTI-adjacent, a non-goal), the same permanence as Rust's
+  `Box<dyn Derived>` -> `Box<dyn Base>`, and part of why ngcpp gates upward
+  conversion behind an explicit opt-in flag.
+- Diamond composition: wanted, deferred. The semantic half is already
+  collapsed, because per-facade conformance yields one `proxy_impl<Base, T>`
+  no matter how many paths reach `Base` (the same effect as Rust's
+  coherence rule). The blocker is mechanical: flattening duplicates the
+  shared ancestor's methods, tripping the unique-name check. The fix is
+  deduplicating repeated ancestor facades during flattening; the shared
+  ancestor's table pointer is the same object along every path.
+- Per-name overload sets via distinct keys sharing an `api` spelling:
+  `method<"foo-0", void()>` and `method<"foo-1", void(int)>` with two `foo`
+  forwarders overloading on the arguments, the same move as C++ name
+  mangling. Nothing in the machinery forbids it today, and on inspection
+  `validate_api` is compatible (it drives each key's slot independently; the
+  boilerplate's natural-name call resolves against the `api` overload set,
+  and convertibility drift in the selection still fails the strict probe),
+  but it is unsupported until a test exercises it. ngcpp supports overloads
+  natively by listing several signatures in one convention.
+- Facade-qualified method names: keys are opaque strings, so a
+  "gunslinger::shoot" spelling convention is available at any time. Making
+  it meaningful (unqualified lookup that searches own methods then bases,
+  with the qualified spelling as the collision-breaker) would relax the
+  unique-name rule from a definition-time error to a call-site ambiguity,
+  which is Rust's model (same-named methods across traits, disambiguated by
+  fully-qualified syntax). Upcasting already provides the other
+  disambiguation route, since a `proxy_view<gunslinger>` only sees the base
+  list. The qualifier itself is best deferred to C++26 reflection, where
+  `identifier_of` recovers the facade type's own name with no extra
+  spelling; a `name<"gunslinger">` facade-list entry (parallel to `extends`)
+  is the pre-reflection fallback shape, at the cost of naming the facade a
+  third time.
+- Overriding an inherited method in a derived facade conflicts with the
+  upcast-consistency invariant (a derived handle and an upcast base handle
+  would disagree about one method), so if it ever happens it has to be
+  shadowing plus qualified access, not a binding-level override. Recorded as
+  a tension to resolve, not a plan.
 
 ## Open questions
 

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -1,8 +1,11 @@
 # Proxy design
 
-Status: phases 1 through 3 built and tested ([proxy.h](proxy.h),
+Status: phases 1 through 5 built and tested ([proxy.h](proxy.h),
 [proxy_test.cpp](../../tests/portable/proxy_test.cpp)): the `api` mixin, its
-`validate_api` drift check, and `extends<Base>` composition with upcasting.
+`validate_api` drift check, `extends<Base>` composition with upcasting,
+facade-qualified names with sibling collisions and diamonds, and the
+ownership round (storage policies, owning upcast, cloning, `unique_ptr`
+interop, vtable-carried downcasting, and the shared/weak tier).
 Plan for `corvid/meta/proxy.h`, a
 registration-based runtime-polymorphism ("proxy") system: type-erased handles
 over an interface definition, without inheritance, vtable pointers in the
@@ -44,6 +47,11 @@ buffer plus dispatch pointer).
 | `make_proxy<F, T>(...)`       | `make_proxy`             | `Box::new`           |
 | `make_proxy_view<F>(t)`       | `make_proxy_view`        | `&x as &dyn T`       |
 | `extends<Base>`               | `add_facade`             | supertrait           |
+| `proxy_policy`                | facade-level constraints | (none)               |
+| `clone()` / `can_clone()`     | copyability constraint   | (dyn-clone idiom)    |
+| `try_downcast<D>()`           | (none)                   | (`dyn Any` adjacent) |
+| `shared_proxy<F>`             | `make_proxy_shared`      | `Rc<dyn T>`          |
+| `weak_proxy<F>`               | (its weak counterpart)   | `Weak<dyn T>`        |
 | (internal) dispatch table     | meta                     | vtable + drop glue   |
 
 Naming notes:
@@ -515,6 +523,179 @@ through the qualified spelling of `B`'s method names, so a derived handle
 keeps satisfying a base-facade bound even when the derived list collides on
 the method's plain name.
 
+## Ownership and storage (built)
+
+Views give all the type-erasure anyone could ask for; a proxy's added value
+is ownership, so ownership is where the knobs are. Every knob lives on the
+handle rather than the facade: registration is per (facade, type) and knows
+nothing about any particular handle's storage, so one facade serves proxies
+of every policy, shared proxies, and views simultaneously, and the checks
+fire at proxy construction, the first moment the policy meets the concrete
+type. (No facade-level knob has yet justified itself; the spec's additive
+design means one can be added later without touching existing
+registrations.)
+
+### Storage policies
+
+`proxy<F, Policy>` takes a `proxy_policy` NTTP whose default reproduces the
+baseline handle: a two-pointer inline buffer at `std::max_align_t`
+alignment, heap fallback. The `fixed_function` lesson is that the default
+SBO is sometimes a little too small, so `sbo_size` and `sbo_align` are
+settable, growing only (a target eligible for the default buffer stays
+eligible for every buffer). `alloc` picks the strategy: `sbo_or_heap` (the
+default), `sbo_only` (an ineligible target is a clean `static_assert` at
+construction), or `heap_only` (every target's address is stable, and the
+handle drops its buffer to become two words, like a view). The chosen mode
+is baked into the owning table's identity: tables are per (facade, birth
+facade, type, mode), and the mode discriminates the storage union at
+runtime through the `relocate` slot (the birth key serves downcasting,
+below).
+
+Proxies of different facades and policies interconvert as rvalues through
+one converting constructor, and the source's policy never forecloses a
+conversion: what matters is whether the destination can accommodate the
+target that actually arrives, decided per target at adoption time. An
+inline arrival relocates into the buffer when it fits (the check is purely
+compile-time when the destination's buffer dominates the source's, which
+covers every same-policy move) and otherwise re-boxes onto the heap; a heap
+arrival moves by pointer steal, or un-boxes into an `sbo_only` proxy's
+buffer, the erased target's size and alignment being checked against the
+buffer through the owning table. Exactly the conversions that might change
+the storage mode can throw: the re-boxing allocation, or
+`std::length_error` when an erased target cannot be stored inline and the
+policy forbids the heap (a real error path rather than a precondition,
+since the caller cannot inspect an erased target's size). A throw happens
+before anything moves, leaving the source intact. The static probe
+`can_adopt(source)` answers up front whether a conversion would be
+accommodated, advertising that adoption is not always possible and letting
+a caller sidestep the throw; it is a property of the destination type
+against the source's runtime target, so it needs no destination instance,
+and only an `sbo_only` destination can ever answer no. The mode-changing thunks
+and the other-mode table cross-links live in the owning tables
+(`sbo_to_heap`/`heap_to_sbo`), whose two modes reference each other by
+address.
+
+### Owning upcast
+
+An rvalue `proxy<D>` converts implicitly to `proxy<B>` for any facade `D`
+extends (Rust: `Box<dyn Derived>` to `Box<dyn Base>`). The move transfers
+the target, by relocation or pointer steal exactly as in a same-facade move,
+and leaves the source empty. The mechanism mirrors the views': the owning
+table embeds each direct base's owning table for the same birth, target,
+and mode, and `upcast_owning_vtable` walks the same compile-time-resolved
+route as `upcast_vtable`. The conversion is one-way as a conversion, but
+unlike Rust's own permanent `Box` upcast it can be undone through
+`try_downcast` (below), since the tables remember the birth facade. One
+consequence of the birth key: an upcast proxy's table pointer is a
+different static object from a directly built base proxy's, with identical
+dispatch, so the two are behaviorally indistinguishable rather than
+pointer-identical.
+
+### Cloning
+
+The owning table carries a `copy` slot, null for a target that is not
+copy-constructible. `can_clone()` reports it at runtime, since cloneability
+is a property of the erased target rather than the proxy type (a container
+of proxies can mix), and `clone()` returns a new proxy of the same policy
+owning a copy. Cloning is deliberately a named method rather than a copy
+constructor: an unconditional copy constructor would satisfy
+`std::copyable` for every proxy while failing at runtime for uncloneable
+targets, turning a concept-probed guarantee into a lie (the `std::function`
+trap, institutionalized). Cloning an empty proxy yields an empty one;
+cloning an uncloneable target is a precondition violation, like calling
+through an empty proxy.
+
+### std smart-pointer interop
+
+Ownership enters and leaves a proxy only by way of `std::unique_ptr`; raw
+pointers are never adopted and never exposed. `proxy<F>` constructs from a
+`std::unique_ptr<T>` (also spelled `make_proxy<F>(std::move(up))`), adopting
+the allocation as-is onto the heap path, so nothing is copied or moved and
+the address stays stable; an `sbo_only` proxy instead un-boxes the target
+into its buffer, the fit being a compile-time fact here since the type is
+concrete. `extract<T>()` is the inverse: it verifies `T`
+against the owning table's type tag at runtime (the address of a per-type
+static; on a mismatch or an empty proxy the result is null and the proxy is
+untouched), hands a heap allocation over as-is, and moves an inline target
+onto the heap first. A `unique_ptr`
+converts to `shared_ptr`, so this also buys the shared tier's interop.
+
+### Downcasting (vtable-carried RTTI)
+
+Every owning proxy remembers the facade its target was born as, priced in
+the tables rather than the handle: instances are many and tables are few,
+cold, and deduplicated statics, so the born identity is baked into the
+owning table's key, per (facade, birth facade, type, mode), instead of
+renting a pointer in every handle. Every pointer a table embeds (the
+direct-base tables, the other-mode sibling, the birth ancestry) stays
+within the same born family, so construction over a concrete target lands
+on the birth-keyed family and every conversion stays in it, with no birth
+carrying anywhere in the handles. The table type stays per facade; the
+birth key only selects which static object is pointed at, so handle layout
+is untouched. (An earlier design carried the birth as an opt-in
+policy-gated pointer in the handle; the vtable-carried form replaced it,
+deleting the policy knob, the extra word, and the unknown-birth case at
+once.)
+
+Each table points at a birth ancestry: a static per-(birth facade, type,
+mode) table of {facade identity tag, owning table} covering the birth
+facade and every facade it transitively extends, diamond-deduped. Each
+storage mode has its own ancestry over its own tables, and a mode-changing
+adoption switches to the table's other-mode sibling, so the tables an
+ancestry hands out always match the target's current home.
+
+The birth is the facade the proxy was constructed as, not the concrete
+type's full conformance: a `texas_ranger` created through
+`make_proxy<marshal, texas_ranger>` downcasts back to `marshal` but never
+to `ranger`, even though the type conforms.
+
+`std::move(p).try_downcast<D>()`, constrained to `D` extending the current
+facade, searches the ancestry at runtime by tag. On success the target
+moves into a `proxy<D>` whose table carries the same birth, so casts keep
+working in both directions; on failure, including an empty source, the
+result is empty and the source is untouched, which is why the operation is
+a method on an rvalue rather than a conversion. Through a diamond, the
+common base can sidecast to either sibling, since both are in the birth
+ancestry. This is the RTTI the library otherwise does without, reinvented
+on the reinvented vtable.
+
+### Shared and weak ownership
+
+`shared_proxy<F>` is Rust's `Rc<dyn Trait>`: a `std::shared_ptr<void>` plus
+the same per-(facade, type) dispatch table the views use. The control block
+already type-erases destruction, so no owning table is needed; there is no
+inline mode, so the target's address is always stable; and the handle is
+copyable for free, a copy sharing the one target rather than cloning it. It
+constructs from `std::shared_ptr<T>` (sharing with outside holders, who keep
+their typed view of the same object) or `std::unique_ptr<T>`, or via
+`make_shared_proxy<F, T>(...)` (target and control block in one
+allocation). Handles upcast implicitly by copy or move; views lend from a
+shared proxy exactly as from an owning one. Deep const is the same guardrail
+it is on the views: copying escapes it. ngcpp built this bespoke
+(`make_proxy_shared`, compact internal refcounts) to beat `shared_ptr`
+overhead; reusing std is our accepted trade.
+
+Unique ownership converts into shared, consuming the proxy: a heap-stored
+target is adopted with its allocation intact, the owning table's destroy
+slot becoming the control block's deleter, and an inline target moves onto
+the heap first. On a control-block allocation failure the target is
+destroyed rather than leaked and the source is left empty, `shared_ptr`'s
+own contract for its deleter-taking constructors, a weaker guarantee than
+proxy-to-proxy conversions. The reverse conversion deliberately does not
+exist, statically: unique ownership cannot be recovered from a shared
+target, even at a use count of one, without racing the other owners, which
+is also why `std::shared_ptr` has no `release`. Likewise, nothing but a
+`shared_proxy` converts to a `weak_proxy`, since there is no shared
+ownership to observe.
+
+`weak_proxy<F>` observes without owning, via `std::weak_ptr<void>`. It
+deliberately carries no dispatch: access always goes through `lock()`, which
+returns a `shared_proxy` (empty when every owner is gone), so there is no
+way to call through a target that might be dying. `expired()` is the usual
+advisory answer. Weak proxies upcast among themselves like every other
+handle, by copy or by move and without locking, so an expired observation
+upcasts as well as a live one; expiry stays `lock()`'s business.
+
 ## Mechanism
 
 - `proxiable<T, F>` is a concept synthesized from the facade definition: for
@@ -554,9 +735,13 @@ the method's plain name.
   noexcept. Supported in the MVP rather than deferred because the qualifier
   is baked into the erased ABI (the thunk pointer types), where a retrofit
   would be a break.
-- The owning table carries housekeeping slots (destroy, relocate/move) in
-  addition to the facade methods, the analog of Rust's drop glue.
-  `proxy_view` carries none, which is why the view is built first.
+- The owning table carries housekeeping slots in addition to the facade
+  methods, the analog of Rust's drop glue: destroy, relocate (null marking
+  the heap mode), copy (null marking an uncloneable target), a type identity
+  tag for typed extraction, the birth ancestry for `try_downcast`, and the
+  direct bases' owning tables for the
+  owning upcast. `proxy_view` carries none of this, which is why the view
+  was built first.
 - Const is handled on two axes. Every handle is deep-const as an instance,
   meaning only const-qualified methods dispatch through a const handle,
   enforced by a constraint on the const `call` overload. For the copyable
@@ -729,10 +914,53 @@ architecture.
    shared method; and a same-signature collision blocks `validate_api` for
    the composed facade, which registers with `api_check::off`.
 
+5. DONE. The ownership round (described under "Ownership and storage"): the
+   owning table's final shape (copy slot, type tag, size and alignment,
+   birth ancestry, embedded base owning tables, and the mode-changing
+   thunks with other-mode cross-links), the owning upcast, `proxy_policy`
+   (SBO size and alignment, `sbo_only`/`heap_only`) with
+   accommodate-what-arrives conversions (relocate, re-box, steal, or
+   un-box, decided per target at adoption) with the `can_adopt` up-front
+   probe, `clone`/`can_clone`,
+   `std::unique_ptr` adoption and
+   `extract<T>()`, `try_downcast`, `shared_proxy`/`weak_proxy` with
+   `make_shared_proxy`, and one-way unique-into-shared adoption. Downcasting
+   was first built as an opt-in `downcast` policy flavor carrying a birth
+   pointer in the handle, then redesigned onto the vtable-carried birth key
+   (see "Downcasting"), which deleted the knob, the handle word, and the
+   unknown-birth case. Verified: upcast dispatch and lifetime balance on
+   both storage paths, diamond upcast, policy sizing (a `heap_only` proxy
+   is two words), every direction of
+   cross-policy conversion including the mode changes with their exact
+   target activity, the throwing un-box leaving its source intact, the
+   noexcept partition of the converting constructor, inline and heap
+   clones with
+   independence and lifetime balance, `unique_ptr` round-trips preserving
+   the exact allocation, typed extraction rejecting the wrong type,
+   downcasts down a chain, past the birth level (failing with the source
+   intact), sideways across a diamond, through storage-mode changes
+   via the per-mode ancestries, and of a target born mid-chain (the birth
+   is the construction facade, not the type's potential), shared copies
+   sharing one
+   target, weak observation across owner death, and interop with outside
+   `shared_ptr` holders. Notes from the build: the analyzer cannot see
+   that the table's `relocate` slot discriminates the storage union, so
+   those reads carry targeted suppressions; the born family's static
+   tables and ancestries reference each other by address,
+   which demands a spelled-out variable type, since `auto` deduction would
+   be circular; the owning-bases tuple is built by a per-facade builder
+   member with a spelled-out return type, because a shared per-entry helper
+   is re-entered mid-instantiation when a diamond's ancestry reaches a
+   sibling's table build, which a deduced return type cannot survive; and an
+   `sbo_only` violation detonates as a single clean `static_assert` at
+   construction (diagnostic on record in the test).
+
 Header: `corvid/meta/proxy.h`, namespace `corvid::meta::prox`, deliberately
 NOT inline: `facade`, `method`, and `key` are too generic to dump into
 `corvid`. The call-site vocabulary (`proxy`, `proxy_view`,
-`const_proxy_view`, `make_proxy`, `make_proxy_view`, `Proxiable`) is
+`const_proxy_view`, `shared_proxy`, `weak_proxy`, `proxy_policy`,
+`proxy_alloc`, `make_proxy`, `make_proxy_view`, `make_shared_proxy`,
+`Proxiable`) is
 exported into `corvid::meta` by using-declarations, so consuming code spells
 `proxy_view<foo_like>` unqualified. Only authoring (facades, impls,
 registration) needs `prox::`, the domain those authors already work in.
@@ -744,8 +972,10 @@ happen).
 
 ## Non-goals (MVP)
 
-Copyability opt-in, shared/weak ownership, operator dispatch, conversion
-dispatch, allocator plumbing, RTTI, per-name overload sets.
+Operator dispatch, conversion dispatch, allocator plumbing, RTTI (beyond
+the facade-level `try_downcast`), per-name overload sets.
+Copyability and shared/weak ownership were non-goals here originally and
+were later built in phase 5.
 
 ## Future
 
@@ -763,21 +993,17 @@ dispatch, allocator plumbing, RTTI, per-name overload sets.
   name-mismatched types that avoids a full custom impl. Overlaps in purpose
   with the partial-override pattern above, which needs no new machinery but
   does need the facade author's cooperation.
-- Shared ownership tier, backed by `std::shared_ptr<void>`. The control
-  block already type-erases the destroyer, so a shared-backed proxy needs
-  no destroy slot in the dispatch table, is copyable for free, and gets a
-  `weak_proxy` nearly free via `std::weak_ptr`. ngcpp built this bespoke
-  (`make_proxy_shared`, compact internal refcounts) to beat `shared_ptr`
-  overhead; reusing std is our accepted trade. The plain heap fallback in
-  phase 2 stays unique-owned (destroy slot, move-only, cheaper).
-- Owning upcast, `proxy<D>` -> `proxy<B>`: wanted, deferred. Needs the
-  base's owning table (destroy and relocate slots) reachable for an erased
-  target, either embedded like the view tables or via ngcpp's
-  dispatched-conversion approach. The conversion is one-way: the D-ness of
-  the stored target is unrecoverable without a downcast mechanism
-  (RTTI-adjacent, a non-goal), the same permanence as Rust's
-  `Box<dyn Derived>` -> `Box<dyn Base>`, and part of why ngcpp gates upward
-  conversion behind an explicit opt-in flag.
+- A guaranteed-copyable proxy flavor: a policy whose construction
+  constrains targets to copyable types, making the handle itself satisfy
+  `std::copyable` with no runtime condition (the shape of ngcpp's
+  `support_copy`). `clone()`/`can_clone()` cover the need at runtime, so
+  this waits for a use case that wants the compile-time guarantee.
+- Downcasting for `shared_proxy` and the views. The vtable-carried birth
+  generalizes: their tables would take the same born key and ancestry hook.
+  Open decision before building: ancestry entries referencing owning tables
+  would drag destroy-thunk instantiation into view-only code, so a parallel
+  ancestry family over view tables is probably wanted. Deferred as the
+  follow-up to the owning-proxy redesign.
 - Per-name overload sets within a single facade, via distinct keys sharing
   an `api` spelling: `method<"foo-0", void()>` and
   `method<"foo-1", void(int)>` with two `foo` forwarders overloading on the

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -85,9 +85,10 @@ struct gunslinger : facade<method<"fire", void(int)>,
                        method<"reload", bool()>> {
   // Written once by the facade author. `on` is the fixed hook name,
   // overloaded on the method key; a fixed name is what keeps the mechanism
-  // spellable without macros.
+  // spellable without macros. Inheriting `impl_base` is optional sugar,
+  // supplying the `method_key` alias so the bindings spell it unqualified.
   template<typename T>
-  struct boilerplate {
+  struct boilerplate : impl_base {
     static void on(method_key<"fire">, T& t, int rounds) { t.fire(rounds); }
     static bool on(method_key<"reload">, T& t) { return t.reload(); }
   };
@@ -104,7 +105,7 @@ consteval auto corvid_proxy_spec(gunslinger*, lawman*) {
 // the impl, here local to the hook itself, so the whole conformance is one
 // self-contained declaration.
 consteval auto corvid_proxy_spec(gunslinger*, robber*) {
-  struct as_gunslinger {
+  struct as_gunslinger : impl_base {
     static void on(method_key<"fire">, robber& r, int rounds) {
       r.shoot(rounds);
     }
@@ -150,6 +151,13 @@ members and member templates, which bindings do not need). Nested in the
 type it serves, the impl additionally reaches the type's private members
 (`turncoat` in the test). Namespace scope works too, but buys nothing over
 the other placements.
+
+Whatever its placement, a binding class may inherit `prox::impl_base`, an
+otherwise-empty base whose one member is a `method_key` alias, so the
+bindings spell the key unqualified (base-class members participate in
+unqualified lookup where namespace-scope names do not; a literally empty
+base would change nothing). It is optional, and a binding class that
+inherits a boilerplate already has it through that base.
 
 The string NTTP rides on the existing
 [fixed_string.h](fixed_string.h). `call<"fire">` resolves at
@@ -363,15 +371,18 @@ made reflexive and argument-flipped), which registers a type for the derived
 facade and every facade it extends in one declaration:
 
 ```cpp
-template<prox::InChainOf<texas_ranger> F>
-consteval auto corvid_proxy_spec(F*, ranger*) {
-  return prox::make_proxy_spec<F, ranger>();
+template<prox::InChainOf<ranger> F>
+consteval auto corvid_proxy_spec(F*, texas_ranger*) {
+  return prox::make_proxy_spec<F, texas_ranger>();
 }
 ```
 
 The hook collapses only the opt-in ceremony; the bindings stay per facade.
 Chain registration is always semantically safe, because conformance to the
-derived facade requires base conformance anyway. A base level that needs a
+derived facade requires base conformance anyway. The anchor facade names the
+outermost level the type conforms to, so a type conforming only partway up a
+chain anchors mid-chain and is registered for that level and everything
+below (`constable` in the test). A base level that needs a
 carried impl (its names diverge at that level only) takes its own plain hook
 alongside the chain hook; overload resolution prefers the non-template hook
 for that level, and the carried impl outranks the boilerplate. A
@@ -599,7 +610,11 @@ architecture.
    "User-facing shape"; precedence pinned by `turncoat` in the test),
    dropped the unregistered full-specialization tier in their favor, and
    restyled the tests to prefer the `api` sugar over `call<>` wherever a
-   facade defines one.
+   facade defines one. A second pass added `impl_base` (the unqualified
+   `method_key` spelling in binding classes), made both views
+   default-constructible as empty with `operator bool`, matching the owning
+   proxy, and pinned mid-chain anchoring of chain hooks (`constable` in the
+   test).
 
 Header: `corvid/meta/proxy.h`, namespace `corvid::meta::prox`, deliberately
 NOT inline: `facade`, `method`, and `key` are too generic to dump into

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -578,7 +578,7 @@ architecture.
    noexcept conformance both ways (a binding lacking `noexcept` fails the
    facade), `noexcept(call)` propagation, and heterogeneous ownership in a
    container.
-3. IN PROGRESS. The `api` mixin is DONE: `details::api_base_t<F>` selects
+3. DONE. The `api` mixin is DONE: `details::api_base_t<F>` selects
    the facade's nested `api` (lazy specialization, empty `no_api` stand-in),
    and all three handles inherit it. Verified: forwarder parity with
    `call<>` through the mutable view, the const view, and the owning proxy
@@ -610,7 +610,7 @@ architecture.
    "User-facing shape"; precedence pinned by `turncoat` in the test),
    dropped the unregistered full-specialization tier in their favor, and
    restyled the tests to prefer the `api` sugar over `call<>` wherever a
-   facade defines one. A second pass added `impl_base` (the unqualified
+   facade defines one. A second pass added `proxy_impl` (the unqualified
    `method_key` spelling in binding classes), made both views
    default-constructible as empty with `operator bool`, matching the owning
    proxy, and pinned mid-chain anchoring of chain hooks (`constable` in the
@@ -702,9 +702,9 @@ dispatch, allocator plumbing, RTTI, per-name overload sets.
 
 ## Open questions
 
-- The member-call sugar pin was resolved in favor of the `api` mixin, now
-  built. Confirm the ergonomics (including the constraint-visibility caveat)
-  once real call sites exist outside the test.
+The member-call sugar pin was an open question until phase 3. It was
+resolved in favor of the `api` mixin, and the test code exercising it
+confirmed the ergonomics.
 
 The const flavor of views was an open question until phase 2. It was
 resolved as the `&T` vs `&mut T` split (`const_proxy_view` alongside a

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -1,0 +1,292 @@
+# Proxy design
+
+Status: phase 1 built and tested ([proxy.h](proxy.h),
+[proxy_test.cpp](../../tests/portable/proxy_test.cpp)); phases 2 and 3
+pending. Plan for `corvid/meta/proxy.h`, a
+registration-based runtime-polymorphism ("proxy") system: type-erased handles
+over an interface definition, without inheritance, vtable pointers in the
+target type, or macros.
+
+## Lineage and positioning
+
+Prior art is [ngcpp/proxy](https://github.com/ngcpp/proxy) (formerly
+microsoft/proxy, on the standards track as P3086) and Rust trait objects
+(`dyn Trait`). We lean toward ngcpp naming because this is C++, but diverge
+on one deliberate axis: conformance is nominal (registered), not structural
+(duck-typed). ngcpp accepts any type whose members happen to match the
+facade; we require an explicit registration, the same philosophy as the
+Corvid registered-enum system (registration, not reflection). Registration
+also dissolves ngcpp's need for macros: their `PRO_DEF_MEM_DISPATCH` macros
+exist solely to mint accessor functions with caller-chosen names, and when
+the user writes the binding explicitly there is no name to mint.
+
+The one-method ancestor within Corvid is
+[fixed_function.h](fixed_function.h): a `proxy` is a `fixed_function`
+generalized from a single anonymous `operator()` to a named suite of
+methods, and the owning flavor reuses the same storage ideas (inline SBO
+buffer plus dispatch pointer).
+
+## Naming map
+
+| Corvid                        | ngcpp/proxy              | Rust                 |
+| ----------------------------- | ------------------------ | -------------------- |
+| `proxy<F>`                    | `pro::proxy<F>`          | `Box<dyn T>`         |
+| `proxy_view<F>`               | `pro::proxy_view<F>`     | `&dyn T`             |
+| `facade`                      | facade (`facade_builder`)| `trait`              |
+| `method<"fire", void(int)>`   | dispatch + convention    | trait method         |
+| `proxy_impl<F, T>`            | (none; structural)       | `impl Trait for Type`|
+| `corvid_proxy_spec(F*, T*)`   | (none)                   | empty `impl` block   |
+| `make_proxy_spec<F, T>()`     | (none)                   | (spec payload)       |
+| `Proxiable<T, F>`             | `proxiable<P, F>`        | `T: Trait` bound     |
+| `make_proxy<F, T>(...)`       | `make_proxy`             | `Box::new`           |
+| `make_proxy_view<F>(t)`       | `make_proxy_view`        | `&x as &dyn T`       |
+| `extends<Base>`               | `add_facade`             | supertrait           |
+| (internal) dispatch table     | meta                     | vtable + drop glue   |
+
+Naming notes:
+
+- Concepts follow the house PascalCase convention: `Facade`, `Proxiable`,
+  `ProxyRegistered`.
+- `facade` over `trait`: matches ngcpp, and "trait(s)" is irreversibly
+  loaded in C++ (`std::char_traits`, type traits).
+- `method` collapses ngcpp's dispatch (the what) and convention (the
+  signature) into one entity; we do not support overload sets per name in
+  the MVP.
+- Nominal identity lives at the facade level: `proxy_impl<F, T>` is keyed on
+  the pair, so declaring `method<"draw", ...>` inline in two unrelated
+  facades cannot cross-contaminate. Conforming to a `weapon` facade says
+  nothing about a `canvas` facade, even if both have a `"draw"`.
+
+## User-facing shape
+
+Conformance is two-layered. The facade author writes a boilerplate impl
+once: a partial specialization of `proxy_impl`, generic over any registered
+`T`, forwarding each method to the natural member name. Only the facade
+author can write it, because only code written with the names in view can
+spell `t.fire`. A conforming type whose method names line up then costs one
+registration line; a type whose names do not line up writes its own impl,
+and a full specialization beats the boilerplate partial by the ordinary
+specialization-ordering rules, with no extra machinery.
+
+```cpp
+// The facade: the interface definition.
+struct gunslinger : facade<method<"fire", void(int)>,
+                       method<"reload", bool()>> {};
+
+// Boilerplate impl, written once by the facade author. `on` is the fixed
+// hook name, overloaded on the method key; a fixed name is what keeps the
+// mechanism spellable without macros.
+template<typename T>
+requires proxy_registered<gunslinger, T>
+struct proxy_impl<gunslinger, T> {
+  static void on(key<"fire">, T& t, int rounds) { t.fire(rounds); }
+  static bool on(key<"reload">, T& t) { return t.reload(); }
+};
+
+// Conforming a type whose methods line up: pure registration. The ADL
+// hook mirrors `corvid_enum_spec`; declare it in the namespace of either
+// the facade or the type.
+consteval auto corvid_proxy_spec(gunslinger*, lawman*) {
+  return make_proxy_spec<gunslinger, lawman>();
+}
+
+// Conforming a type whose methods do not line up: write the impl.
+template<>
+struct proxy_impl<gunslinger, robber> {
+  static void on(key<"fire">, robber& r, int rounds) { r.shoot(rounds); }
+  static bool on(key<"reload">, robber& r) { return r.rearm(); }
+};
+
+proxy<gunslinger> p = make_proxy<gunslinger, lawman>(/*ctor args*/);
+p.call<"fire">(3); // Core spelling: compile-time name -> slot lookup.
+```
+
+The string NTTP rides on the existing
+[fixed_string.h](fixed_string.h). `call<"fire">` resolves at
+compile time to an index into the facade's method list; no runtime name
+lookup exists anywhere.
+
+### Member-call sugar (pinned, leading candidate)
+
+`p->fire(3)` spelling cannot be minted by a C++23 library without macros.
+The leading candidate is an optional hand-written `api` mixin on the facade,
+one forwarding line per method, using deducing `this`; `proxy<F>` and
+`proxy_view<F>` inherit `F::api` when present:
+
+```cpp
+struct gunslinger : facade<method<"fire", void(int)>,
+                       method<"reload", bool()>> {
+  struct api {
+    void fire(this auto&& self, int n) { self.template call<"fire">(n); }
+    bool reload(this auto&& self) { return self.template call<"reload">(); }
+  };
+};
+// ...
+p.fire(3);
+```
+
+This is the "accept a limitation ngcpp will not" trade: they generate these
+accessors with macros; we write them, once per facade (not per conforming
+type). Alternatives considered and rejected: `->*` sugar (unbearable), tag
+objects as free-function customization points (free-function call syntax
+reads as C), `p()<"fire">(3)` (grammatically impossible: explicit template
+arguments may only follow a name that names a template, so the expression
+parses as chained relational operators). A nearby legal family exists via a
+string-literal UDL operator template producing a key object,
+`p("fire"_k, 3)` or `p["fire"_k](3)`; recorded as alternates in case the
+mixin disappoints.
+
+Hosting the `api` inside `proxy_impl` (grouping the sugar next to the `on`
+bindings) was considered and rejected. The erased handle knows only `F`, so
+its sugar base must be nameable from `F` alone, while `proxy_impl` is keyed
+on the (facade, type) pair; the only workaround is a sentinel
+specialization like `proxy_impl<F, void>`, a magic convention that corrupts
+the impl's contract. Ownership also differs: impls have two authors (facade
+author's boilerplate, third parties' custom impls), while the `api` is
+facade-authored and singular; per-impl copies could drift into inconsistent
+sugar for one interface. The facade body keeps "one facade, one sugar"
+structural. The api duplicates only the name spelling (the third of the
+three-spellings-per-method floor), never the bindings: its methods forward
+through `call<>` and the same dispatch table.
+
+## Mechanism
+
+- `proxiable<T, F>` is a concept synthesized from the facade definition: for
+  every `method` of `F`, `proxy_impl<F, T>::on(key<...>, T&, args...)` is
+  invocable and returns the right type. Concepts gate (the converting
+  constructor, static-dispatch template bounds); they cannot generate, since
+  C++ has no introspection over requires-expressions. The facade is the
+  source of truth and the concept is derived from it, never the reverse. An
+  explicit `proxy_impl` specialization satisfies the concept directly; the
+  boilerplate partial satisfies it exactly when the pair is registered, so
+  registration is required precisely when relying on the boilerplate.
+- The registration slot mirrors the enum registry idiom: an ADL-found
+  `corvid_proxy_spec(F*, T*)` hook returns a spec object created by
+  `make_proxy_spec<F, T>()` (as `make_sequence_enum_spec` is returned from
+  `corvid_enum_spec`), read through a central `auto` variable template
+  `proxy_spec_v<F, T>`, with `ProxyRegistered<F, T>` as the derived
+  predicate. The hook keeps the `corvid_` protocol prefix because it is
+  declared in user namespaces; the maker keeps the spec type's name out of
+  user code, resolving the hook-vs-type name confusion. Because either
+  namespace can host the hook, a type you do not own can be conformed to a
+  facade you do not own (the case Rust's orphan rule forbids). The MVP spec
+  type carries no knobs; since each specialization of an `auto` variable
+  template deduces its own type and readers detect capabilities via
+  concepts on the spec (precedent: `NamedSequentialEnum` detecting
+  `intern_name` on the enum spec), richer spec types are additive later,
+  with no change to existing registrations. Maximal slot, minimal values.
+- Conversion to a proxy instantiates one thunk per method
+  (`+[](void* p, args...) { return proxy_impl<F, T>::on(...); }`) and
+  stores a pointer to the resulting per-`(F, T)` `static constexpr` table.
+  Same cost model as a vtable call, and as Rust `dyn`: the table pointer
+  moves out of the object and into the (fat) handle.
+- The owning table carries housekeeping slots (destroy, relocate/move) in
+  addition to the facade methods, the analog of Rust's drop glue.
+  `proxy_view` carries none, which is why the view is built first.
+- Invariant: `proxy<F>` and `proxy_view<F>` themselves satisfy
+  `proxiable<_, F>`, so generic code constrained on the facade accepts
+  concrete and erased arguments interchangeably (Rust: `dyn Trait`
+  implements `Trait`).
+
+## Alternative considered: virtual-model erasure
+
+The external-polymorphism ("Sean Parent" runtime-concept) idiom: a hidden
+abstract `concept_t` with one pure virtual per method, a hidden `model_t<T>`
+whose overrides call `t_.walk()`, and a non-template handle owning the model
+and forwarding through natural member names. It meets both hard requirements
+(no macros, natural `p.walk()` syntax), and its per-method typing cost ties
+the table design at three name-spellings (virtual declaration, model
+override, handle forwarder; versus `method<>` declaration, boilerplate `on`,
+`api` forwarder). Call cost also ties: a virtual call and a table thunk are
+the same shape.
+
+Rejected on structural grounds: composition (`extends`) is table
+concatenation instead of multiple inheritance; facade upcasting is a table
+view instead of a cross-cast; SBO relocation is a table slot instead of
+virtual clone/move on a polymorphic buffer; `proxy_view` stays two plain
+pointers with no embedded polymorphic object; and the `method<"...">` list
+keeps the facade enumerable, which the later tiers (member-pointer specs,
+formatter bridge, reflection-derived boilerplate) lean on.
+
+A facade-holding-`T*` variant without the hidden ABC (handle templates
+deriving from a forwarding facade) was also sketched. It spells each method
+once, but erases nothing: handles templated on the concrete type cannot
+share a container or a non-template function signature, which is static
+dispatch, already free via `proxiable auto&`. The general rule: once a call
+crosses an erasure boundary, the method name must be spelled on both sides
+of it, plus once for member-call sugar; roughly three spellings per method
+is the C++23 floor in any architecture. C++26 reflection lowers the floor
+to one (derive everything from the facade declaration), in either
+architecture.
+
+## Phases
+
+1. DONE. Facade, `method`, `key`, `Proxiable`, and `proxy_view`. The view
+   first, because with no lifetime slots the dispatch-table synthesis is
+   exercised in isolation. Verified: positive and negative conformance
+   `static_assert` tests, const-qualified methods (`std::string() const`
+   dispatching on `const T&`), reference returns, call-through correctness,
+   heterogeneous containers, view-of-view flattening in `make_proxy_view`.
+   Both interesting compile errors are captured as comments in the test:
+   non-conformance walks the constraint chain down to `all_bound_v`, and an
+   unknown method name emits exactly one `static_assert` (an `if constexpr`
+   in `call` discards the dispatch on that path, suppressing follow-on
+   `std::get` noise). Notes from the build: `fixed_string.h` originally
+   lived in the strings band, which inverted the layering; it was moved to
+   `corvid/meta/` (2026-07-08) and joined the `meta.h` umbrella. proxy.h
+   stays out of the umbrella to limit include weight (the formatting.h
+   precedent); include `corvid/meta/proxy.h` directly.
+   Also, in template contexts `call` needs the dependent-name `template`
+   keyword (`pv.template call<"fire">(1)`), a real ergonomic wart the `api`
+   mixin would hide; ammunition for the sugar pin.
+2. Owning `proxy` with SBO, plus `make_proxy`. Move-only by default.
+   Verify: lifetime-counting fixtures (construct/destroy/move balance),
+   with both the SBO and heap paths exercised.
+3. `api` mixin support and `extends<Base>` composition, including
+   `proxy<derived>` -> `proxy_view<base>` conversion (Rust trait
+   upcasting). Verify: mixin call parity with `call<>`, upcast dispatch
+   correctness.
+
+Header: `corvid/meta/proxy.h`, namespace `corvid::meta::prox`, deliberately
+NOT inline: `facade`, `method`, and `key` are too generic to dump into
+`corvid`. Promote to a `corvid/proxy/` family only if it sprawls. Tests:
+`tests/portable/proxy_test.cpp`. `method` derives from its `key`
+(subsumption: a method tag is usable anywhere its key is; also the hook for
+overloading bindings on the full method if per-name overload sets ever
+happen).
+
+## Non-goals (MVP)
+
+Copyability opt-in, shared/weak ownership, operator dispatch, conversion
+dispatch, allocator plumbing, RTTI, per-name overload sets.
+
+## Future
+
+- C++26 reflection plus annotations (P2996/P3394) enables deriving the
+  boilerplate impl itself from the facade's method list, removing even the
+  facade author's forwarding lines. Registration-first is what makes this
+  additive rather than a rewrite.
+- `std::formatter` bridge once the formatter forwarding helper exists (see
+  [../strings/roadmap.md](../strings/roadmap.md) stage 2); the ngcpp analog
+  is `skills::format`.
+- Spec-carried member-pointer binding: a `corvid_proxy_spec` returning a
+  spec that holds `&robber::shoot, &robber::rearm`, bound positionally to
+  the facade's methods. Member pointers are spellable at compile time where
+  member names are not, so this is a one-line middle tier for
+  name-mismatched types that avoids a full custom impl.
+- Shared ownership tier, backed by `std::shared_ptr<void>`. The control
+  block already type-erases the destroyer, so a shared-backed proxy needs
+  no destroy slot in the dispatch table, is copyable for free, and gets a
+  `weak_proxy` nearly free via `std::weak_ptr`. ngcpp built this bespoke
+  (`make_proxy_shared`, compact internal refcounts) to beat `shared_ptr`
+  overhead; reusing std is our accepted trade. The plain heap fallback in
+  phase 2 stays unique-owned (destroy slot, move-only, cheaper).
+
+## Open questions
+
+- The member-call sugar pin: the `api` mixin is the leading candidate
+  (judged plausible); confirm once real call sites exist.
+- `noexcept` qualification on `method` signatures: MVP or defer.
+- Const flavor of views: whether `proxy_view<F>` needs a distinct
+  const-view type (the `&T` vs `&mut T` split) or const-qualified methods
+  suffice.

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -2,7 +2,8 @@
 
 Status: phases 1 and 2 built and tested ([proxy.h](proxy.h),
 [proxy_test.cpp](../../tests/portable/proxy_test.cpp)); phase 3 in
-progress: the `api` mixin is built and tested, `extends<Base>` is pending. Plan for `corvid/meta/proxy.h`, a
+progress: the `api` mixin and its `validate_api` drift check are built and
+tested, `extends<Base>` is pending. Plan for `corvid/meta/proxy.h`, a
 registration-based runtime-polymorphism ("proxy") system: type-erased handles
 over an interface definition, without inheritance, vtable pointers in the
 target type, or macros.
@@ -214,6 +215,10 @@ Caveats, all on the facade author's side of the contract:
   (see `hair_trigger` in the test). Nothing checks the forwarders against
   the method flavors; the sugar is by-hand by design.
 
+The silent-drift half of the risk (a hand-written forwarder whose types are
+merely convertible to the facade's, which compiles and truncates) is closed
+by `validate_api`, below.
+
 Hosting the `api` inside `proxy_impl` (grouping the sugar next to the `on`
 bindings) was considered and rejected. The erased handle knows only `F`, so
 its sugar base must be nameable from `F` alone, while `proxy_impl` is keyed
@@ -223,9 +228,71 @@ the impl's contract. Ownership also differs: impls have two authors (facade
 author's boilerplate, third parties' custom impls), while the `api` is
 facade-authored and singular; per-impl copies could drift into inconsistent
 sugar for one interface. The facade body keeps "one facade, one sugar"
-structural. The api duplicates only the name spelling (the third of the
+structural. The `api` duplicates only the name spelling (the third of the
 three-spellings-per-method floor), never the bindings: its methods forward
 through `call<>` and the same dispatch table.
+
+### API validation (`validate_api`, built)
+
+The `api` is verified against the facade's method list while spelling
+neither the names nor the signatures again, and correctness is opt-out
+rather than opt-in: `make_proxy_spec` runs the check at every registration
+of an `api`-bearing facade. Registration is the right moment because it is
+the first time all three artifacts are necessarily in view: the concrete
+type motivates the facade, the facade carries the `api`, and the
+boilerplate impl (which the registration exists to unlock) must already be
+visible. A facade whose `api` deliberately deviates (say, a widening
+convenience signature)
+registers with `api_check::off`; a registration hook that is itself a
+template defers the check to its own instantiation. The standalone
+spelling, `static_assert(prox::validate_api<F>());`, remains for a facade
+author to assert at the definition site, before any registration exists.
+Handles themselves perform no check: embedding one there would make a
+handle's validity depend on which impl headers a TU happens to include, and
+would detonate in arbitrary consumer code for what is the facade author's
+bug.
+
+The insight is that two independent hand-written respellings of the
+name-to-key binding already exist: the boilerplate impl invokes members by
+natural name (`t.fire(rounds)`), and the `api` declares members with those
+names. The check plays them against each other. `validate_api` instantiates
+the dispatch table for a library-internal probe type (`details::api_probe`)
+that inherits `F::api` and exposes a deliberately strict `call`: argument
+types must match the facade's declared parameters exactly (after stripping
+cv and references, so value-category spelling is ignored but a
+merely-convertible type is rejected), and the result is a `strict_result`
+that converts only to exactly the declared result type. The chain, thunk ->
+boilerplate `on` -> `api` forwarder -> strict `call`, is anchored to the
+facade's exact types at both ends, so convertibility drift anywhere in the
+middle fails to compile with the error pointing at the drifting line. It
+validates the boilerplate as much as the `api`; real conforming types never
+would, since real calls convert legally. The probe is the one type the
+library registers itself (a generic `corvid_proxy_spec` overload in
+`details`), which is what admits it to the registration-gated boilerplate;
+that registration passes `api_check::off`, since a validating one would
+recurse into itself through the boilerplate-visibility check.
+
+Caught: a missing or misspelled forwarder, wrong arity, wrong const flavor
+of `self`, a parameter or declared result type that is merely convertible
+to the facade's (including the silently-truncating kind), and a forwarder
+body dispatching a key with a different signature. Not caught: a missing
+`noexcept` on a forwarder (degrades `noexcept(p.fire(1))`, not behavior);
+by-value versus by-reference parameter spellings (an extra copy, not a
+bug); reference-to-value decay of a declared result (a conversion operator
+cannot distinguish binding a reference from copying out of one); and a body
+dispatching the wrong key with an identical signature, which no shape check
+can see. Closing that last hole would take a behavioral probe (record which
+key each forwarder dispatches and compare) or C++26 reflection, which
+deletes the whole problem by generating the `api` from the facade.
+
+Two structural limits: failures are hard compile errors rather than a
+`false` (a fully generic `FulfillsApi<H, F>` concept is impossible in
+C++23, since no mechanism turns a `fixed_string` into an identifier to
+probe `h.fire(...)`), and the facade must have a boilerplate `proxy_impl`
+partial gated on `ProxyRegistered` for the chain to exist, since that impl
+is the only artifact that invokes the members by name. A registration that
+cannot see such a boilerplate fails a friendly `static_assert` that names
+the opt-out.
 
 ## Mechanism
 
@@ -384,7 +451,14 @@ architecture.
    dependent-name `template` keyword needed in generic code, `noexcept`
    propagation when the facade author marks the forwarders, and empty-base
    optimization keeping the views at two pointers. See the caveats under
-   "Member-call sugar". Remaining: `extends<Base>` composition, including
+   "Member-call sugar". The `validate_api` drift check is also DONE (see
+   "API validation") and runs automatically at registration via
+   `make_proxy_spec`, with `api_check::off` as the opt-out (exercised by
+   `mortar`/`howitzer` in the test); verified empirically that an
+   `int`-to-`long long` parameter drift in a forwarder compiled silently
+   before the check existed and now fails through `lawman`'s registration
+   alone, at the forwarder's own line, with the diagnostic on record in the
+   test. Remaining: `extends<Base>` composition, including
    `proxy<derived>` -> `proxy_view<base>` conversion (Rust trait upcasting).
    Verify: upcast dispatch correctness.
 

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -1013,6 +1013,16 @@ Emptiness propagates along every handle-to-handle edge: an empty source
 produces an empty result, whether lending, upcasting, adopting, or
 downcasting. Only calling through an empty handle violates the contract.
 
+Lent views carry the standard limitations of views. A view lent from an
+owning `proxy` is tied to the proxy's contents, not just its lifetime:
+ownership is exclusive, so removing or replacing the target (moving the
+proxy from, assigning over it, `extract`) invalidates the view, destroying
+an inline target in place and handing a heap target to an owner the view
+cannot track, and use after that is undefined behavior. A view lent from a
+`shared_proxy` follows the underlying object instead: the view never joins
+the ownership, but any owner keeps it valid, and code that must guarantee
+survival holds a `shared_proxy` copy rather than a view.
+
 ## Ownership and storage
 
 Views give all the type-erasure anyone could ask for. A proxy's added

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -1,34 +1,59 @@
-# Proxy design
+# Proxy
 
-Status: phases 1 through 6 built and tested ([proxy.h](proxy.h),
-[proxy_test.cpp](../../tests/portable/proxy_test.cpp)): the `api` mixin, its
-`validate_api` drift check, `extends<Base>` composition with upcasting,
-facade-qualified names with sibling collisions and diamonds, the
-ownership round (storage policies, owning upcast, cloning, `unique_ptr`
-interop, vtable-carried downcasting, and the shared/weak tier), downcasting
-extended to the views and `shared_proxy`, per-name overload sets within a
-facade and across extends levels, and `codegen` (generated `api` and
-boilerplate source, with facades made non-constructible).
-Plan for `corvid/meta/proxy.h`, a
-registration-based runtime-polymorphism ("proxy") system: type-erased handles
-over an interface definition, without inheritance, vtable pointers in the
-target type, or macros.
+[proxy.h](proxy.h) implements registration-based runtime polymorphism
+through proxies, which are type-erased handles over an interface definition.
+They work without inheritance, vtable pointers in the target type, or macros.
+
+This document is the completed system's reference and retrospective. It is
+a tutorial tour of the user-facing surface, the decisions made along the
+way and what they cost, and the lessons from the build. Every feature is
+pinned by [proxy_test.cpp](../../tests/portable/proxy_test.cpp) (the
+fixture hierarchy the tests share is diagrammed under "Test fixture map"
+below).
+
+The full feature set, as built and tested:
+
+- facade-qualified names, sibling collisions, and diamonds
+- the `api` member-call mixin, with its `validate_api` drift check
+- `extends<Base>` composition, with implicit upcasting and safe explicit downcasting
+- storage policies on the owning proxy
+- cloning, and `std::unique_ptr` interop
+- the shared/weak ownership tier, with `std::shared_ptr` interop
+- method overloading, within a facade and across extends levels
+- `prox::codegen`, which generates the "hand-written" artifacts
+
+Two facts frame everything below. First, the manual duplication in
+the facade's `boilerplate` and `api` classes is an artifact of C++23
+lacking reflection, not of the design. The system, as designed, can be
+extended to derive both from the facade's method list under C++26
+reflection, removing the need to define these two classes at all. The
+blocker is compiler support: currently, only gcc enables it, and this
+library is clang-centric.
+
+Second, in the interim, `prox::codegen`
+([proxy_codegen.h](proxy_codegen.h)) writes them for you. It handles all
+the tricky details and edge cases: noexcept propagation, const pairs, the
+using-declaration merges, and diamonds.
 
 ## Lineage and positioning
 
 Prior art is [ngcpp/proxy](https://github.com/ngcpp/proxy) (formerly
 microsoft/proxy, on the standards track as P3086) and Rust trait objects
-(`dyn Trait`). We lean toward ngcpp naming because this is C++, but diverge
-on one deliberate axis: conformance is nominal (registered), not structural
+(`dyn Trait`).
+
+We lean toward ngcpp naming because this is C++, but diverge on one
+deliberate axis: conformance is nominal (registered), not structural
 (duck-typed). ngcpp accepts any type whose members happen to match the
 facade; we require an explicit registration, the same philosophy as the
-Corvid registered-enum system (registration, not reflection). Registration
-also dissolves ngcpp's need for macros: their `PRO_DEF_MEM_DISPATCH` macros
-exist solely to mint accessor functions with caller-chosen names, and when
-the user writes the binding explicitly there is no name to mint.
+Corvid registered-enum system (registration, not reflection).
+
+Registration also dissolves ngcpp's need for macros. Their
+`PRO_DEF_MEM_DISPATCH` macros exist solely to mint accessor functions with
+caller-chosen names. When the user writes the binding explicitly, there is
+no name to mint.
 
 The one-method ancestor within Corvid is
-[fixed_function.h](fixed_function.h): a `proxy` is a `fixed_function`
+[fixed_function.h](fixed_function.h). A `proxy` is a `fixed_function`
 generalized from a single anonymous `operator()` to a named suite of
 methods, and the owning flavor reuses the same storage ideas (inline SBO
 buffer plus dispatch pointer).
@@ -65,7 +90,7 @@ Naming notes:
   loaded in C++ (`std::char_traits`, type traits).
 - `method` collapses ngcpp's dispatch (the what) and convention (the
   signature) into one entity; a per-name overload set is spelled by listing
-  the name repeatedly (ngcpp instead lists several signatures in one
+  each signature as a method (ngcpp instead lists several signatures in one
   convention).
 - Nominal identity lives at the facade level: `proxy_impl<F, T>` is keyed on
   the pair, so declaring `method<"draw", ...>` inline in two unrelated
@@ -74,30 +99,87 @@ Naming notes:
 
 ## User-facing shape
 
-Conformance is tiered. The facade author writes a boilerplate impl
-once: a class template named `boilerplate`, nested in the facade body,
-generic over any registered `T`, forwarding each method to the natural
-member name. Only the facade author can write it, because only code written
-with the names in view can spell `t.fire`. A library-provided constrained
-partial specialization of `proxy_impl` (a C++20 partial specialization with
-the primary's own argument list, legal because it is more constrained)
-delegates every registered pair to the nested boilerplate, so the facade
-needs no namespace-scope impl at all and the boilerplate sits next to the
-method list and `api` it mirrors. A conforming type whose method names line
-up then costs one registration line; a type whose names do not line up
-carries its own impl in the registration. The namespace-scope spelling of
-the boilerplate, a `proxy_impl` partial specialization gated on
-`ProxyRegistered`, predates the nested form and remains equivalent and
-supported (it also outranks the library's delegation by partial ordering, so
-the two styles cannot collide).
+Using the system takes three kinds of declaration. A facade defines the
+interface, along with its optional `api` sugar and `boilerplate` bindings.
+A registration opts a concrete type into a facade. A handle (`proxy`,
+`proxy_view`, or one of their relatives) does the calling. The pieces and
+who writes them:
+
+```mermaid
+flowchart TB
+    F["facade F: name, methods, extends"]
+    API["F::api (member-call sugar)"]
+    BP["F::boilerplate&lt;T&gt; (natural-name bindings)"]
+    HOOK["corvid_proxy_spec(F*, T*) (the registration)"]
+    CI["carried impl (only when names diverge)"]
+    PI["proxy_impl&lt;F, T&gt;"]
+    VT["dispatch table: static, per (F, T)"]
+    H["proxy&lt;F&gt;, proxy_view&lt;F&gt;, shared_proxy&lt;F&gt;, ..."]
+
+    subgraph facade_author["facade author writes"]
+        F
+        API
+        BP
+    end
+    subgraph conformer["type owner (or anyone) writes"]
+        HOOK
+        CI
+    end
+    subgraph library["library synthesizes"]
+        PI
+        VT
+    end
+    F --- API
+    F --- BP
+    HOOK -->|unlocks| PI
+    BP -->|default route| PI
+    CI -->|outranks boilerplate| PI
+    PI -->|one thunk per method| VT
+    H -->|points at| VT
+    API -->|inherited by| H
+```
+
+Conformance is tiered. First, the facade author writes a boilerplate impl.
+This is a class template named `boilerplate`, nested in the facade body.
+It is generic over any registered `T`, forwarding each method to the
+natural member name, so it is written once per facade, not once per type.
+
+No library machinery can produce this mapping, because C++23 has no way to
+turn the declared `"fire"` string into the `.fire` in `t.fire(rounds)`.
+The binding from method key to member name has to appear as literal source
+code, typed by the facade author or pasted from `prox::codegen`.
+
+The library wires the nested boilerplate up automatically. A provided
+partial specialization of `proxy_impl` delegates every registered pair to
+it, so the facade needs no namespace-scope impl at all, and the
+boilerplate sits next to the method list and `api` it mirrors. (The
+specialization repeats the primary template's own argument list, which
+C++20 allows because it is more constrained.)
+
+That is the first tier, and it serves any type whose method names line up:
+conforming such a type costs one registration line. The second tier covers
+types whose methods do not match what the boilerplate expects, say a
+`shoot` where the facade wants `fire`. Such a type's registration carries
+its own impl, which replaces the boilerplate binding for that type alone.
+The example below shows both tiers; the carried impl's mechanics follow
+it.
 
 ```cpp
-// The facade: the interface definition, carrying its own boilerplate.
+// The facade: the interface definition, carrying its own api and boilerplate.
+// This particular facade does not happen to extend previous ones.
 struct gunslinger : facade<name<"gunslinger">,
                        method<"fire", void(int)>,
                        method<"reload", bool()>> {
-  // Written once by the facade author. `on` is the fixed hook name,
-  // overloaded on the method key; a fixed name is what keeps the mechanism
+  // Written, or generated, once by the facade author. This member-call sugar is
+  // technically optional, but is necessary for native calling conventions. It
+  // consists of one deducing-this forwarder per method, inherited by every handle
+  // of this facade (see "Member-call sugar").
+  struct api {
+    void fire(this auto&& self, int n) { self.template call<"fire">(n); }
+    bool reload(this auto&& self) { return self.template call<"reload">(); }
+  };
+  // Written, or generated, once by the facade author. `on` is the fixed hook
+  // name, overloaded on the method key; a fixed name is what keeps the mechanism
   // spellable without macros. Inheriting `proxy_impl_base` is optional sugar,
   // supplying the `method_key` alias so the bindings spell it unqualified.
   template<typename T>
@@ -107,16 +189,18 @@ struct gunslinger : facade<name<"gunslinger">,
   };
 };
 
-// Conforming a type whose methods line up: pure registration. The ADL
+// The `lawman` supports both of the functions that the facade expects, spelled
+// exactly as expected. Therefore, conforming it is pure registration. The ADL
 // hook mirrors `corvid_enum_spec`; declare it in the namespace of either
 // the facade or the type.
 consteval auto corvid_proxy_spec(gunslinger*, lawman*) {
   return make_proxy_spec<gunslinger, lawman>();
 }
 
-// Conforming a type whose methods do not line up: the registration carries
-// the impl, here local to the hook itself, so the whole conformance is one
-// self-contained declaration.
+// The `robber` uses `shoot` instead of `fire` and `rearm` instead of `reload`, so
+// the boilerplate would fail. Therefore, conforming it requires registration that
+// carries the custom impl. Here, the impl is local to the hook itself, so the whole
+// conformance is one self-contained declaration.
 consteval auto corvid_proxy_spec(gunslinger*, robber*) {
   struct as_gunslinger : proxy_impl_base {
     static void on(method_key<"fire">, robber& r, int rounds) {
@@ -129,64 +213,78 @@ consteval auto corvid_proxy_spec(gunslinger*, robber*) {
 
 proxy<gunslinger> p = make_proxy<gunslinger, lawman>(/*ctor args*/);
 p.call<"fire">(3); // Core spelling: compile-time name -> slot lookup.
+p.fire(3);         // Sugar spelling, through the api mixin.
 ```
 
-The registration-carried impl is the spec's first knob: the three-type
-`make_proxy_spec<F, T, Impl>()` returns a `proxy_spec` whose `impl_t` names
-the binding class, a library partial specialization of `proxy_impl` installs
-it for the pair (`SpecCarriesImpl` is the detecting concept), and it
-outranks the facade's boilerplate as the closer declaration. Registration is
-therefore the sole act of conformance, with fewer distinctions between the
-routes: every binding is either the facade's boilerplate or a carried impl,
-and both are opt-in. The unregistered per-type full specialization of
-`proxy_impl`, which was the original wrong-names tier, is subsumed by
-carried impls and dropped from the supported surface: it offered nothing the
-carried impl does not (foreign types take a hook in the facade's namespace;
-generic families take a constrained template hook, like `strongbox` in the
-test), while uniquely enabling conformance with no opt-in declaration and
-inviting ODR mischief, since any TU could silently override another's
-binding. The language cannot forbid such specializations, and `proxy_impl`
-necessarily stays a public name for the namespace-scope boilerplate
-spelling, so this is a contract boundary rather than a mechanical one. A
-namespace-scope boilerplate partial should add `!SpecCarriesImpl<F, T>` to
-its gate to preserve carried-impl precedence, since raw partial ordering
-would prefer it (the nested boilerplate gets this arbitration from the
-library).
+The registration-carried impl is the spec's first knob. The three-type
+`make_proxy_spec<F, T, Impl>()` returns a `proxy_spec` whose `impl_t`
+names the binding class. A library partial specialization of `proxy_impl`
+installs it for the pair (`SpecCarriesImpl` is the detecting concept), and
+it outranks the facade's boilerplate as the closer declaration.
 
-The binding class can live anywhere a type can. Local to the hook, as
-above, the registration is fully self-contained, which is also the only
-self-contained way to conform a type you do not own; this is sound because
-local classes are ordinary template arguments, their static member
-functions are ordinary runtime functions even inside a consteval hook, and
-a consteval function is implicitly inline, so the local type is
-ODR-consistent across translation units (local classes do forgo static data
-members and member templates, which bindings do not need). Nested in the
-type it serves, the impl additionally reaches the type's private members
-(`turncoat` in the test). Namespace scope works too, and a namespace-scope
-binding class that the type forward-declares and befriends reaches private
-members without nesting.
+Registration is therefore the sole act of conformance. Every binding is
+either the facade's boilerplate or a carried impl, and both are opt-in.
 
-Whatever its placement, a binding class may inherit `prox::proxy_impl_base`,
-an
-otherwise-empty base whose one member is a `method_key` alias, so the
-bindings spell the key unqualified (base-class members participate in
-unqualified lookup where namespace-scope names do not; a literally empty
-base would change nothing). It is optional, and a binding class that
-inherits a boilerplate already has it through that base.
+Two other spellings of `proxy_impl` exist at namespace scope, one
+deprecated and one dropped.
 
-The string NTTP rides on the existing
-[fixed_string.h](fixed_string.h). `call<"fire">` resolves at
-compile time to an index into the facade's method list; no runtime name
-lookup exists anywhere.
+The deprecated spelling is the namespace-scope boilerplate: a partial
+specialization constrained on `ProxyRegistered`, serving every registered
+type exactly as the nested form does (`lockbox` in the test). It predates
+the nested form, and it still works: when a facade has both, the partial
+outranks the library's delegation by partial ordering, so the two cannot
+collide. It does need one extra term in its gate, `!SpecCarriesImpl<F, T>`,
+to keep a carried impl winning; raw partial ordering would prefer the
+partial, while the nested boilerplate gets this arbitration from the
+library. The nested form made all of this unnecessary, which is why
+facades should nest their boilerplate, as shown in the examples.
+
+The dropped spelling is the unregistered full specialization. Originally,
+a type whose names did not line up conformed by fully specializing
+`proxy_impl<F, T>` for the concrete pair, with no registration at all.
+Carried impls subsume it, and it is out of the supported surface. It
+offered nothing the carried impl does not: foreign types take a hook in
+the facade's namespace, and generic families take a constrained template
+hook, like `strongbox` in the test. What it uniquely enabled was
+conformance with no opt-in declaration, and that was an ODR footgun, since
+any TU could silently override another's binding. The language cannot
+forbid such specializations, and `proxy_impl` necessarily stays a public
+name for the deprecated boilerplate spelling, so the drop is a contract
+boundary rather than a mechanical one.
+
+The binding class (in other words, the impl) can live anywhere a type can.
+Local to the hook, as above, the registration is fully self-contained, which
+is also the only self-contained way to conform a type you do not own. This
+is sound because local classes are ordinary template arguments, their static
+member functions are ordinary runtime functions even inside a consteval hook,
+and a consteval function is implicitly inline, so the local type is
+ODR-consistent across translation units. (Local classes do forgo static
+data members and member templates, which bindings do not need.)
+
+When instead nested in the type it serves, the impl additionally reaches the
+type's private members (`turncoat` in the test). Namespace scope works too,
+and a namespace-scope binding class that the type forward-declares and befriends
+reaches private members without nesting. This hybrid approach can be a good
+compromise, reducing clutter in the class itself while preserving private access.
+
+Whatever its placement, a binding class may inherit
+`prox::proxy_impl_base`. It is an otherwise-empty base whose one member is
+a `method_key` alias, letting the bindings spell the key unqualified. It is
+optional, although recommended both for convenience and self-documentation.
+A binding class that inherits a boilerplate already has it through that base.
+
+The string NTTP rides on the existing [fixed_string.h](fixed_string.h).
+`call<"fire">` resolves at compile time to an index into the facade's
+method list; no runtime name lookup exists anywhere.
 
 ### Partial override of the boilerplate
 
 When a type's names line up except for one method, a full custom impl
-re-spells every binding just to change one. The nested boilerplate, being an
-ordinary inheritable class template, provides a cheaper middle tier for
-free: a near-conforming type registers a carried impl that inherits
-`F::boilerplate<T>`, re-exposes its `on` overloads with a using-declaration,
-and declares only the divergent binding:
+would need to repeat every binding just to change one. This is unnecessary.
+The nested boilerplate, being an ordinary inheritable class template,
+provides a cheaper middle tier for free. A near-conforming type registers
+a carried impl that inherits `F::boilerplate<T>`, re-exposes its `on`
+overloads with a using-declaration, and declares only the divergent binding:
 
 ```cpp
 // `sheriff` lines up except that `fire` is spelled `shoot`.
@@ -203,234 +301,274 @@ consteval auto corvid_proxy_spec(gunslinger*, sheriff*) {
 
 Mechanics: a derived `on` with the identical parameter list excludes the
 inherited one from the set the using-declaration introduces, so the
-override wins with no ambiguity. The using-declaration is load-bearing:
-without it, the derived `on` hides all the inherited overloads and
+override wins with no ambiguity. The using-declaration is load-bearing.
+Without it, the derived `on` hides all the inherited overloads, and
 conformance fails on the rest. The hidden base binding is never
 instantiated (class-template members instantiate only on use), so its body
 naming the absent member is harmless.
 
-Before the boilerplate moved into the facade, this tier required the facade
-author to factor the bindings into a separately-named class for the
-namespace-scope partial to derive from; with the nested form it is inherent.
-It overlaps in purpose with the spec-carried member-pointer binding sketched
-under Future; the two can coexist. Exercised by `sheriff` in the test.
+Before the boilerplate moved into the facade, this tier required the
+facade author to factor the bindings into a separately-named class for the
+namespace-scope partial to derive from. With the nested form, it is
+inherent. It overlaps in purpose with the spec-carried member-pointer
+binding sketched under "Future work"; the two can coexist. Exercised by
+`sheriff` in the test.
 
-### Member-call sugar (the `api` mixin, built)
+### Member-call sugar (the `api` mixin)
 
 `p->fire(3)` spelling cannot be minted by a C++23 library without macros.
-The answer is an optional hand-written `api` mixin on the facade, one
-forwarding line per method, using deducing `this`; all three handles
-(`proxy<F>`, `proxy_view<F>`, `const_proxy_view<F>`) inherit `F::api` when
-present:
+The answer is the optional "hand-written" `api` mixin shown in the
+`gunslinger` example above. Each of its methods is a forwarder: a one-line
+method, taking `self` by deducing `this`, that passes its arguments
+through to `call<>` with the matching key. Every dispatching handle
+(`proxy<F>`, `proxy_view<F>`, `const_proxy_view<F>`, `shared_proxy<F>`)
+inherits `F::api` when present, which is what lets `p.fire(3)` dispatch.
 
-```cpp
-struct gunslinger : facade<name<"gunslinger">,
-                       method<"fire", void(int)>,
-                       method<"reload", bool()>> {
-  struct api {
-    void fire(this auto&& self, int n) { self.template call<"fire">(n); }
-    bool reload(this auto&& self) { return self.template call<"reload">(); }
-  };
-};
-// ...
-p.fire(3);
-```
+("Mixin" in the deducing-this sense: a stateless class grafted into each
+handle's single-inheritance chain, not a second base sitting beside
+another. Multiple parents appear only among the `api` classes themselves,
+when a facade extends several facades; see "Composition".)
 
-This is the "accept a limitation ngcpp will not" trade: they generate these
-accessors with macros; we write them, once per facade (not per conforming
-type). Alternatives considered and rejected: `->*` sugar (unbearable), tag
-objects as free-function customization points (free-function call syntax
-reads as C), `p()<"fire">(3)` (grammatically impossible: explicit template
-arguments may only follow a name that names a template, so the expression
-parses as chained relational operators). A nearby legal family exists via a
-string-literal UDL operator template producing a key object,
-`p("fire"_k, 3)` or `p["fire"_k](3)`; recorded as alternates in case the
-mixin disappoints.
+This is the "accept a limitation ngcpp will not" trade. They generate
+these accessors with macros. We write them by hand (for now), once per
+facade rather than once per conforming type.
+
+Alternatives considered and rejected:
+
+- `->*` sugar: unbearable.
+- Tag objects as free-function customization points: free-function call
+  syntax reads as C.
+- `p()<"fire">(3)`: grammatically impossible. Explicit template arguments
+  may only follow a name that names a template, so the expression parses
+  as chained relational operators.
+
+A nearby legal family exists via a string-literal UDL operator template
+producing a key object: `p("fire"_k, 3)` or `p["fire"_k](3)`. These were
+recorded as alternates while the mixin was unproven, and never needed once
+the restyled tests confirmed its ergonomics.
 
 Mechanics of the built form: `details::api_base_t<F>` yields `F::api` when
-the facade defines one and an empty `no_api` stand-in otherwise. The
+the facade defines one, and an empty `no_api` stand-in otherwise. The
 selection is a lazy specialization rather than a `std::conditional_t`,
-because naming `F::api` when it does not exist is ill-formed. The views pick
-the base up through their shared `details::view_base`, keeping each view a
-single-inheritance chain; the owning `proxy`, which has no other base,
-inherits it directly. Deducing `this` still sees the complete handle type
-regardless of where in the hierarchy the forwarders sit. The mixin is
-stateless, so empty-base optimization keeps the views at two pointers.
+because naming `F::api` when it does not exist is ill-formed.
+
+The views pick the base up through their shared `details::view_base`,
+keeping each view a single-inheritance chain; the owning `proxy`, which
+has no other base, inherits it directly. Deducing `this` sees the complete
+handle type regardless of where in the hierarchy the forwarders sit. The
+mixin is stateless, so empty-base optimization keeps the views at two
+pointers.
 
 Caveats, all on the facade author's side of the contract:
 
-- Forwarders should declare concrete return types, not `decltype(auto)`: a
+- Forwarders should declare concrete return types, not `decltype(auto)`. A
   deduced return type forces body instantiation during mere overload
   resolution, which turns misuse into errors in contexts that only probe.
-- Plain forwarders are unconstrained declarations, so deep const is enforced
-  inside the forwarder's `call` (a clear hard error at the point of use)
-  rather than at overload resolution. A `requires` probe of the sugar on a
-  const handle therefore succeeds where the same probe of `call<>` fails. A
-  facade author who wants probe-visible sugar can add a trailing
-  requires-clause repeating the `call` expression.
-- The `noexcept` qualifier does not propagate through an unmarked forwarder;
-  the author marks the forwarders of noexcept methods `noexcept` themselves
-  (see `hair_trigger` in the test). Nothing checks the forwarders against
-  the method flavors; the sugar is by-hand by design.
+- Plain forwarders are unconstrained declarations, so deep const is
+  enforced inside the forwarder's `call` (a clear hard error at the point
+  of use) rather than at overload resolution. A `requires` probe of the
+  sugar on a const handle therefore succeeds where the same probe of
+  `call<>` fails. A facade author who wants probe-visible sugar can add a
+  trailing requires-clause repeating the `call` expression.
+- The `noexcept` qualifier does not propagate through an unmarked
+  forwarder. The author marks the forwarders of noexcept methods
+  `noexcept` themselves (see `hair_trigger` in the test). Nothing checks
+  the forwarders against the method flavors; the sugar is by-hand by
+  design.
 
-The silent-drift half of the risk (a hand-written forwarder whose types are
-merely convertible to the facade's, which compiles and truncates) is closed
-by `validate_api`, below.
+The silent-drift half of the risk (a hand-written forwarder whose types
+are merely convertible to the facade's, which compiles and truncates) is
+closed by `validate_api`, below.
 
-Hosting the `api` inside `proxy_impl` (grouping the sugar next to the `on`
-bindings) was considered and rejected. The erased handle knows only `F`, so
-its sugar base must be nameable from `F` alone, while `proxy_impl` is keyed
-on the (facade, type) pair; the only workaround is a sentinel
-specialization like `proxy_impl<F, void>`, a magic convention that corrupts
-the impl's contract. Ownership also differs: impls have two authors (facade
-author's boilerplate, third parties' custom impls), while the `api` is
-facade-authored and singular; per-impl copies could drift into inconsistent
-sugar for one interface. The facade body keeps "one facade, one sugar"
-structural. The `api` duplicates only the name spelling (the third of the
-three-spellings-per-method floor), never the bindings: its methods forward
+Hosting the `api` inside `proxy_impl`, grouping the sugar next to the `on`
+bindings, was considered and rejected for two reasons.
+
+Nameability: the erased handle knows only `F`, so its sugar base must be
+nameable from `F` alone, while `proxy_impl` is keyed on the (facade, type)
+pair. The only workaround is a sentinel specialization like
+`proxy_impl<F, void>`, a magic convention that corrupts the impl's
+contract.
+
+Ownership: impls have two authors (the facade author's boilerplate and
+third parties' custom impls), while the `api` is facade-authored and
+singular. Per-impl copies could drift into inconsistent sugar for one
+interface. The facade body keeps "one facade, one sugar" structural.
+
+Note that the `api` duplicates only the name spelling, the third of the
+three-spellings-per-method floor, never the bindings. Its methods forward
 through `call<>` and the same dispatch table.
 
-### API validation (`validate_api`, built)
+### API validation (`validate_api`)
 
-The `api` is verified against the facade's method list while spelling
-neither the names nor the signatures again, and correctness is opt-out
-rather than opt-in: `make_proxy_spec` runs the check at every registration
-of an `api`-bearing facade. Registration is the right moment because it is
-the first time all three artifacts are necessarily in view: the concrete
-type motivates the facade, the facade carries the `api`, and the
-boilerplate impl (which the registration exists to unlock) must already be
-visible. A facade whose `api` deliberately deviates (say, a widening
-convenience signature)
-registers with `api_check::off`; a registration hook that is itself a
-template defers the check to its own instantiation. The standalone
-spelling, `static_assert(prox::validate_api<F>());`, remains for a facade
-author to assert at the definition site, before any registration exists.
-Handles themselves perform no check: embedding one there would make a
-handle's validity depend on which impl headers a TU happens to include, and
-would detonate in arbitrary consumer code for what is the facade author's
-bug.
+The `api` is verified against the facade's method list without spelling
+the names or signatures again. Correctness is opt-out rather than opt-in:
+`make_proxy_spec` runs the check at every registration of an `api`-bearing
+facade.
+
+Registration is the right moment because it is the first time all three
+artifacts are necessarily in view. The concrete type motivates the facade,
+the facade carries the `api`, and the boilerplate impl (which the
+registration exists to unlock) must already be visible.
+
+A facade whose `api` deliberately deviates, say with a widening
+convenience signature, registers with `api_check::off`. A registration
+hook that is itself a template defers the check to its own instantiation.
+The standalone spelling, `static_assert(prox::validate_api<F>());`,
+remains for a facade author to assert at the definition site, before any
+registration exists.
+
+Handles themselves perform no check. Embedding one there would make a
+handle's validity depend on which impl headers a TU happens to include,
+and would detonate in arbitrary consumer code for what is the facade
+author's bug.
 
 The insight is that two independent hand-written respellings of the
-name-to-key binding already exist: the boilerplate impl invokes members by
+name-to-key binding already exist. The boilerplate impl invokes members by
 natural name (`t.fire(rounds)`), and the `api` declares members with those
-names. The check plays them against each other. `validate_api` instantiates
-the dispatch table for a library-internal probe type (`details::api_probe`)
-that inherits `F::api` and exposes a deliberately strict `call`: argument
-types must match the facade's declared parameters exactly (after stripping
-cv and references, so value-category spelling is ignored but a
-merely-convertible type is rejected), and the result is a `strict_result`
-that converts only to exactly the declared result type. The chain, thunk ->
-boilerplate `on` -> `api` forwarder -> strict `call`, is anchored to the
-facade's exact types at both ends, so convertibility drift anywhere in the
-middle fails to compile with the error pointing at the drifting line. It
-validates the boilerplate as much as the `api`; real conforming types never
-would, since real calls convert legally. The probe is the one type the
-library registers itself (a generic `corvid_proxy_spec` overload in
-`details`), which is what admits it to the registration-gated boilerplate;
-that registration passes `api_check::off`, since a validating one would
-recurse into itself through the boilerplate-visibility check.
+names. The check plays them against each other.
 
-Caught: a missing or misspelled forwarder, wrong arity, wrong const flavor
-of `self`, a parameter or declared result type that is merely convertible
-to the facade's (including the silently-truncating kind), and a forwarder
-body dispatching a key with a different signature. Not caught: a missing
-`noexcept` on a forwarder (degrades `noexcept(p.fire(1))`, not behavior);
-by-value versus by-reference parameter spellings (an extra copy, not a
-bug); reference-to-value decay of a declared result (a conversion operator
-cannot distinguish binding a reference from copying out of one); and a body
-dispatching the wrong key with an identical signature, which no shape check
-can see. Closing that last hole would take a behavioral probe (record which
-key each forwarder dispatches and compare) or C++26 reflection, which
-deletes the whole problem by generating the `api` from the facade.
+`validate_api` instantiates the dispatch table for a library-internal
+probe type (`details::api_probe`) that inherits `F::api` and exposes a
+deliberately strict `call`. Argument types must match the facade's
+declared parameters exactly, after stripping cv and references, so
+value-category spelling is ignored but a merely-convertible type is
+rejected. The result is a `strict_result` that converts only to exactly
+the declared result type. The chain, thunk -> boilerplate `on` -> `api`
+forwarder -> strict `call`, is anchored to the facade's exact types at
+both ends, so convertibility drift anywhere in the middle fails to
+compile, with the error pointing at the drifting line. It validates the
+boilerplate as much as the `api`. Real conforming types never trip it,
+since real calls convert legally.
 
-Two structural limits: failures are hard compile errors rather than a
-`false` (a fully generic `FulfillsApi<H, F>` concept is impossible in
+The probe is the one type the library registers itself, through a generic
+`corvid_proxy_spec` overload in `details`, which is what admits it to the
+registration-gated boilerplate. That registration passes `api_check::off`,
+since a validating one would recurse into itself through the
+boilerplate-visibility check.
+
+Caught:
+
+- a missing or misspelled forwarder
+- wrong arity, or the wrong const flavor of `self`
+- a parameter or declared result type that is merely convertible to the
+  facade's, including the silently-truncating kind
+- a forwarder body dispatching a key with a different signature
+
+Not caught:
+
+- a missing `noexcept` on a forwarder (degrades `noexcept(p.fire(1))`, not
+  behavior)
+- by-value versus by-reference parameter spellings (an extra copy, not a
+  bug)
+- reference-to-value decay of a declared result (a conversion operator
+  cannot distinguish binding a reference from copying out of one)
+- a body dispatching the wrong key with an identical signature, which no
+  shape check can see
+
+Closing that last hole would take a behavioral probe (record which key
+each forwarder dispatches and compare) or C++26 reflection, which deletes
+the whole problem by generating the `api` from the facade.
+
+Two structural limits. First, failures are hard compile errors rather than
+a `false`: a fully generic `FulfillsApi<H, F>` concept is impossible in
 C++23, since no mechanism turns a `fixed_string` into an identifier to
-probe `h.fire(...)`), and the facade must have a boilerplate impl (a nested
-`boilerplate`, or a namespace-scope `proxy_impl` partial gated on
+probe `h.fire(...)`. Second, the facade must have a boilerplate impl (a
+nested `boilerplate`, or a namespace-scope `proxy_impl` partial gated on
 `ProxyRegistered`) for the chain to exist, since that impl is the only
 artifact that invokes the members by name. A registration that cannot see
-such a boilerplate fails a friendly `static_assert` that names the opt-out;
-a nested boilerplate is visible wherever the facade is, so only the
-namespace-scope spelling can trip it.
+such a boilerplate fails a friendly `static_assert` that names the
+opt-out. A nested boilerplate is visible wherever the facade is, so only
+the namespace-scope spelling can trip it.
 
-### Codegen (`prox::codegen`, built)
+### Codegen (`prox::codegen`)
 
 `prox::codegen<F>(os)` writes the canonical `api` and `boilerplate` for a
-facade to a stream, ready to paste into the facade body: define the facade's
-method list, add the one-liner to a scratch `main`, paste the output, delete
-the one-liner. It lives in its own header,
+facade to a stream, ready to paste into the facade body. The workflow:
+define the facade's method list, add the one-liner to a scratch `main`,
+paste the output, delete the one-liner. It lives in its own header,
 [proxy_codegen.h](proxy_codegen.h), so `proxy.h` stays free of streams and
-RTTI. This is the closest thing to reflection available today; the real
-value is that it spells the conventions' edge cases correctly every time:
-`noexcept` propagated onto forwarders and bindings (a plain binding for a
-noexcept method fails conformance), `this const auto&` for const methods,
-the const pair's trailing requires-clause, overload sets sharing one
-`method_key`, base `api` inheritance with the using-declarations that merge
-the names a new forwarder would otherwise hide, redeclared forwarders for
-methods the inherited path does not cover, and the single-path diamond
-shape (inherit the heaviest chain's `api`, redeclare the rest).
+RTTI.
 
-Method signatures carry no parameter names, so codegen mints them:
-one `arg_N` sequence spanning the whole facade, deliberately arbitrary and
-unique across the output, so renaming a parameter after pasting is a single
-search-and-replace that hits the `api` forwarder and the `boilerplate`
-binding together. Base facades are spelled by their demangled C++ type
-names (`naming::friendly_type_name`), not their formal `name<>` entries,
-which need not match (`war_correspondent`'s formal name is
-"correspondent"); type spellings are the demangler's, best-effort
-normalized, and may want touch-up after pasting. Tested against golden
-masters covering each shape above; the generated `posse_leader` and
-`armory` bodies match the hand-written fixtures exactly, modulo the minted
-parameter names.
+This is the closest thing to reflection available today. The real value is
+that it spells the conventions' edge cases correctly every time:
 
-Relatedly, a facade is never a value: `facade`'s default constructor is
+- `noexcept` propagated onto forwarders and bindings (a plain binding for
+  a noexcept method fails conformance)
+- `this const auto&` for const methods
+- the const pair's trailing requires-clause
+- overload sets sharing one `method_key`
+- base `api` inheritance, with the using-declarations that merge the names
+  a new forwarder would otherwise hide
+- redeclared forwarders for methods the inherited path does not cover
+- the single-path diamond shape (inherit the heaviest chain's `api`,
+  redeclare the rest)
+
+Method signatures carry no parameter names, so codegen mints them: one
+`arg_N` sequence spanning the whole facade, deliberately arbitrary and
+unique across the output. Renaming a parameter after pasting is then a
+single search-and-replace that hits the `api` forwarder and the
+`boilerplate` binding together.
+
+Base facades are spelled by their demangled C++ type names
+(`naming::friendly_type_name`), not their formal `name<>` entries, which
+need not match (`war_correspondent`'s formal name is "correspondent").
+Type spellings are the demangler's, best-effort normalized, and may want
+touch-up after pasting.
+
+Codegen is tested against golden masters covering each shape above. The
+generated `posse_leader` and `armory` bodies match the hand-written
+fixtures exactly, modulo the minted parameter names.
+
+Relatedly, a facade is never a value. `facade`'s default constructor is
 deleted and propagates to derived facades, so a stray `gunslinger g;`,
 where a handle was meant, fails at the declaration.
 
-### Composition (`extends`, built)
+### Composition (`extends`)
 
 A facade extends others by listing `extends<Base>` entries alongside its
 methods, conventionally first:
 
 ```cpp
-struct marshal : facade<name<"marshal">, extends<gunslinger>,
+struct marshal : facade<name<"marshal">,  //
+                     extends<gunslinger>, //
                      method<"arrest", bool(int)>> {};
 ```
 
 The derived facade's effective method list is the flattening of its bases'
-lists, in declaration order, followed by its own, and every handle of the
-derived facade dispatches inherited and own methods alike. Flattening keeps
-each method's declaring facade (a slot is a method plus its owner), which is
-what the collision rules, qualified keys, and diamond dedup below all read.
+lists, in declaration order, followed by its own. Every handle of the
+derived facade dispatches inherited and own methods alike. Flattening
+keeps each method's declaring facade (a slot is a method plus its owner),
+which is what the collision rules, qualified keys, and diamond dedup below
+all read.
 
 A method name may recur within one extends chain only as an overload set
-(see "Per-name overload sets"): a derived facade may overload an inherited
+(see "Per-name overload sets"). A derived facade may overload an inherited
 name with a different signature, but a same-signature recurrence is
 rejected by a `static_assert` detonator at first use of the facade's
-machinery, because that is redeclaration (or overriding), and facades carry
-no implementations, so there is nothing to override. Unrelated sibling
-bases MAY collide on a method name (see "Facade names and sibling
-collisions"). Diamonds are supported: a
-shared ancestor reached through more than one path
-dedups to a single set of slots by facade identity, and since conformance is
-per facade there is only one `proxy_impl<Ancestor, T>` to reach no matter
-the path (the effect of Rust's coherence rule), so the collapse is virtual
-inheritance semantics with no opt-in and no duplicated subobjects.
+machinery. That is redeclaration (or overriding), and facades carry no
+implementations, so there is nothing to override. Unrelated sibling bases
+MAY collide on a method name (see "Facade names and sibling collisions").
 
-Conformance is per facade, as with Rust supertraits: `Proxiable<T, marshal>`
-requires `marshal`'s own methods bound through `proxy_impl<marshal, T>` plus
-`Proxiable<T, gunslinger>`, and the derived boilerplate spells only the new
-methods. The alternative, one derived impl covering the whole flattened
-list, was rejected because it lets a directly-built `proxy_view<gunslinger>`
-and an upcast one dispatch different bindings for the same method. Per-facade
-binding defines each inherited method's behavior exactly once, so the two
-are identical by construction.
+Diamonds are supported. A shared ancestor reached through more than one
+path dedups to a single set of slots by facade identity. Since conformance
+is per facade, there is only one `proxy_impl<Ancestor, T>` to reach no
+matter the path (the effect of Rust's coherence rule). The collapse is
+virtual inheritance semantics with no opt-in and no duplicated subobjects.
 
-Registration does not multiply with the chain, though: the idiomatic
+Conformance is per facade, as with Rust supertraits.
+`Proxiable<T, marshal>` requires `marshal`'s own methods bound through
+`proxy_impl<marshal, T>` plus `Proxiable<T, gunslinger>`, and the derived
+boilerplate spells only the new methods. The alternative, one derived impl
+covering the whole flattened list, was rejected because it lets a
+directly-built `proxy_view<gunslinger>` and an upcast one dispatch
+different bindings for the same method. Per-facade binding defines each
+inherited method's behavior exactly once, so the two are identical by
+construction.
+
+Registration does not multiply with the chain, though. The idiomatic
 spelling is a single template hook constrained on `InChainOf` (`Extends`
-made reflexive and argument-flipped), which registers a type for the derived
-facade and every facade it extends in one declaration:
+made reflexive and argument-flipped), which registers a type for the
+derived facade and every facade it extends in one declaration:
 
 ```cpp
 template<prox::InChainOf<ranger> F>
@@ -441,73 +579,91 @@ consteval auto corvid_proxy_spec(F*, texas_ranger*) {
 
 The hook collapses only the opt-in ceremony; the bindings stay per facade.
 Chain registration is always semantically safe, because conformance to the
-derived facade requires base conformance anyway. The anchor facade names the
-outermost level the type conforms to, so a type conforming only partway up a
-chain anchors mid-chain and is registered for that level and everything
-below (`constable` in the test). A base level that needs a
-carried impl (its names diverge at that level only) takes its own plain hook
-alongside the chain hook; overload resolution prefers the non-template hook
-for that level, and the carried impl outranks the boilerplate. A
-deliberately partial registration remains expressible with plain per-facade
-hooks; it produces a type that is not proxiable at the derived facade at
-all, failing loudly at first use (exercised by `vigilante` in the test).
+derived facade requires base conformance anyway.
 
-The dispatch table of a composed facade carries the flattened thunks (bases'
-first), each built through its slot's declaring facade (identical to the
-thunk in that base's own table), plus the address of each direct base's
-table for the same target type. An inherited call is therefore the same
-single indexed load as an own one, and upcasting is reading an embedded
-pointer (walked transitively for grandparents), which is Rust's dyn-upcast
-vtable layout. In a diamond, the shared ancestor's table pointer is the same
-object along every path, so upcast routes cannot disagree. ngcpp reaches the
-same user-visible feature differently: upward conversion is opt-in per
-composition (`add_facade<F, true>`) and works as a dispatched conversion,
-where the per-type thunk manufactures the target handle.
+The anchor facade names the outermost level the type conforms to. A type
+conforming only partway up a chain anchors mid-chain and is registered for
+that level and everything below (`constable` in the test). A base level
+that needs a carried impl, because its names diverge at that level only,
+takes its own plain hook alongside the chain hook. Overload resolution
+prefers the non-template hook for that level, and the carried impl
+outranks the boilerplate.
 
-Handles upcast implicitly, like derived-to-base pointers: `proxy_view<D>`
-and `const_proxy_view<D>` convert to their `B` counterparts (and mutable to
-const, never back), and an lvalue owning proxy converts to a view of its own
-facade or any base, re-pointing at the stored target rather than wrapping
-the handle. The proxy-to-view constructors are lvalue-only so a temporary
-proxy cannot leave a dangling view, and a const proxy yields only the const
-view. Viewing an empty proxy is a precondition violation, like calling
-through one. The generic target constructors exclude handles of the same or
-an extending facade (`details::is_handle_for`), so the re-pointing
-constructors always win over wrapping a handle as a target; wrapping a
+A deliberately partial registration remains expressible with plain
+per-facade hooks. It produces a type that is not proxiable at the derived
+facade at all, failing loudly at first use (exercised by `vigilante` in
+the test).
+
+The dispatch table of a composed facade carries the flattened thunks,
+bases' first. Each thunk is built through its slot's declaring facade,
+identical to the thunk in that base's own table. The table also embeds the
+address of each direct base's table for the same target type. An inherited
+call is therefore the same single indexed load as an own one, and
+upcasting is reading an embedded pointer (walked transitively for
+grandparents), which is Rust's dyn-upcast vtable layout. In a diamond, the
+shared ancestor's table pointer is the same object along every path, so
+upcast routes cannot disagree.
+
+ngcpp reaches the same user-visible feature differently. Its upward
+conversion is opt-in per composition (`add_facade<F, true>`) and works as
+a dispatched conversion, where the per-type thunk manufactures the target
+handle.
+
+Handles are upcast implicitly, like derived-to-base pointers. `proxy_view<D>`
+and `const_proxy_view<D>` convert to their `B` counterparts, and mutable
+converts to const, never back. An lvalue owning proxy converts to a view
+of its own facade or any base, re-pointing at the stored target rather
+than wrapping the handle.
+
+The proxy-to-view constructors are lvalue-only, so a temporary proxy
+cannot leave a dangling view, and a const proxy yields only the const
+view. Emptiness propagates: viewing an empty proxy yields an empty view,
+and upcasting an empty handle yields an empty one, so only calling through
+an empty handle is a contract violation.
+
+The generic target constructors exclude handles of the same or an
+extending facade (`details::is_handle_for`), so the re-pointing
+constructors always win over wrapping a handle as a target. Wrapping a
 handle of an unrelated facade that conforms via a custom impl still works.
 
-The self-conformance invariant stretches across composition: the library
+The self-conformance invariant stretches across composition. The library
 bindings generalize from `proxy_impl<F, handle<F>>` to
-`proxy_impl<B, handle<D>>` for any `D` extending `B`, so a derived handle
-satisfies a base-facade bound (Rust: `dyn Derived` meets a `Base` bound) and
-`make_proxy_view<B>` accepts and upcasts derived handles.
+`proxy_impl<B, handle<D>>` for any `D` extending `B`. A derived handle
+therefore satisfies a base-facade bound (Rust: `dyn Derived` meets a
+`Base` bound), and `make_proxy_view<B>` accepts and upcasts derived
+handles.
 
-A derived facade does not inherit the base's `api` automatically (facade
-types are unrelated as C++ types); the convention is
+A derived facade does not inherit the base's `api` automatically, since
+facade types are unrelated as C++ types. The convention is
 `struct api : gunslinger::api { ... };`, adding only the new forwarders.
-Deducing `this` sees the complete handle either way, so inherited forwarders
-dispatch through the derived handle's flattened table. `validate_api` runs
-through composition: the probe of a facade registers for every facade it
-extends, each base's boilerplate drives the inherited forwarders at the
-derived probe, and the whole flattened list is checked at the derived
-facade's registration.
+Deducing `this` sees the complete handle either way, so inherited
+forwarders dispatch through the derived handle's flattened table.
+
+`validate_api` runs through composition. The probe of a facade registers
+for every facade it extends, each base's boilerplate drives the inherited
+forwarders at the derived probe, and the whole flattened list is checked
+at the derived facade's registration.
 
 An `api` diamond is best built along one path: inherit the heavier chain's
-`api` and redeclare the lighter siblings' own forwarders (the test's
-`posse_leader` inherits `marshal::api` and redeclares `bounty_hunter`'s one
-forwarder). Inheriting every base `api` also works, but costs one
-using-declaration per shared-ancestor method, because the ancestor's
-forwarder names arrive through both bases and plain member lookup is
-ambiguous until a using-declaration pulls in a path, plus one padding word
-in every handle, because the two empty ancestor-`api` subobjects are the
-same type and the ABI must give them distinct addresses, which empty-base
-optimization cannot remove. There is no automatic merge available before
-reflection: using-declarations cannot be pack-expanded over arbitrary names
-(the `overloaded` trick works only for a known name like `operator()`), and
-virtual inheritance would put a vbptr in every handle, costing more than it
-saves.
+`api` and redeclare the lighter siblings' own forwarders. (The test's
+`posse_leader` inherits `marshal::api` and redeclares `bounty_hunter`'s
+one forwarder.)
 
-### Facade names and sibling collisions (`name`, built)
+Inheriting every base `api` also works, but costs two things. It needs one
+using-declaration per shared-ancestor method, because the ancestor's
+forwarder names arrive through both bases, and plain member lookup is
+ambiguous until a using-declaration pulls in a path. It also pads every
+handle by one word, because the two empty ancestor-`api` subobjects are
+the same type, and the ABI must give them distinct addresses, which
+empty-base optimization cannot remove.
+
+There is no automatic merge available before reflection.
+Using-declarations cannot be pack-expanded over arbitrary names (the
+`overloaded` trick works only for a known name like `operator()`), and
+virtual inheritance would put a vbptr in every handle, costing more than
+it saves.
+
+### Facade names and sibling collisions (`name`)
 
 Every facade carries a formal name through a `name` entry, listed
 conventionally first:
@@ -518,189 +674,308 @@ struct camera : facade<name<"camera">,
                     method<"reload", void()>> {};
 ```
 
-Every method then answers to its facade-qualified name as well as its plain
-one: a `call` key containing "::" matches the declaring facade's name plus
-the method name, so `call<"camera::fire">()` names its slot outright, even
-through a derived handle. The entry is required, exactly once per facade,
-enforced by a detonator at first use of the facade's machinery. It was
-briefly optional; requiring it was the user's call, and the right one: a
-downstream composer cannot add a name to a facade it does not own, so an
-optional name would foreclose legal collisions in every composition that
-ever included an unnamed facade, the per-facade overhead is one short entry,
-and mandatory names delete every nameless special case from the machinery
-(the sibling-collisions-need-names detonator, the empty-name skips in
-matching and uniqueness checking, and `qualified_key`'s fallback branch all
-went away). Facade names must be unique within a composition (a detonator
-enforces it), and C++26 reflection is expected to supply the name from the
-facade type itself, retiring the entry.
+Every method then answers to its facade-qualified name as well as its
+plain one. A `call` key containing "::" matches the declaring facade's
+name plus the method name, so `call<"camera::fire">()` names its slot
+outright, even through a derived handle.
+
+The entry is required, exactly once per facade, enforced by a detonator at
+first use of the facade's machinery. It was briefly optional; requiring it
+proved right, for three reasons. A downstream composer cannot add a name
+to a facade it does not own, so an optional name would foreclose legal
+collisions in every composition that ever included an unnamed facade. The
+per-facade overhead is one short entry. And mandatory names deleted every
+nameless special case from the machinery: the
+sibling-collisions-need-names detonator, the empty-name skips in matching
+and uniqueness checking, and `qualified_key`'s fallback branch all went
+away.
+
+Facade names must be unique within a composition (a detonator enforces
+it). C++26 reflection is expected to supply the name from the facade type
+itself, retiring the entry.
 
 Names are what make sibling collisions legal outright: two unrelated bases
-declaring the same method name may always be composed, because the qualified
-spelling is always available as the disambiguator. The rules all follow from
-one structural fact, that handles are type-erased, so visibility and
-ambiguity are facade-level decisions, and whether the concrete type happens
-to serve two colliding slots from one member is invisible at the call site:
+declaring the same method name may always be composed, because the
+qualified spelling is always available as the disambiguator.
 
-- Distinct signatures form an overload set. An unqualified call resolves the
-  way C++ would after `using A::f; using B::f;`: a unique exact signature
-  match wins, else a unique viable candidate, else a `static_assert` naming
-  the ambiguity. The `api` convention is one using-declaration per base,
-  because C++ member lookup finds sibling-base names ambiguous before
-  overload resolution ever runs; with the using-declarations in place the
-  forwarders form the same overload set.
-- A same-signature collision is a lazy call-site error, through `call<>` (a
-  `static_assert`) and through the sugar (an ambiguous overload set) alike.
-  The slots stay reachable through their qualified keys and through upcast
-  handles, where each level's list has no collision. Per-facade conformance
-  means the two slots can carry genuinely different bindings for the same
-  concrete type (the test's `photographer` reloads its gun at the
-  `gunslinger` level and winds its film at the `camera` level).
+The rules all follow from one structural fact: handles are type-erased, so
+visibility and ambiguity are facade-level decisions. Whether the concrete
+type happens to serve two colliding slots from one member is invisible at
+the call site.
+
+- Distinct signatures form an overload set. An unqualified call resolves
+  the way C++ would after `using A::f; using B::f;`: a unique exact
+  signature match wins, else a unique viable candidate, else a
+  `static_assert` naming the ambiguity. The `api` convention is one
+  using-declaration per base, because C++ member lookup finds sibling-base
+  names ambiguous before overload resolution ever runs; with the
+  using-declarations in place the forwarders form the same overload set.
+- A same-signature collision is a lazy call-site error, through `call<>`
+  (a `static_assert`) and through the sugar (an ambiguous overload set)
+  alike. The slots stay reachable through their qualified keys and through
+  upcast handles, where each level's list has no collision. Per-facade
+  conformance means the two slots can carry genuinely different bindings
+  for the same concrete type (the test's `photographer` reloads its gun at
+  the `gunslinger` level and winds its film at the `camera` level).
 - A same-signature collision also blocks `validate_api` for the composed
-  facade, because boilerplates drive the probe by natural name, exactly the
-  spelling the collision makes ambiguous. Such a facade registers with
+  facade, because boilerplates drive the probe by natural name, exactly
+  the spelling the collision makes ambiguous. Such a facade registers with
   `api_check::off`; the base levels validate normally.
 
-The library's self-conformance bindings (`proxy_impl<B, handle<D>>`) forward
-through the qualified spelling of `B`'s method names, so a derived handle
-keeps satisfying a base-facade bound even when the derived list collides on
-the method's plain name.
+The library's self-conformance bindings (`proxy_impl<B, handle<D>>`)
+forward through the qualified spelling of `B`'s method names, so a derived
+handle keeps satisfying a base-facade bound even when the derived list
+collides on the method's plain name.
 
-### Per-name overload sets (built)
+### Per-name overload sets
 
 A facade may declare one method name several times, forming an overload
 set: `method<"issue", int(int)>` alongside `method<"issue", int()>`. A
-same-name pair must differ in its argument lists or in constness; the C++
+same-name pair must differ in its argument lists or in constness. The C++
 member rules apply, so the result type and `noexcept` do not overload, and
 a pair distinguished by nothing else stays a collision.
 
-Overloads span extends levels under the same rule: a derived facade may add
-`issue(int, int)` to a base's `issue` pair, since a base's `foo()` and a
-derived `foo(int)` are different functions that happen to share a spelling,
-exactly as within one facade (what C++'s mangling hides). A same-signature
-recurrence in a chain stays an error, because that is redeclaration, and
-there is nothing to override. Sibling collisions keep their own rules
-above, including the legal same-signature collision; the asymmetry is
-deliberate, since sibling composers cannot coordinate names and
-qualification bails them out, while a chain author can see the base, so a
-chain duplicate is rejected eagerly. Unlike C++, where a derived class's
-`foo(int)` silently hides the base's `foo()` until a using-declaration
-merges them, the erased candidate set merges automatically; an upcast
-handle sees only its own level's overloads.
+Overloads span extends levels under the same rule. A derived facade may
+add `issue(int, int)` to a base's `issue` pair, because a base's `foo()`
+and a derived `foo(int)` are different functions that happen to share a
+spelling, exactly as within one facade (what C++'s mangling hides). A
+same-signature recurrence in a chain stays an error, because that is
+redeclaration, and there is nothing to override.
+
+Sibling collisions keep their own rules above, including the legal
+same-signature collision. The asymmetry is deliberate. Sibling composers
+cannot coordinate names, and qualification bails them out; a chain author
+can see the base, so a chain duplicate is rejected eagerly.
+
+Unlike C++, where a derived class's `foo(int)` silently hides the base's
+`foo()` until a using-declaration merges them, the erased candidate set
+merges automatically. An upcast handle sees only its own level's
+overloads.
 
 An unqualified call resolves over the whole candidate set the way a C++
 call would after a using-merge: a unique exact argument match wins, else a
-unique viable candidate, with C++'s object-parameter preference applied as
-a tiebreak within each tier, so a mutable handle resolves a const pair
+unique viable candidate. C++'s object-parameter preference applies as a
+tiebreak within each tier, so a mutable handle resolves a const pair
 (`method<"count", int&()>` with `method<"count", int() const>`) to its
-non-const member while const handles and `const_proxy_view` dispatch the
+non-const member, while const handles and `const_proxy_view` dispatch the
 const one. The tiebreak is uniform over a candidate set, so a sibling
-collision differing only in constness resolves the same way. Qualified
-keys narrow the candidates to one facade's and then resolve identically,
-which is also how the library's self-conformance bindings keep working
-over overloaded names.
+collision differing only in constness resolves the same way.
+
+Qualified keys narrow the candidates to one facade's and then resolve
+identically. That is also how the library's self-conformance bindings keep
+working over overloaded names.
 
 The two tiers plus the tiebreak are deliberately not full C++
-implicit-conversion ranking. Within the viable tier no candidate outranks
-another by conversion quality (a promotion does not beat a conversion:
-`call<"aim">(short{})` over `aim(int)`/`aim(double)` is ambiguous where
-real overload resolution would promote), and an exact argument match on a
-const method outranks the object-parameter preference where real member
-overloading would weigh the two together. Arguments first, constness
-second, predictably; the `api` sugar, being a genuine C++ overload set,
-follows the full rules, and the two models agree everywhere except these
-edges.
+implicit-conversion ranking, and the divergences are pinned. Within the
+viable tier, no candidate outranks another by conversion quality: a
+promotion does not beat a conversion, so `call<"aim">(short{})` over
+`aim(int)`/`aim(double)` is ambiguous where real overload resolution would
+promote. And an exact argument match on a const method outranks the
+object-parameter preference, where real member overloading would weigh the
+two together.
+
+Arguments first, constness second, predictably. The `api` sugar, being a
+genuine C++ overload set, follows the full rules, and the two models agree
+everywhere except these edges.
 
 Bindings overload naturally, sharing one `method_key` and differing in the
 trailing parameters, or in target constness for a const pair:
 `static int on(method_key<"issue">, T& t, int n)` beside
-`static int on(method_key<"issue">, T& t)`. The `api` forwarders are plain
-overloads too, with one wrinkle for the const pair: the mutable member's
-forwarder must repeat its call in a trailing requires-clause (the caveat
-under "Member-call sugar" made load-bearing), because a `const_proxy_view`
-is a mutable object whose deep const lives in the type, and object
-constness alone would select the mutable forwarder for it. The C++ hiding
-that the dispatch layer escapes does surface in a cross-level `api`: a
-derived forwarder overloading an inherited name hides the base's forwarders
-until a using-declaration merges them (`using arsenal::api::issue;`), the
-same convention as sibling collisions. `validate_api` drives each
-overload's slot independently, so overloaded facades validate at
-registration like any other; the only machinery it needed was the
-constness tiebreak reaching `resolve_exact`, which is how the probe's
-mutable strict call singles out the non-const member of a const pair. It
-also catches a forgotten using-declaration, because the probe drives the
-base slots by natural name through the base boilerplate, where the hidden
-forwarders fail to resolve.
+`static int on(method_key<"issue">, T& t)`.
+
+The `api` forwarders are plain overloads too, with one wrinkle for the
+const pair. The mutable member's forwarder must repeat its call in a
+trailing requires-clause (the caveat under "Member-call sugar" made
+load-bearing). A `const_proxy_view` is a mutable object whose deep const
+lives in the type, and object constness alone would select the mutable
+forwarder for it.
+
+The C++ hiding that the dispatch layer escapes does surface in a
+cross-level `api`: a derived forwarder overloading an inherited name hides
+the base's forwarders until a using-declaration merges them
+(`using arsenal::api::issue;`), the same convention as sibling collisions.
+
+`validate_api` drives each overload's slot independently, so overloaded
+facades validate at registration like any other. The only machinery it
+needed was the constness tiebreak reaching `resolve_exact`, which is how
+the probe's mutable strict call singles out the non-const member of a
+const pair. It also catches a forgotten using-declaration, because the
+probe drives the base slots by natural name through the base boilerplate,
+where the hidden forwarders fail to resolve.
 
 An earlier sketch of this feature used mangled keys (`method<"foo-0", ...>`
 and `method<"foo-1", ...>` sharing one `api` spelling). That remains
 expressible, but same-name declarations subsume it.
 
-## Ownership and storage (built)
+## The handle family
 
-Views give all the type-erasure anyone could ask for; a proxy's added value
-is ownership, so ownership is where the knobs are. Every knob lives on the
-handle rather than the facade: registration is per (facade, type) and knows
-nothing about any particular handle's storage, so one facade serves proxies
-of every policy, shared proxies, and views simultaneously, and the checks
-fire at proxy construction, the first moment the policy meets the concrete
-type. (No facade-level knob has yet justified itself; the spec's additive
-design means one can be added later without touching existing
-registrations.)
+Five handles share one shape (a target plus a pointer to a static
+per-(facade, type) table) and differ in what they own. All of the
+dispatching handles inherit the facade's `api` sugar when it exists,
+through `details::api_base_t<F>`. The two views additionally share their
+storage and const-method `call` through `details::view_base<F, Const>`:
+
+```mermaid
+classDiagram
+    class api_base_t~F~ {
+        <<the facade's api if defined, else empty>>
+    }
+    class view_base~F,Const~ {
+        #target_ : void pointer, const if Const
+        #vtable_ : view table pointer
+        +call() const methods only
+        +operator bool()
+    }
+    class proxy_view~F~ {
+        +call() all methods
+        +try_downcast() const and non-consuming
+    }
+    class const_proxy_view~F~ {
+        +try_downcast() to const views only
+    }
+    class proxy~F,Policy~ {
+        -storage_ : SBO buffer or heap pointer
+        -vtable_ : owning table pointer
+        +call()
+        +clone()
+        +can_clone()
+        +extract() heap allocation out
+        +try_downcast() rvalue, consumes on success
+    }
+    class shared_proxy~F~ {
+        -target_ : shared_ptr of void
+        -vtable_ : view table pointer
+        +call()
+        +try_downcast() sharing or transferring
+    }
+    class weak_proxy~F~ {
+        -target_ : weak_ptr of void
+        -vtable_ : view table pointer
+        +lock()
+        +expired()
+    }
+    api_base_t <|-- view_base
+    view_base <|-- proxy_view
+    view_base <|-- const_proxy_view
+    api_base_t <|-- proxy
+    api_base_t <|-- shared_proxy
+```
+
+`weak_proxy` deliberately inherits no `api` and exposes no `call`. It
+keeps its table pointer only to hand to the `shared_proxy` that `lock()`
+mints.
+
+How the handles and the std smart pointers convert into each other (in
+addition, every handle converts to its own counterpart for any facade the
+current one extends, and `try_downcast` walks the other way):
+
+```mermaid
+flowchart LR
+    UP["std::unique_ptr"]
+    SPT["std::shared_ptr (typed)"]
+    P["proxy (owning)"]
+    PV["proxy_view"]
+    CPV["const_proxy_view"]
+    SP["shared_proxy"]
+    WP["weak_proxy"]
+
+    UP -->|adopt| P
+    P -->|"extract&lt;T&gt;()"| UP
+    UP -->|adopt| SP
+    SPT -->|share| SP
+    P -->|"consume, one way"| SP
+    P -->|lvalue lends| PV
+    SP -->|lends| PV
+    PV -->|one way| CPV
+    SP -->|observe| WP
+    WP -->|"lock()"| SP
+```
+
+Emptiness propagates along every handle-to-handle edge: an empty source
+produces an empty result, whether lending, upcasting, adopting, or
+downcasting. Only calling through an empty handle violates the contract.
+
+## Ownership and storage
+
+Views give all the type-erasure anyone could ask for. A proxy's added
+value is ownership, so ownership is where the knobs are.
+
+Every knob lives on the handle rather than the facade. Registration is per
+(facade, type) and knows nothing about any particular handle's storage, so
+one facade serves proxies of every policy, shared proxies, and views
+simultaneously. The checks fire at proxy construction, the first moment
+the policy meets the concrete type. (No facade-level knob has yet
+justified itself; the spec's additive design means one can be added later
+without touching existing registrations.)
 
 ### Storage policies
 
-`proxy<F, Policy>` takes a `proxy_policy` NTTP whose default reproduces the
-baseline handle: a two-pointer inline buffer at `std::max_align_t`
-alignment, heap fallback. The `fixed_function` lesson is that the default
-SBO is sometimes a little too small, so `sbo_size` and `sbo_align` are
-settable, growing only (a target eligible for the default buffer stays
+`proxy<F, Policy>` takes a `proxy_policy` NTTP whose default reproduces
+the baseline handle: a two-pointer inline buffer at `std::max_align_t`
+alignment, with heap fallback. A target stores inline when it fits the
+buffer, is no more strictly aligned, and is nothrow-move-constructible.
+Anything else is a unique-owned heap allocation. A default-constructed or
+moved-from proxy is empty, testable via `operator bool`, and calling
+through one is undefined behavior.
+
+The policy has three knobs. The `fixed_function` lesson is that the
+default SBO is sometimes a little too small, so `sbo_size` and `sbo_align`
+are settable, growing only (a target eligible for the default buffer stays
 eligible for every buffer). `alloc` picks the strategy: `sbo_or_heap` (the
 default), `sbo_only` (an ineligible target is a clean `static_assert` at
 construction), or `heap_only` (every target's address is stable, and the
-handle drops its buffer to become two words, like a view). The chosen mode
-is baked into the owning table's identity: tables are per (facade, birth
-facade, type, mode), and the mode discriminates the storage union at
-runtime through the `relocate` slot (the birth key serves downcasting,
-below).
+handle drops its buffer to become two words, like a view).
+
+The chosen mode is baked into the owning table's identity. Tables are per
+(facade, birth facade, type, mode), and the mode discriminates the storage
+union at runtime through the `relocate` slot. (The birth key serves
+downcasting, below.)
 
 Proxies of different facades and policies interconvert as rvalues through
-one converting constructor, and the source's policy never forecloses a
+one converting constructor. The source's policy never forecloses a
 conversion: what matters is whether the destination can accommodate the
 target that actually arrives, decided per target at adoption time. An
-inline arrival relocates into the buffer when it fits (the check is purely
-compile-time when the destination's buffer dominates the source's, which
-covers every same-policy move) and otherwise re-boxes onto the heap; a heap
-arrival moves by pointer steal, or un-boxes into an `sbo_only` proxy's
-buffer, the erased target's size and alignment being checked against the
-buffer through the owning table. Exactly the conversions that might change
-the storage mode can throw: the re-boxing allocation, or
-`std::length_error` when an erased target cannot be stored inline and the
-policy forbids the heap (a real error path rather than a precondition,
-since the caller cannot inspect an erased target's size). A throw happens
-before anything moves, leaving the source intact. The static probe
-`can_adopt(source)` answers up front whether a conversion would be
-accommodated, advertising that adoption is not always possible and letting
-a caller sidestep the throw; it is a property of the destination type
-against the source's runtime target, so it needs no destination instance,
-and only an `sbo_only` destination can ever answer no. The mode-changing thunks
-and the other-mode table cross-links live in the owning tables
-(`sbo_to_heap`/`heap_to_sbo`), whose two modes reference each other by
-address.
+inline arrival relocates into the buffer when it fits, and otherwise
+re-boxes onto the heap. (The fit check is purely compile-time when the
+destination's buffer dominates the source's, which covers every
+same-policy move.) A heap arrival moves by pointer steal, or un-boxes into
+an `sbo_only` proxy's buffer, with the erased target's size and alignment
+checked against the buffer through the owning table.
+
+Exactly the conversions that might change the storage mode can throw: the
+re-boxing allocation, or `std::length_error` when an erased target cannot
+be stored inline and the policy forbids the heap. The latter is a real
+error path rather than a precondition, since the caller cannot inspect an
+erased target's size. A throw happens before anything moves, leaving the
+source intact.
+
+The static probe `can_adopt(source)` answers up front whether a conversion
+would be accommodated, advertising that adoption is not always possible
+and letting a caller sidestep the throw. It is a property of the
+destination type against the source's runtime target, so it needs no
+destination instance. Only an `sbo_only` destination can ever answer no.
+
+The mode-changing thunks and the other-mode table cross-links live in the
+owning tables (`sbo_to_heap`/`heap_to_sbo`), whose two modes reference
+each other by address.
 
 ### Owning upcast
 
 An rvalue `proxy<D>` converts implicitly to `proxy<B>` for any facade `D`
 extends (Rust: `Box<dyn Derived>` to `Box<dyn Base>`). The move transfers
-the target, by relocation or pointer steal exactly as in a same-facade move,
-and leaves the source empty. The mechanism mirrors the views': the owning
-table embeds each direct base's owning table for the same birth, target,
-and mode, and `upcast_owning_vtable` walks the same compile-time-resolved
-route as `upcast_vtable`. The conversion is one-way as a conversion, but
-unlike Rust's own permanent `Box` upcast it can be undone through
-`try_downcast` (below), since the tables remember the birth facade. One
-consequence of the birth key: an upcast proxy's table pointer is a
+the target, by relocation or pointer steal exactly as in a same-facade
+move, and leaves the source empty. The mechanism mirrors the views': the
+owning table embeds each direct base's owning table for the same birth,
+target, and mode, and `upcast_owning_vtable` walks the same
+compile-time-resolved route as `upcast_vtable`.
+
+The conversion is one-way as a conversion. Unlike Rust's permanent `Box`
+upcast, though, it can be undone through `try_downcast` (below), since the
+tables remember the birth facade.
+
+One consequence of the birth key: an upcast proxy's table pointer is a
 different static object from a directly built base proxy's, with identical
-dispatch, so the two are behaviorally indistinguishable rather than
+dispatch. The two are behaviorally indistinguishable rather than
 pointer-identical.
 
 ### Cloning
@@ -708,63 +983,74 @@ pointer-identical.
 The owning table carries a `copy` slot, null for a target that is not
 copy-constructible. `can_clone()` reports it at runtime, since cloneability
 is a property of the erased target rather than the proxy type (a container
-of proxies can mix), and `clone()` returns a new proxy of the same policy
-owning a copy. Cloning is deliberately a named method rather than a copy
-constructor: an unconditional copy constructor would satisfy
-`std::copyable` for every proxy while failing at runtime for uncloneable
-targets, turning a concept-probed guarantee into a lie (the `std::function`
-trap, institutionalized). Cloning an empty proxy yields an empty one, and so
-does cloning an uncloneable target; `can_clone()` is the up-front check that
-tells those apart.
+of proxies can mix). `clone()` returns a new proxy of the same policy
+owning a copy.
+
+Cloning is deliberately a named method rather than a copy constructor. An
+unconditional copy constructor would satisfy `std::copyable` for every
+proxy while failing at runtime for uncloneable targets, turning a
+concept-probed guarantee into a lie (the `std::function` trap,
+institutionalized).
+
+Cloning an empty proxy yields an empty one, and so does cloning an
+uncloneable target. `can_clone()` is the up-front check that tells those
+apart.
 
 ### std smart-pointer interop
 
-Ownership enters and leaves a proxy only by way of `std::unique_ptr`; raw
-pointers are never adopted and never exposed. `proxy<F>` constructs from a
-`std::unique_ptr<T>` (also spelled `make_proxy<F>(std::move(up))`), adopting
-the allocation as-is onto the heap path, so nothing is copied or moved and
-the address stays stable; an `sbo_only` proxy instead un-boxes the target
-into its buffer, the fit being a compile-time fact here since the type is
-concrete. `extract<T>()` is the inverse: it verifies `T`
-against the owning table's type tag at runtime (the address of a per-type
-static; on a mismatch or an empty proxy the result is null and the proxy is
-untouched), hands a heap allocation over as-is, and moves an inline target
-onto the heap first. A `unique_ptr`
-converts to `shared_ptr`, so this also buys the shared tier's interop.
+Ownership enters and leaves a proxy only by way of `std::unique_ptr`. Raw
+pointers are never adopted and never exposed.
+
+`proxy<F>` constructs from a `std::unique_ptr<T>` (also spelled
+`make_proxy<F>(std::move(up))`), adopting the allocation as-is onto the
+heap path. Nothing is copied or moved, and the address stays stable. An
+`sbo_only` proxy instead un-boxes the target into its buffer, the fit
+being a compile-time fact here since the type is concrete.
+
+`extract<T>()` is the inverse. It verifies `T` against the owning table's
+type tag at runtime (the address of a per-type static); on a mismatch or
+an empty proxy, the result is null and the proxy is untouched. It hands a
+heap allocation over as-is, and moves an inline target onto the heap
+first.
+
+A `unique_ptr` converts to `shared_ptr`, so this also buys the shared
+tier's interop.
 
 ### Downcasting (vtable-carried RTTI)
 
-Every owning proxy remembers the facade its target was born as, priced in
-the tables rather than the handle: instances are many and tables are few,
-cold, and deduplicated statics, so the born identity is baked into the
-owning table's key, per (facade, birth facade, type, mode), instead of
-renting a pointer in every handle. Every pointer a table embeds (the
-direct-base tables, the other-mode sibling, the birth ancestry) stays
-within the same born family, so construction over a concrete target lands
-on the birth-keyed family and every conversion stays in it, with no birth
-carrying anywhere in the handles. The table type stays per facade; the
-birth key only selects which static object is pointed at, so handle layout
-is untouched. (An earlier design carried the birth as an opt-in
-policy-gated pointer in the handle; the vtable-carried form replaced it,
-deleting the policy knob, the extra word, and the unknown-birth case at
-once.)
+Every owning proxy remembers the facade its target was born as. The memory
+is priced into the tables rather than the handle: instances are many,
+while tables are few, cold, and deduplicated statics. The born identity is
+baked into the owning table's key, per (facade, birth facade, type, mode),
+instead of renting a pointer in every handle.
+
+Every pointer a table embeds (the direct-base tables, the other-mode
+sibling, the birth ancestry) stays within the same born family.
+Construction over a concrete target lands on the birth-keyed family, and
+every conversion stays in it, with no birth carried anywhere in the
+handles. The table type stays per facade; the birth key only selects which
+static object is pointed at, so handle layout is untouched.
+
+(An earlier design carried the birth as an opt-in policy-gated pointer in
+the handle. The vtable-carried form replaced it, deleting the policy knob,
+the extra word, and the unknown-birth case at once.)
 
 Each table points at a birth ancestry: a static per-(birth facade, type,
 mode) table of {facade identity tag, owning table} covering the birth
 facade and every facade it transitively extends, diamond-deduped. Each
-storage mode has its own ancestry over its own tables, and a mode-changing
+storage mode has its own ancestry over its own tables. A mode-changing
 adoption switches to the table's other-mode sibling, so the tables an
 ancestry hands out always match the target's current home.
 
 The birth is the facade the proxy was constructed as, not the concrete
-type's full conformance: a `texas_ranger` created through
+type's full conformance. A `texas_ranger` created through
 `make_proxy<marshal, texas_ranger>` downcasts back to `marshal` but never
 to `ranger`, even though the type conforms.
 
 `std::move(p).try_downcast<D>()`, constrained to `D` extending the current
-facade, searches the ancestry at runtime by tag. On success the target
+facade, searches the ancestry at runtime by tag. On success, the target
 moves into a `proxy<D>` whose table carries the same birth, so casts keep
-working in both directions; on failure, including an empty source, the
+working in both directions. On failure, including an empty source, the
 result is empty and the source is untouched, which is why the operation is
 a method on an rvalue rather than a conversion. Through a diamond, the
 common base can sidecast to either sibling, since both are in the birth
@@ -772,77 +1058,86 @@ ancestry. This is the RTTI the library otherwise does without, reinvented
 on the reinvented vtable.
 
 Downcasting spans the views and the shared tier the same way. The view
-tables took the same born key, defaulting to the facade itself, which is
-the birth of every directly built view and keeps the plain spellings
-untouched, and grew exactly one slot: a pointer to a parallel view
-ancestry whose entries reference view tables rather than owning ones, so
-view-only code never instantiates destroy, relocate, or copy thunks. The
-owning table's embedded view table is built with the owner's birth, and a
-view lent from a `proxy` or `shared_proxy` points into that born family,
-so a lent view recovers exactly what its owner could, while a directly
-built view is born as its own facade.
+tables took the same born key, defaulting to the facade itself. That
+default is the birth of every directly built view, so the plain spellings
+were untouched. The view table grew exactly one slot: a pointer to a
+parallel view ancestry whose entries reference view tables rather than
+owning ones, so view-only code never instantiates destroy, relocate, or
+copy thunks.
+
+The owning table's embedded view table is built with the owner's birth,
+and a view lent from a `proxy` or `shared_proxy` points into that born
+family. A lent view therefore recovers exactly what its owner could, while
+a directly built view is born as its own facade.
 
 On the copyable handles the operation is non-consuming. `try_downcast` on
-a view is const and returns a new view over the same target (escaping the
-instance-level deep-const guardrail exactly as copying does;
+a view is const and returns a new view over the same target. (This escapes
+the instance-level deep-const guardrail exactly as copying does;
 `const_proxy_view` downcasts only to another const view, so the guarantee
-tier stays closed). `shared_proxy` has an lvalue flavor that shares,
+tier stays closed.) `shared_proxy` has an lvalue flavor that shares,
 minting another owner of the one target, and an rvalue flavor that
-transfers, consuming the source only on success; a birth adopted from a
+transfers, consuming the source only on success. A birth adopted from a
 consumed `proxy` carries over. `weak_proxy` deliberately has no downcast,
 as it has no dispatch: `lock()` first.
 
 ### Shared and weak ownership
 
-`shared_proxy<F>` is Rust's `Rc<dyn Trait>`: a `std::shared_ptr<void>` plus
-the same per-(facade, type) dispatch table the views use. The control block
-already type-erases destruction, so no owning table is needed; there is no
-inline mode, so the target's address is always stable; and the handle is
-copyable for free, a copy sharing the one target rather than cloning it. It
-constructs from `std::shared_ptr<T>` (sharing with outside holders, who keep
-their typed view of the same object) or `std::unique_ptr<T>`, or via
-`make_shared_proxy<F, T>(...)` (target and control block in one
-allocation). Handles upcast implicitly by copy or move; views lend from a
-shared proxy exactly as from an owning one. Deep const is the same guardrail
-it is on the views: copying escapes it. Upcasts are undoable through
-`try_downcast`, in a sharing lvalue flavor and a transferring rvalue one
-(see "Downcasting"). ngcpp built this bespoke
-(`make_proxy_shared`, compact internal refcounts) to beat `shared_ptr`
-overhead; reusing std is our accepted trade.
+`shared_proxy<F>` is Rust's `Rc<dyn Trait>`: a `std::shared_ptr<void>`
+plus the same per-(facade, type) dispatch table the views use. The control
+block already type-erases destruction, so no owning table is needed. There
+is no inline mode, so the target's address is always stable. And the
+handle is copyable for free, a copy sharing the one target rather than
+cloning it.
 
-Unique ownership converts into shared, consuming the proxy: a heap-stored
+It constructs from `std::shared_ptr<T>` (sharing with outside holders, who
+keep their typed view of the same object), from `std::unique_ptr<T>`, or
+via `make_shared_proxy<F, T>(...)` (target and control block in one
+allocation). Handles upcast implicitly by copy or move, and views lend
+from a shared proxy exactly as from an owning one. Deep const is the same
+guardrail it is on the views: copying escapes it. Upcasts are undoable
+through `try_downcast`, in a sharing lvalue flavor and a transferring
+rvalue one (see "Downcasting").
+
+ngcpp built this tier bespoke (`make_proxy_shared`, compact internal
+refcounts) to beat `shared_ptr` overhead. Reusing std is our accepted
+trade.
+
+Unique ownership converts into shared, consuming the proxy. A heap-stored
 target is adopted with its allocation intact, the owning table's destroy
-slot becoming the control block's deleter, and an inline target moves onto
-the heap first. On a control-block allocation failure the target is
-destroyed rather than leaked and the source is left empty, `shared_ptr`'s
-own contract for its deleter-taking constructors, a weaker guarantee than
-proxy-to-proxy conversions. The reverse conversion deliberately does not
-exist, statically: unique ownership cannot be recovered from a shared
-target, even at a use count of one, without racing the other owners, which
-is also why `std::shared_ptr` has no `release`. Likewise, nothing but a
-`shared_proxy` converts to a `weak_proxy`, since there is no shared
-ownership to observe.
+slot becoming the control block's deleter; an inline target moves onto the
+heap first. On a control-block allocation failure, the target is destroyed
+rather than leaked and the source is left empty. That is `shared_ptr`'s
+own contract for its deleter-taking constructors, and a weaker guarantee
+than proxy-to-proxy conversions.
+
+The reverse conversion deliberately does not exist, statically. Unique
+ownership cannot be recovered from a shared target, even at a use count of
+one, without racing the other owners, which is also why `std::shared_ptr`
+has no `release`. Likewise, nothing but a `shared_proxy` converts to a
+`weak_proxy`, since there is no shared ownership to observe.
 
 `weak_proxy<F>` observes without owning, via `std::weak_ptr<void>`. It
-deliberately carries no dispatch: access always goes through `lock()`, which
-returns a `shared_proxy` (empty when every owner is gone), so there is no
-way to call through a target that might be dying. `expired()` is the usual
-advisory answer. Weak proxies upcast among themselves like every other
-handle, by copy or by move and without locking, so an expired observation
-upcasts as well as a live one; expiry stays `lock()`'s business.
+deliberately carries no dispatch. Access always goes through `lock()`,
+which returns a `shared_proxy` (empty when every owner is gone), so there
+is no way to call through a target that might be dying. `expired()` is the
+usual advisory answer. Weak proxies upcast among themselves like every
+other handle, by copy or by move and without locking, so an expired
+observation upcasts as well as a live one. Expiry stays `lock()`'s
+business.
 
 ## Mechanism
 
-- `proxiable<T, F>` is a concept synthesized from the facade definition: for
-  every `method` of `F`, `proxy_impl<F, T>::on(method_key<...>, T&, ...)` is
-  invocable and returns the right type. Concepts gate (the converting
-  constructor, static-dispatch template bounds); they cannot generate, since
-  C++ has no introspection over requires-expressions. The facade is the
-  source of truth and the concept is derived from it, never the reverse.
-  Both binding routes are registration-gated, so the concept is satisfied
-  exactly when the pair is registered with a usable binding (the facade's
-  boilerplate or a carried impl).
-- The registration slot mirrors the enum registry idiom: an ADL-found
+- `Proxiable<T, F>` is a concept synthesized from the facade definition.
+  For every `method` of `F`,
+  `proxy_impl<F, T>::on(method_key<...>, T&, ...)` must be invocable and
+  return the right type. Concepts gate (the
+  converting constructor, static-dispatch template bounds); they cannot
+  generate, since C++ has no introspection over requires-expressions. The
+  facade is the source of truth and the concept is derived from it, never
+  the reverse. Both binding routes are registration-gated, so the concept
+  is satisfied exactly when the pair is registered with a usable binding
+  (the facade's boilerplate or a carried impl).
+- The registration slot mirrors the enum registry idiom. An ADL-found
   `corvid_proxy_spec(F*, T*)` hook returns a spec object created by
   `make_proxy_spec<F, T>()` (as `make_sequence_enum_spec` is returned from
   `corvid_enum_spec`), read through a central `auto` variable template
@@ -852,12 +1147,13 @@ upcasts as well as a live one; expiry stays `lock()`'s business.
   user code, resolving the hook-vs-type name confusion. Because either
   namespace can host the hook, a type you do not own can be conformed to a
   facade you do not own (the case Rust's orphan rule forbids). Each
-  specialization of an `auto` variable template deduces its own type and
+  specialization of an `auto` variable template deduces its own type, and
   readers detect capabilities via concepts on the spec (precedent:
-  `NamedSequentialEnum` detecting `intern_name` on the enum spec), so richer
-  spec types are additive, with no change to existing registrations. Maximal
-  slot, minimal values. The first knob to use this is the carried impl
-  (`SpecCarriesImpl`), described under "User-facing shape".
+  `NamedSequentialEnum` detecting `intern_name` on the enum spec), so
+  richer spec types are additive, with no change to existing
+  registrations. Maximal slot, minimal values. The first knob to use this
+  is the carried impl (`SpecCarriesImpl`), described under "User-facing
+  shape".
 - Conversion to a proxy instantiates one thunk per method
   (`+[](void* p, args...) { return proxy_impl<F, T>::on(...); }`) and
   stores a pointer to the resulting per-`(F, T)` `static constexpr` table.
@@ -867,360 +1163,339 @@ upcasts as well as a live one; expiry stays `lock()`'s business.
   For a `noexcept` method, conformance additionally requires the binding
   itself to be noexcept-invocable, the thunk pointer type carries
   `noexcept`, and `call` through either handle is itself conditionally
-  noexcept. Supported in the MVP rather than deferred because the qualifier
-  is baked into the erased ABI (the thunk pointer types), where a retrofit
-  would be a break.
+  noexcept. Supported from the first round rather than deferred, because
+  the qualifier is baked into the erased ABI (the thunk pointer types),
+  where a retrofit would have been a break.
 - The owning table carries housekeeping slots in addition to the facade
   methods, the analog of Rust's drop glue: destroy, relocate (null marking
-  the heap mode), copy (null marking an uncloneable target), a type identity
-  tag for typed extraction, the birth ancestry for `try_downcast`, and the
-  direct bases' owning tables for the
-  owning upcast. The view table carries none of the lifetime machinery,
-  which is why the view was built first; its one slot beyond dispatch is
-  the view-ancestry pointer for its own `try_downcast`.
-- Const is handled on two axes. Every handle is deep-const as an instance,
-  meaning only const-qualified methods dispatch through a const handle,
-  enforced by a constraint on the const `call` overload. For the copyable
-  views this is a guardrail, not a guarantee (copying a `const proxy_view`
-  yields a mutable view, like copying a `T* const` to a `T*`). The guarantee
-  lives in `const_proxy_view`, the `&dyn` to `proxy_view`'s `&mut dyn`,
-  where constness is part of the type. It binds const and mutable targets
-  alike, converts implicitly from `proxy_view` with no path back, and
-  dispatches only const methods while sharing the mutable view's
-  per-(facade, type) dispatch table (the non-const slots are simply
+  the heap mode), copy (null marking an uncloneable target), a type
+  identity tag for typed extraction, the birth ancestry for
+  `try_downcast`, and the direct bases' owning tables for the owning
+  upcast. The view table carries none of the lifetime machinery, which is
+  why the view was built first; its one slot beyond dispatch is the
+  view-ancestry pointer for its own `try_downcast`.
+- Const is handled on two axes. Every handle is deep-const as an instance:
+  only const-qualified methods dispatch through a const handle, enforced
+  by a constraint on the const `call` overload. For the copyable views
+  this is a guardrail, not a guarantee (copying a `const proxy_view`
+  yields a mutable view, like copying a `T* const` to a `T*`). The
+  guarantee lives in `const_proxy_view`, the `&dyn` to `proxy_view`'s
+  `&mut dyn`, where constness is part of the type. It binds const and
+  mutable targets alike, converts implicitly from `proxy_view` with no
+  path back, and dispatches only const methods while sharing the mutable
+  view's per-(facade, type) dispatch table (the non-const slots are simply
   unreachable, so no const-sliced table or index remapping is needed). The
   two views share storage and the const-method `call` through
   `details::view_base<F, Const>`. The mutable view layers the unrestricted
   non-const overload on top and re-exposes the inherited one with a
   using-declaration.
 - Invariant: `proxy<F>` and `proxy_view<F>` themselves satisfy
-  `proxiable<_, F>`, so generic code constrained on the facade accepts
+  `Proxiable<_, F>`, so generic code constrained on the facade accepts
   concrete and erased arguments interchangeably (Rust: `dyn Trait`
   implements `Trait`). Implemented as library-provided `proxy_impl`
   bindings whose `on` forwards through `call` with conditional `noexcept`
   (so the invariant survives noexcept methods). The deep-const handles'
   bindings have const and non-const overloads to match. For
   `const_proxy_view` the invariant holds exactly for all-const facades (as
-  with Rust `&dyn`, whose `&mut self` methods are uncallable). Its binding's
-  `on` is constrained to const methods so a mixed facade fails conformance
-  cleanly at overload resolution rather than erroring during return type
-  deduction.
+  with Rust `&dyn`, whose `&mut self` methods are uncallable). Its
+  binding's `on` is constrained to const methods, so a mixed facade fails
+  conformance cleanly at overload resolution rather than erroring during
+  return type deduction.
 
 ## Alternative considered: virtual-model erasure
 
 The external-polymorphism ("Sean Parent" runtime-concept) idiom: a hidden
-abstract `concept_t` with one pure virtual per method, a hidden `model_t<T>`
-whose overrides call `t_.walk()`, and a non-template handle owning the model
-and forwarding through natural member names. It meets both hard requirements
-(no macros, natural `p.walk()` syntax), and its per-method typing cost ties
-the table design at three name-spellings (virtual declaration, model
-override, handle forwarder; versus `method<>` declaration, boilerplate `on`,
-`api` forwarder). Call cost also ties: a virtual call and a table thunk are
-the same shape.
+abstract `concept_t` with one pure virtual per method, a hidden
+`model_t<T>` whose overrides call `t_.walk()`, and a non-template handle
+owning the model and forwarding through natural member names.
 
-Rejected on structural grounds: composition (`extends`) is table
-concatenation instead of multiple inheritance; facade upcasting is a table
-view instead of a cross-cast; SBO relocation is a table slot instead of
-virtual clone/move on a polymorphic buffer; `proxy_view` stays two plain
-pointers with no embedded polymorphic object; and the `method<"...">` list
-keeps the facade enumerable, which the later tiers (member-pointer specs,
-formatter bridge, reflection-derived boilerplate) lean on.
+It meets both hard requirements (no macros, natural `p.walk()` syntax).
+Its per-method typing cost ties the table design at three name-spellings
+(virtual declaration, model override, handle forwarder; versus `method<>`
+declaration, boilerplate `on`, `api` forwarder). Call cost also ties: a
+virtual call and a table thunk are the same shape.
+
+It was rejected on structural grounds. Composition (`extends`) is table
+concatenation instead of multiple inheritance. Facade upcasting is a table
+view instead of a cross-cast. SBO relocation is a table slot instead of
+virtual clone/move on a polymorphic buffer. `proxy_view` stays two plain
+pointers with no embedded polymorphic object. And the `method<"...">` list
+keeps the facade enumerable, which `prox::codegen` already leans on and
+the future-work items (member-pointer specs, formatter bridge,
+reflection-derived boilerplate) will.
 
 A facade-holding-`T*` variant without the hidden ABC (handle templates
-deriving from a forwarding facade) was also sketched. It spells each method
-once, but erases nothing: handles templated on the concrete type cannot
-share a container or a non-template function signature, which is static
-dispatch, already free via `proxiable auto&`. The general rule: once a call
-crosses an erasure boundary, the method name must be spelled on both sides
-of it, plus once for member-call sugar; roughly three spellings per method
-is the C++23 floor in any architecture. C++26 reflection lowers the floor
-to one (derive everything from the facade declaration), in either
-architecture.
+deriving from a forwarding facade) was also sketched. It spells each
+method once, but erases nothing: handles templated on the concrete type
+cannot share a container or a non-template function signature. That is
+static dispatch, already free via `proxiable auto&`.
 
-## Phases
+The general rule: once a call crosses an erasure boundary, the method name
+must be spelled on both sides of it, plus once for member-call sugar.
+Roughly three spellings per method is the C++23 floor in any architecture.
+C++26 reflection lowers the floor to one (derive everything from the
+facade declaration), in either architecture.
 
-1. DONE. Facade, `method`, `method_key`, `Proxiable`, and `proxy_view`. The
-   view first, because with no lifetime slots the dispatch-table synthesis
-   is exercised in isolation. Verified: positive and negative conformance
-   `static_assert` tests, const-qualified methods (`std::string() const`
-   dispatching on `const T&`), reference returns, call-through correctness,
-   heterogeneous containers, view-of-view flattening in `make_proxy_view`,
-   assignment rebinding, partial override of a factored boilerplate
-   (`sheriff`), and the `"name"_method` UDL (a literal operator
-   template in `prox::literals`, inline since `prox` itself is not).
-   Both interesting compile errors are captured as comments in the test:
-   non-conformance walks the constraint chain down to `all_bound_v`; an
-   unknown method name fires the `static_assert` followed by `std::get`
-   index noise, accepted deliberately (a guarding `if constexpr` was tried
-   and dropped as a simplification: fixing the obvious message removes the
-   noise). Compile-time-only machinery is `consteval`, not `constexpr`;
-   only genuinely runtime-callable paths (`call`, the converting
-   constructor, `make_proxy_view`) are `constexpr`. Notes from the build:
-   `fixed_string.h` originally
-   lived in the strings band, which inverted the layering; it was moved to
-   `corvid/meta/` (2026-07-08) and joined the `meta.h` umbrella. proxy.h
-   stays out of the umbrella to limit include weight (the formatting.h
-   precedent); include `corvid/meta/proxy.h` directly.
-   Also, in template contexts `call` needs the dependent-name `template`
-   keyword (`pv.template call<"fire">(1)`), a real ergonomic wart the `api`
-   mixin would hide; ammunition for the sugar pin.
-2. DONE. Owning `proxy` with SBO, plus `make_proxy` (sugar over an
-   `std::in_place_type_t` constructor). Move-only, and deep-const, so only
-   const-qualified methods dispatch through a const proxy, enforced by a
-   constraint on the const `call` overload so the rejection is visible to
-   `requires` probes (a body `static_assert` would not be, and a
-   requires-expression outside a template gets no SFINAE, so the negative
-   test needed a concept wrapper). Storage is a two-pointer inline buffer
-   for targets that fit, are no more aligned than `std::max_align_t`, and
-   are nothrow-move-constructible. Anything else is a unique-owned heap
-   allocation. The owning dispatch table extends the view's with destroy
-   and relocate slots. A null relocate slot marks the heap path, which
-   moves by pointer steal with no target activity. Default-constructed and
-   moved-from proxies are empty (`operator bool`), and calling through one
-   is undefined behavior. Also in this phase: `noexcept` method flavors,
-   the self-conformance invariant, deep-const `proxy_view`, and
-   `const_proxy_view`, all described under Mechanism.
-   Verified: lifetime-counting fixtures balancing construct/destroy/move
-   on both the SBO and heap paths, move-assignment over a live target,
-   emptiness after move, deep-const positive and negative probes,
-   noexcept conformance both ways (a binding lacking `noexcept` fails the
-   facade), `noexcept(call)` propagation, and heterogeneous ownership in a
-   container.
-3. DONE. The `api` mixin is DONE: `details::api_base_t<F>` selects
-   the facade's nested `api` (lazy specialization, empty `no_api` stand-in),
-   and all three handles inherit it. Verified: forwarder parity with
-   `call<>` through the mutable view, the const view, and the owning proxy
-   (const and mutable), reference returns through the sugar, no
-   dependent-name `template` keyword needed in generic code, `noexcept`
-   propagation when the facade author marks the forwarders, and empty-base
-   optimization keeping the views at two pointers. See the caveats under
-   "Member-call sugar". The `validate_api` drift check is also DONE (see
-   "API validation") and runs automatically at registration via
-   `make_proxy_spec`, with `api_check::off` as the opt-out (exercised by
-   `mortar`/`howitzer` in the test); verified empirically that an
-   `int`-to-`long long` parameter drift in a forwarder compiled silently
-   before the check existed and now fails through `lawman`'s registration
-   alone, at the forwarder's own line, with the diagnostic on record in the
-   test. `extends<Base>` composition is DONE (see "Composition"): flattened
-   dispatch, per-facade conformance, implicit upcasting of views and of
-   lvalue owning proxies (including `proxy<derived>` ->
-   `proxy_view<base>`), cross-facade self-conformance, `api` inheritance by
-   convention, and validation through the chain. Verified: inherited and own
-   dispatch through all three handles, upcast target identity (mutations
-   through the derived handle visible through the upcast view, and
-   reference-return address equality against a directly-built view),
-   two-level chains, deep-const preservation across upcasts, negative
-   conformance with a missing base registration, and the duplicate-name
-   detonator; diagnostics on record in the test. A follow-up ergonomics
-   round, driven by reading the test as an end user, added chain
-   registration (`InChainOf`), moved the boilerplate into the facade body,
-   added registration-carried impls (the delegations described under
-   "User-facing shape"; precedence pinned by `turncoat` in the test),
-   dropped the unregistered full-specialization tier in their favor, and
-   restyled the tests to prefer the `api` sugar over `call<>` wherever a
-   facade defines one. A second pass added `proxy_impl_base` (the unqualified
-   `method_key` spelling in binding classes), made both views
-   default-constructible as empty with `operator bool`, matching the owning
-   proxy, and pinned mid-chain anchoring of chain hooks (`constable` in the
-   test).
+## Assessment
 
-4. DONE. Facade-qualified method names, sibling collisions, and diamond
-   composition (described under "Composition" and "Facade names and sibling
-   collisions"). Built as: flattening reworked onto provenance-carrying
-   slots (a method plus its declaring facade) with dedup by facade
-   identity; the `name<"...">` entry, required exactly once per facade
-   (initially optional; made mandatory on review, which deleted the
-   nameless special cases) plus the unique-within-composition detonator;
-   the strict unique-name detonator replaced by the collision rules (chain
-   redeclaration stays an error, sibling collisions freely legal, facade
-   names unique);
-   `call<>` resolution reworked to qualified-aware candidate sets with
-   exact-then-unique-viable argument matching and a distinct "ambiguous"
-   static_assert; and the validation probe made argument-aware to match.
-   Verified: diamond dispatch and upcast-path identity
-   (`posse_leader`/`trail_boss` in the test), qualified keys through plain,
-   derived, const, and owning handles, the overload set and the
-   same-signature collision (`war_correspondent`/`photographer`), deep
-   const for qualified keys, and re-captured diagnostics for all three
-   detonators plus the ambiguity assert. Discoveries along the way: the
-   library self-conformance bindings must forward through qualified keys,
-   since a plain key forwarded through a derived view is ambiguous under a
-   collision; an `api` diamond costs one padding word (same-type empty
-   subobjects need distinct addresses) plus one using-declaration per
-   shared method; and a same-signature collision blocks `validate_api` for
-   the composed facade, which registers with `api_check::off`.
+The hard requirements all held: no macros anywhere, no inheritance or
+vtable pointer in any target, natural `p.fire(3)` call syntax, and a cost
+model identical to virtual dispatch (one thunk call through a fat handle).
+The price concentrates in hand-written artifacts whose drift risks are
+checked by machinery rather than eliminated.
 
-5. DONE. The ownership round (described under "Ownership and storage"): the
-   owning table's final shape (copy slot, type tag, size and alignment,
-   birth ancestry, embedded base owning tables, and the mode-changing
-   thunks with other-mode cross-links), the owning upcast, `proxy_policy`
-   (SBO size and alignment, `sbo_only`/`heap_only`) with
-   accommodate-what-arrives conversions (relocate, re-box, steal, or
-   un-box, decided per target at adoption) with the `can_adopt` up-front
-   probe, `clone`/`can_clone`,
-   `std::unique_ptr` adoption and
-   `extract<T>()`, `try_downcast`, `shared_proxy`/`weak_proxy` with
-   `make_shared_proxy`, and one-way unique-into-shared adoption. Downcasting
-   was first built as an opt-in `downcast` policy flavor carrying a birth
-   pointer in the handle, then redesigned onto the vtable-carried birth key
-   (see "Downcasting"), which deleted the knob, the handle word, and the
-   unknown-birth case. Verified: upcast dispatch and lifetime balance on
-   both storage paths, diamond upcast, policy sizing (a `heap_only` proxy
-   is two words), every direction of
-   cross-policy conversion including the mode changes with their exact
-   target activity, the throwing un-box leaving its source intact, the
-   noexcept partition of the converting constructor, inline and heap
-   clones with
-   independence and lifetime balance, the graceful empty clone of an
-   uncloneable target with the source intact, `unique_ptr` round-trips
-   preserving
-   the exact allocation, typed extraction rejecting the wrong type,
-   downcasts down a chain, past the birth level (failing with the source
-   intact), sideways across a diamond, through storage-mode changes
-   via the per-mode ancestries, and of a target born mid-chain (the birth
-   is the construction facade, not the type's potential), shared copies
-   sharing one
-   target, weak observation across owner death, and interop with outside
-   `shared_ptr` holders. Notes from the build: the analyzer cannot see
-   that the table's `relocate` slot discriminates the storage union, so
-   those reads carry targeted suppressions; the born family's static
-   tables and ancestries reference each other by address,
-   which demands a spelled-out variable type, since `auto` deduction would
-   be circular; the owning-bases tuple is built by a per-facade builder
-   member with a spelled-out return type, because a shared per-entry helper
-   is re-entered mid-instantiation when a diamond's ancestry reaches a
-   sibling's table build, which a deduced return type cannot survive; and an
-   `sbo_only` violation detonates as a single clean `static_assert` at
-   construction (diagnostic on record in the test).
-6. DONE. Downcasting for the views and `shared_proxy` (described under
-   "Downcasting"): the born key on the view tables, defaulted to the facade
-   so plain spellings were untouched; the parallel view-ancestry family;
-   birth inheritance through the owning table's embedded view table; const
-   non-consuming `try_downcast` on both views; the sharing and transferring
-   flavors on `shared_proxy`; `weak_proxy` stays downcast-free. Verified:
-   view downcast dispatch and target identity, the birth limit on directly
-   built views, lent views recovering the owner's birth from a `proxy` and
-   from a `shared_proxy`, the const view downcasting only to a const view,
-   diamond sidecasts through a view, shared copy-downcasts leaving two
-   owners on one target with balanced lifetimes, the transferring flavor
-   consuming only on success, birth surviving unique-into-shared adoption,
-   empty handles, and the concept probes (views and shared positive,
-   `weak_proxy` negative). Notes from the build: the per-entry view-bases
-   hook was replaced by a per-builder `make_view_bases` with a spelled-out
-   return type, the owning round's diamond re-entrancy rule applied
-   preemptively; and the owning table's embedded view table had to become a
-   copy of the standalone born-keyed instance, because initializing it with
-   a second `make_vtable` call would share one function specialization
-   between two variables, and the view ancestry's back-references re-enter
-   it while it is mid-instantiation (the same hazard, one level up:
-   functions must be entered from exactly one variable, where addresses of
-   mid-instantiation variables are fine).
-7. DONE. Per-name overload sets within a single facade (described under
-   "Per-name overload sets"): the chain-collision detonator relaxed so
-   same-owner same-name slots are legal when they differ in arguments or
-   constness (`legal_overload_pair`), and resolution gained C++'s
-   object-parameter preference as a tiebreak within each tier
-   (`tally_preferring_nonconst`, reaching `resolve` and `resolve_exact`
-   alike, the latter being what lets the validation probe single out the
-   members of a const pair). Verified: arity and argument-type overloads
-   through the sugar and `call<>`, the const pair's result types through
-   mutable, const, and `const_proxy_view` handles, overload sets inherited
-   through `extends` and reached through qualified keys, owning and shared
-   dispatch, self-conformance over overloaded names, sugar-level ambiguity
-   probes with the core-model divergence pinned (a `short` promotes at the
-   sugar, stays ambiguous in the viable tier), `api` validation of an
-   overloaded facade at a default-checked registration, and re-captured
-   diagnostics for the detonator and the ambiguity assert. Notes from the
-   build: the const-pair `api` convention requires the mutable forwarder to
-   carry a trailing requires-clause repeating its call, because a
-   `const_proxy_view` is a mutable object whose deep const lives in the
-   type, so object constness alone would route it to the mutable forwarder;
-   and the ambiguity static_assert's advice was reworded ("qualify the key
-   with the facade name, or match one overload's arguments exactly"), since
-   qualification alone cannot split a within-facade overload set. A
-   follow-up round extended overloads across extends levels: once same-name
-   distinct-signature declarations are admitted as different functions,
-   the level boundary stops mattering, so the detonator simplified to one
-   rule (same chain -> must be a legal overload pair) and resolution needed
-   no changes at all, the flattened candidate set already carrying
-   owner-distinct same-name slots from the sibling machinery. Verified:
-   cross-level dispatch by argument count, upcast narrowing to the base's
-   set, both levels' qualified spellings, the `api` using-merge convention
-   (`armory` overloading `arsenal`'s `issue`), and captured diagnostics for
-   the same-signature redeclaration (still an error, message now "a method
-   name may recur within one extends chain only as overloads differing in
-   arguments or constness") and for a forgotten api using-declaration,
-   which fails at the validating registration inside the base boilerplate's
-   natural-name calls.
-8. DONE. Codegen and never-a-value facades (described under "Codegen").
-   `facade`'s default constructor deleted (diagnostic on record: a single
-   clean error at the stray declaration, with notes walking to the deleted
-   base constructor); `method` grew `args_t` for introspection;
-   `naming::friendly_type_name` added (demangled names normalized: MSVC
-   elaborated-type keywords, inline-namespace segments, the expanded
-   `std::string` spelling, west-const); `prox::codegen<F>(os)` in the new
-   [proxy_codegen.h](proxy_codegen.h). Verified: golden masters for the
-   plain facade, noexcept flavors, overload sets with the const-pair
-   requires-clause, extends with the cross-level using and gap-preserving
-   parameter numbering, two-base composition with sibling usings and
-   redeclared forwarders, and the single-path diamond; the generated
-   `posse_leader` and `armory` bodies match the hand-written fixtures.
-   Notes from the build: emission walks the flattened slot tuple with a
-   per-slot compile-time branch, membership against the inherited path is
-   by (declaring facade, method) pair rather than slot type, since a base's
-   own slots retag when flattened; and parameter numbering spans the whole
-   flattened list, so covered slots consume numbers, keeping the `api` and
-   `boilerplate` spellings of one parameter identical.
+What worked:
 
-Header: `corvid/meta/proxy.h`, namespace `corvid::meta::prox`, deliberately
-NOT inline: `facade`, `method`, and `key` are too generic to dump into
-`corvid`. The call-site vocabulary (`proxy`, `proxy_view`,
-`const_proxy_view`, `shared_proxy`, `weak_proxy`, `proxy_policy`,
-`proxy_alloc`, `make_proxy`, `make_proxy_view`, `make_shared_proxy`,
-`Proxiable`) is
-exported into `corvid::meta` by using-declarations, so consuming code spells
-`proxy_view<foo_like>` unqualified. Only authoring (facades, impls,
+- Registration earned its keep beyond the nominal-conformance rationale.
+  It dissolved ngcpp's macro layer outright, it reads as a statement of
+  intent at the conformance site, and the additive spec design absorbed
+  every later knob (carried impls, `api_check`, chain hooks) without
+  touching an existing registration. C++26 reflection is expected to slot
+  in the same way.
+- Nominal conformance does what it promised: a type with the right shape
+  and no opt-in stays non-proxiable (`cowboy` in the test), and
+  `validate_api` closed the one silent-drift hole the hand-written sugar
+  opened.
+- The handles stay lean: views are two pointers, a `heap_only` proxy is
+  two words, and the `api` mixin is stateless, so the sugar costs no
+  storage anywhere (except the diamond padding word noted under
+  "Composition").
+- Composition reached the full trait-object feature set (implicit upcasts,
+  birth-keyed downcasts, per-facade conformance with its coherence-like
+  uniqueness), plus name semantics designed for authors who cannot
+  coordinate: sibling collisions, qualified keys, and per-name overload
+  sets.
+- The vtable-carried birth redesign (downcast identity priced in the
+  tables rather than in every handle) was the best decision made
+  mid-build: it deleted a policy knob, a handle word, and the
+  unknown-birth case in one stroke.
+
+What it costs:
+
+- Three spellings per method (declaration, boilerplate binding, `api`
+  forwarder) is the C++23 floor, and two of the three are by hand. The
+  conventions have sharp edges: `noexcept` must be propagated onto
+  forwarders manually, the const pair needs a trailing requires-clause,
+  and collisions and cross-level overloads need using-declarations.
+  `prox::codegen` writes all of these correctly, and `validate_api` checks
+  most of what could drift, but the edges exist.
+- `call<>` resolution is deliberately not full implicit-conversion
+  ranking: two pinned divergences from the sugar's genuine C++ overload
+  resolution, described under "Per-name overload sets".
+- Failure surfaces are `static_assert` detonators, deliberately lazy at
+  first use, so an error can appear far from the mistake (a bad facade
+  detonates at first machinery use; a forgotten using-declaration in an
+  `api` surfaces at some later validating registration). Some detonators
+  trail follow-on noise errors; the interesting diagnostics are kept on
+  record as comments in the test.
+- The consteval table graph is fragile to extend. The identity rules it
+  taught (see the retrospective) are documented, but nothing enforces
+  them, and the failure mode is an inscrutable mid-instantiation error.
+- `shared_proxy` accepts `std::shared_ptr`'s control-block overhead where
+  ngcpp built bespoke compact refcounts; the repayment is free interop
+  with outside `shared_ptr` and `weak_ptr` holders.
+- The analyzer cannot see that the owning table's `relocate` slot
+  discriminates the storage union, so those reads carry targeted
+  suppressions.
+
+## Build retrospective
+
+The system was built in eight rounds, each landing with tests and captured
+diagnostics before the next began. The ordering was deliberate: each round
+exercised one new mechanism against machinery the previous rounds had
+already pinned.
+
+1. Views. `proxy_view` first, because with no lifetime slots the
+   dispatch-table synthesis is exercised in isolation: the conformance
+   concepts, const methods, reference returns, heterogeneous containers,
+   and the `"name"_method` UDL.
+2. Ownership basics. The owning `proxy` with SBO and heap fallback,
+   `noexcept` method flavors, deep const on every handle,
+   `const_proxy_view`, and the self-conformance invariant.
+3. Sugar and composition. The `api` mixin, `validate_api` at registration,
+   and the first `extends` round: flattened dispatch, per-facade
+   conformance, implicit upcasts. A follow-up ergonomics round, driven by
+   reading the test as an end user, produced chain registration
+   (`InChainOf`), the facade-nested boilerplate, carried impls, and the
+   removal of the unregistered full-specialization tier.
+4. Names and collisions. The mandatory `name` entry, facade-qualified keys,
+   the sibling collision rules, and diamond dedup by facade identity.
+5. The ownership round. Storage policies, the owning upcast, cloning,
+   `unique_ptr` adoption and `extract`, `try_downcast` on the owning proxy
+   (redesigned mid-round from a handle-carried birth pointer onto the
+   vtable-carried birth key), and the shared/weak tier.
+6. Downcasting everywhere. The born key on the view tables, the parallel
+   view ancestry, birth inheritance through lent views, and the sharing and
+   transferring downcast flavors on `shared_proxy`.
+7. Per-name overload sets, first within a facade, then extended across
+   extends levels once "different functions sharing a spelling" was
+   accepted as the model.
+8. Codegen and never-a-value facades: `facade`'s deleted default
+   constructor and `prox::codegen`, pinned by golden masters.
+
+Two questions stayed open into the build and were settled by their rounds.
+The member-call syntax was resolved in favor of the `api` mixin, whose
+ergonomics the restyled tests confirmed. The const flavor of views was
+resolved as the `&dyn` versus `&mut dyn` split described under
+"Mechanism".
+
+Testing conventions that proved out:
+
+- Negative conformance is asserted as deliberately as positive (`cowboy`,
+  `vigilante`, and a carried impl whose bindings lack `noexcept`).
+- Interesting compile errors are provoked once, captured verbatim as
+  comments next to the assertions nearest them, and re-captured whenever a
+  rework changes them.
+- Lifetime-accounting fixtures balance construct, destroy, move, and copy
+  counts on both storage paths for every conversion.
+- Codegen is pinned by golden masters that must match the hand-written
+  fixtures exactly.
+
+The recurring lesson of the build was the consteval table graph's identity
+rules. The static tables of one born family reference each other by
+address, and the language's rules about what may be named
+mid-instantiation are unforgiving:
+
+- A consteval table-building function must be entered from exactly one
+  variable. Initializing two variables with the same `make_vtable` call
+  shares one function specialization between them, and a back-reference
+  that re-enters it mid-instantiation is ill-formed. A copy of an existing
+  variable is fine, which is why the owning table's embedded view table is
+  a copy of the standalone born-keyed instance rather than a second
+  `make_vtable` call.
+- Deduced return types cannot survive re-entrancy. A diamond's ancestry
+  reaches a sibling's table build while a shared helper is still being
+  instantiated, so the builders that walk bases carry spelled-out return
+  types, and the bases tuples are per-builder members rather than shared
+  helpers.
+- Mutually referencing statics need spelled-out variable types, since
+  `auto` deduction would be circular.
+
+Smaller lessons:
+
+- Compile-time-only machinery is `consteval`, not `constexpr`. Only
+  genuinely runtime-callable paths (`call`, the converting constructors,
+  the makers) are `constexpr`.
+- In template contexts, `call` needs the dependent-name `template` keyword
+  (`pv.template call<"fire">(1)`), a real ergonomic wart that the `api`
+  mixin hides and that helped pin the sugar decision.
+- `fixed_string.h` originally lived in the strings band, which inverted
+  the layering. It moved to `corvid/meta/` (2026-07-08) and joined the
+  `meta.h` umbrella.
+
+## Placement
+
+The header is `corvid/meta/proxy.h`, namespace `corvid::meta::prox`,
+deliberately NOT inline: `facade`, `method`, and `key` are too generic to
+dump into `corvid`.
+
+The call-site vocabulary (`proxy`, `proxy_view`, `const_proxy_view`,
+`shared_proxy`, `weak_proxy`, `proxy_policy`, `proxy_alloc`, `make_proxy`,
+`make_proxy_view`, `make_shared_proxy`, `Proxiable`, `proxy_impl_base`) is
+exported into `corvid::meta` by using-declarations, so consuming code
+spells `proxy_view<foo_like>` unqualified. Only authoring (facades, impls,
 registration) needs `prox::`, the domain those authors already work in.
-Promote to a `corvid/proxy/` family only if it sprawls. Tests:
-`tests/portable/proxy_test.cpp`. `method` derives from its `key`
-(subsumption: a method tag is usable anywhere its key is; also the hook for
-overloading bindings on the full method if per-name overload sets ever
-happen).
 
-## Non-goals (MVP)
+The header stays out of the `meta.h` umbrella to limit include weight (the
+formatting.h precedent); include `corvid/meta/proxy.h` directly. Promote
+to a `corvid/proxy/` family only if it sprawls. Tests:
+`tests/portable/proxy_test.cpp`.
+
+One structural note: `method` derives from its `key`, so a method tag is
+usable anywhere its key is (subsumption).
+
+## Test fixture map
+
+The fixtures in [proxy_test.cpp](../../tests/portable/proxy_test.cpp) form
+one western-themed world, reused across the feature tiers. The
+`gunslinger` family carries composition (the `posse_leader` diamond and
+the `war_correspondent` sibling collision). The `arsenal` chain carries
+the per-name overload sets. The `lockbox` chain carries the ownership and
+lifetime tests. The solo facades pin one feature each (`hair_trigger`:
+noexcept flavors; `mortar`: the `api_check::off` opt-out; `census`: the
+all-const invariant).
+
+The facades, with extends edges pointing from the derived facade to its
+base:
+
+```mermaid
+flowchart BT
+    gunslinger["gunslinger: fire, describe, reload, shots"]
+    camera["camera: fire, reload (deliberate collisions)"]
+    marshal["marshal: + arrest"] --> gunslinger
+    bounty_hunter["bounty_hunter: + claim"] --> gunslinger
+    ranger["ranger: + track"] --> marshal
+    posse_leader["posse_leader: + rally (diamond)"] --> marshal
+    posse_leader --> bounty_hunter
+    war_correspondent["war_correspondent: + byline<br>(formal name: correspondent)"] --> gunslinger
+    war_correspondent --> camera
+    arsenal["arsenal: issue x2, aim x2, const pair count"]
+    armory["armory: + issue(int, int), lock"] --> arsenal
+    lockbox["lockbox: add, gold<br>(no api, namespace-scope boilerplate)"]
+    vault["vault (pure aggregation)"] --> lockbox
+    hair_trigger["hair_trigger: fire, jams (noexcept)"]
+    mortar["mortar: lob (api deviates; api_check off)"]
+    census["census: describe (all const)"]
+```
+
+The conforming types, each attached to the facade its registration anchors
+at (a chain hook registers the anchor level and every facade it extends;
+the edge labels name the registration route):
+
+```mermaid
+flowchart LR
+    lawman -.->|boilerplate| gunslinger & hair_trigger
+    lawman -.->|carried impl| census
+    deputy -->|C++ inheritance| lawman
+    robber -.->|carried impl| gunslinger
+    sheriff -.->|partial override| gunslinger
+    turncoat -.->|nested carried impl| gunslinger
+    howitzer -.->|boilerplate| mortar
+    texas_ranger -.->|chain hook| ranger
+    constable -.->|"chain hook, mid-chain anchor"| marshal
+    trail_boss -.->|chain hook| posse_leader
+    photographer -.->|"chain hook + carried camera impl"| war_correspondent
+    quartermaster -.->|chain hook| armory
+    strongbox -.->|chain hook| vault
+    coffer -.->|chain hook| vault
+```
+
+Three fixtures are deliberately missing from the conformance edges.
+`cowboy` has the right shape and no registration, so nominal conformance
+keeps it non-proxiable. `vigilante` registers for `marshal` alone through
+a plain hook, without the `gunslinger` level, so it is not proxiable at
+all (conformance is per facade, and the derived facade needs the whole
+chain). `robber`'s `hair_trigger` registration carries bindings that are
+not `noexcept`, so the pair stays non-conformant even though it is
+registered. Registration is the act of opting in, not proof of
+conformance.
+
+## Non-goals
 
 Operator dispatch, conversion dispatch, allocator plumbing, RTTI (beyond
-the facade-level `try_downcast`).
+the facade-level `try_downcast`). All were scoped out at the start and
+never turned out to be missed.
 
-## Future
+## Future work
 
 - C++26 reflection plus annotations (P2996/P3394) enables deriving the
   boilerplate impl itself from the facade's method list, removing even the
   facade author's forwarding lines. Registration-first is what makes this
-  additive rather than a rewrite. Until then, `prox::codegen` generates the
-  same artifacts as source to paste; reflection deletes the paste step.
+  additive rather than a rewrite. Until then, `prox::codegen` generates
+  the same artifacts as source to paste; reflection deletes the paste
+  step.
 - `std::formatter` bridge once the formatter forwarding helper exists (see
-  [../strings/roadmap.md](../strings/roadmap.md) stage 2); the ngcpp analog
-  is `skills::format`.
+  [../strings/roadmap.md](../strings/roadmap.md) stage 2); the ngcpp
+  analog is `skills::format`.
 - Spec-carried member-pointer binding: a `corvid_proxy_spec` returning a
   spec that holds `&robber::shoot, &robber::rearm`, bound positionally to
-  the facade's methods. Member pointers are spellable at compile time where
-  member names are not, so this is a one-line middle tier for
-  name-mismatched types that avoids a full custom impl. Overlaps in purpose
-  with the partial-override pattern above, which needs no new machinery but
-  does need the facade author's cooperation.
+  the facade's methods. Member pointers are spellable at compile time
+  where member names are not, so this is a one-line middle tier for
+  name-mismatched types that avoids a full custom impl. Overlaps in
+  purpose with the partial-override pattern above, which needs no new
+  machinery but does need the facade author's cooperation.
 - A guaranteed-copyable proxy flavor: a policy whose construction
   constrains targets to copyable types, making the handle itself satisfy
   `std::copyable` with no runtime condition (the shape of ngcpp's
   `support_copy`). `clone()`/`can_clone()` cover the need at runtime, so
   this waits for a use case that wants the compile-time guarantee.
-
-## Open questions
-
-The member-call sugar pin was an open question until phase 3. It was
-resolved in favor of the `api` mixin, and the test code exercising it
-confirmed the ergonomics.
-
-The const flavor of views was an open question until phase 2. It was
-resolved as the `&T` vs `&mut T` split (`const_proxy_view` alongside a
-deep-const `proxy_view`), described under Mechanism.

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -713,9 +713,9 @@ type happens to serve two colliding slots from one member is invisible at
 the call site.
 
 - Distinct signatures form an overload set. An unqualified call resolves
-  the way C++ would after `using A::f; using B::f;`: a unique exact
-  signature match wins, else a unique viable candidate, else a
-  `static_assert` naming the ambiguity. The `api` convention is one
+  exactly the way C++ would after `using A::f; using B::f;`, because the
+  ranking is the compiler's own (see "Per-name overload sets"), with a
+  `static_assert` naming an ambiguity. The `api` convention is one
   using-declaration per base, because C++ member lookup finds sibling-base
   names ambiguous before overload resolution ever runs; with the
   using-declarations in place the forwarders form the same overload set.
@@ -761,44 +761,52 @@ Unlike C++, where a derived class's `foo(int)` silently hides the base's
 merges automatically. An upcast handle sees only its own level's
 overloads.
 
-An unqualified call resolves over the whole candidate set the way a C++
-call would after a using-merge: a unique exact argument match wins, else a
-unique viable candidate. C++'s object-parameter preference applies as a
-tiebreak within each tier, so a mutable handle resolves a const pair
-(`method<"count", int&()>` with `method<"count", int() const>`) to its
-non-const member, while const handles and `const_proxy_view` dispatch the
-const one. The tiebreak is uniform over a candidate set, so a sibling
-collision differing only in constness resolves the same way.
+An unqualified call resolves over the whole candidate set exactly the way
+a C++ call would after a using-merge, because the ranking is the
+compiler's own. `resolve` synthesizes an overload set from the candidates
+(one call operator per slot, taking the slot's declared parameters, its
+constness mirroring the method's, its result type carrying the slot
+index) and reads the winner out of a real call expression. Promotions,
+conversion ranks, and the object-parameter weighing all apply: a mutable
+handle resolves a const pair (`method<"count", int&()>` with
+`method<"count", int() const>`) to its non-const member, while const
+handles and `const_proxy_view` dispatch the const one, and
+`call<"aim">(short{})` over `aim(int)`/`aim(double)` promotes into the
+int overload. A call the ranking rejects is classified by per-candidate
+viability: some viable candidate is the ambiguity error, none is the
+no-match error.
 
 Qualified keys narrow the candidates to one facade's and then resolve
 identically. That is also how the library's self-conformance bindings keep
 working over overloaded names.
 
-The two tiers plus the tiebreak are deliberately not full C++
-implicit-conversion ranking, and the divergences are pinned. Within the
-viable tier, no candidate outranks another by conversion quality: a
-promotion does not beat a conversion, so `call<"aim">(short{})` over
-`aim(int)`/`aim(double)` is ambiguous where real overload resolution would
-promote. And an exact argument match on a const method outranks the
-object-parameter preference, where real member overloading would weigh the
-two together.
+The probe is the `overloaded` trick pointed at dispatch: `operator()` is
+the known name using-declarations can pack-expand over, and even a
+same-signature candidate pair (the legal sibling collision) merges into
+the set legally and stays a lazy call-site ambiguity. The set spans the
+flattened slot list positionally, with each non-candidate slot
+contributing an overload whose parameter nothing converts to, so the
+winning index needs no translation.
 
-The motivation is feasibility, not a taste for smaller rulebooks.
-Exactness and viability are the only call predicates the language exposes
-to a metaprogram: exactness is type equality after stripping cv and
-references, viability is `std::is_invocable_v`, and no trait orders one
-conversion sequence against another. Ranking within the viable tier would
-mean hand-rolling the standard's conversion-sequence ordering (promotion
-tables, arithmetic ranks, user-defined conversions), a replica whose
-natural failure mode is silent drift from the compiler in corners nobody
-pinned. A coarse model whose few divergences are pinned by tests beats a
-faithful-looking one that quietly disagrees.
+The two spellings therefore cannot disagree: the `api` forwarders are a
+genuine C++ overload set, and `call<>` asks the compiler to rank the same
+candidates under the same rules.
 
-Arguments first, constness second, predictably. The `api` sugar follows
-the full rules regardless of what the library might prefer, because its
-forwarders are ordinary member functions, and opting them out of
-conversion ranking would mean rejecting a `short` argument where `int` is
-declared. The two models agree everywhere except these edges.
+It was not always so. The first build shipped a two-tier approximation (a
+unique exact match wins, else a unique viable candidate, with constness
+as a tiebreak), because exactness and viability are the only predicates
+the language answers directly (type equality after stripping cv and
+references, and `std::is_invocable_v`); no trait orders one conversion
+sequence against another, and hand-rolling the standard's ordering would
+have been a replica that drifts silently from the compiler. The
+approximation's divergences were pinned by tests (a promotion did not
+beat a conversion, and an exact argument match on a const method
+outranked the object-parameter preference) and looked defensible, since
+the `api` path never reached them. Once the conscripted-compiler probe
+was shown viable, the approximation was deleted rather than defended. The
+deliberate remainder is `resolve_exact`, the validation probe's
+strictness, which keeps a constness tiebreak precisely because its
+exact-match filter cannot see the object parameter.
 
 Bindings overload naturally, sharing one `method_key` and differing in the
 trailing parameters, or in target constness for a const pair:
@@ -825,18 +833,17 @@ const pair. It also catches a forgotten using-declaration, because the
 probe drives the base slots by natural name through the base boilerplate,
 where the hidden forwarders fail to resolve.
 
-How much the coarse rules matter depends on the calling tier, and through
-`api`, the norm, they are unreachable. A conforming forwarder's parameters
-are its slot's exact declared types, so full conversion ranking runs once,
-at forwarder selection, and the body forwards arguments that already have
-those types. The inner `call<>` lands in the exact tier on precisely the
-slot the forwarder spells, and the viable tier, the coarse part, never
-runs. The pinned divergences above face only direct `call<>` callers.
+Agreement between the spellings is doubly assured on the `api` path. A
+conforming forwarder's parameters are its slot's exact declared types, so
+conversion ranking runs once, at forwarder selection, and the body
+forwards arguments that already have those types; the inner `call<>`
+resolves them to precisely the slot the forwarder spells, an exact match
+no other candidate can outrank.
 
 That pinning is only as strong as the forwarder's signature. A
 hand-written forwarder whose parameter types drift from the slot's (say,
 `long` where the slot declares `int`) reopens the gap: the inner call
-misses the exact tier and the coarse viable tier decides. This is exactly
+re-ranks over the drifted types and can land elsewhere. This is exactly
 the drift `validate_api` catches, by anchoring the probe chain to the
 facade's declared types at both ends, so a merely-convertible parameter or
 result type in a forwarder fails at registration. The blind spot is a
@@ -1336,9 +1343,6 @@ What it costs:
   and collisions and cross-level overloads need using-declarations.
   `prox::codegen` writes all of these correctly, and `validate_api` checks
   most of what could drift, but the edges exist.
-- `call<>` resolution is deliberately not full implicit-conversion
-  ranking: two pinned divergences from the sugar's genuine C++ overload
-  resolution, described under "Per-name overload sets".
 - Failure surfaces are `static_assert` detonators, deliberately lazy at
   first use, so an error can appear far from the mistake (a bad facade
   detonates at first machinery use; a forgotten using-declaration in an
@@ -1386,7 +1390,10 @@ already pinned.
    transferring downcast flavors on `shared_proxy`.
 7. Per-name overload sets, first within a facade, then extended across
    extends levels once "different functions sharing a spelling" was
-   accepted as the model.
+   accepted as the model. Resolution first shipped as a two-tier
+   approximation of overload ranking with pinned divergences; a later
+   round replaced it with the conscripted-compiler probe (`rank_set`),
+   deleting the divergences.
 8. Codegen and never-a-value facades: `facade`'s deleted default
    constructor and `prox::codegen`, pinned by golden masters.
 

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -464,6 +464,10 @@ Not caught:
   cannot distinguish binding a reference from copying out of one)
 - a body dispatching the wrong key with an identical signature, which no
   shape check can see
+- a missing overload forwarder whose probe call a same-name sibling
+  forwarder absorbs by conversion, landing exactly on the sibling's slot
+  (the overload analog of the wrong-key hole; the `assayer` fixture pins
+  it)
 
 Closing that last hole would take a behavioral probe (record which key
 each forwarder dispatches and compare) or C++26 reflection, which deletes
@@ -684,12 +688,12 @@ plain one. A `call` key containing "::" matches the declaring facade's
 name plus the method name, so `call<"camera::fire">()` names its slot
 outright, even through a derived handle.
 
-The entry is required, exactly once per facade, enforced by a detonator at
-first use of the facade's machinery. It was briefly optional; requiring it
-proved right, for three reasons. A downstream composer cannot add a name
-to a facade it does not own, so an optional name would foreclose legal
-collisions in every composition that ever included an unnamed facade. The
-per-facade overhead is one short entry. And mandatory names deleted every
+The `name` entry is required, exactly once per facade, enforced by a
+detonator at first use of the facade's machinery. It was briefly optional;
+requiring it proved right, for three reasons. A downstream composer cannot
+add a name to a facade it does not own, so an optional name would foreclose
+legal collisions in every composition that ever included an unnamed facade.
+The per-facade overhead is one short entry. And mandatory names deleted every
 nameless special case from the machinery: the
 sibling-collisions-need-names detonator, the empty-name skips in matching
 and uniqueness checking, and `qualified_key`'s fallback branch all went
@@ -779,9 +783,22 @@ promote. And an exact argument match on a const method outranks the
 object-parameter preference, where real member overloading would weigh the
 two together.
 
-Arguments first, constness second, predictably. The `api` sugar, being a
-genuine C++ overload set, follows the full rules, and the two models agree
-everywhere except these edges.
+The motivation is feasibility, not a taste for smaller rulebooks.
+Exactness and viability are the only call predicates the language exposes
+to a metaprogram: exactness is type equality after stripping cv and
+references, viability is `std::is_invocable_v`, and no trait orders one
+conversion sequence against another. Ranking within the viable tier would
+mean hand-rolling the standard's conversion-sequence ordering (promotion
+tables, arithmetic ranks, user-defined conversions), a replica whose
+natural failure mode is silent drift from the compiler in corners nobody
+pinned. A coarse model whose few divergences are pinned by tests beats a
+faithful-looking one that quietly disagrees.
+
+Arguments first, constness second, predictably. The `api` sugar follows
+the full rules regardless of what the library might prefer, because its
+forwarders are ordinary member functions, and opting them out of
+conversion ranking would mean rejecting a `short` argument where `int` is
+declared. The two models agree everywhere except these edges.
 
 Bindings overload naturally, sharing one `method_key` and differing in the
 trailing parameters, or in target constness for a const pair:
@@ -807,6 +824,41 @@ the probe's mutable strict call singles out the non-const member of a
 const pair. It also catches a forgotten using-declaration, because the
 probe drives the base slots by natural name through the base boilerplate,
 where the hidden forwarders fail to resolve.
+
+How much the coarse rules matter depends on the calling tier, and through
+`api`, the norm, they are unreachable. A conforming forwarder's parameters
+are its slot's exact declared types, so full conversion ranking runs once,
+at forwarder selection, and the body forwards arguments that already have
+those types. The inner `call<>` lands in the exact tier on precisely the
+slot the forwarder spells, and the viable tier, the coarse part, never
+runs. The pinned divergences above face only direct `call<>` callers.
+
+That pinning is only as strong as the forwarder's signature. A
+hand-written forwarder whose parameter types drift from the slot's (say,
+`long` where the slot declares `int`) reopens the gap: the inner call
+misses the exact tier and the coarse viable tier decides. This is exactly
+the drift `validate_api` catches, by anchoring the probe chain to the
+facade's declared types at both ends, so a merely-convertible parameter or
+result type in a forwarder fails at registration. The blind spot is a
+drift whose arguments and result both land exactly on a same-name sibling
+slot, where the strict probe matches the sibling and passes; that is the
+overload analog of the wrong-key-same-signature hole already on the
+not-caught list. The `assayer` fixture pins it live: an `api` missing its
+`weigh(int)` forwarder validates green, and an int-argument sugar call is
+absorbed by the `weigh(long)` forwarder and dispatches the sibling slot.
+
+The object parameter is the one axis a parameter list cannot pin, and it
+produced the one real routing bug of this shape: object constness alone
+would select a const pair's mutable forwarder for a `const_proxy_view`,
+whose deep const lives in the type rather than on the object. The
+trailing requires-clause above is the fix, making the mutable forwarder
+non-viable whenever its own inner call would not resolve.
+
+`prox::codegen` closes the loop by construction. The forwarder signature,
+the inner `call<>` arguments, the requires-clause, and the name-merging
+using-declarations are all generated from the same slot metadata, so the
+forwarder C++ selects and the slot `call<>` dispatches cannot disagree.
+Hand-edited output still has `validate_api` behind it.
 
 An earlier sketch of this feature used mangled keys (`method<"foo-0", ...>`
 and `method<"foo-1", ...>` sharing one `api` spelling). That remains
@@ -1418,7 +1470,8 @@ the `war_correspondent` sibling collision). The `arsenal` chain carries
 the per-name overload sets. The `lockbox` chain carries the ownership and
 lifetime tests. The solo facades pin one feature each (`hair_trigger`:
 noexcept flavors; `mortar`: the `api_check::off` opt-out; `census`: the
-all-const invariant).
+all-const invariant; `assayer`: the overload-absorption blind spot in
+`validate_api`).
 
 The facades, with extends edges pointing from the derived facade to its
 base:
@@ -1441,6 +1494,7 @@ flowchart BT
     hair_trigger["hair_trigger: fire, jams (noexcept)"]
     mortar["mortar: lob (api deviates; api_check off)"]
     census["census: describe (all const)"]
+    assayer["assayer: weigh x2 (api misses one forwarder)"]
 ```
 
 The conforming types, each attached to the facade its registration anchors
@@ -1461,6 +1515,7 @@ flowchart LR
     trail_boss -.->|chain hook| posse_leader
     photographer -.->|"chain hook + carried camera impl"| war_correspondent
     quartermaster -.->|chain hook| armory
+    prospector -.->|boilerplate| assayer
     strongbox -.->|chain hook| vault
     coffer -.->|chain hook| vault
 ```

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -4,6 +4,26 @@
 through proxies, which are type-erased handles over an interface definition.
 They work without inheritance, vtable pointers in the target type, or macros.
 
+The contrast with the traditional mechanism, an abstract base class with
+virtual methods, is one of coupling. A virtual interface is intrusive: a
+type opts in at definition time by inheriting, so it must know every
+interface it will ever serve, carries a vtable pointer in every object,
+and cannot be a type you do not own, a plain aggregate, or an `int`.
+
+A facade points the other way. The interface is declared on the consumer's
+side, and any type whose methods line up conforms through one
+registration line, after the fact and without modification; one type can
+serve any number of facades, and the dispatch machinery lives in the
+handle, so targets stay plain.
+
+Because the handles are ordinary values rather than base-class pointers,
+they also offer what pointer-based polymorphism structurally cannot:
+inline storage under a policy, deep const (a const handle dispatches only
+const methods, which no const smart pointer propagates), and view, owning,
+shared, and weak flavors with explicit conversion rules.
+
+---
+
 This document is the completed system's reference and retrospective. It is
 a tutorial tour of the user-facing surface, the decisions made along the
 way and what they cost, and the lessons from the build. Every feature is
@@ -34,6 +54,40 @@ Second, in the interim, `prox::codegen`
 ([proxy_codegen.h](proxy_codegen.h)) writes them for you. It handles all
 the tricky details and edge cases: noexcept propagation, const pairs, the
 using-declaration merges, and diamonds.
+
+## Contents
+
+- [Lineage and positioning](#lineage-and-positioning)
+- [Naming map](#naming-map)
+- [User-facing shape](#user-facing-shape)
+  - [Partial override of the boilerplate](#partial-override-of-the-boilerplate)
+  - [Member-call sugar (the `api` mixin)](#member-call-sugar-the-api-mixin)
+  - [API validation (`validate_api`)](#api-validation-validate_api)
+  - [Codegen (`prox::codegen`)](#codegen-proxcodegen)
+  - [Composition (`extends`)](#composition-extends)
+  - [Facade names and sibling collisions (`name`)](#facade-names-and-sibling-collisions-name)
+  - [Per-name overload sets](#per-name-overload-sets)
+- [The handle family](#the-handle-family)
+- [Ownership and storage](#ownership-and-storage)
+  - [Storage policies](#storage-policies)
+  - [Owning upcast](#owning-upcast)
+  - [Cloning](#cloning)
+  - [std smart-pointer interop](#std-smart-pointer-interop)
+  - [Downcasting (vtable-carried RTTI)](#downcasting-vtable-carried-rtti)
+  - [Shared and weak ownership](#shared-and-weak-ownership)
+- [Mechanism](#mechanism)
+- [Tables and thunks](#tables-and-thunks)
+  - [The thunk](#the-thunk)
+  - [The dispatch table](#the-dispatch-table)
+  - [A call, step by step](#a-call-step-by-step)
+  - [The owning table](#the-owning-table)
+- [Alternative considered: virtual-model erasure](#alternative-considered-virtual-model-erasure)
+- [Assessment](#assessment)
+- [Build retrospective](#build-retrospective)
+- [Placement](#placement)
+- [Test fixture map](#test-fixture-map)
+- [Non-goals](#non-goals)
+- [Future work](#future-work)
 
 ## Lineage and positioning
 
@@ -1134,7 +1188,7 @@ and a view lent from a `proxy` or `shared_proxy` points into that born
 family. A lent view therefore recovers exactly what its owner could, while
 a directly built view is born as its own facade.
 
-On the copyable handles the operation is non-consuming. `try_downcast` on
+On the copyable handles, the operation is non-consuming. `try_downcast` on
 a view is const and returns a new view over the same target. (This escapes
 the instance-level deep-const guardrail exactly as copying does;
 `const_proxy_view` downcasts only to another const view, so the guarantee
@@ -1163,8 +1217,16 @@ through `try_downcast`, in a sharing lvalue flavor and a transferring
 rvalue one (see "Downcasting").
 
 ngcpp built this tier bespoke (`make_proxy_shared`, compact internal
-refcounts) to beat `shared_ptr` overhead. Reusing std is our accepted
-trade.
+refcounts) to beat `shared_ptr` overhead. This library reuses std, and
+that is a different tradeoff rather than a concession. The classic
+`shared_ptr` cost, a second allocation for the control block, does not
+apply on the primary path, because `make_shared_proxy` funnels through
+`std::make_shared`. And the reuse is precisely what makes the tier
+interoperable: a `shared_proxy` shares ownership with outside
+`shared_ptr<T>` and `weak_ptr<T>` holders, under the thread-safe counting
+semantics C++ code already assumes. What is conceded is minor: the std
+control block is larger than a minimal refcount, and its counts are
+atomic whether or not the sharing crosses threads.
 
 Unique ownership converts into shared, consuming the proxy. A heap-stored
 target is adopted with its allocation intact, the owning table's destroy
@@ -1222,7 +1284,8 @@ business.
   (`+[](void* p, args...) { return proxy_impl<F, T>::on(...); }`) and
   stores a pointer to the resulting per-`(F, T)` `static constexpr` table.
   Same cost model as a vtable call, and as Rust `dyn`: the table pointer
-  moves out of the object and into the (fat) handle.
+  moves out of the object and into the (fat) handle. The full walk of
+  this machinery is under "Tables and thunks".
 - Method signatures come in four flavors, `const` crossed with `noexcept`.
   For a `noexcept` method, conformance additionally requires the binding
   itself to be noexcept-invocable, the thunk pointer type carries
@@ -1265,6 +1328,193 @@ business.
   binding's `on` is constrained to const methods, so a mixed facade fails
   conformance cleanly at overload resolution rather than erroring during
   return type deduction.
+
+## Tables and thunks
+
+The bullets above say what the tables achieve; this section walks the
+machinery itself. The examples use the `constable` fixture, a
+marshal-shaped type registered for `marshal` and the `gunslinger` it
+extends.
+
+### The thunk
+
+All of the type erasure funnels through one artifact. A thunk is an
+ordinary function pointer, minted by `make_thunk` per (declaring facade,
+target type, method) as a captureless lambda:
+
+```cpp
+[](void* target, Args... args) noexcept(Noexcept) -> R {
+  return proxy_impl<F, T>::on(method_key<Name>{},
+      *static_cast<T*>(target), std::forward<Args>(args)...);
+}
+```
+
+(For a const method, the erased pointer is `const void*` and the cast
+target is `const T`.) Three facts about this lambda do all the work:
+
+- The cast from `void*` back to `T` happens here and only here. Nothing
+  downstream of a thunk sees an erased pointer, and nothing upstream
+  knows the target type.
+- The binding is reached by the `proxy_impl<F, T>::on` spelling, so the
+  thunk is where registration-based conformance is spent. For an
+  inherited slot, `slot_thunk` substitutes the declaring facade for `F`,
+  so the method binds through `proxy_impl<Base, T>` no matter which
+  level's table carries it. That is how per-facade conformance survives
+  flattening, and it has a pleasant corollary: a derived table's
+  inherited entries and the base's own table hold literally the same
+  pointer values, because they name the same specialization.
+- `noexcept` is part of the pointer type
+  (`R (*)(void*, Args...) noexcept`), so the qualifier is baked into the
+  erased ABI rather than promised in a comment.
+
+A thunk has no state, and nothing in the dispatch path is per object.
+Every instance of the same (facade, type) pair shares the same static
+table of the same thunks.
+
+### The dispatch table
+
+`vtable_t`, the table behind the views (and embedded in the owning
+table), has three parts:
+
+- `thunks`: a `std::tuple` holding one thunk pointer per flattened slot,
+  bases' methods first, then own. It is a tuple rather than an array
+  because each signature (and `noexcept` flavor) is its own pointer type.
+- `ancestry`: a pointer to the born family's birth ancestry, the flat
+  array `try_downcast` searches.
+- `bases`: one pointer per direct base facade, to that base's table for
+  the same target and birth. This is what makes upcasting a pointer read.
+
+Each table is a `static constexpr` variable, `vtable_for<F, T, Born>`,
+so it lives in read-only storage and is shared by every handle over that
+combination. The handle itself is two words, a target pointer and a
+table pointer: the fat-handle layout, with the table pointer moved out
+of the object (where a virtual base would put it) and into the handle.
+
+For a `proxy_view<marshal>` over a `constable`:
+
+```mermaid
+flowchart LR
+    subgraph H["proxy_view of marshal (two words)"]
+        TP["target_: void* to the constable"]
+        VP["vtable_: table pointer"]
+    end
+    subgraph MT["marshal table for constable"]
+        MK["thunks: fire, describe, reload, shots, arrest"]
+        MB["bases: gunslinger's table"]
+        MA["ancestry"]
+    end
+    subgraph GT["gunslinger table for constable, born marshal"]
+        GK["thunks: fire, describe, reload, shots"]
+        GA["ancestry"]
+    end
+    subgraph AN["view ancestry for (marshal, constable)"]
+        A0["tag of marshal -> marshal's table"]
+        A1["tag of gunslinger -> gunslinger's table"]
+    end
+    VP --> MT
+    MB --> GT
+    MA --> AN
+    GA --> AN
+    A0 -.-> MT
+    A1 -.-> GT
+```
+
+Upcasting `proxy_view<marshal>` to `proxy_view<gunslinger>` re-points the
+handle at the embedded base table (`upcast_vtable` resolves the route at
+compile time and follows one `bases` pointer per composition level); the
+target pointer does not change. The ancestry is the reverse map: an
+array of (facade tag, table) pairs covering the birth facade and every
+facade it extends, where a tag is the address of an empty per-facade
+static, the library's no-RTTI identity. `try_downcast` is a linear scan
+of that array comparing tag addresses, and the matched entry hands back
+the right table, already keyed to the same birth.
+
+### A call, step by step
+
+Method names do not exist at runtime. `resolve` turns the key (plus the
+argument types, through the `rank_set` probe when the name is
+overloaded) into a slot index entirely at compile time, and `dispatch`
+spends it as a `std::get` on the thunk tuple:
+
+```mermaid
+flowchart TB
+    subgraph CT["resolved at compile time"]
+        A["pv.arrest(2), the api forwarder"] --> B["call keyed arrest"]
+        B --> C["resolve: key and argument types to slot index 4"]
+    end
+    subgraph RT["executed at runtime"]
+        D["load thunk 4 from the table"] --> E["thunk casts the void* back to constable&"]
+        E --> F["proxy_impl on(arrest key, t, 2)"]
+        F --> G["t.arrest(2)"]
+    end
+    C --> D
+```
+
+The runtime residue is one indexed load from a cold static table plus an
+indirect call, the same shape as a virtual call. Everything above the
+line (name lookup, overload ranking, constness checks, the ambiguity and
+no-match detonators) burned no cycles.
+
+### The owning table
+
+`proxy` needs lifetime machinery the views never touch, so its table,
+`owning_vtable_t`, wraps a copy of the dispatch table (`vt`, which is
+also what a lent view points at, carrying the owner's birth over) and
+adds housekeeping slots, the analog of Rust's drop glue. Null encodes
+absent capability throughout:
+
+- `destroy`, `relocate`, `copy`: destruction, buffer-to-buffer move
+  (null marks a heap-mode table, whose target moves by pointer steal),
+  and cloning (null marks an uncopyable target, which is what
+  `can_clone` reads).
+- `to_heap` + `heap_table`, `to_sbo` + `sbo_table`: the mode-changing
+  pairs. Each mode's table points across at its sibling of the other
+  mode, so an adopting proxy can re-box an inline arrival or un-box a
+  heap one and land on the right table (`sbo_table` is null for a target
+  that can never live inline, lacking a nothrow move).
+- `type_tag`, `size`, `align`: the target's no-RTTI identity (the
+  address of a per-type static) and footprint, which is how `extract<T>`
+  verifies its type and how `can_adopt` checks an erased arrival against
+  a buffer.
+- `ancestry` and `bases`: as on the dispatch table, but over owning
+  tables, and per storage mode, so a downcast or upcast lands on a table
+  whose lifetime thunks match where the target actually lives.
+
+```mermaid
+flowchart LR
+    subgraph P["proxy of marshal"]
+        SB["storage_: inline buffer or heap pointer"]
+        VP2["vtable_: owning table pointer"]
+    end
+    subgraph OS["inline-mode owning table"]
+        V1["vt: embedded dispatch table"]
+        L1["destroy, relocate, copy"]
+        X1["to_heap + heap sibling"]
+        I1["type_tag, size, align"]
+        N1["ancestry (inline), bases"]
+    end
+    subgraph OH["heap-mode owning table"]
+        V2["vt: embedded dispatch table"]
+        L2["destroy, copy (relocate null)"]
+        X2["to_sbo + inline sibling"]
+        N2["ancestry (heap), bases"]
+    end
+    VP2 --> OS
+    X1 -.-> OH
+    X2 -.-> OS
+```
+
+Tables are keyed by (facade, born facade, target type, storage mode).
+Instances are many and tables are few, cold, and deduplicated, which is
+why the birth identity lives here rather than costing the handle a word:
+every embedded pointer (bases, mode siblings, ancestry entries) stays
+within one born family, so upcasts, mode changes, and downcasts preserve
+the birth without the handle carrying anything.
+
+All of these statics initialize at compile time and reference each other
+by address, which is what the consteval identity rules in the
+retrospective are about: builders entered from exactly one variable,
+spelled-out types where deduction would be circular or re-entrant.
 
 ## Alternative considered: virtual-model erasure
 
@@ -1352,9 +1602,11 @@ What it costs:
 - The consteval table graph is fragile to extend. The identity rules it
   taught (see the retrospective) are documented, but nothing enforces
   them, and the failure mode is an inscrutable mid-instantiation error.
-- `shared_proxy` accepts `std::shared_ptr`'s control-block overhead where
-  ngcpp built bespoke compact refcounts; the repayment is free interop
-  with outside `shared_ptr` and `weak_ptr` holders.
+- `shared_proxy` rides `std::shared_ptr` where ngcpp built bespoke
+  compact refcounts. The residual cost is small (`make_shared_proxy`
+  already puts target and control block in one allocation, leaving the
+  block's size and always-atomic counts), and the repayment is full
+  interop with outside `shared_ptr` and `weak_ptr` holders.
 - The analyzer cannot see that the owning table's `relocate` slot
   discriminates the storage union, so those reads carry targeted
   suppressions.

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -1270,9 +1270,13 @@ business.
   converting constructor, static-dispatch template bounds); they cannot
   generate, since C++ has no introspection over requires-expressions. The
   facade is the source of truth and the concept is derived from it, never
-  the reverse. Both binding routes are registration-gated, so the concept
-  is satisfied exactly when the pair is registered with a usable binding
-  (the facade's boilerplate or a carried impl).
+  the reverse. Both binding routes are registration-gated, and the concept
+  carries an explicit opt-in term besides: the pair must be registered, or
+  `T` must be a proxy handle of `F`'s chain (the self-conformance
+  bindings). The explicit term is what keeps a facade whose method list
+  gives the bindings nothing to prove (a name-only marker, or an
+  aggregation level adding no methods) from being backed by every type in
+  the program.
 - The registration slot mirrors the enum registry idiom. An ADL-found
   `corvid_proxy_spec(F*, T*)` hook returns a spec object created by
   `make_proxy_spec<F, T>()` (as `make_sequence_enum_spec` is returned from

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -231,7 +231,7 @@ through `call<>` and the same dispatch table.
   stores a pointer to the resulting per-`(F, T)` `static constexpr` table.
   Same cost model as a vtable call, and as Rust `dyn`: the table pointer
   moves out of the object and into the (fat) handle.
-- Method signatures come in four flavors: `const` crossed with `noexcept`.
+- Method signatures come in four flavors, `const` crossed with `noexcept`.
   For a `noexcept` method, conformance additionally requires the binding
   itself to be noexcept-invocable, the thunk pointer type carries
   `noexcept`, and `call` through either handle is itself conditionally
@@ -241,29 +241,30 @@ through `call<>` and the same dispatch table.
 - The owning table carries housekeeping slots (destroy, relocate/move) in
   addition to the facade methods, the analog of Rust's drop glue.
   `proxy_view` carries none, which is why the view is built first.
-- Const is handled on two axes. Every handle is deep-const as an instance:
-  only const-qualified methods dispatch through a const handle, enforced by a
-  constraint on the const `call` overload. For the copyable views this is a
-  guardrail, not a guarantee (copying a `const proxy_view` yields a mutable
-  view, like copying a `T* const` to a `T*`); the guarantee lives in
-  `const_proxy_view`, the `&dyn` to `proxy_view`'s `&mut dyn`, where
-  constness is part of the type. It binds const and mutable targets alike,
-  converts implicitly from `proxy_view` with no path back, and dispatches
-  only const methods while sharing the mutable view's per-(facade, type)
-  dispatch table (the non-const slots are simply unreachable, so no
-  const-sliced table or index remapping is needed). The two views share
-  storage and the const-method `call` through `details::view_base<F,
-  Const>`; the mutable view layers the unrestricted non-const overload on
-  top and re-exposes the inherited one with a using-declaration.
+- Const is handled on two axes. Every handle is deep-const as an instance,
+  meaning only const-qualified methods dispatch through a const handle,
+  enforced by a constraint on the const `call` overload. For the copyable
+  views this is a guardrail, not a guarantee (copying a `const proxy_view`
+  yields a mutable view, like copying a `T* const` to a `T*`). The guarantee
+  lives in `const_proxy_view`, the `&dyn` to `proxy_view`'s `&mut dyn`,
+  where constness is part of the type. It binds const and mutable targets
+  alike, converts implicitly from `proxy_view` with no path back, and
+  dispatches only const methods while sharing the mutable view's
+  per-(facade, type) dispatch table (the non-const slots are simply
+  unreachable, so no const-sliced table or index remapping is needed). The
+  two views share storage and the const-method `call` through
+  `details::view_base<F, Const>`. The mutable view layers the unrestricted
+  non-const overload on top and re-exposes the inherited one with a
+  using-declaration.
 - Invariant: `proxy<F>` and `proxy_view<F>` themselves satisfy
   `proxiable<_, F>`, so generic code constrained on the facade accepts
   concrete and erased arguments interchangeably (Rust: `dyn Trait`
   implements `Trait`). Implemented as library-provided `proxy_impl`
   bindings whose `on` forwards through `call` with conditional `noexcept`
-  (so the invariant survives noexcept methods); the deep-const handles'
+  (so the invariant survives noexcept methods). The deep-const handles'
   bindings have const and non-const overloads to match. For
   `const_proxy_view` the invariant holds exactly for all-const facades (as
-  with Rust `&dyn`, whose `&mut self` methods are uncallable); its binding's
+  with Rust `&dyn`, whose `&mut self` methods are uncallable). Its binding's
   `on` is constrained to const methods so a mixed facade fails conformance
   cleanly at overload resolution rather than erroring during return type
   deduction.
@@ -327,20 +328,20 @@ architecture.
    keyword (`pv.template call<"fire">(1)`), a real ergonomic wart the `api`
    mixin would hide; ammunition for the sugar pin.
 2. DONE. Owning `proxy` with SBO, plus `make_proxy` (sugar over an
-   `std::in_place_type_t` constructor). Move-only, and deep-const: only
+   `std::in_place_type_t` constructor). Move-only, and deep-const, so only
    const-qualified methods dispatch through a const proxy, enforced by a
    constraint on the const `call` overload so the rejection is visible to
-   `requires` probes (a body `static_assert` would not be; and a
+   `requires` probes (a body `static_assert` would not be, and a
    requires-expression outside a template gets no SFINAE, so the negative
    test needed a concept wrapper). Storage is a two-pointer inline buffer
    for targets that fit, are no more aligned than `std::max_align_t`, and
-   are nothrow-move-constructible; anything else is a unique-owned heap
+   are nothrow-move-constructible. Anything else is a unique-owned heap
    allocation. The owning dispatch table extends the view's with destroy
-   and relocate slots; a null relocate slot marks the heap path, which
+   and relocate slots. A null relocate slot marks the heap path, which
    moves by pointer steal with no target activity. Default-constructed and
-   moved-from proxies are empty (`operator bool`); calling through one is
-   undefined behavior. Also in this phase: `noexcept` method flavors, the
-   self-conformance invariant, deep-const `proxy_view`, and
+   moved-from proxies are empty (`operator bool`), and calling through one
+   is undefined behavior. Also in this phase: `noexcept` method flavors,
+   the self-conformance invariant, deep-const `proxy_view`, and
    `const_proxy_view`, all described under Mechanism.
    Verified: lifetime-counting fixtures balancing construct/destroy/move
    on both the SBO and heap paths, move-assignment over a live target,
@@ -358,7 +359,7 @@ NOT inline: `facade`, `method`, and `key` are too generic to dump into
 `corvid`. The call-site vocabulary (`proxy`, `proxy_view`,
 `const_proxy_view`, `make_proxy`, `make_proxy_view`, `Proxiable`) is
 exported into `corvid::meta` by using-declarations, so consuming code spells
-`proxy_view<foo_like>` unqualified; only authoring (facades, impls,
+`proxy_view<foo_like>` unqualified. Only authoring (facades, impls,
 registration) needs `prox::`, the domain those authors already work in.
 Promote to a `corvid/proxy/` family only if it sprawls. Tests:
 `tests/portable/proxy_test.cpp`. `method` derives from its `key`
@@ -400,6 +401,6 @@ dispatch, allocator plumbing, RTTI, per-name overload sets.
 - The member-call sugar pin: the `api` mixin is the leading candidate
   (judged plausible); confirm once real call sites exist.
 
-The const flavor of views was an open question until phase 2: resolved as
-the `&T` vs `&mut T` split (`const_proxy_view` alongside a deep-const
-`proxy_view`), described under Mechanism.
+The const flavor of views was an open question until phase 2. It was
+resolved as the `&T` vs `&mut T` split (`const_proxy_view` alongside a
+deep-const `proxy_view`), described under Mechanism.

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -94,10 +94,10 @@ struct gunslinger : facade<name<"gunslinger">,
                        method<"reload", bool()>> {
   // Written once by the facade author. `on` is the fixed hook name,
   // overloaded on the method key; a fixed name is what keeps the mechanism
-  // spellable without macros. Inheriting `prox_impl` is optional sugar,
+  // spellable without macros. Inheriting `proxy_impl_base` is optional sugar,
   // supplying the `method_key` alias so the bindings spell it unqualified.
   template<typename T>
-  struct boilerplate : prox_impl {
+  struct boilerplate : proxy_impl_base {
     static void on(method_key<"fire">, T& t, int rounds) { t.fire(rounds); }
     static bool on(method_key<"reload">, T& t) { return t.reload(); }
   };
@@ -114,7 +114,7 @@ consteval auto corvid_proxy_spec(gunslinger*, lawman*) {
 // the impl, here local to the hook itself, so the whole conformance is one
 // self-contained declaration.
 consteval auto corvid_proxy_spec(gunslinger*, robber*) {
-  struct as_gunslinger : impl_base {
+  struct as_gunslinger : proxy_impl_base {
     static void on(method_key<"fire">, robber& r, int rounds) {
       r.shoot(rounds);
     }
@@ -158,10 +158,12 @@ a consteval function is implicitly inline, so the local type is
 ODR-consistent across translation units (local classes do forgo static data
 members and member templates, which bindings do not need). Nested in the
 type it serves, the impl additionally reaches the type's private members
-(`turncoat` in the test). Namespace scope works too, but buys nothing over
-the other placements.
+(`turncoat` in the test). Namespace scope works too, and a namespace-scope
+binding class that the type forward-declares and befriends reaches private
+members without nesting.
 
-Whatever its placement, a binding class may inherit `prox::impl_base`, an
+Whatever its placement, a binding class may inherit `prox::proxy_impl_base`,
+an
 otherwise-empty base whose one member is a `method_key` alias, so the
 bindings spell the key unqualified (base-class members participate in
 unqualified lookup where namespace-scope names do not; a literally empty
@@ -601,9 +603,9 @@ owning a copy. Cloning is deliberately a named method rather than a copy
 constructor: an unconditional copy constructor would satisfy
 `std::copyable` for every proxy while failing at runtime for uncloneable
 targets, turning a concept-probed guarantee into a lie (the `std::function`
-trap, institutionalized). Cloning an empty proxy yields an empty one;
-cloning an uncloneable target is a precondition violation, like calling
-through an empty proxy.
+trap, institutionalized). Cloning an empty proxy yields an empty one, and so
+does cloning an uncloneable target; `can_clone()` is the up-front check that
+tells those apart.
 
 ### std smart-pointer interop
 
@@ -882,7 +884,7 @@ architecture.
    "User-facing shape"; precedence pinned by `turncoat` in the test),
    dropped the unregistered full-specialization tier in their favor, and
    restyled the tests to prefer the `api` sugar over `call<>` wherever a
-   facade defines one. A second pass added `prox_impl` (the unqualified
+   facade defines one. A second pass added `proxy_impl_base` (the unqualified
    `method_key` spelling in binding classes), made both views
    default-constructible as empty with `operator bool`, matching the owning
    proxy, and pinned mid-chain anchoring of chain hooks (`constable` in the

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -1,7 +1,7 @@
 # Proxy design
 
-Status: phase 1 built and tested ([proxy.h](proxy.h),
-[proxy_test.cpp](../../tests/portable/proxy_test.cpp)); phases 2 and 3
+Status: phases 1 and 2 built and tested ([proxy.h](proxy.h),
+[proxy_test.cpp](../../tests/portable/proxy_test.cpp)); phase 3
 pending. Plan for `corvid/meta/proxy.h`, a
 registration-based runtime-polymorphism ("proxy") system: type-erased handles
 over an interface definition, without inheritance, vtable pointers in the
@@ -230,13 +230,23 @@ through `call<>` and the same dispatch table.
   stores a pointer to the resulting per-`(F, T)` `static constexpr` table.
   Same cost model as a vtable call, and as Rust `dyn`: the table pointer
   moves out of the object and into the (fat) handle.
+- Method signatures come in four flavors: `const` crossed with `noexcept`.
+  For a `noexcept` method, conformance additionally requires the binding
+  itself to be noexcept-invocable, the thunk pointer type carries
+  `noexcept`, and `call` through either handle is itself conditionally
+  noexcept. Supported in the MVP rather than deferred because the qualifier
+  is baked into the erased ABI (the thunk pointer types), where a retrofit
+  would be a break.
 - The owning table carries housekeeping slots (destroy, relocate/move) in
   addition to the facade methods, the analog of Rust's drop glue.
   `proxy_view` carries none, which is why the view is built first.
 - Invariant: `proxy<F>` and `proxy_view<F>` themselves satisfy
   `proxiable<_, F>`, so generic code constrained on the facade accepts
   concrete and erased arguments interchangeably (Rust: `dyn Trait`
-  implements `Trait`).
+  implements `Trait`). Implemented as library-provided `proxy_impl`
+  bindings whose `on` forwards through `call` with conditional `noexcept`
+  (so the invariant survives noexcept methods); the owning proxy's binding
+  has const and non-const overloads to respect its deep const.
 
 ## Alternative considered: virtual-model erasure
 
@@ -296,9 +306,27 @@ architecture.
    Also, in template contexts `call` needs the dependent-name `template`
    keyword (`pv.template call<"fire">(1)`), a real ergonomic wart the `api`
    mixin would hide; ammunition for the sugar pin.
-2. Owning `proxy` with SBO, plus `make_proxy`. Move-only by default.
-   Verify: lifetime-counting fixtures (construct/destroy/move balance),
-   with both the SBO and heap paths exercised.
+2. DONE. Owning `proxy` with SBO, plus `make_proxy` (sugar over an
+   `std::in_place_type_t` constructor). Move-only, and deep-const: only
+   const-qualified methods dispatch through a const proxy, enforced by a
+   constraint on the const `call` overload so the rejection is visible to
+   `requires` probes (a body `static_assert` would not be; and a
+   requires-expression outside a template gets no SFINAE, so the negative
+   test needed a concept wrapper). Storage is a two-pointer inline buffer
+   for targets that fit, are no more aligned than `std::max_align_t`, and
+   are nothrow-move-constructible; anything else is a unique-owned heap
+   allocation. The owning dispatch table extends the view's with destroy
+   and relocate slots; a null relocate slot marks the heap path, which
+   moves by pointer steal with no target activity. Default-constructed and
+   moved-from proxies are empty (`operator bool`); calling through one is
+   undefined behavior. Also in this phase: `noexcept` method flavors and
+   the self-conformance invariant, both described under Mechanism.
+   Verified: lifetime-counting fixtures balancing construct/destroy/move
+   on both the SBO and heap paths, move-assignment over a live target,
+   emptiness after move, deep-const positive and negative probes,
+   noexcept conformance both ways (a binding lacking `noexcept` fails the
+   facade), `noexcept(call)` propagation, and heterogeneous ownership in a
+   container.
 3. `api` mixin support and `extends<Base>` composition, including
    `proxy<derived>` -> `proxy_view<base>` conversion (Rust trait
    upcasting). Verify: mixin call parity with `call<>`, upcast dispatch
@@ -345,7 +373,7 @@ dispatch, allocator plumbing, RTTI, per-name overload sets.
 
 - The member-call sugar pin: the `api` mixin is the leading candidate
   (judged plausible); confirm once real call sites exist.
-- `noexcept` qualification on `method` signatures: MVP or defer.
 - Const flavor of views: whether `proxy_view<F>` needs a distinct
   const-view type (the `&T` vs `&mut T` split) or const-qualified methods
-  suffice.
+  suffice. The owning proxy answered its half of the question (deep const,
+  in phase 2); the view remains shallow-const pending this.

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -109,6 +109,53 @@ The string NTTP rides on the existing
 compile time to an index into the facade's method list; no runtime name
 lookup exists anywhere.
 
+### Partial override of the boilerplate
+
+When a type's names line up except for one method, a full custom impl
+re-spells every binding just to change one. The facade author can enable a
+cheaper middle tier by factoring the boilerplate's bindings into a plain,
+inheritable class template, with the partial specialization deriving from
+it. A near-conforming type then writes a full specialization that inherits
+the factored class, re-exposes its `on` overloads with a using-declaration,
+and declares only the divergent binding:
+
+```cpp
+// Facade author: factor the bindings so they are inheritable.
+template<typename T>
+struct proxy_impl_gunslinger {
+  static void on(method_key<"fire">, T& t, int rounds) { t.fire(rounds); }
+  static bool on(method_key<"reload">, T& t) { return t.reload(); }
+};
+
+template<typename T>
+requires ProxyRegistered<gunslinger, T>
+struct proxy_impl<gunslinger, T>: proxy_impl_gunslinger<T> {};
+
+// `sheriff` lines up except that `fire` is spelled `shoot`.
+template<>
+struct proxy_impl<gunslinger, sheriff>: proxy_impl_gunslinger<sheriff> {
+  using proxy_impl_gunslinger<sheriff>::on;
+  static void on(method_key<"fire">, sheriff& s, int rounds) {
+    s.shoot(rounds);
+  }
+};
+```
+
+Mechanics: a derived `on` with the identical parameter list excludes the
+inherited one from the set the using-declaration introduces, so the
+override wins with no ambiguity. The using-declaration is load-bearing:
+without it, the derived `on` hides all the inherited overloads and
+conformance fails on the rest. The hidden base binding is never
+instantiated (class-template members instantiate only on use), so its body
+naming the absent member is harmless. As with any full specialization, no
+registration is involved.
+
+The trade is that the tier exists only if the facade author exposes the
+bindings as a named class rather than writing them inline in the partial
+specialization. It overlaps in purpose with the spec-carried member-pointer
+binding sketched under Future; the two can coexist. Exercised by `sheriff`
+in the test.
+
 ### Member-call sugar (pinned, leading candidate)
 
 `p->fire(3)` spelling cannot be minted by a C++23 library without macros.
@@ -230,7 +277,8 @@ architecture.
    `static_assert` tests, const-qualified methods (`std::string() const`
    dispatching on `const T&`), reference returns, call-through correctness,
    heterogeneous containers, view-of-view flattening in `make_proxy_view`,
-   assignment rebinding, and the `"name"_method` UDL (a literal operator
+   assignment rebinding, partial override of a factored boilerplate
+   (`sheriff`), and the `"name"_method` UDL (a literal operator
    template in `prox::literals`, inline since `prox` itself is not).
    Both interesting compile errors are captured as comments in the test:
    non-conformance walks the constraint chain down to `all_bound_v`; an
@@ -282,7 +330,9 @@ dispatch, allocator plumbing, RTTI, per-name overload sets.
   spec that holds `&robber::shoot, &robber::rearm`, bound positionally to
   the facade's methods. Member pointers are spellable at compile time where
   member names are not, so this is a one-line middle tier for
-  name-mismatched types that avoids a full custom impl.
+  name-mismatched types that avoids a full custom impl. Overlaps in purpose
+  with the partial-override pattern above, which needs no new machinery but
+  does need the facade author's cooperation.
 - Shared ownership tier, backed by `std::shared_ptr<void>`. The control
   block already type-erases the destroyer, so a shared-backed proxy needs
   no destroy slot in the dispatch table, is copyable for free, and gets a

--- a/corvid/meta/proxy.md
+++ b/corvid/meta/proxy.md
@@ -37,6 +37,7 @@ buffer plus dispatch pointer).
 | `proxy_impl<F, T>`            | (none; structural)       | `impl Trait for Type`|
 | `corvid_proxy_spec(F*, T*)`   | (none)                   | empty `impl` block   |
 | `make_proxy_spec<F, T>()`     | (none)                   | (spec payload)       |
+| `"name"_method` UDL           | (none)                   | (none)               |
 | `Proxiable<T, F>`             | `proxiable<P, F>`        | `T: Trait` bound     |
 | `make_proxy<F, T>(...)`       | `make_proxy`             | `Box::new`           |
 | `make_proxy_view<F>(t)`       | `make_proxy_view`        | `&x as &dyn T`       |
@@ -77,10 +78,10 @@ struct gunslinger : facade<method<"fire", void(int)>,
 // hook name, overloaded on the method key; a fixed name is what keeps the
 // mechanism spellable without macros.
 template<typename T>
-requires proxy_registered<gunslinger, T>
+requires ProxyRegistered<gunslinger, T>
 struct proxy_impl<gunslinger, T> {
-  static void on(key<"fire">, T& t, int rounds) { t.fire(rounds); }
-  static bool on(key<"reload">, T& t) { return t.reload(); }
+  static void on(method_key<"fire">, T& t, int rounds) { t.fire(rounds); }
+  static bool on(method_key<"reload">, T& t) { return t.reload(); }
 };
 
 // Conforming a type whose methods line up: pure registration. The ADL
@@ -93,8 +94,10 @@ consteval auto corvid_proxy_spec(gunslinger*, lawman*) {
 // Conforming a type whose methods do not line up: write the impl.
 template<>
 struct proxy_impl<gunslinger, robber> {
-  static void on(key<"fire">, robber& r, int rounds) { r.shoot(rounds); }
-  static bool on(key<"reload">, robber& r) { return r.rearm(); }
+  static void on(method_key<"fire">, robber& r, int rounds) {
+    r.shoot(rounds);
+  }
+  static bool on(method_key<"reload">, robber& r) { return r.rearm(); }
 };
 
 proxy<gunslinger> p = make_proxy<gunslinger, lawman>(/*ctor args*/);
@@ -152,7 +155,7 @@ through `call<>` and the same dispatch table.
 ## Mechanism
 
 - `proxiable<T, F>` is a concept synthesized from the facade definition: for
-  every `method` of `F`, `proxy_impl<F, T>::on(key<...>, T&, args...)` is
+  every `method` of `F`, `proxy_impl<F, T>::on(method_key<...>, T&, ...)` is
   invocable and returns the right type. Concepts gate (the converting
   constructor, static-dispatch template bounds); they cannot generate, since
   C++ has no introspection over requires-expressions. The facade is the
@@ -221,17 +224,23 @@ architecture.
 
 ## Phases
 
-1. DONE. Facade, `method`, `key`, `Proxiable`, and `proxy_view`. The view
-   first, because with no lifetime slots the dispatch-table synthesis is
-   exercised in isolation. Verified: positive and negative conformance
+1. DONE. Facade, `method`, `method_key`, `Proxiable`, and `proxy_view`. The
+   view first, because with no lifetime slots the dispatch-table synthesis
+   is exercised in isolation. Verified: positive and negative conformance
    `static_assert` tests, const-qualified methods (`std::string() const`
    dispatching on `const T&`), reference returns, call-through correctness,
-   heterogeneous containers, view-of-view flattening in `make_proxy_view`.
+   heterogeneous containers, view-of-view flattening in `make_proxy_view`,
+   assignment rebinding, and the `"name"_method` UDL (a literal operator
+   template in `prox::literals`, inline since `prox` itself is not).
    Both interesting compile errors are captured as comments in the test:
-   non-conformance walks the constraint chain down to `all_bound_v`, and an
-   unknown method name emits exactly one `static_assert` (an `if constexpr`
-   in `call` discards the dispatch on that path, suppressing follow-on
-   `std::get` noise). Notes from the build: `fixed_string.h` originally
+   non-conformance walks the constraint chain down to `all_bound_v`; an
+   unknown method name fires the `static_assert` followed by `std::get`
+   index noise, accepted deliberately (a guarding `if constexpr` was tried
+   and dropped as a simplification: fixing the obvious message removes the
+   noise). Compile-time-only machinery is `consteval`, not `constexpr`;
+   only genuinely runtime-callable paths (`call`, the converting
+   constructor, `make_proxy_view`) are `constexpr`. Notes from the build:
+   `fixed_string.h` originally
    lived in the strings band, which inverted the layering; it was moved to
    `corvid/meta/` (2026-07-08) and joined the `meta.h` umbrella. proxy.h
    stays out of the umbrella to limit include weight (the formatting.h

--- a/corvid/meta/proxy_codegen.h
+++ b/corvid/meta/proxy_codegen.h
@@ -121,13 +121,21 @@ consteval std::size_t heaviest_base() noexcept {
 
 // `codegen_path_t`: the base facade whose `api` the generated one inherits,
 // or `void` for a facade with no bases.
+//
+// A heaviest base that defines no `api` (supported, not recommended) also
+// yields `void`: there is nothing to inherit, so the generated `api` spells
+// every flattened forwarder itself.
 template<Facade F>
 consteval auto do_codegen_path() noexcept {
   if constexpr (vtbuild_t<F>::base_count_v == 0)
     return std::type_identity<void>{};
-  else
-    return std::type_identity<
-        typename vtbuild_t<F>::template base_t<heaviest_base<F>()>>{};
+  else {
+    using heavy_t = vtbuild_t<F>::template base_t<heaviest_base<F>()>;
+    if constexpr (requires { typename heavy_t::api; })
+      return std::type_identity<heavy_t>{};
+    else
+      return std::type_identity<void>{};
+  }
 }
 template<Facade F>
 using codegen_path_t = decltype(do_codegen_path<F>())::type;
@@ -215,7 +223,9 @@ void emit_boilerplate_slot(std::ostream& os, std::size_t next) {
 // methods and for any inherited methods that path does not cover, adds the
 // using-declarations that merge names those forwarders would otherwise
 // hide, marks noexcept forwarders, and carries the const-pair
-// requires-clause. The `boilerplate` covers the facade's own methods. This
+// requires-clause. When the heaviest base defines no `api` (supported, not
+// recommended), nothing is inherited and every flattened method gets its
+// own forwarder. The `boilerplate` covers the facade's own methods. This
 // is the closest thing to reflection available today; when C++26 reflection
 // lands, it deletes the paste step.
 //

--- a/corvid/meta/proxy_codegen.h
+++ b/corvid/meta/proxy_codegen.h
@@ -1,0 +1,285 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "naming.h"
+#include "proxy.h"
+
+// Source generation for facade authors.
+//
+// `prox::codegen<F>(os)` writes the canonical `api` and `boilerplate` for a
+// facade, ready to paste into its body.
+//
+// A separate header, so `proxy.h` itself stays free of streams and RTTI-based
+// type naming.
+namespace corvid { inline namespace meta { namespace prox {
+
+namespace details {
+
+// `codegen_starts`: facade-wide parameter numbering, one sequence spanning
+// every slot of the flattened list; entry `ndx` is slot ndx's first number.
+//
+// One shared sequence is what keeps a parameter's generated name identical
+// between the `api` forwarder and the `boilerplate` binding, so renaming it
+// after pasting is a single search-and-replace that hits both. A slot the
+// generated `api` does not spell (one an inherited base `api` covers) still
+// consumes numbers, which is harmless; the names are arbitrary by design.
+template<typename... Ss>
+consteval std::array<std::size_t, sizeof...(Ss)>
+codegen_starts(std::tuple<Ss...>*) noexcept {
+  std::array<std::size_t, sizeof...(Ss)> starts{};
+  std::size_t next = 1;
+  std::size_t ndx = 0;
+  ((starts[ndx++] = next,
+       next += std::tuple_size_v<typename Ss::method_t::args_t>),
+      ...);
+  return starts;
+}
+
+// `declared_in`: whether the method `M`, declared by facade `Owner`, appears
+// in facade `P`'s flattened list, meaning an inherited `P::api` already
+// covers it.
+//
+// The tuple pointer parameter carries `P`'s flattened slots in deducible
+// position.
+template<typename Owner, typename M, Facade P, typename... Ps>
+consteval bool declared_in(std::tuple<Ps...>*) noexcept {
+  return (
+      (std::same_as<Owner,
+           std::conditional_t<std::is_void_v<typename Ps::owner_t>, P,
+               typename Ps::owner_t>> &&
+          std::same_as<M, typename Ps::method_t>) ||
+      ...);
+}
+
+// `name_declared_in`: whether any slot of the flattened list answers to
+// `name`.
+template<typename... Ps>
+consteval bool
+name_declared_in(std::string_view name, std::tuple<Ps...>*) noexcept {
+  return ((Ps::name_v.view() == name) || ...);
+}
+
+// `has_const_twin`: whether the facade also declares a const method with
+// slot `S`'s name and arguments, making `S` the mutable member of a const
+// pair.
+//
+// Its generated forwarder then carries the trailing requires-clause (see the
+// `api` caveats under "Member-call sugar").
+template<typename S, typename... Ss>
+consteval bool has_const_twin(std::tuple<Ss...>*) noexcept {
+  return (
+      (!std::same_as<S, Ss> && Ss::const_v && !S::const_v &&
+          Ss::name_v.view() == S::name_v.view() &&
+          std::same_as<
+              typename method_traits<typename S::method_t>::norm_args_t,
+              typename method_traits<typename Ss::method_t>::norm_args_t>) ||
+      ...);
+}
+
+// `heaviest_base`: index of the direct base with the largest flattened
+// method list (ties to the first), the base whose `api` the generated one
+// inherits.
+//
+// This is the single-path diamond shape the `api` documentation recommends.
+template<Facade F>
+consteval std::size_t heaviest_base() noexcept {
+  return []<std::size_t... Ndxs>(std::index_sequence<Ndxs...>) {
+    constexpr std::array<std::size_t, sizeof...(Ndxs)> sizes{
+        std::tuple_size_v<typename vtbuild_t<
+            typename vtbuild_t<F>::template base_t<Ndxs>>::flat_slots_t>...};
+    std::size_t best = 0;
+    for (std::size_t ndx = 1; ndx != sizes.size(); ++ndx)
+      if (sizes[ndx] > sizes[best]) best = ndx;
+    return best;
+  }(std::make_index_sequence<vtbuild_t<F>::base_count_v>{});
+}
+
+// `codegen_path_t`: the base facade whose `api` the generated one inherits,
+// or `void` for a facade with no bases.
+template<Facade F>
+consteval auto do_codegen_path() noexcept {
+  if constexpr (vtbuild_t<F>::base_count_v == 0)
+    return std::type_identity<void>{};
+  else
+    return std::type_identity<
+        typename vtbuild_t<F>::template base_t<heaviest_base<F>()>>{};
+}
+template<Facade F>
+using codegen_path_t = decltype(do_codegen_path<F>())::type;
+
+// `api_emits`: whether the generated `api` spells a forwarder for slot `S`:
+// every own method, plus every inherited method the path base `P` does not
+// cover.
+template<typename S, typename P>
+consteval bool api_emits() noexcept {
+  if constexpr (std::is_void_v<typename S::owner_t> || std::is_void_v<P>)
+    return true;
+  else
+    return !declared_in<typename S::owner_t, typename S::method_t, P>(
+        static_cast<vtbuild_t<P>::flat_slots_t*>(nullptr));
+}
+
+// `emit_params`: emit `, T arg_N` for each declared parameter, numbering
+// from `next`.
+template<typename... Args>
+void emit_params(std::ostream& os, std::size_t next, std::tuple<Args...>*) {
+  ((os << ", " << friendly_type_name<Args>() << " arg_" << next++), ...);
+}
+
+// `emit_args`: emit `arg_N, arg_N+1, ...`, numbering from `next`.
+template<typename... Args>
+void emit_args(std::ostream& os, std::size_t next, std::tuple<Args...>*) {
+  for (std::size_t ndx = 0; ndx != sizeof...(Args); ++ndx)
+    os << (ndx ? ", " : "") << "arg_" << next + ndx;
+}
+
+// `emit_api_slot`: one `api` forwarder for slot `S` of facade `F`.
+template<Facade F, typename S>
+void emit_api_slot(std::ostream& os, std::size_t next) {
+  using result_t = S::result_t;
+  constexpr auto* args = static_cast<S::method_t::args_t*>(nullptr);
+  const auto name = S::name_v.view();
+  const auto result = friendly_type_name<result_t>();
+  os << "    " << result << " " << name << "(this "
+     << (S::const_v ? "const auto&" : "auto&&") << " self";
+  emit_params(os, next, args);
+  os << ")";
+  if constexpr (S::noexcept_v) os << " noexcept";
+  constexpr bool twin =
+      has_const_twin<S>(static_cast<vtbuild_t<F>::flat_slots_t*>(nullptr));
+  if constexpr (twin) {
+    os << "\n    requires(requires {\n      { self.template call<\"" << name
+       << "\">(";
+    emit_args(os, next, args);
+    os << ") } -> std::same_as<" << result << ">;\n    })\n    {\n";
+  } else {
+    os << " {\n";
+  }
+  os << "      ";
+  if constexpr (!std::is_void_v<result_t>) os << "return ";
+  os << "self.template call<\"" << name << "\">(";
+  emit_args(os, next, args);
+  os << ");\n    }\n";
+}
+
+// `emit_boilerplate_slot`: one `boilerplate` binding for slot `S`.
+template<typename S>
+void emit_boilerplate_slot(std::ostream& os, std::size_t next) {
+  using result_t = S::result_t;
+  constexpr auto* args = static_cast<S::method_t::args_t*>(nullptr);
+  const auto name = S::name_v.view();
+  os << "    static " << friendly_type_name<result_t>() << " on(method_key<\""
+     << name << "\">, " << (S::const_v ? "const T& t" : "T& t");
+  emit_params(os, next, args);
+  os << ")";
+  if constexpr (S::noexcept_v) os << " noexcept";
+  os << " {\n      ";
+  if constexpr (!std::is_void_v<result_t>) os << "return ";
+  os << "t." << name << "(";
+  emit_args(os, next, args);
+  os << ");\n    }\n";
+}
+
+} // namespace details
+
+// `codegen`: write the canonical `api` and `boilerplate` for facade `F` to
+// `os`, ready to paste into the facade body.
+//
+// The generated `api` inherits the heaviest direct base's `api` (the
+// single-path diamond shape), spells forwarders for the facade's own
+// methods and for any inherited methods that path does not cover, adds the
+// using-declarations that merge names those forwarders would otherwise
+// hide, marks noexcept forwarders, and carries the const-pair
+// requires-clause. The `boilerplate` covers the facade's own methods. This
+// is the closest thing to reflection available today; when C++26 reflection
+// lands, it deletes the paste step.
+//
+// Parameter names are generated as one `arg_N` sequence spanning the whole
+// facade, so each name is unique across the output and renaming one after
+// pasting is a single search-and-replace hitting the `api` and the
+// `boilerplate` together.
+//
+// Base `api` spellings use the demangled C++ type name of the base facade
+// (via `friendly_type_name`), not its formal `name<>` entry, which need not
+// match the type name. Type spellings are the demangler's, best-effort
+// normalized; touch up after pasting where they fall short.
+template<Facade F>
+void codegen(std::ostream& os) {
+  using slots_t = details::vtbuild_t<F>::flat_slots_t;
+  using path_t = details::codegen_path_t<F>;
+  constexpr auto* slots = static_cast<slots_t*>(nullptr);
+  constexpr auto starts = details::codegen_starts(slots);
+  constexpr auto count = std::tuple_size_v<slots_t>;
+  const auto walk = [&]<typename Fn>(Fn&& fn) {
+    [&]<std::size_t... Ndxs>(std::index_sequence<Ndxs...>) {
+      (fn.template operator()<std::tuple_element_t<Ndxs, slots_t>>(
+           starts[Ndxs]),
+          ...);
+    }(std::make_index_sequence<count>{});
+  };
+
+  os << "  struct api";
+  std::string path_name;
+  if constexpr (!std::is_void_v<path_t>) {
+    path_name = friendly_type_name<path_t>();
+    os << ": " << path_name << "::api";
+  }
+  os << " {\n";
+  if constexpr (!std::is_void_v<path_t>) {
+    // A forwarder hides every inherited overload of its name until a
+    // using-declaration merges them back in.
+    std::vector<std::string_view> merged;
+    walk([&]<typename S>(std::size_t) {
+      constexpr auto* path_slots =
+          static_cast<details::vtbuild_t<path_t>::flat_slots_t*>(nullptr);
+      if constexpr (details::api_emits<S, path_t>() &&
+                    details::name_declared_in(S::name_v.view(), path_slots))
+      {
+        const auto name = S::name_v.view();
+        if (std::find(merged.begin(), merged.end(), name) == merged.end())
+          merged.push_back(name);
+      }
+    });
+    for (const auto name : merged)
+      os << "    using " << path_name << "::api::" << name << ";\n";
+  }
+  walk([&]<typename S>(std::size_t next) {
+    if constexpr (details::api_emits<S, path_t>())
+      details::emit_api_slot<F, S>(os, next);
+  });
+  os << "  };\n";
+
+  os << "  template<typename T>\n  struct boilerplate: proxy_impl_base {\n";
+  walk([&]<typename S>(std::size_t next) {
+    if constexpr (std::is_void_v<typename S::owner_t>)
+      details::emit_boilerplate_slot<S>(os, next);
+  });
+  os << "  };\n";
+}
+
+}}} // namespace corvid::meta::prox

--- a/corvid/strings.h
+++ b/corvid/strings.h
@@ -17,7 +17,6 @@
 #pragma once
 #include "strings/strings_shared.h"
 #include "strings/cstring_view.h"
-#include "strings/fixed_string.h"
 #include "strings/fixed_string_utils.h"
 #include "strings/cases.h"
 #include "strings/locating.h"

--- a/corvid/strings/fixed_string_utils.h
+++ b/corvid/strings/fixed_string_utils.h
@@ -17,7 +17,7 @@
 #pragma once
 #include "strings_shared.h"
 #include "trimming.h"
-#include "fixed_string.h"
+#include "../meta/fixed_string.h"
 
 namespace corvid::strings { inline namespace fixed {
 
@@ -30,8 +30,8 @@ namespace corvid::strings { inline namespace fixed {
 // characters to trim from each piece; pass "" to disable trimming. `D` is a
 // set of delimiter characters, not a multi-character token. The delimiter must
 // be non-empty, as enforced below.
-template<strings::fixed_string W, strings::fixed_string D = ",",
-    strings::fixed_string WS = "">
+template<meta::fixed_string W, meta::fixed_string D = ",",
+    meta::fixed_string WS = "">
 consteval auto fixed_split() {
   constexpr auto whole = W.view();
   constexpr auto delim = D.view();
@@ -61,8 +61,8 @@ consteval auto fixed_split() {
 // by specified whitespace.
 //
 // Splits `W` using delimiter characters, trimming pieces with the `WS` set.
-template<strings::fixed_string W, strings::fixed_string WS = " ",
-    strings::fixed_string D = ",">
+template<meta::fixed_string W, meta::fixed_string WS = " ",
+    meta::fixed_string D = ",">
 consteval auto fixed_split_trim() {
   return fixed_split<W, D, WS>();
 }
@@ -73,13 +73,13 @@ consteval auto fixed_split_trim() {
 // Return a copy of `W` with every occurrence of `F` replaced by `T`. The
 // length is unchanged, so this is handy for swapping a delimiter, such as
 // turning a comma-delimited list into a null-delimited one.
-template<strings::fixed_string W, char F, char T>
+template<meta::fixed_string W, char F, char T>
 consteval auto fixed_replaced() {
   constexpr std::size_t n = W.size();
   char buf[n + 1]{};
   for (std::size_t ndx = 0; ndx != n; ++ndx)
     buf[ndx] = W[ndx] == F ? T : W[ndx];
-  return strings::basic_fixed_string{buf,
+  return meta::basic_fixed_string{buf,
       std::integral_constant<std::size_t, n>{}};
 }
 

--- a/corvid/strings/roadmap.md
+++ b/corvid/strings/roadmap.md
@@ -123,7 +123,7 @@ underlying `view()` for dynamic-width debug on a known non-null wrapper.
 
 `basic_fixed_string` cannot be null, so its formatter is pure delegation with
 no debug branch. Define it at the bottom of
-[fixed_string.h](fixed_string.h): call the value's `view()` and
+[fixed_string.h](../meta/fixed_string.h): call the value's `view()` and
 forward to `std::formatter<std::basic_string_view<Char>, Char>`.
 
 #### containers
@@ -149,7 +149,7 @@ Done / covered:
 Strings:
 
 - [x] `fixed_string` (`basic_fixed_string`,
-  [fixed_string.h](fixed_string.h)): own formatter forwarding
+  [fixed_string.h](../meta/fixed_string.h)): own formatter forwarding
   `view()`, per the `fixed_string` section above. Not a wrapper child, cannot be
   null; like the wrappers it exposes `begin`/`end`, so it also sets
   `format_kind = disabled`. Tested in `fixed_string_test.cpp`.

--- a/tests/portable/bitmask_enum_test.cpp
+++ b/tests/portable/bitmask_enum_test.cpp
@@ -793,7 +793,7 @@ TEST_CASE("SafeWhite", "[BitMaskTest]") {
 }
 #pragma endregion
 
-template<strings::fixed_string W>
+template<meta::fixed_string W>
 consteval auto cvbfbn() {
   return bitmask::details::calc_valid_bits_from_bit_names<W>();
 }
@@ -817,7 +817,7 @@ TEST_CASE("EnumCalcBitNames", "[BitMaskTest]") {
 }
 #pragma endregion
 
-template<strings::fixed_string W>
+template<meta::fixed_string W>
 consteval auto cvbfvn() {
   return bitmask::details::calc_valid_bits_from_value_names<W>();
 }

--- a/tests/portable/fixed_string_test.cpp
+++ b/tests/portable/fixed_string_test.cpp
@@ -19,7 +19,8 @@
 #include <sstream>
 #include <vector>
 
-#include "corvid/strings/fixed_string.h"
+#include "corvid/meta/fixed_string.h"
+#include "corvid/strings/cstring_view.h"
 #include "corvid/strings/fixed_string_utils.h"
 #include "catch2_main.h"
 
@@ -29,17 +30,17 @@ using namespace corvid::literals;
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
-template<strings::fixed_string W>
+template<meta::fixed_string W>
 constexpr std::string_view GetFixedString() {
   return W;
 }
 
-template<strings::fixed_string W>
+template<meta::fixed_string W>
 constexpr std::string_view GetSecondString() {
   return strings::fixed_split<W>()[1];
 }
 
-template<strings::fixed_string W>
+template<meta::fixed_string W>
 constexpr cstring_view GetFixedCString() {
   return W.cview();
 }
@@ -50,7 +51,7 @@ consteval auto test_split() { return GetSecondString<"abc,def">(); }
 
 consteval auto test_cstr() { return GetFixedCString<"abc">(); }
 
-template<strings::fixed_string D>
+template<meta::fixed_string D>
 consteval bool CanSplit() {
   if constexpr (D.view().size() == 0) {
     return false;
@@ -96,29 +97,29 @@ TEST_CASE("General", "[FixedStringTest]") {
 
 TEST_CASE("Constructors", "[FixedStringTest]") {
   SECTION("fixed_string is the char alias") {
-    STATIC_REQUIRE(std::is_same_v<strings::fixed_string<3>,
-        strings::basic_fixed_string<char, 3>>);
+    STATIC_REQUIRE(std::is_same_v<meta::fixed_string<3>,
+        meta::basic_fixed_string<char, 3>>);
   }
 
   SECTION("literal ctor deduces CharT and length") {
-    constexpr strings::basic_fixed_string fs{"abc"};
+    constexpr meta::basic_fixed_string fs{"abc"};
     STATIC_REQUIRE(std::is_same_v<std::remove_const_t<decltype(fs)>,
-        strings::basic_fixed_string<char, 3>>);
+        meta::basic_fixed_string<char, 3>>);
     STATIC_REQUIRE(fs.view() == "abc"sv);
     CHECK(fs.view() == "abc"sv);
     CHECK(fs.c_str() == "abc"sv);
   }
 
   SECTION("literal ctor generalizes over CharT") {
-    constexpr strings::basic_fixed_string fs{L"hello"};
+    constexpr meta::basic_fixed_string fs{L"hello"};
     STATIC_REQUIRE(std::is_same_v<std::remove_const_t<decltype(fs)>,
-        strings::basic_fixed_string<wchar_t, 5>>);
+        meta::basic_fixed_string<wchar_t, 5>>);
     CHECK(fs.view() == L"hello"sv);
   }
 
   SECTION("pointer ctor with size tag") {
     constexpr const char* p = "abcdef";
-    constexpr strings::basic_fixed_string<char, 3> fs{p,
+    constexpr meta::basic_fixed_string<char, 3> fs{p,
         std::integral_constant<std::size_t, 3>{}};
     STATIC_REQUIRE(fs.view() == "abc"sv);
     CHECK(fs.view() == "abc"sv);
@@ -126,23 +127,23 @@ TEST_CASE("Constructors", "[FixedStringTest]") {
 
   SECTION("pointer ctor deduces CharT and length") {
     constexpr const char* p = "abcdef";
-    constexpr strings::basic_fixed_string fs{p,
+    constexpr meta::basic_fixed_string fs{p,
         std::integral_constant<std::size_t, 3>{}};
     STATIC_REQUIRE(std::is_same_v<std::remove_const_t<decltype(fs)>,
-        strings::basic_fixed_string<char, 3>>);
+        meta::basic_fixed_string<char, 3>>);
     STATIC_REQUIRE(fs.view() == "abc"sv);
   }
 
   SECTION("character pack ctor") {
-    constexpr strings::basic_fixed_string<char, 3> fs{'a', 'b', 'c'};
+    constexpr meta::basic_fixed_string<char, 3> fs{'a', 'b', 'c'};
     STATIC_REQUIRE(fs.view() == "abc"sv);
     CHECK(fs.view() == "abc"sv);
   }
 
   SECTION("character pack ctor deduces CharT and length") {
-    constexpr strings::basic_fixed_string fs{'a', 'b', 'c'};
+    constexpr meta::basic_fixed_string fs{'a', 'b', 'c'};
     STATIC_REQUIRE(std::is_same_v<std::remove_const_t<decltype(fs)>,
-        strings::basic_fixed_string<char, 3>>);
+        meta::basic_fixed_string<char, 3>>);
     STATIC_REQUIRE(fs.view() == "abc"sv);
   }
 }
@@ -152,7 +153,7 @@ TEST_CASE("Constructors", "[FixedStringTest]") {
 
 TEST_CASE("Accessors", "[FixedStringTest]") {
   SECTION("size, data, and indexing") {
-    constexpr strings::basic_fixed_string fs{"abc"};
+    constexpr meta::basic_fixed_string fs{"abc"};
     STATIC_REQUIRE(!fs.empty());
     STATIC_REQUIRE(fs.size() == 3);
     STATIC_REQUIRE(fs.data() == fs.c_str());
@@ -162,13 +163,13 @@ TEST_CASE("Accessors", "[FixedStringTest]") {
   }
 
   SECTION("empty") {
-    constexpr strings::basic_fixed_string fs{""};
+    constexpr meta::basic_fixed_string fs{""};
     STATIC_REQUIRE(fs.empty());
     STATIC_REQUIRE(fs.size() == 0);
   }
 
   SECTION("iteration spans the value, not the terminator") {
-    constexpr strings::basic_fixed_string fs{"abc"};
+    constexpr meta::basic_fixed_string fs{"abc"};
     STATIC_REQUIRE(fs.end() - fs.begin() == 3);
     STATIC_REQUIRE(fs.begin() == fs.cbegin());
     STATIC_REQUIRE(fs.end() == fs.cend());
@@ -182,40 +183,37 @@ TEST_CASE("Accessors", "[FixedStringTest]") {
 TEST_CASE("Operations", "[FixedStringTest]") {
   SECTION("concatenation grows the length") {
     constexpr auto fs =
-        strings::basic_fixed_string{"ab"} + strings::basic_fixed_string{"cde"};
+        meta::basic_fixed_string{"ab"} + meta::basic_fixed_string{"cde"};
     STATIC_REQUIRE(std::is_same_v<std::remove_const_t<decltype(fs)>,
-        strings::basic_fixed_string<char, 5>>);
+        meta::basic_fixed_string<char, 5>>);
     STATIC_REQUIRE(fs.view() == "abcde"sv);
     CHECK(fs.view() == "abcde"sv);
   }
 
   SECTION("equality, same length") {
     STATIC_REQUIRE(
-        strings::basic_fixed_string{"abc"} ==
-        strings::basic_fixed_string{"abc"});
+        meta::basic_fixed_string{"abc"} == meta::basic_fixed_string{"abc"});
     STATIC_REQUIRE(
-        strings::basic_fixed_string{"abc"} !=
-        strings::basic_fixed_string{"abd"});
+        meta::basic_fixed_string{"abc"} != meta::basic_fixed_string{"abd"});
   }
 
   SECTION("equality, different length is never equal") {
     STATIC_REQUIRE(
-        strings::basic_fixed_string{"abc"} !=
-        strings::basic_fixed_string{"abcd"});
+        meta::basic_fixed_string{"abc"} != meta::basic_fixed_string{"abcd"});
   }
 
   SECTION("ordering") {
     STATIC_REQUIRE(
-        (strings::basic_fixed_string{"abc"} <=>
-            strings::basic_fixed_string{"abd"}) < 0);
+        (meta::basic_fixed_string{"abc"} <=> meta::basic_fixed_string{"abd"}) <
+        0);
     STATIC_REQUIRE(
-        (strings::basic_fixed_string{"abc"} <=>
-            strings::basic_fixed_string{"ab"}) > 0);
+        (meta::basic_fixed_string{"abc"} <=> meta::basic_fixed_string{"ab"}) >
+        0);
   }
 
   SECTION("stream insertion") {
     std::ostringstream os;
-    os << strings::basic_fixed_string{"abc"};
+    os << meta::basic_fixed_string{"abc"};
     CHECK(os.str() == "abc");
   }
 }
@@ -227,7 +225,7 @@ TEST_CASE("fixed_replaced", "[FixedStringTest]") {
   SECTION("swaps every occurrence, preserving length") {
     constexpr auto r = strings::fixed_replaced<"a,b,c", ',', '|'>();
     STATIC_REQUIRE(std::is_same_v<std::remove_const_t<decltype(r)>,
-        strings::basic_fixed_string<char, 5>>);
+        meta::basic_fixed_string<char, 5>>);
     STATIC_REQUIRE(r.view() == "a|b|c"sv);
   }
 
@@ -248,7 +246,7 @@ TEST_CASE("fixed_replaced", "[FixedStringTest]") {
 #pragma region Formatting
 
 TEST_CASE("Fixed string formats like its view", "[FixedStringTest]") {
-  static constexpr strings::basic_fixed_string fs{"hi"};
+  static constexpr meta::basic_fixed_string fs{"hi"};
   CHECK(std::format("{}", fs) == "hi");
   CHECK(std::format("{:?}", fs) == R"("hi")");
   CHECK(std::format("{:>5}", fs) == "   hi");
@@ -256,7 +254,7 @@ TEST_CASE("Fixed string formats like its view", "[FixedStringTest]") {
   // and the range formatter quotes it.
   CHECK(std::format("{}", std::vector{fs, fs}) == R"(["hi", "hi"])");
 
-  static constexpr strings::basic_fixed_string wfs{L"hi"};
+  static constexpr meta::basic_fixed_string wfs{L"hi"};
   CHECK(std::format(L"{}", wfs) == L"hi");
 }
 

--- a/tests/portable/meta_test.cpp
+++ b/tests/portable/meta_test.cpp
@@ -488,6 +488,25 @@ TEST_CASE("TypeName", "[MetaTest]") {
 
   // Value-based overload matches type-based version
   CHECK(type_name<T>() == type_name(T{}));
+
+  // Friendly names collapse spaced closing brackets at any nesting depth,
+  // not just pairs.
+  CHECK(friendly_type_name<std::vector<std::vector<std::vector<int>>>>() ==
+        "std::vector<std::vector<std::vector<int, std::allocator<int>>, "
+        "std::allocator<std::vector<int, std::allocator<int>>>>, "
+        "std::allocator<std::vector<std::vector<int, std::allocator<int>>, "
+        "std::allocator<std::vector<int, std::allocator<int>>>>>>");
+
+  // An incomplete collapse used to leave a space that broke the
+  // `std::string` contraction for nested strings.
+  CHECK(friendly_type_name<std::vector<std::string>>() ==
+        "std::vector<std::string, std::allocator<std::string>>");
+
+  // The space before east const is not bracket spacing and must survive the
+  // collapse. (The tail spelling is platform-dependent, so no exact golden.)
+  const auto ptr = friendly_type_name<const std::vector<int>*>();
+  CHECK(ptr.contains("> const"));
+  CHECK_FALSE(ptr.contains("> >"));
 }
 
 #pragma endregion

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -763,6 +763,49 @@ consteval auto corvid_proxy_spec(F*, quartermaster*) {
   return prox::make_proxy_spec<F, quartermaster>();
 }
 
+// `assayer` pins the blind spot in `validate_api` over overload sets, the
+// overload analog of the wrong-key-same-signature hole: its hand-written
+// `api` omits the `weigh(int)` forwarder, so an int-argument sugar call is
+// absorbed by the `weigh(long)` forwarder through a conversion and
+// dispatches the sibling slot. The probe cannot see the omission, because
+// the absorbed call lands exactly on the sibling slot in arguments and
+// result, so the validating registration compiles anyway.
+struct assayer
+    : prox::facade<prox::name<"assayer">,     //
+          prox::method<"weigh", int(int)>,    //
+          prox::method<"weigh", int(long)>> { //
+  struct api {
+    int weigh(this auto&& self, long grains) {
+      return self.template call<"weigh">(grains);
+    }
+  };
+  template<typename T>
+  struct boilerplate: proxy_impl_base {
+    static int on(method_key<"weigh">, T& t, int nuggets) {
+      return t.weigh(nuggets);
+    }
+    static int on(method_key<"weigh">, T& t, long grains) {
+      return t.weigh(grains);
+    }
+  };
+};
+
+// `prospector` tells the two `weigh` overloads apart by sign.
+struct prospector {
+  int weigh(int nuggets) {
+    (void)this;
+    return nuggets;
+  }
+  int weigh(long grains) {
+    (void)this;
+    return -static_cast<int>(grains);
+  }
+};
+
+consteval auto corvid_proxy_spec(assayer*, prospector*) {
+  return prox::make_proxy_spec<assayer, prospector>();
+}
+
 // Lifetime accounting shared by the owning-proxy targets.
 struct life_stats {
   int constructed{};
@@ -1962,6 +2005,25 @@ TEST_CASE("Per-name overloads", "[proxy]") {
   auto sp = make_shared_proxy<arsenal, quartermaster>();
   CHECK(sp.issue() == 19);
   CHECK(sp.count() == 19);
+}
+
+TEST_CASE("Overload absorption blind spot", "[proxy]") {
+  // The registration validates and this assert passes despite the missing
+  // `weigh(int)` forwarder, because the probe's int-slot call is absorbed by
+  // the long forwarder and lands exactly on the sibling slot.
+  static_assert(prox::validate_api<assayer>());
+
+  prospector p;
+  proxy_view<assayer> v = p;
+
+  // The core spelling reaches both slots by exact match.
+  CHECK(v.call<"weigh">(5) == 5);
+  CHECK(v.call<"weigh">(5L) == -5);
+
+  // The sugar has only the long forwarder to select, so an int argument
+  // converts and dispatches the sibling slot: the misrouting the blind spot
+  // hides, observed live.
+  CHECK(v.weigh(5) == -5);
 }
 
 TEST_CASE("Diamond composition", "[proxy]") {

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -1260,16 +1260,16 @@ static_assert(std::same_as<
 // At the sugar level the forwarders are a plain C++ overload set, so an
 // argument both `aim`s can only convert to (a `long`) is a probeable
 // ambiguity; the unqualified core spelling is the same lazy error via
-// static_assert (diagnostic below). A `short` shows the documented
-// divergence: real overload resolution promotes it into the int forwarder,
-// while the core model's viable tier does not rank conversions (see
-// `resolve`), so `call<"aim">(short{})` is the ambiguity static_assert.
+// static_assert (diagnostic below). A `short` promotes into the int
+// overload through both spellings alike, because `resolve` hands ranking to
+// the compiler; the runtime checks live in "Per-name overloads".
 //
-// Diagnostic on record (clang 22, captured 2026-07-10): `v.call<"aim">(1L)`
-// fires "static assertion failed due to requirement 'ndx !=
-// ...::ambiguous_v': ambiguous method call; qualify the key with the facade
-// name, or match one overload's arguments exactly", followed by the
-// accepted "tuple index out of bounds" noise.
+// Diagnostic on record (clang 22, captured 2026-07-10, re-verified
+// unchanged 2026-07-11 after ranking moved to the compiler):
+// `v.call<"aim">(1L)` fires "static assertion failed due to requirement
+// 'ndx != ...::ambiguous_v': ambiguous method call; qualify the key with
+// the facade name, or match one overload's arguments exactly", followed by
+// the accepted "tuple index out of bounds" noise.
 template<typename P, typename A>
 concept CanAimSugar = requires(P& p, A a) { p.aim(a); };
 static_assert(CanAimSugar<proxy_view<arsenal>, int>);
@@ -1974,6 +1974,15 @@ TEST_CASE("Per-name overloads", "[proxy]") {
   CHECK(v.aim(0.5) == 50);
   CHECK(v.call<"aim">(7) == 7);
   CHECK(v.call<"aim">(0.25) == 25);
+
+  // Ranking is the compiler's own, so promotions rank through the core
+  // spelling exactly as through the sugar: a short promotes into the int
+  // overload and a float into the double one, where mere convertibility (a
+  // long) stays the ambiguity error.
+  CHECK(v.aim(short{9}) == 9);
+  CHECK(v.call<"aim">(short{9}) == 9);
+  CHECK(v.aim(0.5F) == 50);
+  CHECK(v.call<"aim">(0.5F) == 50);
 
   // The const pair: a mutable handle prefers the non-const member, so the
   // accessor writes through; const handles dispatch the read-only query.

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -92,6 +92,11 @@ struct lawman {
   }
   void reload() { rounds_fired = 0; }
   int& shots() { return rounds_fired; }
+  // For `hair_trigger`.
+  [[nodiscard]] bool jams() const {
+    (void)this;
+    return false;
+  }
 
   int rounds_fired{};
 };
@@ -193,7 +198,8 @@ struct cowboy {
 // A facade with noexcept methods. Conformance requires the bindings
 // themselves to be noexcept.
 //
-// The api forwarders are marked `noexcept` so the sugar carries the qualifier
+// The `api` forwarders are marked `noexcept` so the sugar carries the
+// qualifier
 // the way `call` does. This is on the facade author; nothing checks the
 // forwarders against the method flavors.
 struct hair_trigger
@@ -210,15 +216,22 @@ struct hair_trigger
   };
 };
 
-// Bindings marked noexcept: conforms. The target's own methods need not be
-// noexcept; the binding is the terminate boundary.
-template<>
-struct prox::proxy_impl<hair_trigger, lawman> {
-  static int on(method_key<"fire">, lawman& l, int rounds) noexcept {
-    return l.fire(rounds);
+// Boilerplate impl for `hair_trigger`, with bindings marked noexcept as
+// conformance requires. The targets' own methods need not be noexcept; the
+// binding is the terminate boundary.
+template<typename T>
+requires prox::ProxyRegistered<hair_trigger, T>
+struct prox::proxy_impl<hair_trigger, T> {
+  static int on(method_key<"fire">, T& t, int rounds) noexcept {
+    return t.fire(rounds);
   }
-  static bool on(method_key<"jams">, const lawman&) noexcept { return false; }
+  static bool on(method_key<"jams">, const T& t) noexcept { return t.jams(); }
 };
+
+// Registration for `lawman`, which conforms through the boilerplate.
+consteval auto corvid_proxy_spec(hair_trigger*, lawman*) {
+  return prox::make_proxy_spec<hair_trigger, lawman>();
+}
 
 // Bindings not marked noexcept: must NOT conform, even though the shapes
 // otherwise line up.
@@ -229,6 +242,36 @@ struct prox::proxy_impl<hair_trigger, robber> {
   }
   static bool on(method_key<"jams">, const robber&) { return false; }
 };
+
+// A facade whose `api` deliberately deviates from the method list: the
+// forwarder widens the parameter as a convenience, which registration-time
+// validation would reject. Its registrations opt out with `api_check::off`.
+struct mortar: prox::facade<prox::method<"lob", int(int)>> {
+  struct api {
+    int lob(this auto&& self, long long shells) {
+      return self.template call<"lob">(shells);
+    }
+  };
+};
+
+// Boilerplate impl for `mortar`.
+template<typename T>
+requires prox::ProxyRegistered<mortar, T>
+struct prox::proxy_impl<mortar, T> {
+  static int on(method_key<"lob">, T& t, int shells) { return t.lob(shells); }
+};
+
+// A conforming type. The registration passes `api_check::off`, so the
+// deviating `api` is accepted as written.
+struct howitzer {
+  int lob(int shells) { return fired += shells; }
+
+  int fired{};
+};
+
+consteval auto corvid_proxy_spec(mortar*, howitzer*) {
+  return prox::make_proxy_spec<mortar, howitzer, prox::api_check::off>();
+}
 
 // Lifetime accounting shared by the owning-proxy targets.
 struct life_stats {
@@ -427,7 +470,7 @@ static_assert(
 static_assert(std::same_as<const_proxy_view<gunslinger>,
     prox::const_proxy_view<gunslinger>>);
 
-// The api mixin is stateless, so empty-base optimization keeps the views at
+// The `api` mixin is stateless, so empty-base optimization keeps the views at
 // two pointers, with or without one (`lockbox` defines no `api`).
 static_assert(sizeof(proxy_view<gunslinger>) == 2 * sizeof(void*));
 static_assert(sizeof(const_proxy_view<gunslinger>) == 2 * sizeof(void*));
@@ -436,6 +479,28 @@ static_assert(sizeof(proxy_view<lockbox>) == 2 * sizeof(void*));
 // The sugar carries `noexcept` when the facade author marks the forwarders.
 static_assert(noexcept(std::declval<proxy_view<hair_trigger>&>().fire(1)));
 static_assert(!noexcept(std::declval<proxy_view<gunslinger>&>().fire(1)));
+
+// The `api` is validated automatically at registration: `make_proxy_spec`
+// plays the boilerplate impl (which invokes members by natural name) against
+// the `api` (which declares those members), exactly type-checked at both
+// ends.
+// `mortar` above deviates deliberately and opts out with `api_check::off`.
+// The standalone asserts below exercise the public spelling, which a facade
+// author can place before any registration exists; here they are redundant
+// with the registrations.
+//
+// Diagnostics on record (clang 22, captured 2026-07-08). Drifting the
+// `api`'s
+// `fire` parameter from `int` to `long long`, with these standalone asserts
+// removed, fails through `lawman`'s registration alone, at the forwarder's
+// own line: "no matching member function for call to 'call' ... candidate
+// template ignored: constraints not satisfied [with K = ... \"fire\", Args =
+// <long long &>] ... because 'vtbuild_t<gunslinger>::template exact_args<...
+// \"fire\", long long &>()' evaluated to false". Before the check existed,
+// the same drift compiled silently, with the sugar truncating wide arguments
+// at the thunk boundary.
+static_assert(prox::validate_api<gunslinger>());
+static_assert(prox::validate_api<hair_trigger>());
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
@@ -672,7 +737,7 @@ TEST_CASE("Member-call sugar via the api mixin", "[proxy]") {
   };
   CHECK(fire_once(l) == 1);
 
-  // The owning proxy inherits the same api. Deep const holds: only the
+  // The owning proxy inherits the same `api`. Deep const holds: only the
   // const forwarder dispatches through a const proxy.
   auto p = make_proxy<gunslinger, robber>();
   CHECK(p.fire(6) == 6);
@@ -688,6 +753,12 @@ TEST_CASE("Member-call sugar via the api mixin", "[proxy]") {
   proxy_view<hair_trigger> ht{l};
   CHECK(ht.fire(2) == 3);
   CHECK(!ht.jams());
+
+  // A deliberately deviating `api`, registered with `api_check::off`: the
+  // widening forwarder still dispatches through the same table.
+  howitzer h;
+  proxy_view<mortar> mv{h};
+  CHECK(mv.lob(3) == 3);
 }
 
 TEST_CASE("Heterogeneous ownership", "[proxy]") {

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -2971,6 +2971,26 @@ TEST_CASE("Codegen", "[proxy]") {
   oss.str({});
   prox::codegen<posse_leader>(oss);
   CHECK(oss.str() == posse_leader_golden);
+
+  // A heaviest base with no `api` (`lockbox`, supported but not recommended)
+  // is not inherited: the generated `api` spells every flattened forwarder
+  // itself. The `boilerplate` stays empty because `vault` adds no methods of
+  // its own.
+  constexpr std::string_view vault_golden = R"(  struct api {
+    int add(this auto&& self, int arg_1) {
+      return self.template call<"add">(arg_1);
+    }
+    int gold(this const auto& self) {
+      return self.template call<"gold">();
+    }
+  };
+  template<typename T>
+  struct boilerplate: proxy_impl_base {
+  };
+)";
+  oss.str({});
+  prox::codegen<vault>(oss);
+  CHECK(oss.str() == vault_golden);
 }
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -155,10 +155,11 @@ static_assert(std::same_as<decltype(prox::proxy_spec_v<gunslinger, lawman>),
 // satisfied [with T = cowboy] ... because 'Proxiable<cowboy, gunslinger>'
 // evaluated to false ... because
 // 'details::info_t<gunslinger>::all_bound_v<gunslinger, cowboy>' evaluated
-// to false". Calling `pv.call<"missing">()` emits exactly one error:
-// "static assertion failed ... facade has no method with this name" (the
-// `if constexpr` in `call` discards the dispatch on that path, so the
-// assert is not followed by `std::get` index noise).
+// to false". Calling `pv.call<"missing">()` fires the static_assert
+// "facade has no method with this name", followed by `std::get` index-noise
+// errors; the follow-on noise is accepted (a guarding `if constexpr` was
+// tried and dropped as a simplification), since fixing the obvious message
+// also removes the noise.
 static_assert(prox::Proxiable<lawman, gunslinger>);
 static_assert(prox::Proxiable<robber, gunslinger>);
 static_assert(!prox::Proxiable<cowboy, gunslinger>);
@@ -166,6 +167,11 @@ static_assert(!prox::Proxiable<int, gunslinger>);
 
 // A view satisfies its own facade.
 static_assert(prox::Proxiable<prox::proxy_view<gunslinger>, gunslinger>);
+
+// Views are value-semantic: copyable and rebindable by assignment. The table
+// member is pointer-to-const, not a const member, so assignment stays viable.
+static_assert(std::assignable_from<prox::proxy_view<gunslinger>&,
+    const prox::proxy_view<gunslinger>&>);
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
@@ -218,6 +224,17 @@ TEST_CASE("Heterogeneous dispatch", "[proxy]") {
   auto pv2 = gang[0];
   pv2.call<"fire">(1);
   CHECK(l.rounds_fired == 3);
+}
+
+TEST_CASE("Views rebind by assignment", "[proxy]") {
+  lawman l;
+  robber r;
+  prox::proxy_view<gunslinger> pv{l};
+  CHECK(pv.call<"describe">() == "lawman"s);
+
+  // Assignment rebinds both the target and the dispatch table.
+  pv = prox::proxy_view<gunslinger>{r};
+  CHECK(pv.call<"describe">() == "robber"s);
 }
 
 TEST_CASE("Generic code accepts concrete and erased alike", "[proxy]") {

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -254,8 +254,8 @@ consteval auto corvid_proxy_spec(lockbox*, strongbox<Pad>*) {
 // One size fits the inline buffer exactly; the other forces the heap path.
 using small_box = strongbox<4>;
 using big_box = strongbox<64>;
-static_assert(sizeof(small_box) <= prox::proxy<lockbox>::sbo_size);
-static_assert(sizeof(big_box) > prox::proxy<lockbox>::sbo_size);
+static_assert(sizeof(small_box) <= proxy<lockbox>::sbo_size);
+static_assert(sizeof(big_box) > proxy<lockbox>::sbo_size);
 
 // Facade detection.
 static_assert(prox::Facade<gunslinger>);
@@ -298,11 +298,11 @@ static_assert(std::same_as<decltype(prox::proxy_spec_v<gunslinger, lawman>),
 // errors; the follow-on noise is accepted (a guarding `if constexpr` was
 // tried and dropped as a simplification), since fixing the obvious message
 // also removes the noise.
-static_assert(prox::Proxiable<lawman, gunslinger>);
-static_assert(prox::Proxiable<robber, gunslinger>);
-static_assert(prox::Proxiable<sheriff, gunslinger>);
-static_assert(!prox::Proxiable<cowboy, gunslinger>);
-static_assert(!prox::Proxiable<int, gunslinger>);
+static_assert(Proxiable<lawman, gunslinger>);
+static_assert(Proxiable<robber, gunslinger>);
+static_assert(Proxiable<sheriff, gunslinger>);
+static_assert(!Proxiable<cowboy, gunslinger>);
+static_assert(!Proxiable<int, gunslinger>);
 
 // Noexcept qualification is part of the method flavor.
 static_assert(!prox::method<"fire", int(int)>::noexcept_v);
@@ -311,30 +311,30 @@ static_assert(prox::method<"jams", bool() const noexcept>::const_v);
 static_assert(prox::method<"jams", bool() const noexcept>::noexcept_v);
 
 // Noexcept conformance: the binding itself must be noexcept.
-static_assert(prox::Proxiable<lawman, hair_trigger>);
-static_assert(!prox::Proxiable<robber, hair_trigger>);
+static_assert(Proxiable<lawman, hair_trigger>);
+static_assert(!Proxiable<robber, hair_trigger>);
 
 // The erased call carries the method's noexcept.
 static_assert(
-    noexcept(std::declval<prox::proxy_view<hair_trigger>&>().call<"fire">(1)));
+    noexcept(std::declval<proxy_view<hair_trigger>&>().call<"fire">(1)));
 static_assert(
-    !noexcept(std::declval<prox::proxy_view<gunslinger>&>().call<"fire">(1)));
+    !noexcept(std::declval<proxy_view<gunslinger>&>().call<"fire">(1)));
 
 // Both handles satisfy their own facade, including facades with noexcept
 // methods.
-static_assert(prox::Proxiable<prox::proxy_view<gunslinger>, gunslinger>);
-static_assert(prox::Proxiable<prox::proxy<gunslinger>, gunslinger>);
-static_assert(prox::Proxiable<prox::proxy_view<hair_trigger>, hair_trigger>);
-static_assert(prox::Proxiable<prox::proxy<hair_trigger>, hair_trigger>);
+static_assert(Proxiable<proxy_view<gunslinger>, gunslinger>);
+static_assert(Proxiable<proxy<gunslinger>, gunslinger>);
+static_assert(Proxiable<proxy_view<hair_trigger>, hair_trigger>);
+static_assert(Proxiable<proxy<hair_trigger>, hair_trigger>);
 
 // Views are value-semantic: copyable and rebindable by assignment. The table
 // member is pointer-to-const, not a const member, so assignment stays viable.
-static_assert(std::assignable_from<prox::proxy_view<gunslinger>&,
-    const prox::proxy_view<gunslinger>&>);
+static_assert(std::assignable_from<proxy_view<gunslinger>&,
+    const proxy_view<gunslinger>&>);
 
 // The owning proxy is move-only.
-static_assert(!std::copy_constructible<prox::proxy<gunslinger>>);
-static_assert(std::movable<prox::proxy<gunslinger>>);
+static_assert(!std::copy_constructible<proxy<gunslinger>>);
+static_assert(std::movable<proxy<gunslinger>>);
 
 // Deep const: non-const facade methods are not callable on a const handle,
 // and never exist on a `const_proxy_view` at all. The probes go through a
@@ -345,32 +345,35 @@ concept CanFire = requires(P& p) { p.template call<"fire">(1); };
 template<typename P>
 concept CanDescribe = requires(P& p) { p.template call<"describe">(); };
 
-static_assert(CanFire<prox::proxy<gunslinger>>);
-static_assert(!CanFire<const prox::proxy<gunslinger>>);
-static_assert(CanDescribe<const prox::proxy<gunslinger>>);
-static_assert(CanFire<prox::proxy_view<gunslinger>>);
-static_assert(!CanFire<const prox::proxy_view<gunslinger>>);
-static_assert(CanDescribe<const prox::proxy_view<gunslinger>>);
-static_assert(!CanFire<prox::const_proxy_view<gunslinger>>);
-static_assert(!CanFire<const prox::const_proxy_view<gunslinger>>);
-static_assert(CanDescribe<prox::const_proxy_view<gunslinger>>);
+static_assert(CanFire<proxy<gunslinger>>);
+static_assert(!CanFire<const proxy<gunslinger>>);
+static_assert(CanDescribe<const proxy<gunslinger>>);
+static_assert(CanFire<proxy_view<gunslinger>>);
+static_assert(!CanFire<const proxy_view<gunslinger>>);
+static_assert(CanDescribe<const proxy_view<gunslinger>>);
+static_assert(!CanFire<const_proxy_view<gunslinger>>);
+static_assert(!CanFire<const const_proxy_view<gunslinger>>);
+static_assert(CanDescribe<const_proxy_view<gunslinger>>);
 
 // Const-view conversion rules: a target loses mutability implicitly, never
 // regains it. A const target binds only to the const view.
-static_assert(std::convertible_to<prox::proxy_view<gunslinger>,
-    prox::const_proxy_view<gunslinger>>);
-static_assert(!std::constructible_from<prox::proxy_view<gunslinger>,
-    prox::const_proxy_view<gunslinger>&>);
-static_assert(std::constructible_from<prox::const_proxy_view<gunslinger>,
-    const lawman&>);
 static_assert(
-    !std::constructible_from<prox::proxy_view<gunslinger>, const lawman&>);
+    std::convertible_to<proxy_view<gunslinger>, const_proxy_view<gunslinger>>);
+static_assert(!std::constructible_from<proxy_view<gunslinger>,
+    const_proxy_view<gunslinger>&>);
+static_assert(
+    std::constructible_from<const_proxy_view<gunslinger>, const lawman&>);
+static_assert(!std::constructible_from<proxy_view<gunslinger>, const lawman&>);
 
 // An all-const facade is the one case where a const view satisfies the
 // invariant; a mixed facade correctly fails it (the mutable methods are not
 // dispatchable, so conformance is impossible; Rust's `&dyn` analog).
 struct census: prox::facade<prox::method<"describe", std::string() const>> {};
 
+// Conformance here is a deliberate one-off full specialization: the
+// boilerplate and registration tiers are already exercised by `gunslinger`
+// and `lockbox`, and `census` exists only to serve the const-view
+// assertions.
 template<>
 struct prox::proxy_impl<census, lawman> {
   static std::string on(method_key<"describe">, const lawman& l) {
@@ -378,15 +381,24 @@ struct prox::proxy_impl<census, lawman> {
   }
 };
 
-static_assert(prox::Proxiable<prox::const_proxy_view<census>, census>);
+static_assert(Proxiable<const_proxy_view<census>, census>);
+static_assert(!Proxiable<const_proxy_view<gunslinger>, gunslinger>);
+
+// The call-site vocabulary is exported to `corvid::meta`, so this file uses
+// the unqualified spellings throughout; only authoring (facades, impls,
+// registration) needs `prox::`. These confirm both spellings name the same
+// entity.
+static_assert(std::same_as<proxy<gunslinger>, prox::proxy<gunslinger>>);
 static_assert(
-    !prox::Proxiable<prox::const_proxy_view<gunslinger>, gunslinger>);
+    std::same_as<proxy_view<gunslinger>, prox::proxy_view<gunslinger>>);
+static_assert(std::same_as<const_proxy_view<gunslinger>,
+    prox::const_proxy_view<gunslinger>>);
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
 TEST_CASE("Boilerplate impl through registration", "[proxy]") {
   lawman l;
-  prox::proxy_view<gunslinger> pv{l};
+  proxy_view<gunslinger> pv{l};
 
   CHECK(pv.call<"fire">(3) == 3);
   CHECK(pv.call<"fire">(2) == 5);
@@ -403,7 +415,7 @@ TEST_CASE("Boilerplate impl through registration", "[proxy]") {
 
 TEST_CASE("Custom impl without registration", "[proxy]") {
   robber r;
-  prox::proxy_view<gunslinger> pv{r};
+  proxy_view<gunslinger> pv{r};
 
   CHECK(pv.call<"fire">(6) == 6);
   CHECK(r.fired == 6);
@@ -416,7 +428,7 @@ TEST_CASE("Custom impl without registration", "[proxy]") {
 
 TEST_CASE("Partially-overridden boilerplate impl", "[proxy]") {
   sheriff s;
-  prox::proxy_view<gunslinger> pv{s};
+  proxy_view<gunslinger> pv{s};
 
   // The overriding binding: "fire" routes to `shoot`.
   CHECK(pv.call<"fire">(4) == 4);
@@ -432,7 +444,7 @@ TEST_CASE("Partially-overridden boilerplate impl", "[proxy]") {
 TEST_CASE("Heterogeneous dispatch", "[proxy]") {
   lawman l;
   robber r;
-  std::vector<prox::proxy_view<gunslinger>> gang{l, r};
+  std::vector<proxy_view<gunslinger>> gang{l, r};
 
   std::string roll_call;
   // Mutable references: "fire" no longer dispatches through a const view.
@@ -454,49 +466,49 @@ TEST_CASE("Heterogeneous dispatch", "[proxy]") {
 TEST_CASE("Views rebind by assignment", "[proxy]") {
   lawman l;
   robber r;
-  prox::proxy_view<gunslinger> pv{l};
+  proxy_view<gunslinger> pv{l};
   CHECK(pv.call<"describe">() == "lawman"s);
 
   // Assignment rebinds both the target and the dispatch table.
-  pv = prox::proxy_view<gunslinger>{r};
+  pv = proxy_view<gunslinger>{r};
   CHECK(pv.call<"describe">() == "robber"s);
 }
 
 TEST_CASE("Const view", "[proxy]") {
   // A const target binds directly; only const methods exist on this view.
   const lawman cl{};
-  prox::const_proxy_view<gunslinger> cv{cl};
+  const_proxy_view<gunslinger> cv{cl};
   CHECK(cv.call<"describe">() == "lawman"s);
 
   // A const instance of the mutable view enforces the same restriction.
   lawman l;
-  const prox::proxy_view<gunslinger> cpv{l};
+  const proxy_view<gunslinger> cpv{l};
   CHECK(cpv.call<"describe">() == "lawman"s);
 
   // The mutable view converts implicitly, and const views rebind by
   // assignment like any view.
-  prox::proxy_view<gunslinger> pv{l};
-  prox::const_proxy_view<gunslinger> cv2{pv};
+  proxy_view<gunslinger> pv{l};
+  const_proxy_view<gunslinger> cv2{pv};
   CHECK(cv2.call<"describe">() == "lawman"s);
   cv = cv2;
   CHECK(cv.call<"describe">() == "lawman"s);
 
   // All-const facades keep the invariant: generic code constrained on the
   // facade accepts the concrete const target and the const view alike.
-  auto describe_it = [](const prox::Proxiable<census> auto& t) {
-    prox::const_proxy_view<census> v{t};
+  auto describe_it = [](const Proxiable<census> auto& t) {
+    const_proxy_view<census> v{t};
     return v.template call<"describe">();
   };
   CHECK(describe_it(cl) == "lawman"s);
-  prox::const_proxy_view<census> census_view{cl};
+  const_proxy_view<census> census_view{cl};
   CHECK(describe_it(census_view) == "lawman"s);
 }
 
 TEST_CASE("Generic code accepts concrete and erased alike", "[proxy]") {
   // Facade-constrained generic code: erase, then call. `Proxiable` is the
   // trait bound for the static-dispatch half.
-  auto fire_twice = [](prox::Proxiable<gunslinger> auto& g) {
-    auto pv = prox::make_proxy_view<gunslinger>(g);
+  auto fire_twice = [](Proxiable<gunslinger> auto& g) {
+    auto pv = make_proxy_view<gunslinger>(g);
     // In a template context the view's type is dependent, hence `template`.
     pv.template call<"fire">(1);
     return pv.template call<"fire">(1);
@@ -507,22 +519,22 @@ TEST_CASE("Generic code accepts concrete and erased alike", "[proxy]") {
 
   // Passing a view works too, and flattens rather than stacking a second
   // indirection.
-  prox::proxy_view<gunslinger> pv{l};
+  proxy_view<gunslinger> pv{l};
   CHECK(fire_twice(pv) == 4);
 
   // The library-provided view impl is also usable directly.
-  CHECK(prox::proxy_impl<gunslinger, prox::proxy_view<gunslinger>>::on(
+  CHECK(prox::proxy_impl<gunslinger, proxy_view<gunslinger>>::on(
             "describe"_method, pv) == "lawman"s);
 
   // An owning proxy satisfies the facade too, so it erases the same way.
-  auto p = prox::make_proxy<gunslinger, lawman>();
+  auto p = make_proxy<gunslinger, lawman>();
   CHECK(fire_twice(p) == 2);
 }
 
 TEST_CASE("Owning proxy, inline target", "[proxy]") {
   life_stats stats;
   if (true) {
-    auto p = prox::make_proxy<lockbox, small_box>(stats);
+    auto p = make_proxy<lockbox, small_box>(stats);
     CHECK(stats.constructed == 1);
     CHECK(stats.destroyed == 0);
     CHECK(p);
@@ -550,7 +562,7 @@ TEST_CASE("Owning proxy, inline target", "[proxy]") {
 TEST_CASE("Owning proxy, heap target", "[proxy]") {
   life_stats stats;
   if (true) {
-    auto p = prox::make_proxy<lockbox, big_box>(stats);
+    auto p = make_proxy<lockbox, big_box>(stats);
     CHECK(stats.constructed == 1);
     CHECK(p.call<"add">(7) == 7);
 
@@ -562,7 +574,7 @@ TEST_CASE("Owning proxy, heap target", "[proxy]") {
     CHECK(q.call<"gold">() == 7);
 
     // Move assignment over a live target destroys the old target first.
-    q = prox::make_proxy<lockbox, big_box>(stats);
+    q = make_proxy<lockbox, big_box>(stats);
     CHECK(stats.constructed == 2);
     CHECK(stats.destroyed == 1);
     CHECK(q.call<"gold">() == 0);
@@ -573,17 +585,17 @@ TEST_CASE("Owning proxy, heap target", "[proxy]") {
 TEST_CASE("Owning proxy is deep-const", "[proxy]") {
   // Only const-qualified facade methods dispatch through a const proxy; the
   // negative half is covered by the `CanFire` static_asserts above.
-  const auto p = prox::make_proxy<gunslinger, lawman>();
+  const auto p = make_proxy<gunslinger, lawman>();
   CHECK(p.call<"describe">() == "lawman"s);
 }
 
 TEST_CASE("Noexcept facade methods", "[proxy]") {
   lawman l;
-  prox::proxy_view<hair_trigger> pv{l};
+  proxy_view<hair_trigger> pv{l};
   CHECK(pv.call<"fire">(2) == 2);
   CHECK(!pv.call<"jams">());
 
-  auto p = prox::make_proxy<hair_trigger, lawman>();
+  auto p = make_proxy<hair_trigger, lawman>();
   CHECK(p.call<"fire">(4) == 4);
   static_assert(noexcept(p.call<"fire">(4)));
   const auto& cp = p;
@@ -592,9 +604,9 @@ TEST_CASE("Noexcept facade methods", "[proxy]") {
 }
 
 TEST_CASE("Heterogeneous ownership", "[proxy]") {
-  std::vector<prox::proxy<gunslinger>> gang;
-  gang.push_back(prox::make_proxy<gunslinger, lawman>());
-  gang.push_back(prox::make_proxy<gunslinger, robber>());
+  std::vector<proxy<gunslinger>> gang;
+  gang.push_back(make_proxy<gunslinger, lawman>());
+  gang.push_back(make_proxy<gunslinger, robber>());
 
   std::string roll_call;
   for (auto& p : gang) {

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -492,12 +492,13 @@ struct bounty_hunter
 // redeclare the lighter siblings' own forwarders. Inheriting every base
 // `api` also works, but costs a using-declaration per shared-ancestor
 // method (two subobjects of the same empty `api` type make plain member
-// lookup ambiguous until a using-declaration pulls in one path) plus one
-// padding word in every handle (same-type subobjects need distinct
-// addresses, which empty-base optimization cannot paper over). There is no
-// automatic merge to reach for: using-declarations cannot be pack-expanded
-// over arbitrary names before reflection, and virtual inheritance would put
-// a vbptr in every handle.
+// lookup ambiguous until a using-declaration pulls in one path) plus, under
+// the MS ABI, one padding word in every handle (same-type subobjects need
+// distinct addresses; Itanium hides the second inside the data members, MS
+// never overlaps empty bases with members). There is no automatic merge to
+// reach for: using-declarations cannot be pack-expanded over arbitrary
+// names before reflection, and virtual inheritance would put a vbptr in
+// every handle.
 struct posse_leader
     : prox::facade<prox::name<"posse_leader">, //
           prox::extends<marshal>,              //

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -24,14 +24,31 @@
 
 using namespace std::literals;
 using namespace corvid;
-using namespace corvid::meta::prox;
 using namespace corvid::meta::prox::literals;
 
 // The facade under test: mixes value returns, a const method, a void
 // mutator, and a reference return.
 struct gunslinger
-    : facade<method<"fire", int(int)>, method<"describe", std::string() const>,
-          method<"reload", void()>, method<"shots", int&()>> {};
+    : prox::facade<                                      //
+          prox::method<"fire", int(int)>,                //
+          prox::method<"describe", std::string() const>, //
+          prox::method<"reload", void()>,                //
+          prox::method<"shots", int&()>> {};             //
+
+// Boilerplate impl for `gunslinger`: written once by the facade author,
+// generic over any registered type whose member names line up.
+template<typename T>
+requires prox::ProxyRegistered<gunslinger, T>
+struct prox::proxy_impl<gunslinger, T> {
+  static int on(method_key<"fire">, T& t, int rounds) {
+    return t.fire(rounds);
+  }
+  static std::string on(method_key<"describe">, const T& t) {
+    return t.describe();
+  }
+  static void on(method_key<"reload">, T& t) { t.reload(); }
+  static int& on(method_key<"shots">, T& t) { return t.shots(); }
+};
 
 // A type whose method names line up with the facade; conforms by
 // registration through the boilerplate impl.
@@ -50,6 +67,11 @@ struct lawman {
   int rounds_fired{};
 };
 
+// Registration for `lawman`: pure opt-in, one hook, no bindings.
+consteval auto corvid_proxy_spec(gunslinger*, lawman*) {
+  return prox::make_proxy_spec<gunslinger, lawman>();
+}
+
 // A type with the right shape but the wrong names; conforms through an
 // explicit impl, with no registration.
 struct robber {
@@ -64,6 +86,22 @@ struct robber {
   void rearm() { fired = 0; }
 
   int fired{};
+};
+
+// Custom impl for `robber`.
+//
+// A full specialization outranks the boilerplate and needs no registration.
+// Note the name adaptation, including binding "shots" to a data member.
+template<>
+struct prox::proxy_impl<gunslinger, robber> {
+  static int on(method_key<"fire">, robber& r, int rounds) {
+    return r.shoot(rounds);
+  }
+  static std::string on(method_key<"describe">, const robber& r) {
+    return r.description();
+  }
+  static void on(method_key<"reload">, robber& r) { r.rearm(); }
+  static int& on(method_key<"shots">, robber& r) { return r.fired; }
 };
 
 // A type whose method names line up but which never opts in. Nominal
@@ -83,67 +121,29 @@ struct cowboy {
   int count{};
 };
 
-// Registration for `lawman`: pure opt-in, one hook, no bindings.
-consteval auto corvid_proxy_spec(gunslinger*, lawman*) {
-  return make_proxy_spec<gunslinger, lawman>();
-}
-
-namespace corvid {
-
-// Boilerplate impl for `gunslinger`: written once by the facade author,
-// generic over any registered type whose member names line up.
-template<typename T>
-requires ProxyRegistered<gunslinger, T>
-struct proxy_impl<gunslinger, T> {
-  static int on(method_key<"fire">, T& t, int rounds) {
-    return t.fire(rounds);
-  }
-  static std::string on(method_key<"describe">, const T& t) {
-    return t.describe();
-  }
-  static void on(method_key<"reload">, T& t) { t.reload(); }
-  static int& on(method_key<"shots">, T& t) { return t.shots(); }
-};
-
-// Custom impl for `robber`: a full specialization outranks the boilerplate
-// and needs no registration. Note the name adaptation, including binding
-// "shots" to a data member.
-template<>
-struct proxy_impl<gunslinger, robber> {
-  static int on(method_key<"fire">, robber& r, int rounds) {
-    return r.shoot(rounds);
-  }
-  static std::string on(method_key<"describe">, const robber& r) {
-    return r.description();
-  }
-  static void on(method_key<"reload">, robber& r) { r.rearm(); }
-  static int& on(method_key<"shots">, robber& r) { return r.fired; }
-};
-
-} // namespace corvid
-
 // Facade detection.
-static_assert(Facade<gunslinger>);
-static_assert(!Facade<lawman>);
-static_assert(!Facade<int>);
+static_assert(prox::Facade<gunslinger>);
+static_assert(!prox::Facade<lawman>);
+static_assert(!prox::Facade<int>);
 
 // A method is-a key: usable anywhere its key is.
-static_assert(std::derived_from<method<"fire", int(int)>, method_key<"fire">>);
-static_assert(std::derived_from<method<"describe", std::string() const>,
-    method_key<"describe">>);
-static_assert(
-    !std::derived_from<method<"fire", int(int)>, method_key<"reload">>);
+static_assert(std::derived_from<prox::method<"fire", int(int)>,
+    prox::method_key<"fire">>);
+static_assert(std::derived_from<prox::method<"describe", std::string() const>,
+    prox::method_key<"describe">>);
+static_assert(!std::derived_from<prox::method<"fire", int(int)>,
+    prox::method_key<"reload">>);
 
-// UDL: `"name"_method` is a `method_key<"name">`.
-static_assert(std::same_as<decltype("fire"_method), method_key<"fire">>);
+// UDL: `"name"_method` is a `prox::method_key<"name">`.
+static_assert(std::same_as<decltype("fire"_method), prox::method_key<"fire">>);
 
 // Registration state: lawman is registered, robber conforms without
 // registration, cowboy neither registers nor conforms.
-static_assert(ProxyRegistered<gunslinger, lawman>);
-static_assert(!ProxyRegistered<gunslinger, robber>);
-static_assert(!ProxyRegistered<gunslinger, cowboy>);
-static_assert(std::same_as<decltype(proxy_spec_v<gunslinger, lawman>),
-    const proxy_spec<gunslinger, lawman>>);
+static_assert(prox::ProxyRegistered<gunslinger, lawman>);
+static_assert(!prox::ProxyRegistered<gunslinger, robber>);
+static_assert(!prox::ProxyRegistered<gunslinger, cowboy>);
+static_assert(std::same_as<decltype(prox::proxy_spec_v<gunslinger, lawman>),
+    const prox::proxy_spec<gunslinger, lawman>>);
 
 // Conformance: boilerplate via registration, explicit impl directly, and
 // matching names alone are NOT enough.
@@ -159,19 +159,19 @@ static_assert(std::same_as<decltype(proxy_spec_v<gunslinger, lawman>),
 // "static assertion failed ... facade has no method with this name" (the
 // `if constexpr` in `call` discards the dispatch on that path, so the
 // assert is not followed by `std::get` index noise).
-static_assert(Proxiable<lawman, gunslinger>);
-static_assert(Proxiable<robber, gunslinger>);
-static_assert(!Proxiable<cowboy, gunslinger>);
-static_assert(!Proxiable<int, gunslinger>);
+static_assert(prox::Proxiable<lawman, gunslinger>);
+static_assert(prox::Proxiable<robber, gunslinger>);
+static_assert(!prox::Proxiable<cowboy, gunslinger>);
+static_assert(!prox::Proxiable<int, gunslinger>);
 
 // A view satisfies its own facade.
-static_assert(Proxiable<proxy_view<gunslinger>, gunslinger>);
+static_assert(prox::Proxiable<prox::proxy_view<gunslinger>, gunslinger>);
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
 TEST_CASE("Boilerplate impl through registration", "[proxy]") {
   lawman l;
-  proxy_view<gunslinger> pv{l};
+  prox::proxy_view<gunslinger> pv{l};
 
   CHECK(pv.call<"fire">(3) == 3);
   CHECK(pv.call<"fire">(2) == 5);
@@ -188,7 +188,7 @@ TEST_CASE("Boilerplate impl through registration", "[proxy]") {
 
 TEST_CASE("Custom impl without registration", "[proxy]") {
   robber r;
-  proxy_view<gunslinger> pv{r};
+  prox::proxy_view<gunslinger> pv{r};
 
   CHECK(pv.call<"fire">(6) == 6);
   CHECK(r.fired == 6);
@@ -202,7 +202,7 @@ TEST_CASE("Custom impl without registration", "[proxy]") {
 TEST_CASE("Heterogeneous dispatch", "[proxy]") {
   lawman l;
   robber r;
-  std::vector<proxy_view<gunslinger>> gang{l, r};
+  std::vector<prox::proxy_view<gunslinger>> gang{l, r};
 
   std::string roll_call;
   for (const auto& pv : gang) {
@@ -223,8 +223,8 @@ TEST_CASE("Heterogeneous dispatch", "[proxy]") {
 TEST_CASE("Generic code accepts concrete and erased alike", "[proxy]") {
   // Facade-constrained generic code: erase, then call. `Proxiable` is the
   // trait bound for the static-dispatch half.
-  auto fire_twice = [](Proxiable<gunslinger> auto& g) {
-    auto pv = make_proxy_view<gunslinger>(g);
+  auto fire_twice = [](prox::Proxiable<gunslinger> auto& g) {
+    auto pv = prox::make_proxy_view<gunslinger>(g);
     // In a template context the view's type is dependent, hence `template`.
     pv.template call<"fire">(1);
     return pv.template call<"fire">(1);
@@ -235,11 +235,11 @@ TEST_CASE("Generic code accepts concrete and erased alike", "[proxy]") {
 
   // Passing a view works too, and flattens rather than stacking a second
   // indirection.
-  proxy_view<gunslinger> pv{l};
+  prox::proxy_view<gunslinger> pv{l};
   CHECK(fire_twice(pv) == 4);
 
   // The library-provided view impl is also usable directly.
-  CHECK(prox::proxy_impl<gunslinger, proxy_view<gunslinger>>::on(
+  CHECK(prox::proxy_impl<gunslinger, prox::proxy_view<gunslinger>>::on(
             "describe"_method, pv) == "lawman"s);
 }
 

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -38,8 +38,8 @@ struct gunslinger
           prox::method<"shots", int&()>> {};             //
 
 // This base class for proxy_impl<gunslinger, T> would not normally be
-// necessary, but it's used for `sheriff`. It also wouldn't need `prox::method`
-// to be fully specified.
+// necessary, but it's used for `sheriff`. It also wouldn't need
+// `prox::method_key` to be scoped to its namespace.
 template<typename T>
 struct proxy_impl_gunslinger {
   static int on(prox::method_key<"fire">, T& t, int rounds) {
@@ -52,8 +52,10 @@ struct proxy_impl_gunslinger {
   static int& on(prox::method_key<"shots">, T& t) { return t.shots(); }
 };
 
-// Boilerplate impl for `gunslinger`: written once by the facade author,
-// generic over any registered type whose member names line up.
+// Boilerplate impl for `gunslinger`.
+//
+// Written once by the facade author, generic over any registered type whose
+// member names line up.
 //
 // Again, it would normally contain the guts of what's been moved to
 // `proxy_impl_gunslinger`.
@@ -61,7 +63,7 @@ template<typename T>
 requires prox::ProxyRegistered<gunslinger, T>
 struct prox::proxy_impl<gunslinger, T>: proxy_impl_gunslinger<T> {};
 
-// A type whose method names line up with the facade; conforms by
+// A type whose method names line up with the facade. Conforms by
 // registration through the boilerplate impl.
 struct lawman {
   int fire(int rounds) {
@@ -78,12 +80,15 @@ struct lawman {
   int rounds_fired{};
 };
 
-// Registration for `lawman`: pure opt-in, one hook, no bindings.
+// Registration for `lawman`. Pure opt-in, one hook, no bindings.
 consteval auto corvid_proxy_spec(gunslinger*, lawman*) {
   return prox::make_proxy_spec<gunslinger, lawman>();
 }
 
 // Exactly like a lawman, but with a different name. Works automatically.
+// Note that, if this subclass were more significant, it would run into
+// problems caused by the lack of a virtual destructor in the base. However,
+// combining `virtual` and `proxy` is a code smell.
 struct deputy: public lawman {
   // NOLINTNEXTLINE(bugprone-derived-method-shadowing-base-method)
   [[nodiscard]] std::string describe() const {
@@ -92,7 +97,7 @@ struct deputy: public lawman {
   }
 };
 
-// A type with the right shape but the wrong names; conforms through an
+// A type with the right shape but the wrong names. Conforms through an
 // explicit impl, with no registration.
 struct robber {
   int shoot(int rounds) {
@@ -169,7 +174,7 @@ struct cowboy {
   int count{};
 };
 
-// A facade with noexcept methods: conformance requires the bindings
+// A facade with noexcept methods. Conformance requires the bindings
 // themselves to be noexcept.
 struct hair_trigger
     : prox::facade<                                //
@@ -251,7 +256,7 @@ consteval auto corvid_proxy_spec(lockbox*, strongbox<Pad>*) {
   return prox::make_proxy_spec<lockbox, strongbox<Pad>>();
 }
 
-// One size fits the inline buffer exactly; the other forces the heap path.
+// One size fits the inline buffer exactly, the other forces the heap path.
 using small_box = strongbox<4>;
 using big_box = strongbox<64>;
 static_assert(sizeof(small_box) <= proxy<lockbox>::sbo_size);
@@ -273,7 +278,7 @@ static_assert(!std::derived_from<prox::method<"fire", int(int)>,
 // UDL: `"name"_method` is a `prox::method_key<"name">`.
 static_assert(std::same_as<decltype("fire"_method), prox::method_key<"fire">>);
 
-// Registration state: lawman is registered, robber conforms without
+// Registration state. Lawman is registered, robber conforms without
 // registration, cowboy neither registers nor conforms.
 static_assert(prox::ProxyRegistered<gunslinger, lawman>);
 static_assert(prox::ProxyRegistered<gunslinger, deputy>);
@@ -283,7 +288,7 @@ static_assert(!prox::ProxyRegistered<gunslinger, cowboy>);
 static_assert(std::same_as<decltype(prox::proxy_spec_v<gunslinger, lawman>),
     const prox::proxy_spec<gunslinger, lawman>>);
 
-// Conformance: boilerplate via registration, explicit impl directly, and
+// Conformance. Boilerplate via registration, explicit impl directly, and
 // matching names alone are NOT enough.
 //
 // Diagnostics on record (clang 22, captured 2026-07-08). Constructing
@@ -336,7 +341,7 @@ static_assert(std::assignable_from<proxy_view<gunslinger>&,
 static_assert(!std::copy_constructible<proxy<gunslinger>>);
 static_assert(std::movable<proxy<gunslinger>>);
 
-// Deep const: non-const facade methods are not callable on a const handle,
+// Deep const. The non-const facade methods are not callable on a const handle,
 // and never exist on a `const_proxy_view` at all. The probes go through a
 // concept so the negative case is a constraint failure rather than a hard
 // error (a requires-expression outside a template does not get SFINAE).
@@ -355,7 +360,7 @@ static_assert(!CanFire<const_proxy_view<gunslinger>>);
 static_assert(!CanFire<const const_proxy_view<gunslinger>>);
 static_assert(CanDescribe<const_proxy_view<gunslinger>>);
 
-// Const-view conversion rules: a target loses mutability implicitly, never
+// Const-view conversion rules. A target loses mutability implicitly, never
 // regains it. A const target binds only to the const view.
 static_assert(
     std::convertible_to<proxy_view<gunslinger>, const_proxy_view<gunslinger>>);
@@ -366,14 +371,13 @@ static_assert(
 static_assert(!std::constructible_from<proxy_view<gunslinger>, const lawman&>);
 
 // An all-const facade is the one case where a const view satisfies the
-// invariant; a mixed facade correctly fails it (the mutable methods are not
+// invariant. A mixed facade correctly fails it (the mutable methods are not
 // dispatchable, so conformance is impossible; Rust's `&dyn` analog).
 struct census: prox::facade<prox::method<"describe", std::string() const>> {};
 
-// Conformance here is a deliberate one-off full specialization: the
-// boilerplate and registration tiers are already exercised by `gunslinger`
-// and `lockbox`, and `census` exists only to serve the const-view
-// assertions.
+// Conformance here is a deliberate one-off full specialization. The
+// boilerplate and registration tiers are already exercised by `gunslinger` and
+// `lockbox`, and `census` exists only to serve the const-view assertions.
 template<>
 struct prox::proxy_impl<census, lawman> {
   static std::string on(method_key<"describe">, const lawman& l) {
@@ -385,7 +389,7 @@ static_assert(Proxiable<const_proxy_view<census>, census>);
 static_assert(!Proxiable<const_proxy_view<gunslinger>, gunslinger>);
 
 // The call-site vocabulary is exported to `corvid::meta`, so this file uses
-// the unqualified spellings throughout; only authoring (facades, impls,
+// the unqualified spellings throughout. Only authoring (facades, impls,
 // registration) needs `prox::`. These confirm both spellings name the same
 // entity.
 static_assert(std::same_as<proxy<gunslinger>, prox::proxy<gunslinger>>);
@@ -447,7 +451,8 @@ TEST_CASE("Heterogeneous dispatch", "[proxy]") {
   std::vector<proxy_view<gunslinger>> gang{l, r};
 
   std::string roll_call;
-  // Mutable references: "fire" no longer dispatches through a const view.
+  // Mutable references. The "fire" method no longer dispatches through a const
+  // view.
   for (auto& pv : gang) {
     pv.call<"fire">(2);
     roll_call += pv.call<"describe">();
@@ -457,7 +462,7 @@ TEST_CASE("Heterogeneous dispatch", "[proxy]") {
   CHECK(l.rounds_fired == 2);
   CHECK(r.fired == 2);
 
-  // Copies are shallow: both views alias the same target.
+  // Copies are shallow, so both views alias the same target.
   auto pv2 = gang[0];
   pv2.call<"fire">(1);
   CHECK(l.rounds_fired == 3);
@@ -475,7 +480,7 @@ TEST_CASE("Views rebind by assignment", "[proxy]") {
 }
 
 TEST_CASE("Const view", "[proxy]") {
-  // A const target binds directly; only const methods exist on this view.
+  // A const target binds directly. Only const methods exist on this view.
   const lawman cl{};
   const_proxy_view<gunslinger> cv{cl};
   CHECK(cv.call<"describe">() == "lawman"s);
@@ -493,7 +498,7 @@ TEST_CASE("Const view", "[proxy]") {
   cv = cv2;
   CHECK(cv.call<"describe">() == "lawman"s);
 
-  // All-const facades keep the invariant: generic code constrained on the
+  // All-const facades keep the invariant. Generic code constrained on the
   // facade accepts the concrete const target and the const view alike.
   auto describe_it = [](const Proxiable<census> auto& t) {
     const_proxy_view<census> v{t};
@@ -505,7 +510,7 @@ TEST_CASE("Const view", "[proxy]") {
 }
 
 TEST_CASE("Generic code accepts concrete and erased alike", "[proxy]") {
-  // Facade-constrained generic code: erase, then call. `Proxiable` is the
+  // Facade-constrained generic code. Erase, then call. `Proxiable` is the
   // trait bound for the static-dispatch half.
   auto fire_twice = [](Proxiable<gunslinger> auto& g) {
     auto pv = make_proxy_view<gunslinger>(g);
@@ -566,14 +571,15 @@ TEST_CASE("Owning proxy, heap target", "[proxy]") {
     CHECK(stats.constructed == 1);
     CHECK(p.call<"add">(7) == 7);
 
-    // Heap targets move by pointer steal: no target activity at all.
+    // Heap targets move by pointer steal, so there's no target activity at
+    // all.
     auto q = std::move(p);
     CHECK(stats.moves == 0);
     CHECK(stats.constructed == 1);
     CHECK(stats.destroyed == 0);
     CHECK(q.call<"gold">() == 7);
 
-    // Move assignment over a live target destroys the old target first.
+    // Move assignment over a live target destroys the old target.
     q = make_proxy<lockbox, big_box>(stats);
     CHECK(stats.constructed == 2);
     CHECK(stats.destroyed == 1);
@@ -583,7 +589,7 @@ TEST_CASE("Owning proxy, heap target", "[proxy]") {
 }
 
 TEST_CASE("Owning proxy is deep-const", "[proxy]") {
-  // Only const-qualified facade methods dispatch through a const proxy; the
+  // Only const-qualified facade methods dispatch through a const proxy. The
   // negative half is covered by the `CanFire` static_asserts above.
   const auto p = make_proxy<gunslinger, lawman>();
   CHECK(p.call<"describe">() == "lawman"s);

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -636,6 +636,107 @@ consteval auto corvid_proxy_spec(F*, photographer*) {
     return prox::make_proxy_spec<F, photographer, check>();
 }
 
+// `arsenal` exercises per-name overload sets within one facade: `issue`
+// overloads on arity, `aim` on argument type, and `count` is the const pair
+// (a mutable accessor and a read-only query sharing the name, like a
+// container's `front`).
+//
+// The bindings overload naturally: the boilerplate's `on`s share one
+// `method_key` and differ in the trailing parameters, or in the constness
+// of the target for the const pair. The `api` follows the standard member
+// idiom, with the const pair split across `this auto&&` and
+// `this const auto&` forwarders, so overload resolution picks the const
+// flavor for const handles exactly as it would for a real member pair. The
+// registration validates the `api` by default, pinning that `validate_api`
+// drives each overload independently.
+struct arsenal
+    : prox::facade<prox::name<"arsenal">,       //
+          prox::method<"issue", int(int)>,      //
+          prox::method<"issue", int()>,         //
+          prox::method<"aim", int(int)>,        //
+          prox::method<"aim", int(double)>,     //
+          prox::method<"count", int&()>,        //
+          prox::method<"count", int() const>> { //
+  struct api {
+    int issue(this auto&& self, int rifles) {
+      return self.template call<"issue">(rifles);
+    }
+    int issue(this auto&& self) { return self.template call<"issue">(); }
+    int aim(this auto&& self, int paces) {
+      return self.template call<"aim">(paces);
+    }
+    int aim(this auto&& self, double radians) {
+      return self.template call<"aim">(radians);
+    }
+    // The mutable accessor's forwarder repeats its call in a trailing
+    // requires-clause (the documented api caveat, load-bearing here): a
+    // `const_proxy_view` is a mutable object whose deep const lives in the
+    // type, so object constness alone would send it to this overload, and
+    // the constraint routes it to the const forwarder instead.
+    int& count(this auto&& self)
+    requires(requires {
+      { self.template call<"count">() } -> std::same_as<int&>;
+    })
+    {
+      return self.template call<"count">();
+    }
+    int count(this const auto& self) { return self.template call<"count">(); }
+  };
+  template<typename T>
+  struct boilerplate: proxy_impl_base {
+    static int on(method_key<"issue">, T& t, int rifles) {
+      return t.issue(rifles);
+    }
+    static int on(method_key<"issue">, T& t) { return t.issue(); }
+    static int on(method_key<"aim">, T& t, int paces) { return t.aim(paces); }
+    static int on(method_key<"aim">, T& t, double radians) {
+      return t.aim(radians);
+    }
+    static int& on(method_key<"count">, T& t) { return t.count(); }
+    static int on(method_key<"count">, const T& t) { return t.count(); }
+  };
+};
+
+// `armory` extends `arsenal`, inheriting the overload sets whole.
+struct armory
+    : prox::facade<prox::name<"armory">,  //
+          prox::extends<arsenal>,         //
+          prox::method<"lock", void()>> { //
+  struct api: arsenal::api {
+    void lock(this auto&& self) { self.template call<"lock">(); }
+  };
+  template<typename T>
+  struct boilerplate: proxy_impl_base {
+    static void on(method_key<"lock">, T& t) { t.lock(); }
+  };
+};
+
+// `quartermaster` conforms with naturally overloaded members, including the
+// const pair.
+struct quartermaster {
+  int issue(int rifles) { return stock_ -= rifles; }
+  int issue() { return issue(1); }
+  int aim(int paces) {
+    (void)this;
+    return paces;
+  }
+  int aim(double radians) {
+    (void)this;
+    return static_cast<int>(radians * 100);
+  }
+  int& count() { return stock_; }
+  [[nodiscard]] int count() const { return stock_; }
+  void lock() { ++locked_; }
+
+  int stock_{20};
+  int locked_{};
+};
+
+template<prox::InChainOf<armory> F>
+consteval auto corvid_proxy_spec(F*, quartermaster*) {
+  return prox::make_proxy_spec<F, quartermaster>();
+}
+
 // Lifetime accounting shared by the owning-proxy targets.
 struct life_stats {
   int constructed{};
@@ -936,13 +1037,15 @@ static_assert(!prox::Extends<marshal, marshal>);
 // to false"; the walk does not name the missing base facade. Redeclaring an
 // inherited name (`facade<extends<gunslinger>, method<"fire", int(int)>>`)
 // detonates at first use of the facade's machinery: "static assertion
-// failed ... 'no_chain_collision_against<...>()': a facade cannot declare a
-// method name twice or redeclare an inherited one", with the flattened slot
-// list, duplicate and declaring facades included, spelled out in the
-// requirement, followed by one follow-on "no type named 'vtable_t'" noise
-// error. (Before the rework, the same shape failed 'unique_method_names'
-// with "method names must be unique across the facade and its extends
-// bases".)
+// failed ... 'no_chain_collision_against<...>()': a method name may recur
+// within one facade only as overloads differing in arguments or constness,
+// and never across an extends chain", with the flattened slot list,
+// duplicate and declaring facades included, spelled out in the requirement,
+// followed by one follow-on "no type named 'vtable_t'" noise error. (Before
+// per-name overloads the message read "a facade cannot declare a method
+// name twice or redeclare an inherited one"; before the collision-rules
+// rework, the same shape failed 'unique_method_names' with "method names
+// must be unique across the facade and its extends bases".)
 static_assert(Proxiable<texas_ranger, gunslinger>);
 static_assert(Proxiable<texas_ranger, marshal>);
 static_assert(Proxiable<texas_ranger, ranger>);
@@ -1015,16 +1118,76 @@ static_assert(prox::validate_api<camera>());
 //
 // The unqualified core spelling is the same lazy error, via static_assert
 // rather than overload resolution, so it cannot be probed by a concept.
-// Diagnostic on record instead (clang 22, captured 2026-07-09):
-// `wc.call<"reload">()` fires "static assertion failed due to requirement
-// 'ndx != ...::ambiguous_v': ambiguous method name; qualify the key with
-// the facade name", followed by the accepted "tuple index out of bounds"
-// noise, matching the unknown-name case.
+// Diagnostic on record instead (clang 22, captured 2026-07-09, message
+// re-worded 2026-07-10 when per-name overloads made the qualify-the-key
+// advice insufficient on its own): `wc.call<"reload">()` fires "static
+// assertion failed due to requirement 'ndx != ...::ambiguous_v': ambiguous
+// method call; qualify the key with the facade name, or match one
+// overload's arguments exactly", followed by the accepted "tuple index out
+// of bounds" noise, matching the unknown-name case.
 template<typename P>
 concept CanReloadSugar = requires(P& p) { p.reload(); };
 static_assert(CanReloadSugar<proxy_view<gunslinger>>);
 static_assert(CanReloadSugar<proxy_view<camera>>);
 static_assert(!CanReloadSugar<proxy_view<war_correspondent>>);
+
+// Per-name overload sets within one facade (`arsenal`). Legal when each
+// same-name pair differs in arguments or constness; overloading on the
+// result type or on `noexcept` alone stays a collision, and redeclaring an
+// inherited name stays an error, whatever its signature (the chain rules
+// are untouched). Registration validates the overloaded `api` by default.
+//
+// Diagnostics on record (clang 22, captured 2026-07-10). A pair differing
+// only in the result type (`method<"x", int()>` plus `method<"x", long()>`)
+// detonates at first use of the facade's machinery: "static assertion
+// failed ... 'no_chain_collision_against<...>()': a method name may recur
+// within one facade only as overloads differing in arguments or constness,
+// and never across an extends chain", both slots spelled out in the
+// requirement, followed by the usual single "no type named 'vtable_t'"
+// noise error. A pair differing only in `noexcept` fires the same assert.
+static_assert(Proxiable<quartermaster, arsenal>);
+static_assert(Proxiable<quartermaster, armory>);
+static_assert(prox::validate_api<arsenal>());
+static_assert(prox::validate_api<armory>());
+
+// Self-conformance holds through overload sets: the library bindings
+// forward through qualified keys, which narrow the candidates to one
+// facade's and then resolve by arguments like any overloaded call.
+static_assert(Proxiable<proxy_view<arsenal>, arsenal>);
+static_assert(Proxiable<proxy_view<armory>, arsenal>);
+static_assert(Proxiable<proxy<armory>, arsenal>);
+
+// The const pair's result types pin the object-parameter preference: a
+// mutable handle resolves `count` to the mutable accessor, and const
+// handles to the read-only query.
+static_assert(std::same_as<
+    decltype(std::declval<proxy_view<arsenal>&>().call<"count">()), int&>);
+static_assert(std::same_as<
+    decltype(std::declval<const proxy_view<arsenal>&>().call<"count">()),
+    int>);
+static_assert(std::same_as<
+    decltype(std::declval<const_proxy_view<arsenal>&>().call<"count">()),
+    int>);
+
+// At the sugar level the forwarders are a plain C++ overload set, so an
+// argument both `aim`s can only convert to (a `long`) is a probeable
+// ambiguity; the unqualified core spelling is the same lazy error via
+// static_assert (diagnostic below). A `short` shows the documented
+// divergence: real overload resolution promotes it into the int forwarder,
+// while the core model's viable tier does not rank conversions (see
+// `resolve`), so `call<"aim">(short{})` is the ambiguity static_assert.
+//
+// Diagnostic on record (clang 22, captured 2026-07-10): `v.call<"aim">(1L)`
+// fires "static assertion failed due to requirement 'ndx !=
+// ...::ambiguous_v': ambiguous method call; qualify the key with the facade
+// name, or match one overload's arguments exactly", followed by the
+// accepted "tuple index out of bounds" noise.
+template<typename P, typename A>
+concept CanAimSugar = requires(P& p, A a) { p.aim(a); };
+static_assert(CanAimSugar<proxy_view<arsenal>, int>);
+static_assert(CanAimSugar<proxy_view<arsenal>, double>);
+static_assert(CanAimSugar<proxy_view<arsenal>, short>);
+static_assert(!CanAimSugar<proxy_view<arsenal>, long>);
 
 // Handles of a derived facade satisfy the base facade too (Rust: a `dyn
 // Derived` meets a `Base` bound).
@@ -1637,6 +1800,45 @@ TEST_CASE("Sibling method collisions", "[proxy]") {
   gun.reload();
   CHECK(ph.rounds_fired == 0);
   CHECK(ph.film_wound == 2);
+}
+
+TEST_CASE("Per-name overloads", "[proxy]") {
+  quartermaster q;
+  proxy_view<arsenal> v = q;
+
+  // Arity overloads resolve by argument count, through the sugar and the
+  // core spelling alike.
+  CHECK(v.issue(2) == 18);
+  CHECK(v.issue() == 17);
+  CHECK(v.call<"issue">(2) == 15);
+  CHECK(v.call<"issue">() == 14);
+
+  // Type overloads resolve by exact argument match.
+  CHECK(v.aim(3) == 3);
+  CHECK(v.aim(0.5) == 50);
+  CHECK(v.call<"aim">(7) == 7);
+  CHECK(v.call<"aim">(0.25) == 25);
+
+  // The const pair: a mutable handle prefers the non-const member, so the
+  // accessor writes through; const handles dispatch the read-only query.
+  v.count() = 30;
+  CHECK(q.stock_ == 30);
+  CHECK(std::as_const(v).count() == 30);
+  const_proxy_view<arsenal> cv = v;
+  CHECK(cv.count() == 30);
+
+  // The overload sets survive extends flattening and the qualified
+  // spelling, on owning and shared handles alike.
+  auto p = make_proxy<armory, quartermaster>();
+  CHECK(p.issue(4) == 16);
+  p.count() = 8;
+  CHECK(std::as_const(p).count() == 8);
+  CHECK(p.call<"arsenal::issue">() == 7);
+  p.lock();
+
+  auto sp = make_shared_proxy<arsenal, quartermaster>();
+  CHECK(sp.issue() == 19);
+  CHECK(sp.count() == 19);
 }
 
 TEST_CASE("Diamond composition", "[proxy]") {

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -941,6 +941,29 @@ consteval auto corvid_proxy_spec(F*, coffer<Pad>*) {
   return prox::make_proxy_spec<F, coffer<Pad>>();
 }
 
+// `tin` conforms to `lockbox` and registers for it alone, pinning that
+// conformance to a base does not leak upward into `vault`, the aggregation
+// level above it, whose method list adds nothing to check.
+struct tin {
+  int add(int nuggets) { return gold_ += nuggets; }
+  [[nodiscard]] int gold() const { return gold_; }
+
+  int gold_{};
+};
+
+consteval auto corvid_proxy_spec(lockbox*, tin*) {
+  return prox::make_proxy_spec<lockbox, tin>();
+}
+
+// `keepsake` is a name-only marker facade: no methods, so binding-existence
+// is vacuously true for every type, and conformance rides on registration
+// alone.
+struct keepsake: prox::facade<prox::name<"keepsake">> {};
+
+consteval auto corvid_proxy_spec(keepsake*, tin*) {
+  return prox::make_proxy_spec<keepsake, tin>();
+}
+
 // One size fits the inline buffer exactly, the other forces the heap path.
 using small_box = strongbox<4>;
 using big_box = strongbox<64>;
@@ -988,6 +1011,22 @@ static_assert(std::same_as<decltype(prox::proxy_spec_v<gunslinger, lawman>),
 static_assert(!prox::ProxyRegistered<gunslinger, drifter>);
 static_assert(!prox::ProxyRegistered<hair_trigger, drifter>);
 static_assert(!Proxiable<drifter, gunslinger>);
+
+// Conformance requires the pair's own opt-in even when the facade adds no
+// methods for bindings to prove it. `tin` conforms to `lockbox` but never
+// registered for `vault`, so the aggregation level does not come along for
+// free; `keepsake` has no methods at all and conforms exactly where
+// registered. Handles stay self-conformant with no registration, including
+// at the aggregation level.
+static_assert(Proxiable<tin, lockbox>);
+static_assert(!prox::ProxyRegistered<vault, tin>);
+static_assert(!Proxiable<tin, vault>);
+static_assert(Proxiable<small_box, vault>); // the chain hook covers vault
+static_assert(Proxiable<tin, keepsake>);
+static_assert(!Proxiable<small_box, keepsake>);
+static_assert(!Proxiable<int, keepsake>);
+static_assert(Proxiable<proxy_view<vault>, lockbox>);
+static_assert(Proxiable<proxy_view<vault>, vault>);
 
 // Conformance. Boilerplate or carried impl, always via registration;
 // matching names alone are NOT enough.

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -302,6 +302,36 @@ consteval auto corvid_proxy_spec(hair_trigger*, robber*) {
   return prox::make_proxy_spec<hair_trigger, robber, as_hair_trigger>();
 }
 
+// `drifter` conforms to `gunslinger` by name, but its hooks return specs
+// naming the wrong pair, one the wrong target and one the wrong facade.
+// Neither counts as registration: the spec must name the pair the hook is
+// keyed on, so a copy-paste slip blocks conformance instead of silently
+// registering.
+struct drifter {
+  int fire(int rounds) {
+    (void)this;
+    return rounds;
+  }
+  [[nodiscard]] std::string describe() const {
+    (void)this;
+    return "drifter";
+  }
+  void reload() {}
+  int& shots() { return count; }
+
+  int count{};
+};
+
+consteval auto corvid_proxy_spec(gunslinger*, drifter*) {
+  // Wrong target: the spec names cowboy.
+  return prox::make_proxy_spec<gunslinger, cowboy>();
+}
+
+consteval auto corvid_proxy_spec(hair_trigger*, drifter*) {
+  // Wrong facade: the spec names gunslinger.
+  return prox::make_proxy_spec<gunslinger, drifter>();
+}
+
 // `mortar` is a facade whose `api` deliberately deviates from the method list:
 // the forwarder widens the parameter as a convenience, which registration-time
 // validation would reject. Its registrations opt out with `api_check::off`.
@@ -952,6 +982,12 @@ static_assert(prox::ProxyRegistered<gunslinger, sheriff>);
 static_assert(!prox::ProxyRegistered<gunslinger, cowboy>);
 static_assert(std::same_as<decltype(prox::proxy_spec_v<gunslinger, lawman>),
     const prox::proxy_spec<gunslinger, lawman>>);
+
+// A hook whose spec names a different pair is not a registration for the
+// pair the hook is keyed on, despite drifter's names lining up.
+static_assert(!prox::ProxyRegistered<gunslinger, drifter>);
+static_assert(!prox::ProxyRegistered<hair_trigger, drifter>);
+static_assert(!Proxiable<drifter, gunslinger>);
 
 // Conformance. Boilerplate or carried impl, always via registration;
 // matching names alone are NOT enough.

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -50,7 +50,7 @@ using namespace corvid::meta::prox::literals;
 // automatically from the facade method list. For now, let your AI do it for
 // you.
 struct gunslinger
-    : prox::facade<                                      //
+    : prox::facade<prox::name<"gunslinger">,             //
           prox::method<"fire", int(int)>,                //
           prox::method<"describe", std::string() const>, //
           prox::method<"reload", void()>,                //
@@ -246,8 +246,12 @@ struct cowboy {
 // The `api` forwarders are marked `noexcept` so the sugar carries the
 // qualifier the way `call` does. This is on the facade author; nothing checks
 // the forwarders against the method flavors.
+//
+// The boilerplate's bindings are marked noexcept, as conformance requires. The
+// targets' own methods need not be noexcept; the binding is the terminate
+// boundary.
 struct hair_trigger
-    : prox::facade<                                //
+    : prox::facade<prox::name<"hair_trigger">,     //
           prox::method<"fire", int(int) noexcept>, //
           prox::method<"jams", bool() const noexcept>> {
   struct api {
@@ -258,10 +262,6 @@ struct hair_trigger
       return self.template call<"jams">();
     }
   };
-
-  // The boilerplate's bindings are marked noexcept, as conformance requires.
-  // The targets' own methods need not be noexcept; the binding is the
-  // terminate boundary.
   template<typename T>
   struct boilerplate: prox_impl {
     static int on(method_key<"fire">, T& t, int rounds) noexcept {
@@ -294,13 +294,14 @@ consteval auto corvid_proxy_spec(hair_trigger*, robber*) {
 // `mortar` is a facade whose `api` deliberately deviates from the method list:
 // the forwarder widens the parameter as a convenience, which registration-time
 // validation would reject. Its registrations opt out with `api_check::off`.
-struct mortar: prox::facade<prox::method<"lob", int(int)>> {
+struct mortar
+    : prox::facade<prox::name<"mortar">, //
+          prox::method<"lob", int(int)>> {
   struct api {
     int lob(this auto&& self, long long shells) {
       return self.template call<"lob">(shells);
     }
   };
-
   template<typename T>
   struct boilerplate: prox_impl {
     static int on(method_key<"lob">, T& t, int shells) {
@@ -322,16 +323,17 @@ consteval auto corvid_proxy_spec(mortar*, howitzer*) {
 }
 
 // `marshal` is a composed facade, effectively inheriting from `gunslinger` by
-// extending it with an arrest method (Rust supertrait). Its `api` inherits the
-// base facade's, adding only the new forwarder; deducing `this` sees the
-// complete handle either way, so the inherited forwarders dispatch through the
-// derived handle's flattened table.
+// extending it with an arrest method (Rust supertrait).
+//
+// Its `api` inherits the base facade's, adding only the new forwarder;
+// deducing `this` sees the complete handle either way, so the inherited
+// forwarders dispatch through the derived handle's flattened table.
 //
 // The boilerplate covers only the facade's own methods. The inherited
 // `gunslinger` methods bind through `proxy_impl<gunslinger, T>`, which is
 // what keeps an upcast view and a directly-built one identical.
 struct marshal
-    : prox::facade<                            //
+    : prox::facade<prox::name<"marshal">,      //
           prox::extends<gunslinger>,           //
           prox::method<"arrest", bool(int)>> { //
   struct api: gunslinger::api {
@@ -350,7 +352,7 @@ struct marshal
 // `ranger` is a second composition level: `gunslinger` -> `marshal` ->
 // `ranger`.
 struct ranger
-    : prox::facade<                             //
+    : prox::facade<prox::name<"ranger">,        //
           prox::extends<marshal>,               //
           prox::method<"track", int() const>> { //
   struct api: marshal::api {
@@ -383,9 +385,10 @@ struct texas_ranger {
 };
 
 // One chain hook registers `texas_ranger` for `ranger` and every facade it
-// extends. The bindings stay per facade (each inherited method still binds
-// through its declaring facade's impl); the hook only collapses the opt-in
-// ceremony.
+// extends.
+//
+// The bindings stay per facade (each inherited method still binds through its
+// declaring facade's impl); the hook only collapses the opt-in ceremony.
 template<prox::InChainOf<ranger> F>
 consteval auto corvid_proxy_spec(F*, texas_ranger*) {
   return prox::make_proxy_spec<F, texas_ranger>();
@@ -418,9 +421,11 @@ consteval auto corvid_proxy_spec(F*, constable*) {
 }
 
 // A `vigilante` is `gunslinger`-shaped, but deliberately registered for
-// `marshal` alone (a plain per-facade hook rather than a chain one): an
-// incomplete registration, so this must NOT be proxiable as a marshal at all,
-// and the failure is loud at first use. Pins the per-facade conformance rule.
+// `marshal` alone (a plain per-facade hook rather than a chain one).
+//
+// This is an incomplete registration, so it must NOT be proxiable as a marshal
+// at all, and the failure is loud at first use. Pins the per-facade
+// conformance rule. That's what you get for breaking the law: error messages.
 struct vigilante {
   int fire(int rounds) { return rounds_fired += rounds; }
   [[nodiscard]] std::string describe() const {
@@ -441,6 +446,183 @@ struct vigilante {
 // technique, as `constable` does.
 consteval auto corvid_proxy_spec(marshal*, vigilante*) {
   return prox::make_proxy_spec<marshal, vigilante>();
+}
+
+// `bounty_hunter` is a sibling of `marshal`: a second facade extending
+// `gunslinger`, setting up the diamond below.
+struct bounty_hunter
+    : prox::facade<prox::name<"bounty_hunter">, //
+          prox::extends<gunslinger>,            //
+          prox::method<"claim", int(int)>> {    //
+  struct api: gunslinger::api {
+    int claim(this auto&& self, int bounties) {
+      return self.template call<"claim">(bounties);
+    }
+  };
+  template<typename T>
+  struct boilerplate: prox_impl {
+    static int on(method_key<"claim">, T& t, int bounties) {
+      return t.claim(bounties);
+    }
+  };
+};
+
+// `posse_leader` is a diamond: it extends `marshal` and `bounty_hunter`,
+// which both extend `gunslinger`.
+//
+// Flattening dedups the shared ancestor by facade identity, so `gunslinger`'s
+// methods occupy one slot each and both upcast paths reach the same base
+// table; there is no ambiguity to resolve, because conformance is per facade
+// and only one `proxy_impl<gunslinger, T>` exists no matter the path (unlike a
+// C++ non-virtual diamond, which has duplicated subobjects).
+//
+// The `api` diamond does need the facade author's help: both base `api`s
+// inherit `gunslinger::api`, so the shared ancestor's forwarder names are
+// ambiguous by ordinary C++ member lookup until a using-declaration pulls in
+// one path. One line per shared-ancestor method, through either base.
+struct posse_leader
+    : prox::facade<prox::name<"posse_leader">, //
+          prox::extends<marshal>,              //
+          prox::extends<bounty_hunter>,        //
+          prox::method<"rally", void()>> {     //
+  struct api: marshal::api, bounty_hunter::api {
+    using marshal::api::fire, marshal::api::describe, marshal::api::reload,
+        marshal::api::shots;
+    void rally(this auto&& self) { self.template call<"rally">(); }
+  };
+  template<typename T>
+  struct boilerplate: prox_impl {
+    static void on(method_key<"rally">, T& t) { t.rally(); }
+  };
+};
+
+// `trail_boss` conforms to the whole diamond, registered by one chain hook.
+struct trail_boss {
+  int fire(int rounds) { return rounds_fired += rounds; }
+  [[nodiscard]] std::string describe() const {
+    (void)this;
+    return "trail_boss";
+  }
+  void reload() { rounds_fired = 0; }
+  int& shots() { return rounds_fired; }
+  bool arrest(int outlaws) {
+    arrested += outlaws;
+    return true;
+  }
+  int claim(int bounties) { return claimed += bounties; }
+  void rally() { ++rallies; }
+
+  int rounds_fired{};
+  int arrested{};
+  int claimed{};
+  int rallies{};
+};
+
+template<prox::InChainOf<posse_leader> F>
+consteval auto corvid_proxy_spec(F*, trail_boss*) {
+  return prox::make_proxy_spec<F, trail_boss>();
+}
+
+// `camera` is an unrelated facade that deliberately collides with
+// `gunslinger` on two method names: `fire`, with a different signature (an
+// overload set once composed), and `reload`, with the same signature
+// (reachable only through the qualified key or an upcast, once composed).
+struct camera
+    : prox::facade<prox::name<"camera">,             //
+          prox::method<"fire", std::string() const>, //
+          prox::method<"reload", void()>> {          //
+  struct api {
+    std::string fire(this const auto& self) {
+      return self.template call<"fire">();
+    }
+    void reload(this auto&& self) { self.template call<"reload">(); }
+  };
+  template<typename T>
+  struct boilerplate: prox_impl {
+    static std::string on(method_key<"fire">, const T& t) { return t.fire(); }
+    static void on(method_key<"reload">, T& t) { t.reload(); }
+  };
+};
+
+// `war_correspondent` composes the colliding siblings.
+//
+// The `api` convention for a collision is one using-declaration per base,
+// because C++ member lookup finds sibling-base names ambiguous before overload
+// resolution ever runs.
+//
+// For `fire`, whose signatures differ, the using-declarations merge the
+// forwarders into a working overload set;. For `reload`, whose signatures
+// match, the merged set is ambiguous at any unqualified call, lazily, which is
+// the pinned model: the qualified key or an upcast disambiguates. There's no
+// point injecting either `reload` with using declarations.
+//
+// The same-signature collision also makes the natural-name spelling
+// ambiguous inside the validation probe, so this facade's registrations
+// pass `api_check::off`; the base levels still validate normally.
+struct war_correspondent
+    : prox::facade<prox::name<"correspondent">, //
+          prox::extends<gunslinger>,            //
+          prox::extends<camera>,                //
+          prox::method<"byline", std::string() const>> {
+  struct api: gunslinger::api, camera::api {
+    using gunslinger::api::fire, camera::api::fire;
+    std::string byline(this const auto& self) {
+      return self.template call<"byline">();
+    }
+  };
+  template<typename T>
+  struct boilerplate: prox_impl {
+    static std::string on(method_key<"byline">, const T& t) {
+      return t.byline();
+    }
+  };
+};
+
+// `photographer` conforms to the whole composition.
+//
+//  One class serves both `fire` methods with an ordinary member overload set,
+//  while the same-name same-signature `reload` collision demonstrates
+//  per-facade bindings: the gunslinger level reloads the gun through the
+//  boilerplate, and the camera level carries an impl that winds the film
+//  instead.
+struct photographer {
+  int fire(int rounds) { return rounds_fired += rounds; }
+  [[nodiscard]] std::string fire() const {
+    (void)this;
+    return "click";
+  }
+  [[nodiscard]] std::string describe() const {
+    (void)this;
+    return "photographer";
+  }
+  void reload() { rounds_fired = 0; }
+  int& shots() { return rounds_fired; }
+  void wind() { ++film_wound; }
+  [[nodiscard]] std::string byline() const {
+    (void)this;
+    return "photo credit";
+  }
+
+  int rounds_fired{};
+  int film_wound{};
+};
+
+// One chain hook covers the composition, varying by level: the camera level
+// carries the film-winding impl, the composed level opts out of api
+// validation (see the facade comment), and the rest ride the boilerplates.
+template<prox::InChainOf<war_correspondent> F>
+consteval auto corvid_proxy_spec(F*, photographer*) {
+  if constexpr (std::same_as<F, camera>) {
+    struct as_camera: camera::boilerplate<photographer> {
+      using camera::boilerplate<photographer>::on;
+      static void on(method_key<"reload">, photographer& p) { p.wind(); }
+    };
+    return prox::make_proxy_spec<F, photographer, as_camera>();
+  } else if constexpr (std::same_as<F, war_correspondent>) {
+    return prox::make_proxy_spec<F, photographer, prox::api_check::off>();
+  } else {
+    return prox::make_proxy_spec<F, photographer>();
+  }
 }
 
 // Lifetime accounting shared by the owning-proxy targets.
@@ -479,8 +661,8 @@ struct strongbox {
 // The facade for the lifetime tests. For testing purposes, we're not providing
 // an `api`, or including the `boilerplate` inside the facade.
 struct lockbox
-    : prox::facade<                      //
-          prox::method<"add", int(int)>, //
+    : prox::facade<prox::name<"lockbox">, //
+          prox::method<"add", int(int)>,  //
           prox::method<"gold", int() const>> {};
 
 // Boilerplate impl for `lockbox`, in the namespace-scope spelling: a
@@ -615,6 +797,18 @@ concept CanFire = requires(P& p) { p.template call<"fire">(1); };
 template<typename P>
 concept CanDescribe = requires(P& p) { p.template call<"describe">(); };
 
+// Qualified keys resolve through the same machinery, so they obey the same
+// deep-const gating, including through a derived facade's handle.
+template<typename P>
+concept CanFireQualified = requires(P& p) {
+  p.template call<"gunslinger::fire">(1);
+};
+
+static_assert(CanFireQualified<proxy_view<gunslinger>>);
+static_assert(!CanFireQualified<const proxy_view<gunslinger>>);
+static_assert(CanFireQualified<proxy_view<ranger>>);
+static_assert(CanFireQualified<proxy<gunslinger>>);
+
 static_assert(CanFire<proxy<gunslinger>>);
 static_assert(!CanFire<const proxy<gunslinger>>);
 static_assert(CanDescribe<const proxy<gunslinger>>);
@@ -635,11 +829,14 @@ static_assert(
     std::constructible_from<const_proxy_view<gunslinger>, const lawman&>);
 static_assert(!std::constructible_from<proxy_view<gunslinger>, const lawman&>);
 
-// `census` is an all-const facade. This is the only case where a const view
-// satisfies the invariant for the facade as a whole. A mixed facade correctly
-// fails it (the mutable methods are not dispatchable, so conformance is
-// impossible; Rust's `&dyn` analog).
-struct census: prox::facade<prox::method<"describe", std::string() const>> {};
+// `census` is an all-const facade.
+//
+// This is the only case where a const view satisfies the invariant for the
+// facade as a whole. A mixed facade correctly fails it (the mutable methods
+// are not dispatchable, so conformance is impossible; Rust's `&dyn` analog).
+struct census
+    : prox::facade<prox::name<"census">,
+          prox::method<"describe", std::string() const>> {};
 
 // Conformance here is a one-off carried impl: `census` exists only to serve
 // the const-view assertions, so it defines no boilerplate at all.
@@ -669,17 +866,21 @@ static_assert(!prox::Extends<marshal, marshal>);
 // alone is not enough (Rust's separate `impl Base for T`), and conforming to
 // the base says nothing about the derived facade.
 //
-// Diagnostics on record (clang 22, captured 2026-07-08). Constructing
+// Diagnostics on record (clang 22, captured 2026-07-08, detonator halves
+// re-captured 2026-07-09 after the collision-rules rework). Constructing
 // `proxy_view<marshal>` from `vigilante` emits one error with the same
 // constraint walk as the `cowboy` case, ending at
 // 'details::vtbuild_t<marshal>::all_bound_v<marshal, vigilante>' evaluated
 // to false"; the walk does not name the missing base facade. Redeclaring an
 // inherited name (`facade<extends<gunslinger>, method<"fire", int(int)>>`)
-// detonates at first use of the facade's machinery: "static assertion failed
-// ... 'unique_method_names<...>()': method names must be unique across the
-// facade and its extends bases", with the flattened list, duplicate
-// included, spelled out in the requirement, followed by one follow-on
-// "no type named 'vtable_t'" noise error.
+// detonates at first use of the facade's machinery: "static assertion
+// failed ... 'no_chain_collision_against<...>()': a facade cannot declare a
+// method name twice or redeclare an inherited one", with the flattened slot
+// list, duplicate and declaring facades included, spelled out in the
+// requirement, followed by one follow-on "no type named 'vtable_t'" noise
+// error. (Before the rework, the same shape failed 'unique_method_names'
+// with "method names must be unique across the facade and its extends
+// bases".)
 static_assert(Proxiable<texas_ranger, gunslinger>);
 static_assert(Proxiable<texas_ranger, marshal>);
 static_assert(Proxiable<texas_ranger, ranger>);
@@ -701,6 +902,68 @@ static_assert(!prox::ProxyRegistered<ranger, constable>);
 static_assert(Proxiable<constable, marshal>);
 static_assert(Proxiable<constable, gunslinger>);
 static_assert(!Proxiable<constable, ranger>);
+
+// Diamond composition. The shared ancestor's methods flatten to one slot
+// each (dedup by facade identity), so the diamond is legal, `Extends` holds
+// through both paths, and the whole shape validates. Before dedup, this
+// detonated on the duplicate-name check.
+static_assert(prox::Extends<posse_leader, marshal>);
+static_assert(prox::Extends<posse_leader, bounty_hunter>);
+static_assert(prox::Extends<posse_leader, gunslinger>);
+static_assert(Proxiable<trail_boss, posse_leader>);
+static_assert(Proxiable<trail_boss, marshal>);
+static_assert(Proxiable<trail_boss, bounty_hunter>);
+static_assert(Proxiable<trail_boss, gunslinger>);
+static_assert(prox::validate_api<posse_leader>());
+
+// The `api` diamond has one honest cost: the two empty `gunslinger::api`
+// subobjects are the same type, so the ABI must give them distinct
+// addresses, and the handle picks up a padding word that empty-base
+// optimization cannot remove. An author who cares can avoid it by
+// inheriting one path only and redeclaring the other base's own forwarders.
+static_assert(sizeof(proxy_view<posse_leader>) == 3 * sizeof(void*));
+
+// Sibling collisions. The composition is legal outright (every facade
+// carries a name, so the qualified spelling is always available),
+// conformance stays per facade (including the deliberately different
+// `reload` bindings), and the base levels still validate their own `api`s.
+//
+// Diagnostics on record (clang 22, captured 2026-07-09). Omitting the
+// `name` entry from a facade detonates at first use of its machinery, as a
+// single clean error with the fold spelled out over the entries: "static
+// assertion failed due to requirement '0 + entry_name<method<...>,
+// ...>::is_name_v == 1': every facade must carry exactly one name entry".
+// Composing two facades whose name<> entries match (`copycat` claiming
+// name<"gunslinger">) detonates even without a method collision:
+// "static assertion failed ... 'owner_names_unique_against<...>()': facade
+// names must be unique within a composition", spelling the slot list, with
+// declaring facades, in the requirement, followed by the usual single "no
+// type named 'vtable_t'" noise error.
+static_assert(prox::Extends<war_correspondent, gunslinger>);
+static_assert(prox::Extends<war_correspondent, camera>);
+static_assert(Proxiable<photographer, war_correspondent>);
+static_assert(Proxiable<photographer, camera>);
+static_assert(Proxiable<photographer, gunslinger>);
+static_assert(prox::SpecCarriesImpl<camera, photographer>);
+static_assert(!prox::SpecCarriesImpl<gunslinger, photographer>);
+static_assert(prox::validate_api<camera>());
+
+// The same-signature collision is a lazy call-site error through the sugar:
+// the merged `reload` forwarders are an ambiguous overload set on the
+// composed handle, while each base handle keeps its own working forwarder.
+//
+// The unqualified core spelling is the same lazy error, via static_assert
+// rather than overload resolution, so it cannot be probed by a concept.
+// Diagnostic on record instead (clang 22, captured 2026-07-09):
+// `wc.call<"reload">()` fires "static assertion failed due to requirement
+// 'ndx != ...::ambiguous_v': ambiguous method name; qualify the key with
+// the facade name", followed by the accepted "tuple index out of bounds"
+// noise, matching the unknown-name case.
+template<typename P>
+concept CanReloadSugar = requires(P& p) { p.reload(); };
+static_assert(CanReloadSugar<proxy_view<gunslinger>>);
+static_assert(CanReloadSugar<proxy_view<camera>>);
+static_assert(!CanReloadSugar<proxy_view<war_correspondent>>);
 
 // Handles of a derived facade satisfy the base facade too (Rust: a `dyn
 // Derived` meets a `Base` bound).
@@ -1073,6 +1336,55 @@ TEST_CASE("Member-call sugar via the api mixin", "[proxy]") {
   CHECK(mv.lob(3) == 3);
 }
 
+TEST_CASE("Facade-qualified method keys", "[proxy]") {
+  lawman l;
+  proxy_view<gunslinger> pv{l};
+  int n{};
+
+  // A named facade's methods answer to their qualified spelling as well as
+  // the plain one: same slot, same dispatch table, interchangeable.
+  CHECK(pv.call<"gunslinger::fire">(3) == (n += 3));
+  CHECK(pv.call<"fire">(3) == (n += 3));
+  CHECK(pv.fire(3) == (n += 3));
+  CHECK(pv.call<"gunslinger::describe">() == "lawman"s);
+  CHECK(pv.call<"describe">() == "lawman"s);
+  CHECK(pv.describe() == "lawman"s);
+  pv.call<"gunslinger::reload">();
+  pv.call<"reload">();
+  pv.reload();
+  CHECK(l.rounds_fired == 0);
+
+  // Every method keeps its declaring facade's qualifier through a derived
+  // handle: each level of the chain contributes its own prefix.
+  texas_ranger tr;
+  proxy_view<ranger> rv{tr};
+  n = 0;
+  CHECK(rv.call<"gunslinger::fire">(2) == (n += 2));
+  CHECK(rv.call<"fire">(2) == (n += 2));
+  CHECK(rv.fire(2) == (n += 2));
+  CHECK(rv.call<"gunslinger::describe">() == "texas_ranger"s);
+  CHECK(rv.call<"describe">() == "texas_ranger"s);
+  CHECK(rv.describe() == "texas_ranger"s);
+  CHECK(rv.call<"marshal::arrest">(1));
+  CHECK(rv.call<"arrest">(1));
+  CHECK(rv.arrest(1));
+  CHECK(rv.call<"ranger::track">() == 3);
+  CHECK(rv.call<"track">() == 3);
+  CHECK(rv.track() == 3);
+
+  // Qualified keys through the const view and the owning proxy.
+  const lawman cl{};
+  const_proxy_view<gunslinger> cv{cl};
+  CHECK(cv.call<"gunslinger::describe">() == "lawman"s);
+  CHECK(cv.call<"describe">() == "lawman"s);
+  CHECK(cv.describe() == "lawman"s);
+  auto p = make_proxy<gunslinger, robber>();
+  n = 0;
+  CHECK(p.call<"gunslinger::fire">(6) == (n += 6));
+  CHECK(p.call<"fire">(6) == (n += 6));
+  CHECK(p.fire(6) == (n += 6));
+}
+
 TEST_CASE("Facade composition", "[proxy]") {
   texas_ranger tr;
   proxy_view<marshal> mv{tr};
@@ -1109,6 +1421,84 @@ TEST_CASE("Facade composition", "[proxy]") {
   CHECK(c.arrested == 2);
   proxy_view<gunslinger> cgv = cmv;
   CHECK(cgv.describe() == "constable"s);
+}
+
+TEST_CASE("Sibling method collisions", "[proxy]") {
+  photographer ph;
+  proxy_view<war_correspondent> wc{ph};
+
+  // Different signatures merge into a working overload set, through the api
+  // sugar (one using-declaration per base) and through unqualified `call<>`
+  // alike: the arguments pick the slot, exactly as `using A::f; using
+  // B::f;` would in plain C++.
+  CHECK(wc.fire(3) == 3);
+  CHECK(wc.fire() == "click"s);
+  CHECK(wc.call<"fire">(2) == 5);
+  CHECK(wc.call<"fire">() == "click"s);
+
+  // The qualified spelling always works, collision or not.
+  CHECK(wc.call<"gunslinger::fire">(1) == 6);
+  CHECK(wc.call<"camera::fire">() == "click"s);
+  CHECK(wc.call<"correspondent::byline">() == "photo credit"s);
+
+  // The same-signature collision is reachable through qualified keys. The
+  // two slots carry genuinely different bindings for the same concrete
+  // type: the gun reloads at the gunslinger level, the film winds at the
+  // camera level. (The unqualified spellings are the pinned lazy call-site
+  // errors; the sugar half is the `CanReloadSugar` static_asserts.)
+  wc.call<"gunslinger::reload">();
+  CHECK(ph.rounds_fired == 0);
+  wc.call<"camera::reload">();
+  CHECK(ph.film_wound == 1);
+  // Note that `wc.reload();` would be ambigous and fail at compile time.
+  // In contrast, `ph.reload();` is unambiguous and works, because
+  // `photographer` uses that name for the `gunslinger` binding.
+
+  // An upcast handle sees only its own level's list, so each name is
+  // unambiguous again.
+  proxy_view<camera> cam = wc;
+  cam.reload();
+  CHECK(ph.film_wound == 2);
+  CHECK(cam.fire() == "click"s);
+  proxy_view<gunslinger> gun = wc;
+  gun.fire(4);
+  gun.reload();
+  CHECK(ph.rounds_fired == 0);
+  CHECK(ph.film_wound == 2);
+}
+
+TEST_CASE("Diamond composition", "[proxy]") {
+  trail_boss tb;
+  proxy_view<posse_leader> plv{tb};
+
+  // Every level dispatches through the flattened table: the shared
+  // ancestor's methods (one slot each), both mid-level facades', and the
+  // diamond's own.
+  CHECK(plv.fire(2) == 2);
+  CHECK(plv.describe() == "trail_boss"s);
+  CHECK(plv.arrest(1));
+  CHECK(plv.claim(3) == 3);
+  plv.rally();
+  CHECK(tb.rallies == 1);
+
+  // Upcasting to the shared ancestor through either mid-level path, or
+  // directly, lands on the same target and the same base table.
+  proxy_view<marshal> mv = plv;
+  proxy_view<bounty_hunter> bv = plv;
+  proxy_view<gunslinger> via_marshal = mv;
+  proxy_view<gunslinger> via_bounty = bv;
+  proxy_view<gunslinger> direct = plv;
+  CHECK(&via_marshal.shots() == &via_bounty.shots());
+  CHECK(&via_marshal.shots() == &direct.shots());
+  CHECK(via_bounty.fire(1) == 3);
+  CHECK(tb.rounds_fired == 3);
+
+  // An owning proxy of the diamond dispatches the whole shape too.
+  auto p = make_proxy<posse_leader, trail_boss>();
+  CHECK(p.fire(4) == 4);
+  CHECK(p.claim(2) == 2);
+  CHECK(p.arrest(1));
+  p.rally();
 }
 
 TEST_CASE("Upcasting views", "[proxy]") {

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -315,10 +315,10 @@ static_assert(prox::Proxiable<lawman, hair_trigger>);
 static_assert(!prox::Proxiable<robber, hair_trigger>);
 
 // The erased call carries the method's noexcept.
-static_assert(noexcept(
-    std::declval<const prox::proxy_view<hair_trigger>&>().call<"fire">(1)));
-static_assert(!noexcept(
-    std::declval<const prox::proxy_view<gunslinger>&>().call<"fire">(1)));
+static_assert(
+    noexcept(std::declval<prox::proxy_view<hair_trigger>&>().call<"fire">(1)));
+static_assert(
+    !noexcept(std::declval<prox::proxy_view<gunslinger>&>().call<"fire">(1)));
 
 // Both handles satisfy their own facade, including facades with noexcept
 // methods.
@@ -336,8 +336,8 @@ static_assert(std::assignable_from<prox::proxy_view<gunslinger>&,
 static_assert(!std::copy_constructible<prox::proxy<gunslinger>>);
 static_assert(std::movable<prox::proxy<gunslinger>>);
 
-// Deep const: non-const facade methods are not callable on a const proxy,
-// but const ones are. The view stays shallow-const. The probes go through a
+// Deep const: non-const facade methods are not callable on a const handle,
+// and never exist on a `const_proxy_view` at all. The probes go through a
 // concept so the negative case is a constraint failure rather than a hard
 // error (a requires-expression outside a template does not get SFINAE).
 template<typename P>
@@ -348,7 +348,39 @@ concept CanDescribe = requires(P& p) { p.template call<"describe">(); };
 static_assert(CanFire<prox::proxy<gunslinger>>);
 static_assert(!CanFire<const prox::proxy<gunslinger>>);
 static_assert(CanDescribe<const prox::proxy<gunslinger>>);
-static_assert(CanFire<const prox::proxy_view<gunslinger>>);
+static_assert(CanFire<prox::proxy_view<gunslinger>>);
+static_assert(!CanFire<const prox::proxy_view<gunslinger>>);
+static_assert(CanDescribe<const prox::proxy_view<gunslinger>>);
+static_assert(!CanFire<prox::const_proxy_view<gunslinger>>);
+static_assert(!CanFire<const prox::const_proxy_view<gunslinger>>);
+static_assert(CanDescribe<prox::const_proxy_view<gunslinger>>);
+
+// Const-view conversion rules: a target loses mutability implicitly, never
+// regains it. A const target binds only to the const view.
+static_assert(std::convertible_to<prox::proxy_view<gunslinger>,
+    prox::const_proxy_view<gunslinger>>);
+static_assert(!std::constructible_from<prox::proxy_view<gunslinger>,
+    prox::const_proxy_view<gunslinger>&>);
+static_assert(std::constructible_from<prox::const_proxy_view<gunslinger>,
+    const lawman&>);
+static_assert(
+    !std::constructible_from<prox::proxy_view<gunslinger>, const lawman&>);
+
+// An all-const facade is the one case where a const view satisfies the
+// invariant; a mixed facade correctly fails it (the mutable methods are not
+// dispatchable, so conformance is impossible; Rust's `&dyn` analog).
+struct census: prox::facade<prox::method<"describe", std::string() const>> {};
+
+template<>
+struct prox::proxy_impl<census, lawman> {
+  static std::string on(method_key<"describe">, const lawman& l) {
+    return l.describe();
+  }
+};
+
+static_assert(prox::Proxiable<prox::const_proxy_view<census>, census>);
+static_assert(
+    !prox::Proxiable<prox::const_proxy_view<gunslinger>, gunslinger>);
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
@@ -403,7 +435,8 @@ TEST_CASE("Heterogeneous dispatch", "[proxy]") {
   std::vector<prox::proxy_view<gunslinger>> gang{l, r};
 
   std::string roll_call;
-  for (const auto& pv : gang) {
+  // Mutable references: "fire" no longer dispatches through a const view.
+  for (auto& pv : gang) {
     pv.call<"fire">(2);
     roll_call += pv.call<"describe">();
     roll_call += ' ';
@@ -427,6 +460,36 @@ TEST_CASE("Views rebind by assignment", "[proxy]") {
   // Assignment rebinds both the target and the dispatch table.
   pv = prox::proxy_view<gunslinger>{r};
   CHECK(pv.call<"describe">() == "robber"s);
+}
+
+TEST_CASE("Const view", "[proxy]") {
+  // A const target binds directly; only const methods exist on this view.
+  const lawman cl{};
+  prox::const_proxy_view<gunslinger> cv{cl};
+  CHECK(cv.call<"describe">() == "lawman"s);
+
+  // A const instance of the mutable view enforces the same restriction.
+  lawman l;
+  const prox::proxy_view<gunslinger> cpv{l};
+  CHECK(cpv.call<"describe">() == "lawman"s);
+
+  // The mutable view converts implicitly, and const views rebind by
+  // assignment like any view.
+  prox::proxy_view<gunslinger> pv{l};
+  prox::const_proxy_view<gunslinger> cv2{pv};
+  CHECK(cv2.call<"describe">() == "lawman"s);
+  cv = cv2;
+  CHECK(cv.call<"describe">() == "lawman"s);
+
+  // All-const facades keep the invariant: generic code constrained on the
+  // facade accepts the concrete const target and the const view alike.
+  auto describe_it = [](const prox::Proxiable<census> auto& t) {
+    prox::const_proxy_view<census> v{t};
+    return v.template call<"describe">();
+  };
+  CHECK(describe_it(cl) == "lawman"s);
+  prox::const_proxy_view<census> census_view{cl};
+  CHECK(describe_it(census_view) == "lawman"s);
 }
 
 TEST_CASE("Generic code accepts concrete and erased alike", "[proxy]") {

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -30,12 +30,28 @@ using namespace corvid::meta::prox::literals;
 
 // The facade under test: mixes value returns, a const method, a void
 // mutator, and a reference return.
+//
+// The nested `api` is the optional member-call sugar: one deducing-this
+// forwarder per method, inherited by every handle of this facade. A const
+// method's forwarder takes `self` by const reference, mirroring the erased
+// signature.
 struct gunslinger
     : prox::facade<                                      //
           prox::method<"fire", int(int)>,                //
           prox::method<"describe", std::string() const>, //
           prox::method<"reload", void()>,                //
-          prox::method<"shots", int&()>> {};             //
+          prox::method<"shots", int&()>> {               //
+  struct api {
+    int fire(this auto&& self, int rounds) {
+      return self.template call<"fire">(rounds);
+    }
+    std::string describe(this const auto& self) {
+      return self.template call<"describe">();
+    }
+    void reload(this auto&& self) { self.template call<"reload">(); }
+    int& shots(this auto&& self) { return self.template call<"shots">(); }
+  };
+};
 
 // This base class for proxy_impl<gunslinger, T> would not normally be
 // necessary, but it's used for `sheriff`. It also wouldn't need
@@ -176,10 +192,23 @@ struct cowboy {
 
 // A facade with noexcept methods. Conformance requires the bindings
 // themselves to be noexcept.
+//
+// The api forwarders are marked `noexcept` so the sugar carries the qualifier
+// the way `call` does. This is on the facade author; nothing checks the
+// forwarders against the method flavors.
 struct hair_trigger
     : prox::facade<                                //
           prox::method<"fire", int(int) noexcept>, //
-          prox::method<"jams", bool() const noexcept>> {};
+          prox::method<"jams", bool() const noexcept>> {
+  struct api {
+    int fire(this auto&& self, int rounds) noexcept {
+      return self.template call<"fire">(rounds);
+    }
+    bool jams(this const auto& self) noexcept {
+      return self.template call<"jams">();
+    }
+  };
+};
 
 // Bindings marked noexcept: conforms. The target's own methods need not be
 // noexcept; the binding is the terminate boundary.
@@ -398,6 +427,16 @@ static_assert(
 static_assert(std::same_as<const_proxy_view<gunslinger>,
     prox::const_proxy_view<gunslinger>>);
 
+// The api mixin is stateless, so empty-base optimization keeps the views at
+// two pointers, with or without one (`lockbox` defines no `api`).
+static_assert(sizeof(proxy_view<gunslinger>) == 2 * sizeof(void*));
+static_assert(sizeof(const_proxy_view<gunslinger>) == 2 * sizeof(void*));
+static_assert(sizeof(proxy_view<lockbox>) == 2 * sizeof(void*));
+
+// The sugar carries `noexcept` when the facade author marks the forwarders.
+static_assert(noexcept(std::declval<proxy_view<hair_trigger>&>().fire(1)));
+static_assert(!noexcept(std::declval<proxy_view<gunslinger>&>().fire(1)));
+
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
 TEST_CASE("Boilerplate impl through registration", "[proxy]") {
@@ -607,6 +646,48 @@ TEST_CASE("Noexcept facade methods", "[proxy]") {
   const auto& cp = p;
   CHECK(!cp.call<"jams">());
   static_assert(noexcept(cp.call<"jams">()));
+}
+
+TEST_CASE("Member-call sugar via the api mixin", "[proxy]") {
+  lawman l;
+  proxy_view<gunslinger> pv{l};
+
+  // The forwarders are sugar over `call`: same slots, same dispatch table,
+  // interchangeable mid-stream.
+  CHECK(pv.fire(3) == 3);
+  CHECK(pv.call<"fire">(2) == 5);
+  CHECK(pv.describe() == "lawman"s);
+
+  // Reference return through the sugar.
+  pv.shots() = 42;
+  CHECK(l.rounds_fired == 42);
+  pv.reload();
+  CHECK(l.rounds_fired == 0);
+
+  // In a template context the sugar needs no dependent-name `template`
+  // keyword, unlike spelling `call` directly.
+  auto fire_once = [](Proxiable<gunslinger> auto& g) {
+    auto v = make_proxy_view<gunslinger>(g);
+    return v.fire(1);
+  };
+  CHECK(fire_once(l) == 1);
+
+  // The owning proxy inherits the same api. Deep const holds: only the
+  // const forwarder dispatches through a const proxy.
+  auto p = make_proxy<gunslinger, robber>();
+  CHECK(p.fire(6) == 6);
+  const auto& cp = p;
+  CHECK(cp.describe() == "robber"s);
+
+  // The const view exposes the const forwarders.
+  const lawman cl{};
+  const_proxy_view<gunslinger> cv{cl};
+  CHECK(cv.describe() == "lawman"s);
+
+  // Noexcept forwarders, propagation confirmed by the static_asserts above.
+  proxy_view<hair_trigger> ht{l};
+  CHECK(ht.fire(2) == 3);
+  CHECK(!ht.jams());
 }
 
 TEST_CASE("Heterogeneous ownership", "[proxy]") {

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -1153,6 +1153,17 @@ static_assert(!prox::Extends<marshal, marshal>);
 // or redeclare an inherited one"; before the collision-rules rework, the
 // same shape failed 'unique_method_names' with "method names must be
 // unique across the facade and its extends bases".)
+//
+// Listing the identical entry twice, whether a `method` or an `extends`,
+// detonates at first use of the facade's machinery (diagnostic on record,
+// clang 22, captured 2026-07-11): "static assertion failed ...
+// 'entry_listed_once<...>()': a facade may not list the identical method or
+// extends entry twice", with the duplicated entry spelled out in the
+// requirement and no follow-on noise. Dedup would otherwise collapse the
+// duplicate silently; a diamond's two DISTINCT `extends` entries sharing an
+// ancestor stay legal, as does an explicit re-extension alongside a path that
+// already covers it.
+//
 // A facade is never a value: the deleted default constructor on `facade`
 // propagates, so declaring a `gunslinger` where a handle over one was meant
 // fails at the declaration. Handles stay constructible as always.

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -25,6 +25,7 @@
 using namespace std::literals;
 using namespace corvid;
 using namespace corvid::meta::prox;
+using namespace corvid::meta::prox::literals;
 
 // The facade under test: mixes value returns, a const method, a void
 // mutator, and a reference return.
@@ -94,10 +95,14 @@ namespace corvid {
 template<typename T>
 requires ProxyRegistered<gunslinger, T>
 struct proxy_impl<gunslinger, T> {
-  static int on(key<"fire">, T& t, int rounds) { return t.fire(rounds); }
-  static std::string on(key<"describe">, const T& t) { return t.describe(); }
-  static void on(key<"reload">, T& t) { t.reload(); }
-  static int& on(key<"shots">, T& t) { return t.shots(); }
+  static int on(method_key<"fire">, T& t, int rounds) {
+    return t.fire(rounds);
+  }
+  static std::string on(method_key<"describe">, const T& t) {
+    return t.describe();
+  }
+  static void on(method_key<"reload">, T& t) { t.reload(); }
+  static int& on(method_key<"shots">, T& t) { return t.shots(); }
 };
 
 // Custom impl for `robber`: a full specialization outranks the boilerplate
@@ -105,12 +110,14 @@ struct proxy_impl<gunslinger, T> {
 // "shots" to a data member.
 template<>
 struct proxy_impl<gunslinger, robber> {
-  static int on(key<"fire">, robber& r, int rounds) { return r.shoot(rounds); }
-  static std::string on(key<"describe">, const robber& r) {
+  static int on(method_key<"fire">, robber& r, int rounds) {
+    return r.shoot(rounds);
+  }
+  static std::string on(method_key<"describe">, const robber& r) {
     return r.description();
   }
-  static void on(key<"reload">, robber& r) { r.rearm(); }
-  static int& on(key<"shots">, robber& r) { return r.fired; }
+  static void on(method_key<"reload">, robber& r) { r.rearm(); }
+  static int& on(method_key<"shots">, robber& r) { return r.fired; }
 };
 
 } // namespace corvid
@@ -121,10 +128,14 @@ static_assert(!Facade<lawman>);
 static_assert(!Facade<int>);
 
 // A method is-a key: usable anywhere its key is.
-static_assert(std::derived_from<method<"fire", int(int)>, key<"fire">>);
+static_assert(std::derived_from<method<"fire", int(int)>, method_key<"fire">>);
 static_assert(std::derived_from<method<"describe", std::string() const>,
-    key<"describe">>);
-static_assert(!std::derived_from<method<"fire", int(int)>, key<"reload">>);
+    method_key<"describe">>);
+static_assert(
+    !std::derived_from<method<"fire", int(int)>, method_key<"reload">>);
+
+// UDL: `"name"_method` is a `method_key<"name">`.
+static_assert(std::same_as<decltype("fire"_method), method_key<"fire">>);
 
 // Registration state: lawman is registered, robber conforms without
 // registration, cowboy neither registers nor conforms.
@@ -229,7 +240,7 @@ TEST_CASE("Generic code accepts concrete and erased alike", "[proxy]") {
 
   // The library-provided view impl is also usable directly.
   CHECK(prox::proxy_impl<gunslinger, proxy_view<gunslinger>>::on(
-            key<"describe">{}, pv) == "lawman"s);
+            "describe"_method, pv) == "lawman"s);
 }
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -43,6 +43,8 @@ using namespace corvid::meta::prox::literals;
 // member names line up. Being an ordinary inheritable class, it is also the
 // base for partial overrides (see `sheriff`). It is used when a class is
 // registered for a facade, but can be partially or fully overridden.
+// Inheriting `prox_impl` is optional sugar: it carries the `method_key`
+// alias, so the bindings spell it unqualified.
 //
 // With reflection, both the API and boilerplate will be generated
 // automatically from the facade method list. For now, let your AI do it for
@@ -64,15 +66,15 @@ struct gunslinger
     int& shots(this auto&& self) { return self.template call<"shots">(); }
   };
   template<typename T>
-  struct boilerplate {
-    static int on(prox::method_key<"fire">, T& t, int rounds) {
+  struct boilerplate: prox_impl {
+    static int on(method_key<"fire">, T& t, int rounds) {
       return t.fire(rounds);
     }
-    static std::string on(prox::method_key<"describe">, const T& t) {
+    static std::string on(method_key<"describe">, const T& t) {
       return t.describe();
     }
-    static void on(prox::method_key<"reload">, T& t) { t.reload(); }
-    static int& on(prox::method_key<"shots">, T& t) { return t.shots(); }
+    static void on(method_key<"reload">, T& t) { t.reload(); }
+    static int& on(method_key<"shots">, T& t) { return t.shots(); }
   };
 };
 
@@ -148,15 +150,15 @@ struct robber {
 
 // Note the name adaptation, including binding "shots" to a data member.
 consteval auto corvid_proxy_spec(gunslinger*, robber*) {
-  struct as_gunslinger {
-    static int on(prox::method_key<"fire">, robber& r, int rounds) {
+  struct as_gunslinger: prox_impl {
+    static int on(method_key<"fire">, robber& r, int rounds) {
       return r.shoot(rounds);
     }
-    static std::string on(prox::method_key<"describe">, const robber& r) {
+    static std::string on(method_key<"describe">, const robber& r) {
       return r.description();
     }
-    static void on(prox::method_key<"reload">, robber& r) { r.rearm(); }
-    static int& on(prox::method_key<"shots">, robber& r) { return r.fired; }
+    static void on(method_key<"reload">, robber& r) { r.rearm(); }
+    static int& on(method_key<"shots">, robber& r) { return r.fired; }
   };
   return prox::make_proxy_spec<gunslinger, robber, as_gunslinger>();
 }
@@ -185,7 +187,7 @@ struct sheriff {
 consteval auto corvid_proxy_spec(gunslinger*, sheriff*) {
   struct as_gunslinger: gunslinger::boilerplate<sheriff> {
     using gunslinger::boilerplate<sheriff>::on;
-    static int on(prox::method_key<"fire">, sheriff& s, int rounds) {
+    static int on(method_key<"fire">, sheriff& s, int rounds) {
       return s.shoot(rounds);
     }
   };
@@ -210,7 +212,7 @@ struct turncoat {
 
   struct as_gunslinger: gunslinger::boilerplate<turncoat> {
     using gunslinger::boilerplate<turncoat>::on;
-    static std::string on(prox::method_key<"describe">, const turncoat&) {
+    static std::string on(method_key<"describe">, const turncoat&) {
       return "undercover";
     }
   };
@@ -261,11 +263,11 @@ struct hair_trigger
   // The targets' own methods need not be noexcept; the binding is the
   // terminate boundary.
   template<typename T>
-  struct boilerplate {
-    static int on(prox::method_key<"fire">, T& t, int rounds) noexcept {
+  struct boilerplate: prox_impl {
+    static int on(method_key<"fire">, T& t, int rounds) noexcept {
       return t.fire(rounds);
     }
-    static bool on(prox::method_key<"jams">, const T& t) noexcept {
+    static bool on(method_key<"jams">, const T& t) noexcept {
       return t.jams();
     }
   };
@@ -280,11 +282,11 @@ consteval auto corvid_proxy_spec(hair_trigger*, lawman*) {
 // shapes otherwise line up. Registration is the act of opting in, not proof
 // of conformance.
 consteval auto corvid_proxy_spec(hair_trigger*, robber*) {
-  struct as_hair_trigger {
-    static int on(prox::method_key<"fire">, robber& r, int rounds) {
+  struct as_hair_trigger: prox_impl {
+    static int on(method_key<"fire">, robber& r, int rounds) {
       return r.shoot(rounds);
     }
-    static bool on(prox::method_key<"jams">, const robber&) { return false; }
+    static bool on(method_key<"jams">, const robber&) { return false; }
   };
   return prox::make_proxy_spec<hair_trigger, robber, as_hair_trigger>();
 }
@@ -300,8 +302,8 @@ struct mortar: prox::facade<prox::method<"lob", int(int)>> {
   };
 
   template<typename T>
-  struct boilerplate {
-    static int on(prox::method_key<"lob">, T& t, int shells) {
+  struct boilerplate: prox_impl {
+    static int on(method_key<"lob">, T& t, int shells) {
       return t.lob(shells);
     }
   };
@@ -338,16 +340,16 @@ struct marshal
     }
   };
   template<typename T>
-  struct boilerplate {
-    static bool on(prox::method_key<"arrest">, T& t, int outlaws) {
+  struct boilerplate: prox_impl {
+    static bool on(method_key<"arrest">, T& t, int outlaws) {
       return t.arrest(outlaws);
     }
   };
 };
 
-// `texas_ranger` is a second composition level: `gunslinger` -> `marshal` ->
-// `texas_ranger`.
-struct texas_ranger
+// `ranger` is a second composition level: `gunslinger` -> `marshal` ->
+// `ranger`.
+struct ranger
     : prox::facade<                             //
           prox::extends<marshal>,               //
           prox::method<"track", int() const>> { //
@@ -355,18 +357,18 @@ struct texas_ranger
     int track(this const auto& self) { return self.template call<"track">(); }
   };
   template<typename T>
-  struct boilerplate {
-    static int on(prox::method_key<"track">, const T& t) { return t.track(); }
+  struct boilerplate: prox_impl {
+    static int on(method_key<"track">, const T& t) { return t.track(); }
   };
 };
 
-// `ranger` is a type conforming to the whole `texas_ranger` chain. Conformance
+// `texas_ranger` is a type conforming to the whole `ranger` chain. Conformance
 // is per facade, but one chain hook below registers every level.
-struct ranger {
+struct texas_ranger {
   int fire(int rounds) { return rounds_fired += rounds; }
   [[nodiscard]] std::string describe() const {
     (void)this;
-    return "ranger";
+    return "texas_ranger";
   }
   void reload() { rounds_fired = 0; }
   int& shots() { return rounds_fired; }
@@ -380,13 +382,39 @@ struct ranger {
   int arrested{};
 };
 
-// One chain hook registers `ranger` for `texas_ranger` and every facade it
+// One chain hook registers `texas_ranger` for `ranger` and every facade it
 // extends. The bindings stay per facade (each inherited method still binds
 // through its declaring facade's impl); the hook only collapses the opt-in
 // ceremony.
-template<prox::InChainOf<texas_ranger> F>
-consteval auto corvid_proxy_spec(F*, ranger*) {
-  return prox::make_proxy_spec<F, ranger>();
+template<prox::InChainOf<ranger> F>
+consteval auto corvid_proxy_spec(F*, texas_ranger*) {
+  return prox::make_proxy_spec<F, texas_ranger>();
+}
+
+// `constable` conforms only partway up the chain: it can `arrest` but not
+// `track`. Anchoring its chain hook at `marshal` registers it for that level
+// and everything below, and nothing above; the anchor names the outermost
+// facade the type actually conforms to.
+struct constable {
+  int fire(int rounds) { return rounds_fired += rounds; }
+  [[nodiscard]] std::string describe() const {
+    (void)this;
+    return "constable";
+  }
+  void reload() { rounds_fired = 0; }
+  int& shots() { return rounds_fired; }
+  bool arrest(int outlaws) {
+    arrested += outlaws;
+    return true;
+  }
+
+  int rounds_fired{};
+  int arrested{};
+};
+
+template<prox::InChainOf<marshal> F>
+consteval auto corvid_proxy_spec(F*, constable*) {
+  return prox::make_proxy_spec<F, constable>();
 }
 
 // A `vigilante` is `gunslinger`-shaped, but deliberately registered for
@@ -410,7 +438,7 @@ struct vigilante {
 };
 
 // This is bad, actually. For it to work, it would need to use the `InChainOf`
-// technique.
+// technique, as `constable` does.
 consteval auto corvid_proxy_spec(marshal*, vigilante*) {
   return prox::make_proxy_spec<marshal, vigilante>();
 }
@@ -569,6 +597,11 @@ static_assert(Proxiable<proxy<hair_trigger>, hair_trigger>);
 static_assert(std::assignable_from<proxy_view<gunslinger>&,
     const proxy_view<gunslinger>&>);
 
+// Views are also default-constructible as empty, like the owning proxy, and
+// testable via `operator bool`.
+static_assert(std::default_initializable<proxy_view<gunslinger>>);
+static_assert(std::default_initializable<const_proxy_view<gunslinger>>);
+
 // The owning proxy is move-only.
 static_assert(!std::copy_constructible<proxy<gunslinger>>);
 static_assert(std::movable<proxy<gunslinger>>);
@@ -611,8 +644,8 @@ struct census: prox::facade<prox::method<"describe", std::string() const>> {};
 // Conformance here is a one-off carried impl: `census` exists only to serve
 // the const-view assertions, so it defines no boilerplate at all.
 consteval auto corvid_proxy_spec(census*, lawman*) {
-  struct as_census {
-    static std::string on(prox::method_key<"describe">, const lawman& l) {
+  struct as_census: prox_impl {
+    static std::string on(method_key<"describe">, const lawman& l) {
       return l.describe();
     }
   };
@@ -623,11 +656,12 @@ static_assert(Proxiable<const_proxy_view<census>, census>);
 static_assert(!Proxiable<const_proxy_view<gunslinger>, gunslinger>);
 
 // Composition. A composed facade flattens its bases' methods ahead of its
-// own; `Extends` is transitive and strict.
+// own; `Extends` is transitive and strict (false for the facade itself, per
+// the last assert; the walk covers only the bases).
 static_assert(prox::Facade<marshal>);
 static_assert(prox::Extends<marshal, gunslinger>);
-static_assert(prox::Extends<texas_ranger, marshal>);
-static_assert(prox::Extends<texas_ranger, gunslinger>);
+static_assert(prox::Extends<ranger, marshal>);
+static_assert(prox::Extends<ranger, gunslinger>);
 static_assert(!prox::Extends<gunslinger, marshal>);
 static_assert(!prox::Extends<marshal, marshal>);
 
@@ -646,32 +680,40 @@ static_assert(!prox::Extends<marshal, marshal>);
 // facade and its extends bases", with the flattened list, duplicate
 // included, spelled out in the requirement, followed by one follow-on
 // "no type named 'vtable_t'" noise error.
-static_assert(Proxiable<ranger, gunslinger>);
-static_assert(Proxiable<ranger, marshal>);
-static_assert(Proxiable<ranger, texas_ranger>);
+static_assert(Proxiable<texas_ranger, gunslinger>);
+static_assert(Proxiable<texas_ranger, marshal>);
+static_assert(Proxiable<texas_ranger, ranger>);
 static_assert(!Proxiable<vigilante, marshal>);
 static_assert(!Proxiable<vigilante, gunslinger>);
 static_assert(!Proxiable<lawman, marshal>);
 
 // The chain hook registers every level of the chain, and nothing else.
-static_assert(prox::ProxyRegistered<texas_ranger, ranger>);
-static_assert(prox::ProxyRegistered<marshal, ranger>);
-static_assert(prox::ProxyRegistered<gunslinger, ranger>);
-static_assert(!prox::ProxyRegistered<hair_trigger, ranger>);
+static_assert(prox::ProxyRegistered<ranger, texas_ranger>);
+static_assert(prox::ProxyRegistered<marshal, texas_ranger>);
+static_assert(prox::ProxyRegistered<gunslinger, texas_ranger>);
+static_assert(!prox::ProxyRegistered<hair_trigger, texas_ranger>);
+
+// A chain hook anchored mid-chain registers its level and everything below,
+// and nothing above.
+static_assert(prox::ProxyRegistered<marshal, constable>);
+static_assert(prox::ProxyRegistered<gunslinger, constable>);
+static_assert(!prox::ProxyRegistered<ranger, constable>);
+static_assert(Proxiable<constable, marshal>);
+static_assert(Proxiable<constable, gunslinger>);
+static_assert(!Proxiable<constable, ranger>);
 
 // Handles of a derived facade satisfy the base facade too (Rust: a `dyn
 // Derived` meets a `Base` bound).
 static_assert(Proxiable<proxy_view<marshal>, gunslinger>);
-static_assert(Proxiable<proxy_view<texas_ranger>, marshal>);
-static_assert(Proxiable<proxy<texas_ranger>, gunslinger>);
+static_assert(Proxiable<proxy_view<ranger>, marshal>);
+static_assert(Proxiable<proxy<ranger>, gunslinger>);
 
 // Upcast conversions exist in exactly the safe directions: no downcasts, no
 // regaining mutability, and no views of temporary proxies.
 static_assert(
     std::convertible_to<proxy_view<marshal>, proxy_view<gunslinger>>);
-static_assert(
-    std::convertible_to<proxy_view<texas_ranger>, proxy_view<gunslinger>>);
-static_assert(std::convertible_to<const_proxy_view<texas_ranger>,
+static_assert(std::convertible_to<proxy_view<ranger>, proxy_view<gunslinger>>);
+static_assert(std::convertible_to<const_proxy_view<ranger>,
     const_proxy_view<gunslinger>>);
 static_assert(
     std::convertible_to<proxy_view<marshal>, const_proxy_view<gunslinger>>);
@@ -705,7 +747,7 @@ static_assert(std::same_as<const_proxy_view<gunslinger>,
 static_assert(sizeof(proxy_view<gunslinger>) == 2 * sizeof(void*));
 static_assert(sizeof(const_proxy_view<gunslinger>) == 2 * sizeof(void*));
 static_assert(sizeof(proxy_view<lockbox>) == 2 * sizeof(void*));
-static_assert(sizeof(proxy_view<texas_ranger>) == 2 * sizeof(void*));
+static_assert(sizeof(proxy_view<ranger>) == 2 * sizeof(void*));
 
 // The sugar carries `noexcept` when the facade author marks the forwarders.
 static_assert(noexcept(std::declval<proxy_view<hair_trigger>&>().fire(1)));
@@ -737,7 +779,7 @@ static_assert(prox::validate_api<hair_trigger>());
 // forwarders (brought in here by deriving the `api` from the base facade's)
 // against the flattened method list.
 static_assert(prox::validate_api<marshal>());
-static_assert(prox::validate_api<texas_ranger>());
+static_assert(prox::validate_api<ranger>());
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
@@ -834,6 +876,20 @@ TEST_CASE("Views rebind by assignment", "[proxy]") {
   // Assignment rebinds both the target and the dispatch table.
   pv = proxy_view<gunslinger>{r};
   CHECK(pv.describe() == "robber"s);
+
+  // A default-constructed view is empty until assigned a target; calling
+  // through it before that is undefined behavior.
+  proxy_view<gunslinger> ev;
+  CHECK(!ev);
+  ev = pv;
+  CHECK(ev);
+  CHECK(ev.describe() == "robber"s);
+
+  const_proxy_view<gunslinger> cev;
+  CHECK(!cev);
+  cev = pv;
+  CHECK(cev);
+  CHECK(cev.describe() == "robber"s);
 }
 
 TEST_CASE("Const view", "[proxy]") {
@@ -1018,51 +1074,59 @@ TEST_CASE("Member-call sugar via the api mixin", "[proxy]") {
 }
 
 TEST_CASE("Facade composition", "[proxy]") {
-  ranger r;
-  proxy_view<marshal> mv{r};
+  texas_ranger tr;
+  proxy_view<marshal> mv{tr};
 
   // Inherited and own methods dispatch through the same flattened table,
   // through the inherited and own `api` forwarders alike.
   CHECK(mv.fire(2) == 2);
-  CHECK(mv.describe() == "ranger"s);
+  CHECK(mv.describe() == "texas_ranger"s);
   CHECK(mv.arrest(1));
-  CHECK(r.arrested == 1);
+  CHECK(tr.arrested == 1);
 
   // The core spelling hits the same slot, inherited or not.
   CHECK(mv.call<"fire">(1) == 3);
   CHECK(mv.call<"arrest">(2));
-  CHECK(r.arrested == 3);
+  CHECK(tr.arrested == 3);
 
   // Two composition levels down, same story.
-  proxy_view<texas_ranger> tv{r};
-  CHECK(tv.track() == 3);
-  CHECK(tv.fire(1) == 4);
-  CHECK(tv.arrest(1));
-  CHECK(tv.track() == 4);
+  proxy_view<ranger> rv{tr};
+  CHECK(rv.track() == 3);
+  CHECK(rv.fire(1) == 4);
+  CHECK(rv.arrest(1));
+  CHECK(rv.track() == 4);
 
   // An owning proxy of a composed facade dispatches the whole chain too.
-  auto p = make_proxy<texas_ranger, ranger>();
+  auto p = make_proxy<ranger, texas_ranger>();
   CHECK(p.fire(5) == 5);
   CHECK(p.arrest(1));
   CHECK(p.track() == 1);
+
+  // A mid-chain conformer dispatches through the levels it registered for.
+  constable c;
+  proxy_view<marshal> cmv{c};
+  CHECK(cmv.arrest(2));
+  CHECK(c.arrested == 2);
+  proxy_view<gunslinger> cgv = cmv;
+  CHECK(cgv.describe() == "constable"s);
 }
 
 TEST_CASE("Upcasting views", "[proxy]") {
-  ranger r;
-  proxy_view<texas_ranger> tv{r};
+  texas_ranger tr;
+  proxy_view<ranger> rv{tr};
 
   // Upcast to the immediate base and to the root. Every view aliases the
   // same target, so mutations are visible through all of them.
-  proxy_view<marshal> mv = tv;
-  proxy_view<gunslinger> gv = tv;
+  proxy_view<marshal> mv = rv;
+  proxy_view<gunslinger> gv = rv;
   CHECK(gv.fire(2) == 2);
   CHECK(mv.fire(1) == 3);
-  CHECK(r.rounds_fired == 3);
+  CHECK(tr.rounds_fired == 3);
   CHECK(mv.arrest(1));
-  CHECK(gv.describe() == "ranger"s);
+  CHECK(gv.describe() == "texas_ranger"s);
 
   // An upcast view is indistinguishable from a directly-built one.
-  proxy_view<gunslinger> direct{r};
+  proxy_view<gunslinger> direct{tr};
   CHECK(&direct.shots() == &gv.shots());
 
   // Upcasts rebind by assignment like any view.
@@ -1070,26 +1134,26 @@ TEST_CASE("Upcasting views", "[proxy]") {
   gv = proxy_view<gunslinger>{l};
   CHECK(gv.describe() == "lawman"s);
   gv = mv;
-  CHECK(gv.describe() == "ranger"s);
+  CHECK(gv.describe() == "texas_ranger"s);
 
   // Const upcasts: from the mutable view, and from a const view of a const
   // target.
-  const_proxy_view<gunslinger> cgv = tv;
-  CHECK(cgv.describe() == "ranger"s);
-  const ranger cr{};
-  const_proxy_view<texas_ranger> ctv{cr};
-  const_proxy_view<gunslinger> cgv2 = ctv;
-  CHECK(cgv2.describe() == "ranger"s);
+  const_proxy_view<gunslinger> cgv = rv;
+  CHECK(cgv.describe() == "texas_ranger"s);
+  const texas_ranger ctr{};
+  const_proxy_view<ranger> crv{ctr};
+  const_proxy_view<gunslinger> cgv2 = crv;
+  CHECK(cgv2.describe() == "texas_ranger"s);
 }
 
 TEST_CASE("Viewing an owning proxy", "[proxy]") {
-  auto p = make_proxy<texas_ranger, ranger>();
+  auto p = make_proxy<ranger, texas_ranger>();
 
   // The view re-points at the stored target rather than wrapping the handle,
   // so it aliases the proxy's state, same facade or upcast.
-  proxy_view<texas_ranger> tv = p;
+  proxy_view<ranger> rv = p;
   proxy_view<gunslinger> gv = p;
-  CHECK(tv.fire(2) == 2);
+  CHECK(rv.fire(2) == 2);
   CHECK(gv.shots() == 2);
   gv.reload();
   CHECK(p.shots() == 0);
@@ -1097,7 +1161,7 @@ TEST_CASE("Viewing an owning proxy", "[proxy]") {
   // A const proxy yields only the const view.
   const auto& cp = p;
   const_proxy_view<gunslinger> cgv = cp;
-  CHECK(cgv.describe() == "ranger"s);
+  CHECK(cgv.describe() == "texas_ranger"s);
 
   // Facade-constrained generic code accepts the derived handles under the
   // base bound (cross-facade self-conformance), and `make_proxy_view`
@@ -1107,7 +1171,7 @@ TEST_CASE("Viewing an owning proxy", "[proxy]") {
     return v.fire(1);
   };
   CHECK(fire_once(p) == 1);
-  CHECK(fire_once(tv) == 2);
+  CHECK(fire_once(rv) == 2);
 }
 
 TEST_CASE("Heterogeneous ownership", "[proxy]") {

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -16,7 +16,9 @@
 // limitations under the License.
 
 #include <concepts>
+#include <cstddef>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "corvid/meta/proxy.h"
@@ -83,6 +85,7 @@ consteval auto corvid_proxy_spec(gunslinger*, lawman*) {
 
 // Exactly like a lawman, but with a different name. Works automatically.
 struct deputy: public lawman {
+  // NOLINTNEXTLINE(bugprone-derived-method-shadowing-base-method)
   [[nodiscard]] std::string describe() const {
     (void)this;
     return "deputy";
@@ -166,6 +169,94 @@ struct cowboy {
   int count{};
 };
 
+// A facade with noexcept methods: conformance requires the bindings
+// themselves to be noexcept.
+struct hair_trigger
+    : prox::facade<                                //
+          prox::method<"fire", int(int) noexcept>, //
+          prox::method<"jams", bool() const noexcept>> {};
+
+// Bindings marked noexcept: conforms. The target's own methods need not be
+// noexcept; the binding is the terminate boundary.
+template<>
+struct prox::proxy_impl<hair_trigger, lawman> {
+  static int on(method_key<"fire">, lawman& l, int rounds) noexcept {
+    return l.fire(rounds);
+  }
+  static bool on(method_key<"jams">, const lawman&) noexcept { return false; }
+};
+
+// Bindings not marked noexcept: must NOT conform, even though the shapes
+// otherwise line up.
+template<>
+struct prox::proxy_impl<hair_trigger, robber> {
+  static int on(method_key<"fire">, robber& r, int rounds) {
+    return r.shoot(rounds);
+  }
+  static bool on(method_key<"jams">, const robber&) { return false; }
+};
+
+// Lifetime accounting shared by the owning-proxy targets.
+struct life_stats {
+  int constructed{};
+  int destroyed{};
+  int moves{};
+};
+
+// Move-only lifetime-counting target. `Pad` scales the footprint so one
+// instantiation fits the proxy's inline buffer and another forces the heap
+// path.
+template<std::size_t Pad>
+struct strongbox {
+  explicit strongbox(life_stats& stats) noexcept : stats_{&stats} {
+    ++stats_->constructed;
+  }
+  strongbox(strongbox&& other) noexcept
+      : stats_{other.stats_}, gold_{other.gold_} {
+    ++stats_->constructed;
+    ++stats_->moves;
+  }
+  strongbox(const strongbox&) = delete;
+  strongbox& operator=(const strongbox&) = delete;
+  strongbox& operator=(strongbox&&) = delete;
+  ~strongbox() { ++stats_->destroyed; }
+
+  int add(int nuggets) { return gold_ += nuggets; }
+  [[nodiscard]] int gold() const { return gold_; }
+
+  life_stats* stats_{};
+  int gold_{};
+  std::byte pad_[Pad]{};
+};
+
+// The facade for the lifetime tests.
+struct lockbox
+    : prox::facade<                      //
+          prox::method<"add", int(int)>, //
+          prox::method<"gold", int() const>> {};
+
+// Boilerplate impl for `lockbox`.
+template<typename T>
+requires prox::ProxyRegistered<lockbox, T>
+struct prox::proxy_impl<lockbox, T> {
+  static int on(method_key<"add">, T& t, int nuggets) {
+    return t.add(nuggets);
+  }
+  static int on(method_key<"gold">, const T& t) { return t.gold(); }
+};
+
+// Registration for every `strongbox` size, via a template hook.
+template<std::size_t Pad>
+consteval auto corvid_proxy_spec(lockbox*, strongbox<Pad>*) {
+  return prox::make_proxy_spec<lockbox, strongbox<Pad>>();
+}
+
+// One size fits the inline buffer exactly; the other forces the heap path.
+using small_box = strongbox<4>;
+using big_box = strongbox<64>;
+static_assert(sizeof(small_box) <= prox::proxy<lockbox>::sbo_size);
+static_assert(sizeof(big_box) > prox::proxy<lockbox>::sbo_size);
+
 // Facade detection.
 static_assert(prox::Facade<gunslinger>);
 static_assert(!prox::Facade<lawman>);
@@ -213,13 +304,51 @@ static_assert(prox::Proxiable<sheriff, gunslinger>);
 static_assert(!prox::Proxiable<cowboy, gunslinger>);
 static_assert(!prox::Proxiable<int, gunslinger>);
 
-// A view satisfies its own facade.
+// Noexcept qualification is part of the method flavor.
+static_assert(!prox::method<"fire", int(int)>::noexcept_v);
+static_assert(prox::method<"fire", int(int) noexcept>::noexcept_v);
+static_assert(prox::method<"jams", bool() const noexcept>::const_v);
+static_assert(prox::method<"jams", bool() const noexcept>::noexcept_v);
+
+// Noexcept conformance: the binding itself must be noexcept.
+static_assert(prox::Proxiable<lawman, hair_trigger>);
+static_assert(!prox::Proxiable<robber, hair_trigger>);
+
+// The erased call carries the method's noexcept.
+static_assert(noexcept(
+    std::declval<const prox::proxy_view<hair_trigger>&>().call<"fire">(1)));
+static_assert(!noexcept(
+    std::declval<const prox::proxy_view<gunslinger>&>().call<"fire">(1)));
+
+// Both handles satisfy their own facade, including facades with noexcept
+// methods.
 static_assert(prox::Proxiable<prox::proxy_view<gunslinger>, gunslinger>);
+static_assert(prox::Proxiable<prox::proxy<gunslinger>, gunslinger>);
+static_assert(prox::Proxiable<prox::proxy_view<hair_trigger>, hair_trigger>);
+static_assert(prox::Proxiable<prox::proxy<hair_trigger>, hair_trigger>);
 
 // Views are value-semantic: copyable and rebindable by assignment. The table
 // member is pointer-to-const, not a const member, so assignment stays viable.
 static_assert(std::assignable_from<prox::proxy_view<gunslinger>&,
     const prox::proxy_view<gunslinger>&>);
+
+// The owning proxy is move-only.
+static_assert(!std::copy_constructible<prox::proxy<gunslinger>>);
+static_assert(std::movable<prox::proxy<gunslinger>>);
+
+// Deep const: non-const facade methods are not callable on a const proxy,
+// but const ones are. The view stays shallow-const. The probes go through a
+// concept so the negative case is a constraint failure rather than a hard
+// error (a requires-expression outside a template does not get SFINAE).
+template<typename P>
+concept CanFire = requires(P& p) { p.template call<"fire">(1); };
+template<typename P>
+concept CanDescribe = requires(P& p) { p.template call<"describe">(); };
+
+static_assert(CanFire<prox::proxy<gunslinger>>);
+static_assert(!CanFire<const prox::proxy<gunslinger>>);
+static_assert(CanDescribe<const prox::proxy<gunslinger>>);
+static_assert(CanFire<const prox::proxy_view<gunslinger>>);
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
@@ -321,6 +450,96 @@ TEST_CASE("Generic code accepts concrete and erased alike", "[proxy]") {
   // The library-provided view impl is also usable directly.
   CHECK(prox::proxy_impl<gunslinger, prox::proxy_view<gunslinger>>::on(
             "describe"_method, pv) == "lawman"s);
+
+  // An owning proxy satisfies the facade too, so it erases the same way.
+  auto p = prox::make_proxy<gunslinger, lawman>();
+  CHECK(fire_twice(p) == 2);
+}
+
+TEST_CASE("Owning proxy, inline target", "[proxy]") {
+  life_stats stats;
+  if (true) {
+    auto p = prox::make_proxy<lockbox, small_box>(stats);
+    CHECK(stats.constructed == 1);
+    CHECK(stats.destroyed == 0);
+    CHECK(p);
+    CHECK(p.call<"add">(3) == 3);
+    CHECK(p.call<"gold">() == 3);
+
+    // Inline targets move by relocation: one move-construct plus one destroy.
+    auto q = std::move(p);
+    CHECK(stats.moves == 1);
+    CHECK(stats.constructed == 2);
+    CHECK(stats.destroyed == 1);
+    CHECK(q.call<"gold">() == 3);
+
+    // The moved-from proxy is empty; assigning into it is the sanctioned
+    // reuse.
+    CHECK(!p); // NOLINT(bugprone-use-after-move): probing moved-from state.
+    p = std::move(q);
+    CHECK(p.call<"gold">() == 3);
+  }
+  // Everything constructed was destroyed exactly once.
+  CHECK(stats.constructed == 3);
+  CHECK(stats.destroyed == stats.constructed);
+}
+
+TEST_CASE("Owning proxy, heap target", "[proxy]") {
+  life_stats stats;
+  if (true) {
+    auto p = prox::make_proxy<lockbox, big_box>(stats);
+    CHECK(stats.constructed == 1);
+    CHECK(p.call<"add">(7) == 7);
+
+    // Heap targets move by pointer steal: no target activity at all.
+    auto q = std::move(p);
+    CHECK(stats.moves == 0);
+    CHECK(stats.constructed == 1);
+    CHECK(stats.destroyed == 0);
+    CHECK(q.call<"gold">() == 7);
+
+    // Move assignment over a live target destroys the old target first.
+    q = prox::make_proxy<lockbox, big_box>(stats);
+    CHECK(stats.constructed == 2);
+    CHECK(stats.destroyed == 1);
+    CHECK(q.call<"gold">() == 0);
+  }
+  CHECK(stats.destroyed == stats.constructed);
+}
+
+TEST_CASE("Owning proxy is deep-const", "[proxy]") {
+  // Only const-qualified facade methods dispatch through a const proxy; the
+  // negative half is covered by the `CanFire` static_asserts above.
+  const auto p = prox::make_proxy<gunslinger, lawman>();
+  CHECK(p.call<"describe">() == "lawman"s);
+}
+
+TEST_CASE("Noexcept facade methods", "[proxy]") {
+  lawman l;
+  prox::proxy_view<hair_trigger> pv{l};
+  CHECK(pv.call<"fire">(2) == 2);
+  CHECK(!pv.call<"jams">());
+
+  auto p = prox::make_proxy<hair_trigger, lawman>();
+  CHECK(p.call<"fire">(4) == 4);
+  static_assert(noexcept(p.call<"fire">(4)));
+  const auto& cp = p;
+  CHECK(!cp.call<"jams">());
+  static_assert(noexcept(cp.call<"jams">()));
+}
+
+TEST_CASE("Heterogeneous ownership", "[proxy]") {
+  std::vector<prox::proxy<gunslinger>> gang;
+  gang.push_back(prox::make_proxy<gunslinger, lawman>());
+  gang.push_back(prox::make_proxy<gunslinger, robber>());
+
+  std::string roll_call;
+  for (auto& p : gang) {
+    p.call<"fire">(2);
+    roll_call += p.call<"describe">();
+    roll_call += ' ';
+  }
+  CHECK(roll_call == "lawman robber "s);
 }
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -31,10 +31,22 @@ using namespace corvid::meta::prox::literals;
 // The facade under test: mixes value returns, a const method, a void
 // mutator, and a reference return.
 //
-// The nested `api` is the optional member-call sugar: one deducing-this
-// forwarder per method, inherited by every handle of this facade. A const
-// method's forwarder takes `self` by const reference, mirroring the erased
-// signature.
+// The nested `api` is the (technically optional) member-call sugar, mapping
+// regular C++ methods over the facade's methods. It has one deducing-this
+// forwarder per method, and a const method's forwarder takes `self` by const
+// reference, mirroring the erased signature. The API is inherited by every
+// handle of this facade: the `proxy`, `proxy_view`, and `const_proxy_view`.
+//
+// The nested `boilerplate` is the facade author's impl, mapping the regular
+// methods of a class to the facade's method list. In essence, it's the reverse
+// of the API. It's written once and generic over any registered type whose
+// member names line up. Being an ordinary inheritable class, it is also the
+// base for partial overrides (see `sheriff`). It is used when a class is
+// registered for a facade, but can be partially or fully overridden.
+//
+// With reflection, both the API and boilerplate will be generated
+// automatically from the facade method list. For now, let your AI do it for
+// you.
 struct gunslinger
     : prox::facade<                                      //
           prox::method<"fire", int(int)>,                //
@@ -51,36 +63,22 @@ struct gunslinger
     void reload(this auto&& self) { self.template call<"reload">(); }
     int& shots(this auto&& self) { return self.template call<"shots">(); }
   };
+  template<typename T>
+  struct boilerplate {
+    static int on(prox::method_key<"fire">, T& t, int rounds) {
+      return t.fire(rounds);
+    }
+    static std::string on(prox::method_key<"describe">, const T& t) {
+      return t.describe();
+    }
+    static void on(prox::method_key<"reload">, T& t) { t.reload(); }
+    static int& on(prox::method_key<"shots">, T& t) { return t.shots(); }
+  };
 };
-
-// This base class for proxy_impl<gunslinger, T> would not normally be
-// necessary, but it's used for `sheriff`. It also wouldn't need
-// `prox::method_key` to be scoped to its namespace.
-template<typename T>
-struct proxy_impl_gunslinger {
-  static int on(prox::method_key<"fire">, T& t, int rounds) {
-    return t.fire(rounds);
-  }
-  static std::string on(prox::method_key<"describe">, const T& t) {
-    return t.describe();
-  }
-  static void on(prox::method_key<"reload">, T& t) { t.reload(); }
-  static int& on(prox::method_key<"shots">, T& t) { return t.shots(); }
-};
-
-// Boilerplate impl for `gunslinger`.
-//
-// Written once by the facade author, generic over any registered type whose
-// member names line up.
-//
-// Again, it would normally contain the guts of what's been moved to
-// `proxy_impl_gunslinger`.
-template<typename T>
-requires prox::ProxyRegistered<gunslinger, T>
-struct prox::proxy_impl<gunslinger, T>: proxy_impl_gunslinger<T> {};
 
 // A type whose method names line up with the facade. Conforms by
-// registration through the boilerplate impl.
+// registration through the boilerplate impl. This is the simple case of a type
+// designed to be a `gunslinger`, and probably the motivating case.
 struct lawman {
   int fire(int rounds) {
     rounds_fired += rounds;
@@ -106,10 +104,18 @@ consteval auto corvid_proxy_spec(gunslinger*, lawman*) {
   return prox::make_proxy_spec<gunslinger, lawman>();
 }
 
-// Exactly like a lawman, but with a different name. Works automatically.
-// Note that, if this subclass were more significant, it would run into
-// problems caused by the lack of a virtual destructor in the base. However,
-// combining `virtual` and `proxy` is a code smell.
+// A `deputy` is exactly like a lawman, but with a different name. Works
+// automatically, without explicit registration, because a `deputy` is-a
+// `lawman`.
+//
+// Note that, even though `describe` is not virtual, calling it through a
+// `lawman` proxy invokes the `deputy`'s override. In contrast, calling it
+// through a `lawman` reference would invoke the `lawman`'s own method. This
+// illustrates how proxies function as a sort of replacement for virtual.
+//
+// Having said that, if this class owned resources, then you would need to make
+// the parent's destructor virtual, for correctness. This is true even though
+// combining virtual and proxy is otherwise a code smell.
 struct deputy: public lawman {
   // NOLINTNEXTLINE(bugprone-derived-method-shadowing-base-method)
   [[nodiscard]] std::string describe() const {
@@ -118,8 +124,14 @@ struct deputy: public lawman {
   }
 };
 
-// A type with the right shape but the wrong names. Conforms through an
-// explicit impl, with no registration.
+// `robber` is a type with the right shape but the wrong names.
+//
+// Conforms by carrying its impl in the registration, via the three-type
+// `make_proxy_spec`. The binding class is local to the hook, making the whole
+// conformance one self-contained declaration, which also works for a type you
+// do not own. Nesting the impl in the type instead (see `turncoat`)
+// additionally grants access to its private members. You could also
+// forward-declare and friend the impl.
 struct robber {
   int shoot(int rounds) {
     fired += rounds;
@@ -134,25 +146,26 @@ struct robber {
   int fired{};
 };
 
-// Custom impl for `robber`.
-//
-// A full specialization outranks the boilerplate and needs no registration.
 // Note the name adaptation, including binding "shots" to a data member.
-template<>
-struct prox::proxy_impl<gunslinger, robber> {
-  static int on(method_key<"fire">, robber& r, int rounds) {
-    return r.shoot(rounds);
-  }
-  static std::string on(method_key<"describe">, const robber& r) {
-    return r.description();
-  }
-  static void on(method_key<"reload">, robber& r) { r.rearm(); }
-  static int& on(method_key<"shots">, robber& r) { return r.fired; }
-};
+consteval auto corvid_proxy_spec(gunslinger*, robber*) {
+  struct as_gunslinger {
+    static int on(prox::method_key<"fire">, robber& r, int rounds) {
+      return r.shoot(rounds);
+    }
+    static std::string on(prox::method_key<"describe">, const robber& r) {
+      return r.description();
+    }
+    static void on(prox::method_key<"reload">, robber& r) { r.rearm(); }
+    static int& on(prox::method_key<"shots">, robber& r) { return r.fired; }
+  };
+  return prox::make_proxy_spec<gunslinger, robber, as_gunslinger>();
+}
 
-// A type whose method names line up, with one exception: `shoot` instead of
-// `fire`. Uses a full specialization that inherits and overrides the
-// boilerplate impl.
+// `sheriff` is a type whose method names line up, with one exception: `shoot`
+// instead of `fire`.
+//
+// Its registration carries an impl that inherits the facade's boilerplate,
+// re-exposes its `on` overloads, and overrides only the divergent binding.
 struct sheriff {
   int shoot(int rounds) {
     rounds_fired += rounds;
@@ -168,18 +181,48 @@ struct sheriff {
   int rounds_fired{};
 };
 
-// Custom impl for `sheriff`: inherits the boilerplate and overrides the
-// one method whose name differs.
-template<>
-struct prox::proxy_impl<gunslinger, sheriff>: proxy_impl_gunslinger<sheriff> {
-  using proxy_impl_gunslinger<sheriff>::on;
-  static int on(method_key<"fire">, sheriff& s, int rounds) {
-    return s.shoot(rounds);
+// Note how `using on` brings in the `sheriff`'s boilerplate.
+consteval auto corvid_proxy_spec(gunslinger*, sheriff*) {
+  struct as_gunslinger: gunslinger::boilerplate<sheriff> {
+    using gunslinger::boilerplate<sheriff>::on;
+    static int on(prox::method_key<"fire">, sheriff& s, int rounds) {
+      return s.shoot(rounds);
+    }
+  };
+  return prox::make_proxy_spec<gunslinger, sheriff, as_gunslinger>();
+}
+
+// `turncoat` could be registered as a `gunslinger` without any extra work,
+// but is used to demonstrate two features. First, the `as_gunslinger` is
+// inside the class instead of local to the `corvid_proxy_spec` call, which
+// grants it access to the type's private members. Second, we replace the call
+// to `describe` with a custom value.
+struct turncoat {
+  int fire(int rounds) { return rounds_fired += rounds; }
+  [[nodiscard]] std::string describe() const {
+    (void)this;
+    return "turncoat";
   }
+  void reload() { rounds_fired = 0; }
+  int& shots() { return rounds_fired; }
+
+  int rounds_fired{};
+
+  struct as_gunslinger: gunslinger::boilerplate<turncoat> {
+    using gunslinger::boilerplate<turncoat>::on;
+    static std::string on(prox::method_key<"describe">, const turncoat&) {
+      return "undercover";
+    }
+  };
 };
 
-// A type whose method names line up but which never opts in. Nominal
-// conformance means this must NOT be proxiable.
+consteval auto corvid_proxy_spec(gunslinger*, turncoat*) {
+  return prox::make_proxy_spec<gunslinger, turncoat,
+      turncoat::as_gunslinger>();
+}
+
+// `cowboy` is a type whose method names line up but which never opts in.
+// Nominal conformance means this must NOT be proxiable.
 struct cowboy {
   int fire(int rounds) {
     (void)this;
@@ -199,9 +242,8 @@ struct cowboy {
 // themselves to be noexcept.
 //
 // The `api` forwarders are marked `noexcept` so the sugar carries the
-// qualifier
-// the way `call` does. This is on the facade author; nothing checks the
-// forwarders against the method flavors.
+// qualifier the way `call` does. This is on the facade author; nothing checks
+// the forwarders against the method flavors.
 struct hair_trigger
     : prox::facade<                                //
           prox::method<"fire", int(int) noexcept>, //
@@ -214,18 +256,19 @@ struct hair_trigger
       return self.template call<"jams">();
     }
   };
-};
 
-// Boilerplate impl for `hair_trigger`, with bindings marked noexcept as
-// conformance requires. The targets' own methods need not be noexcept; the
-// binding is the terminate boundary.
-template<typename T>
-requires prox::ProxyRegistered<hair_trigger, T>
-struct prox::proxy_impl<hair_trigger, T> {
-  static int on(method_key<"fire">, T& t, int rounds) noexcept {
-    return t.fire(rounds);
-  }
-  static bool on(method_key<"jams">, const T& t) noexcept { return t.jams(); }
+  // The boilerplate's bindings are marked noexcept, as conformance requires.
+  // The targets' own methods need not be noexcept; the binding is the
+  // terminate boundary.
+  template<typename T>
+  struct boilerplate {
+    static int on(prox::method_key<"fire">, T& t, int rounds) noexcept {
+      return t.fire(rounds);
+    }
+    static bool on(prox::method_key<"jams">, const T& t) noexcept {
+      return t.jams();
+    }
+  };
 };
 
 // Registration for `lawman`, which conforms through the boilerplate.
@@ -233,18 +276,21 @@ consteval auto corvid_proxy_spec(hair_trigger*, lawman*) {
   return prox::make_proxy_spec<hair_trigger, lawman>();
 }
 
-// Bindings not marked noexcept: must NOT conform, even though the shapes
-// otherwise line up.
-template<>
-struct prox::proxy_impl<hair_trigger, robber> {
-  static int on(method_key<"fire">, robber& r, int rounds) {
-    return r.shoot(rounds);
-  }
-  static bool on(method_key<"jams">, const robber&) { return false; }
-};
+// Carried bindings not marked noexcept: must NOT conform, even though the
+// shapes otherwise line up. Registration is the act of opting in, not proof
+// of conformance.
+consteval auto corvid_proxy_spec(hair_trigger*, robber*) {
+  struct as_hair_trigger {
+    static int on(prox::method_key<"fire">, robber& r, int rounds) {
+      return r.shoot(rounds);
+    }
+    static bool on(prox::method_key<"jams">, const robber&) { return false; }
+  };
+  return prox::make_proxy_spec<hair_trigger, robber, as_hair_trigger>();
+}
 
-// A facade whose `api` deliberately deviates from the method list: the
-// forwarder widens the parameter as a convenience, which registration-time
+// `mortar` is a facade whose `api` deliberately deviates from the method list:
+// the forwarder widens the parameter as a convenience, which registration-time
 // validation would reject. Its registrations opt out with `api_check::off`.
 struct mortar: prox::facade<prox::method<"lob", int(int)>> {
   struct api {
@@ -252,13 +298,13 @@ struct mortar: prox::facade<prox::method<"lob", int(int)>> {
       return self.template call<"lob">(shells);
     }
   };
-};
 
-// Boilerplate impl for `mortar`.
-template<typename T>
-requires prox::ProxyRegistered<mortar, T>
-struct prox::proxy_impl<mortar, T> {
-  static int on(method_key<"lob">, T& t, int shells) { return t.lob(shells); }
+  template<typename T>
+  struct boilerplate {
+    static int on(prox::method_key<"lob">, T& t, int shells) {
+      return t.lob(shells);
+    }
+  };
 };
 
 // A conforming type. The registration passes `api_check::off`, so the
@@ -273,6 +319,102 @@ consteval auto corvid_proxy_spec(mortar*, howitzer*) {
   return prox::make_proxy_spec<mortar, howitzer, prox::api_check::off>();
 }
 
+// `marshal` is a composed facade, effectively inheriting from `gunslinger` by
+// extending it with an arrest method (Rust supertrait). Its `api` inherits the
+// base facade's, adding only the new forwarder; deducing `this` sees the
+// complete handle either way, so the inherited forwarders dispatch through the
+// derived handle's flattened table.
+//
+// The boilerplate covers only the facade's own methods. The inherited
+// `gunslinger` methods bind through `proxy_impl<gunslinger, T>`, which is
+// what keeps an upcast view and a directly-built one identical.
+struct marshal
+    : prox::facade<                            //
+          prox::extends<gunslinger>,           //
+          prox::method<"arrest", bool(int)>> { //
+  struct api: gunslinger::api {
+    bool arrest(this auto&& self, int outlaws) {
+      return self.template call<"arrest">(outlaws);
+    }
+  };
+  template<typename T>
+  struct boilerplate {
+    static bool on(prox::method_key<"arrest">, T& t, int outlaws) {
+      return t.arrest(outlaws);
+    }
+  };
+};
+
+// `texas_ranger` is a second composition level: `gunslinger` -> `marshal` ->
+// `texas_ranger`.
+struct texas_ranger
+    : prox::facade<                             //
+          prox::extends<marshal>,               //
+          prox::method<"track", int() const>> { //
+  struct api: marshal::api {
+    int track(this const auto& self) { return self.template call<"track">(); }
+  };
+  template<typename T>
+  struct boilerplate {
+    static int on(prox::method_key<"track">, const T& t) { return t.track(); }
+  };
+};
+
+// `ranger` is a type conforming to the whole `texas_ranger` chain. Conformance
+// is per facade, but one chain hook below registers every level.
+struct ranger {
+  int fire(int rounds) { return rounds_fired += rounds; }
+  [[nodiscard]] std::string describe() const {
+    (void)this;
+    return "ranger";
+  }
+  void reload() { rounds_fired = 0; }
+  int& shots() { return rounds_fired; }
+  bool arrest(int outlaws) {
+    arrested += outlaws;
+    return true;
+  }
+  [[nodiscard]] int track() const { return arrested; }
+
+  int rounds_fired{};
+  int arrested{};
+};
+
+// One chain hook registers `ranger` for `texas_ranger` and every facade it
+// extends. The bindings stay per facade (each inherited method still binds
+// through its declaring facade's impl); the hook only collapses the opt-in
+// ceremony.
+template<prox::InChainOf<texas_ranger> F>
+consteval auto corvid_proxy_spec(F*, ranger*) {
+  return prox::make_proxy_spec<F, ranger>();
+}
+
+// A `vigilante` is `gunslinger`-shaped, but deliberately registered for
+// `marshal` alone (a plain per-facade hook rather than a chain one): an
+// incomplete registration, so this must NOT be proxiable as a marshal at all,
+// and the failure is loud at first use. Pins the per-facade conformance rule.
+struct vigilante {
+  int fire(int rounds) { return rounds_fired += rounds; }
+  [[nodiscard]] std::string describe() const {
+    (void)this;
+    return "vigilante";
+  }
+  void reload() { rounds_fired = 0; }
+  int& shots() { return rounds_fired; }
+  bool arrest(int outlaws) {
+    (void)this;
+    return outlaws > 0;
+  }
+
+  int rounds_fired{};
+};
+
+// This is bad, actually. For it to work, it would need to use the `InChainOf`
+// technique.
+consteval auto corvid_proxy_spec(marshal*, vigilante*) {
+  return prox::make_proxy_spec<marshal, vigilante>();
+}
+
 // Lifetime accounting shared by the owning-proxy targets.
 struct life_stats {
   int constructed{};
@@ -280,9 +422,9 @@ struct life_stats {
   int moves{};
 };
 
-// Move-only lifetime-counting target. `Pad` scales the footprint so one
-// instantiation fits the proxy's inline buffer and another forces the heap
-// path.
+// `strongbox` is a move-only lifetime-counting target. `Pad` scales the
+// footprint so one instantiation fits the proxy's inline buffer and another
+// forces the heap path.
 template<std::size_t Pad>
 struct strongbox {
   explicit strongbox(life_stats& stats) noexcept : stats_{&stats} {
@@ -306,15 +448,24 @@ struct strongbox {
   std::byte pad_[Pad]{};
 };
 
-// The facade for the lifetime tests.
+// The facade for the lifetime tests. For testing purposes, we're not providing
+// an `api`, or including the `boilerplate` inside the facade.
 struct lockbox
     : prox::facade<                      //
           prox::method<"add", int(int)>, //
           prox::method<"gold", int() const>> {};
 
-// Boilerplate impl for `lockbox`.
+// Boilerplate impl for `lockbox`, in the namespace-scope spelling: a
+// `proxy_impl` partial specialization gated on `ProxyRegistered`.
+//
+// Still supported and equivalent; the other facades in this file host theirs
+// nested (see `gunslinger`). The `SpecCarriesImpl` exclusion keeps a
+// registration-carried impl winning over this boilerplate, which the nested
+// form gets from the library automatically; without it, partial ordering
+// would prefer this specialization.
 template<typename T>
-requires prox::ProxyRegistered<lockbox, T>
+requires(
+    prox::ProxyRegistered<lockbox, T> && !prox::SpecCarriesImpl<lockbox, T>)
 struct prox::proxy_impl<lockbox, T> {
   static int on(method_key<"add">, T& t, int nuggets) {
     return t.add(nuggets);
@@ -350,36 +501,45 @@ static_assert(!std::derived_from<prox::method<"fire", int(int)>,
 // UDL: `"name"_method` is a `prox::method_key<"name">`.
 static_assert(std::same_as<decltype("fire"_method), prox::method_key<"fire">>);
 
-// Registration state. Lawman is registered, robber conforms without
-// registration, cowboy neither registers nor conforms.
+// Registration state. Every conforming type is registered; cowboy neither
+// registers nor conforms.
 static_assert(prox::ProxyRegistered<gunslinger, lawman>);
 static_assert(prox::ProxyRegistered<gunslinger, deputy>);
-static_assert(!prox::ProxyRegistered<gunslinger, robber>);
-static_assert(!prox::ProxyRegistered<gunslinger, sheriff>);
+static_assert(prox::ProxyRegistered<gunslinger, robber>);
+static_assert(prox::ProxyRegistered<gunslinger, sheriff>);
 static_assert(!prox::ProxyRegistered<gunslinger, cowboy>);
 static_assert(std::same_as<decltype(prox::proxy_spec_v<gunslinger, lawman>),
     const prox::proxy_spec<gunslinger, lawman>>);
 
-// Conformance. Boilerplate via registration, explicit impl directly, and
+// Conformance. Boilerplate or carried impl, always via registration;
 // matching names alone are NOT enough.
 //
-// Diagnostics on record (clang 22, captured 2026-07-08). Constructing
-// `proxy_view<gunslinger>` from an unregistered `cowboy` emits exactly one
-// error: "no matching constructor for initialization of
-// 'proxy_view<gunslinger>' ... candidate template ignored: constraints not
-// satisfied [with T = cowboy] ... because 'Proxiable<cowboy, gunslinger>'
-// evaluated to false ... because
-// 'details::info_t<gunslinger>::all_bound_v<gunslinger, cowboy>' evaluated
-// to false". Calling `pv.call<"missing">()` fires the static_assert
-// "facade has no method with this name", followed by `std::get` index-noise
-// errors; the follow-on noise is accepted (a guarding `if constexpr` was
-// tried and dropped as a simplification), since fixing the obvious message
-// also removes the noise.
+// Diagnostics on record (clang 22, re-captured 2026-07-08 after the
+// composition refactor). Constructing `proxy_view<gunslinger>` from an
+// unregistered `cowboy` emits exactly one error: "no matching constructor
+// for initialization of 'proxy_view<gunslinger>' ... candidate template
+// ignored: constraints not satisfied [with T = cowboy] ... because
+// 'Proxiable<cowboy, gunslinger>' evaluated to false ... because
+// 'details::vtbuild_t<gunslinger>::all_bound_v<gunslinger, cowboy>'
+// evaluated to false", plus two "could not match" notes for the dedicated
+// upcasting and proxy-viewing constructors. Calling `pv.call<"missing">()`
+// fires the static_assert "facade has no method with this name", followed by
+// `std::get` index-noise errors; the follow-on noise is accepted (a guarding
+// `if constexpr` was tried and dropped as a simplification), since fixing
+// the obvious message also removes the noise.
 static_assert(Proxiable<lawman, gunslinger>);
 static_assert(Proxiable<robber, gunslinger>);
 static_assert(Proxiable<sheriff, gunslinger>);
 static_assert(!Proxiable<cowboy, gunslinger>);
 static_assert(!Proxiable<int, gunslinger>);
+
+// The concept reports exactly the carried registrations: boilerplate-only
+// registrations like lawman's carry nothing.
+static_assert(Proxiable<turncoat, gunslinger>);
+static_assert(prox::SpecCarriesImpl<gunslinger, robber>);
+static_assert(prox::SpecCarriesImpl<gunslinger, sheriff>);
+static_assert(prox::SpecCarriesImpl<gunslinger, turncoat>);
+static_assert(!prox::SpecCarriesImpl<gunslinger, lawman>);
 
 // Noexcept qualification is part of the method flavor.
 static_assert(!prox::method<"fire", int(int)>::noexcept_v);
@@ -442,23 +602,93 @@ static_assert(
     std::constructible_from<const_proxy_view<gunslinger>, const lawman&>);
 static_assert(!std::constructible_from<proxy_view<gunslinger>, const lawman&>);
 
-// An all-const facade is the one case where a const view satisfies the
-// invariant. A mixed facade correctly fails it (the mutable methods are not
-// dispatchable, so conformance is impossible; Rust's `&dyn` analog).
+// `census` is an all-const facade. This is the only case where a const view
+// satisfies the invariant for the facade as a whole. A mixed facade correctly
+// fails it (the mutable methods are not dispatchable, so conformance is
+// impossible; Rust's `&dyn` analog).
 struct census: prox::facade<prox::method<"describe", std::string() const>> {};
 
-// Conformance here is a deliberate one-off full specialization. The
-// boilerplate and registration tiers are already exercised by `gunslinger` and
-// `lockbox`, and `census` exists only to serve the const-view assertions.
-template<>
-struct prox::proxy_impl<census, lawman> {
-  static std::string on(method_key<"describe">, const lawman& l) {
-    return l.describe();
-  }
-};
+// Conformance here is a one-off carried impl: `census` exists only to serve
+// the const-view assertions, so it defines no boilerplate at all.
+consteval auto corvid_proxy_spec(census*, lawman*) {
+  struct as_census {
+    static std::string on(prox::method_key<"describe">, const lawman& l) {
+      return l.describe();
+    }
+  };
+  return prox::make_proxy_spec<census, lawman, as_census>();
+}
 
 static_assert(Proxiable<const_proxy_view<census>, census>);
 static_assert(!Proxiable<const_proxy_view<gunslinger>, gunslinger>);
+
+// Composition. A composed facade flattens its bases' methods ahead of its
+// own; `Extends` is transitive and strict.
+static_assert(prox::Facade<marshal>);
+static_assert(prox::Extends<marshal, gunslinger>);
+static_assert(prox::Extends<texas_ranger, marshal>);
+static_assert(prox::Extends<texas_ranger, gunslinger>);
+static_assert(!prox::Extends<gunslinger, marshal>);
+static_assert(!prox::Extends<marshal, marshal>);
+
+// Conformance is per facade in the chain. Registering the derived facade
+// alone is not enough (Rust's separate `impl Base for T`), and conforming to
+// the base says nothing about the derived facade.
+//
+// Diagnostics on record (clang 22, captured 2026-07-08). Constructing
+// `proxy_view<marshal>` from `vigilante` emits one error with the same
+// constraint walk as the `cowboy` case, ending at
+// 'details::vtbuild_t<marshal>::all_bound_v<marshal, vigilante>' evaluated
+// to false"; the walk does not name the missing base facade. Redeclaring an
+// inherited name (`facade<extends<gunslinger>, method<"fire", int(int)>>`)
+// detonates at first use of the facade's machinery: "static assertion failed
+// ... 'unique_method_names<...>()': method names must be unique across the
+// facade and its extends bases", with the flattened list, duplicate
+// included, spelled out in the requirement, followed by one follow-on
+// "no type named 'vtable_t'" noise error.
+static_assert(Proxiable<ranger, gunslinger>);
+static_assert(Proxiable<ranger, marshal>);
+static_assert(Proxiable<ranger, texas_ranger>);
+static_assert(!Proxiable<vigilante, marshal>);
+static_assert(!Proxiable<vigilante, gunslinger>);
+static_assert(!Proxiable<lawman, marshal>);
+
+// The chain hook registers every level of the chain, and nothing else.
+static_assert(prox::ProxyRegistered<texas_ranger, ranger>);
+static_assert(prox::ProxyRegistered<marshal, ranger>);
+static_assert(prox::ProxyRegistered<gunslinger, ranger>);
+static_assert(!prox::ProxyRegistered<hair_trigger, ranger>);
+
+// Handles of a derived facade satisfy the base facade too (Rust: a `dyn
+// Derived` meets a `Base` bound).
+static_assert(Proxiable<proxy_view<marshal>, gunslinger>);
+static_assert(Proxiable<proxy_view<texas_ranger>, marshal>);
+static_assert(Proxiable<proxy<texas_ranger>, gunslinger>);
+
+// Upcast conversions exist in exactly the safe directions: no downcasts, no
+// regaining mutability, and no views of temporary proxies.
+static_assert(
+    std::convertible_to<proxy_view<marshal>, proxy_view<gunslinger>>);
+static_assert(
+    std::convertible_to<proxy_view<texas_ranger>, proxy_view<gunslinger>>);
+static_assert(std::convertible_to<const_proxy_view<texas_ranger>,
+    const_proxy_view<gunslinger>>);
+static_assert(
+    std::convertible_to<proxy_view<marshal>, const_proxy_view<gunslinger>>);
+static_assert(
+    !std::convertible_to<proxy_view<gunslinger>, proxy_view<marshal>>);
+static_assert(!std::constructible_from<proxy_view<gunslinger>,
+    const_proxy_view<marshal>&>);
+static_assert(std::convertible_to<proxy<marshal>&, proxy_view<marshal>>);
+static_assert(std::convertible_to<proxy<marshal>&, proxy_view<gunslinger>>);
+static_assert(
+    std::convertible_to<proxy<marshal>&, const_proxy_view<gunslinger>>);
+static_assert(
+    std::convertible_to<const proxy<marshal>&, const_proxy_view<gunslinger>>);
+static_assert(
+    !std::constructible_from<proxy_view<gunslinger>, const proxy<marshal>&>);
+static_assert(
+    !std::constructible_from<proxy_view<gunslinger>, proxy<gunslinger>>);
 
 // The call-site vocabulary is exported to `corvid::meta`, so this file uses
 // the unqualified spellings throughout. Only authoring (facades, impls,
@@ -475,6 +705,7 @@ static_assert(std::same_as<const_proxy_view<gunslinger>,
 static_assert(sizeof(proxy_view<gunslinger>) == 2 * sizeof(void*));
 static_assert(sizeof(const_proxy_view<gunslinger>) == 2 * sizeof(void*));
 static_assert(sizeof(proxy_view<lockbox>) == 2 * sizeof(void*));
+static_assert(sizeof(proxy_view<texas_ranger>) == 2 * sizeof(void*));
 
 // The sugar carries `noexcept` when the facade author marks the forwarders.
 static_assert(noexcept(std::declval<proxy_view<hair_trigger>&>().fire(1)));
@@ -502,12 +733,22 @@ static_assert(!noexcept(std::declval<proxy_view<gunslinger>&>().fire(1)));
 static_assert(prox::validate_api<gunslinger>());
 static_assert(prox::validate_api<hair_trigger>());
 
+// For a composed facade, the same chain also validates the inherited
+// forwarders (brought in here by deriving the `api` from the base facade's)
+// against the flattened method list.
+static_assert(prox::validate_api<marshal>());
+static_assert(prox::validate_api<texas_ranger>());
+
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
 TEST_CASE("Boilerplate impl through registration", "[proxy]") {
   lawman l;
   proxy_view<gunslinger> pv{l};
 
+  // This case deliberately exercises the core `call<>` spelling end to end.
+  // Real call sites prefer the `api` sugar, which the rest of this file uses
+  // wherever a facade defines one; "Member-call sugar" below pins the
+  // equivalence of the two spellings.
   CHECK(pv.call<"fire">(3) == 3);
   CHECK(pv.call<"fire">(2) == 5);
   CHECK(l.rounds_fired == 5);
@@ -521,16 +762,17 @@ TEST_CASE("Boilerplate impl through registration", "[proxy]") {
   CHECK(l.rounds_fired == 0);
 }
 
-TEST_CASE("Custom impl without registration", "[proxy]") {
+TEST_CASE("Registration-carried impl", "[proxy]") {
+  // `robber` conforms through the impl its registration names.
   robber r;
   proxy_view<gunslinger> pv{r};
 
-  CHECK(pv.call<"fire">(6) == 6);
+  CHECK(pv.fire(6) == 6);
   CHECK(r.fired == 6);
-  CHECK(pv.call<"describe">() == "robber"s);
-  CHECK(pv.call<"shots">() == 6);
+  CHECK(pv.describe() == "robber"s);
+  CHECK(pv.shots() == 6);
 
-  pv.call<"reload">();
+  pv.reload();
   CHECK(r.fired == 0);
 }
 
@@ -539,14 +781,25 @@ TEST_CASE("Partially-overridden boilerplate impl", "[proxy]") {
   proxy_view<gunslinger> pv{s};
 
   // The overriding binding: "fire" routes to `shoot`.
-  CHECK(pv.call<"fire">(4) == 4);
+  CHECK(pv.fire(4) == 4);
   CHECK(s.rounds_fired == 4);
 
   // The inherited boilerplate bindings still serve the rest.
-  CHECK(pv.call<"describe">() == "sheriff"s);
-  CHECK(pv.call<"shots">() == 4);
-  pv.call<"reload">();
+  CHECK(pv.describe() == "sheriff"s);
+  CHECK(pv.shots() == 4);
+  pv.reload();
   CHECK(s.rounds_fired == 0);
+}
+
+TEST_CASE("Carried impl outranks the boilerplate", "[proxy]") {
+  // `turncoat`'s names line up, so the boilerplate would serve it, but its
+  // registration carries an impl overriding one binding. The rest still
+  // dispatch through the inherited boilerplate bindings.
+  turncoat t;
+  proxy_view<gunslinger> tv{t};
+  CHECK(tv.fire(2) == 2);
+  CHECK(t.rounds_fired == 2);
+  CHECK(tv.describe() == "undercover"s);
 }
 
 TEST_CASE("Heterogeneous dispatch", "[proxy]") {
@@ -558,8 +811,8 @@ TEST_CASE("Heterogeneous dispatch", "[proxy]") {
   // Mutable references. The "fire" method no longer dispatches through a const
   // view.
   for (auto& pv : gang) {
-    pv.call<"fire">(2);
-    roll_call += pv.call<"describe">();
+    pv.fire(2);
+    roll_call += pv.describe();
     roll_call += ' ';
   }
   CHECK(roll_call == "lawman robber "s);
@@ -568,7 +821,7 @@ TEST_CASE("Heterogeneous dispatch", "[proxy]") {
 
   // Copies are shallow, so both views alias the same target.
   auto pv2 = gang[0];
-  pv2.call<"fire">(1);
+  pv2.fire(1);
   CHECK(l.rounds_fired == 3);
 }
 
@@ -576,34 +829,36 @@ TEST_CASE("Views rebind by assignment", "[proxy]") {
   lawman l;
   robber r;
   proxy_view<gunslinger> pv{l};
-  CHECK(pv.call<"describe">() == "lawman"s);
+  CHECK(pv.describe() == "lawman"s);
 
   // Assignment rebinds both the target and the dispatch table.
   pv = proxy_view<gunslinger>{r};
-  CHECK(pv.call<"describe">() == "robber"s);
+  CHECK(pv.describe() == "robber"s);
 }
 
 TEST_CASE("Const view", "[proxy]") {
   // A const target binds directly. Only const methods exist on this view.
   const lawman cl{};
   const_proxy_view<gunslinger> cv{cl};
-  CHECK(cv.call<"describe">() == "lawman"s);
+  CHECK(cv.describe() == "lawman"s);
 
   // A const instance of the mutable view enforces the same restriction.
   lawman l;
   const proxy_view<gunslinger> cpv{l};
-  CHECK(cpv.call<"describe">() == "lawman"s);
+  CHECK(cpv.describe() == "lawman"s);
 
   // The mutable view converts implicitly, and const views rebind by
   // assignment like any view.
   proxy_view<gunslinger> pv{l};
   const_proxy_view<gunslinger> cv2{pv};
-  CHECK(cv2.call<"describe">() == "lawman"s);
+  CHECK(cv2.describe() == "lawman"s);
   cv = cv2;
-  CHECK(cv.call<"describe">() == "lawman"s);
+  CHECK(cv.describe() == "lawman"s);
 
   // All-const facades keep the invariant. Generic code constrained on the
   // facade accepts the concrete const target and the const view alike.
+  // `census` defines no `api`, so `call<>` is its real spelling (and needs
+  // the dependent-name `template` keyword in this generic context).
   auto describe_it = [](const Proxiable<census> auto& t) {
     const_proxy_view<census> v{t};
     return v.template call<"describe">();
@@ -618,9 +873,8 @@ TEST_CASE("Generic code accepts concrete and erased alike", "[proxy]") {
   // trait bound for the static-dispatch half.
   auto fire_twice = [](Proxiable<gunslinger> auto& g) {
     auto pv = make_proxy_view<gunslinger>(g);
-    // In a template context the view's type is dependent, hence `template`.
-    pv.template call<"fire">(1);
-    return pv.template call<"fire">(1);
+    pv.fire(1);
+    return pv.fire(1);
   };
 
   lawman l;
@@ -696,20 +950,22 @@ TEST_CASE("Owning proxy is deep-const", "[proxy]") {
   // Only const-qualified facade methods dispatch through a const proxy. The
   // negative half is covered by the `CanFire` static_asserts above.
   const auto p = make_proxy<gunslinger, lawman>();
-  CHECK(p.call<"describe">() == "lawman"s);
+  CHECK(p.describe() == "lawman"s);
 }
 
 TEST_CASE("Noexcept facade methods", "[proxy]") {
   lawman l;
   proxy_view<hair_trigger> pv{l};
-  CHECK(pv.call<"fire">(2) == 2);
-  CHECK(!pv.call<"jams">());
+  CHECK(pv.fire(2) == 2);
+  CHECK(!pv.jams());
 
+  // The `call<>` asserts pin the erased call's own noexcept; the sugar's is
+  // pinned at file scope.
   auto p = make_proxy<hair_trigger, lawman>();
-  CHECK(p.call<"fire">(4) == 4);
+  CHECK(p.fire(4) == 4);
   static_assert(noexcept(p.call<"fire">(4)));
   const auto& cp = p;
-  CHECK(!cp.call<"jams">());
+  CHECK(!cp.jams());
   static_assert(noexcept(cp.call<"jams">()));
 }
 
@@ -761,6 +1017,99 @@ TEST_CASE("Member-call sugar via the api mixin", "[proxy]") {
   CHECK(mv.lob(3) == 3);
 }
 
+TEST_CASE("Facade composition", "[proxy]") {
+  ranger r;
+  proxy_view<marshal> mv{r};
+
+  // Inherited and own methods dispatch through the same flattened table,
+  // through the inherited and own `api` forwarders alike.
+  CHECK(mv.fire(2) == 2);
+  CHECK(mv.describe() == "ranger"s);
+  CHECK(mv.arrest(1));
+  CHECK(r.arrested == 1);
+
+  // The core spelling hits the same slot, inherited or not.
+  CHECK(mv.call<"fire">(1) == 3);
+  CHECK(mv.call<"arrest">(2));
+  CHECK(r.arrested == 3);
+
+  // Two composition levels down, same story.
+  proxy_view<texas_ranger> tv{r};
+  CHECK(tv.track() == 3);
+  CHECK(tv.fire(1) == 4);
+  CHECK(tv.arrest(1));
+  CHECK(tv.track() == 4);
+
+  // An owning proxy of a composed facade dispatches the whole chain too.
+  auto p = make_proxy<texas_ranger, ranger>();
+  CHECK(p.fire(5) == 5);
+  CHECK(p.arrest(1));
+  CHECK(p.track() == 1);
+}
+
+TEST_CASE("Upcasting views", "[proxy]") {
+  ranger r;
+  proxy_view<texas_ranger> tv{r};
+
+  // Upcast to the immediate base and to the root. Every view aliases the
+  // same target, so mutations are visible through all of them.
+  proxy_view<marshal> mv = tv;
+  proxy_view<gunslinger> gv = tv;
+  CHECK(gv.fire(2) == 2);
+  CHECK(mv.fire(1) == 3);
+  CHECK(r.rounds_fired == 3);
+  CHECK(mv.arrest(1));
+  CHECK(gv.describe() == "ranger"s);
+
+  // An upcast view is indistinguishable from a directly-built one.
+  proxy_view<gunslinger> direct{r};
+  CHECK(&direct.shots() == &gv.shots());
+
+  // Upcasts rebind by assignment like any view.
+  lawman l;
+  gv = proxy_view<gunslinger>{l};
+  CHECK(gv.describe() == "lawman"s);
+  gv = mv;
+  CHECK(gv.describe() == "ranger"s);
+
+  // Const upcasts: from the mutable view, and from a const view of a const
+  // target.
+  const_proxy_view<gunslinger> cgv = tv;
+  CHECK(cgv.describe() == "ranger"s);
+  const ranger cr{};
+  const_proxy_view<texas_ranger> ctv{cr};
+  const_proxy_view<gunslinger> cgv2 = ctv;
+  CHECK(cgv2.describe() == "ranger"s);
+}
+
+TEST_CASE("Viewing an owning proxy", "[proxy]") {
+  auto p = make_proxy<texas_ranger, ranger>();
+
+  // The view re-points at the stored target rather than wrapping the handle,
+  // so it aliases the proxy's state, same facade or upcast.
+  proxy_view<texas_ranger> tv = p;
+  proxy_view<gunslinger> gv = p;
+  CHECK(tv.fire(2) == 2);
+  CHECK(gv.shots() == 2);
+  gv.reload();
+  CHECK(p.shots() == 0);
+
+  // A const proxy yields only the const view.
+  const auto& cp = p;
+  const_proxy_view<gunslinger> cgv = cp;
+  CHECK(cgv.describe() == "ranger"s);
+
+  // Facade-constrained generic code accepts the derived handles under the
+  // base bound (cross-facade self-conformance), and `make_proxy_view`
+  // re-points rather than wrapping.
+  auto fire_once = [](Proxiable<gunslinger> auto& g) {
+    auto v = make_proxy_view<gunslinger>(g);
+    return v.fire(1);
+  };
+  CHECK(fire_once(p) == 1);
+  CHECK(fire_once(tv) == 2);
+}
+
 TEST_CASE("Heterogeneous ownership", "[proxy]") {
   std::vector<proxy<gunslinger>> gang;
   gang.push_back(make_proxy<gunslinger, lawman>());
@@ -768,8 +1117,8 @@ TEST_CASE("Heterogeneous ownership", "[proxy]") {
 
   std::string roll_call;
   for (auto& p : gang) {
-    p.call<"fire">(2);
-    roll_call += p.call<"describe">();
+    p.fire(2);
+    roll_call += p.describe();
     roll_call += ' ';
   }
   CHECK(roll_call == "lawman robber "s);

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -697,16 +697,31 @@ struct arsenal
   };
 };
 
-// `armory` extends `arsenal`, inheriting the overload sets whole.
+// `armory` extends `arsenal`, inheriting the overload sets whole, and
+// overloads the inherited `issue` across the level boundary with a
+// two-argument flavor: different functions sharing a spelling, exactly as
+// within one facade.
 struct armory
-    : prox::facade<prox::name<"armory">,  //
-          prox::extends<arsenal>,         //
-          prox::method<"lock", void()>> { //
+    : prox::facade<prox::name<"armory">,        //
+          prox::extends<arsenal>,               //
+          prox::method<"issue", int(int, int)>, //
+          prox::method<"lock", void()>> {       //
   struct api: arsenal::api {
+    // The new forwarder hides the inherited `issue` forwarders until the
+    // using-declaration merges them, the same convention as sibling
+    // collisions; forgetting it is caught by `validate_api` at
+    // registration (diagnostic on record at the conformance asserts).
+    using arsenal::api::issue;
+    int issue(this auto&& self, int rifles, int crates) {
+      return self.template call<"issue">(rifles, crates);
+    }
     void lock(this auto&& self) { self.template call<"lock">(); }
   };
   template<typename T>
   struct boilerplate: proxy_impl_base {
+    static int on(method_key<"issue">, T& t, int rifles, int crates) {
+      return t.issue(rifles, crates);
+    }
     static void on(method_key<"lock">, T& t) { t.lock(); }
   };
 };
@@ -716,6 +731,7 @@ struct armory
 struct quartermaster {
   int issue(int rifles) { return stock_ -= rifles; }
   int issue() { return issue(1); }
+  int issue(int rifles, int crates) { return stock_ -= rifles * crates; }
   int aim(int paces) {
     (void)this;
     return paces;
@@ -1035,17 +1051,19 @@ static_assert(!prox::Extends<marshal, marshal>);
 // constraint walk as the `cowboy` case, ending at
 // 'details::vtbuild_t<marshal>::all_bound_v<marshal, vigilante>' evaluated
 // to false"; the walk does not name the missing base facade. Redeclaring an
-// inherited name (`facade<extends<gunslinger>, method<"fire", int(int)>>`)
+// inherited name with the same signature
+// (`facade<extends<gunslinger>, method<"fire", int(int)>>`)
 // detonates at first use of the facade's machinery: "static assertion
 // failed ... 'no_chain_collision_against<...>()': a method name may recur
-// within one facade only as overloads differing in arguments or constness,
-// and never across an extends chain", with the flattened slot list,
-// duplicate and declaring facades included, spelled out in the requirement,
-// followed by one follow-on "no type named 'vtable_t'" noise error. (Before
-// per-name overloads the message read "a facade cannot declare a method
-// name twice or redeclare an inherited one"; before the collision-rules
-// rework, the same shape failed 'unique_method_names' with "method names
-// must be unique across the facade and its extends bases".)
+// within one extends chain only as overloads differing in arguments or
+// constness", with the flattened slot list, duplicate and declaring facades
+// included, spelled out in the requirement, followed by one follow-on "no
+// type named 'vtable_t'" noise error. (A different signature is a legal
+// cross-level overload since the chain relaxation; before per-name
+// overloads the message read "a facade cannot declare a method name twice
+// or redeclare an inherited one"; before the collision-rules rework, the
+// same shape failed 'unique_method_names' with "method names must be
+// unique across the facade and its extends bases".)
 static_assert(Proxiable<texas_ranger, gunslinger>);
 static_assert(Proxiable<texas_ranger, marshal>);
 static_assert(Proxiable<texas_ranger, ranger>);
@@ -1131,20 +1149,22 @@ static_assert(CanReloadSugar<proxy_view<gunslinger>>);
 static_assert(CanReloadSugar<proxy_view<camera>>);
 static_assert(!CanReloadSugar<proxy_view<war_correspondent>>);
 
-// Per-name overload sets within one facade (`arsenal`). Legal when each
-// same-name pair differs in arguments or constness; overloading on the
-// result type or on `noexcept` alone stays a collision, and redeclaring an
-// inherited name stays an error, whatever its signature (the chain rules
-// are untouched). Registration validates the overloaded `api` by default.
+// Per-name overload sets (`arsenal`, and `armory` across the level
+// boundary). Legal when each same-name pair differs in arguments or
+// constness, whether the declarations share a facade or span an extends
+// chain; overloading on the result type or on `noexcept` alone stays a
+// collision, and a same-signature recurrence in a chain stays an error
+// (that is redeclaration). Registration validates the overloaded `api` by
+// default.
 //
 // Diagnostics on record (clang 22, captured 2026-07-10). A pair differing
 // only in the result type (`method<"x", int()>` plus `method<"x", long()>`)
 // detonates at first use of the facade's machinery: "static assertion
 // failed ... 'no_chain_collision_against<...>()': a method name may recur
-// within one facade only as overloads differing in arguments or constness,
-// and never across an extends chain", both slots spelled out in the
-// requirement, followed by the usual single "no type named 'vtable_t'"
-// noise error. A pair differing only in `noexcept` fires the same assert.
+// within one extends chain only as overloads differing in arguments or
+// constness", both slots spelled out in the requirement, followed by the
+// usual single "no type named 'vtable_t'" noise error. A pair differing
+// only in `noexcept` fires the same assert.
 static_assert(Proxiable<quartermaster, arsenal>);
 static_assert(Proxiable<quartermaster, armory>);
 static_assert(prox::validate_api<arsenal>());
@@ -1188,6 +1208,32 @@ static_assert(CanAimSugar<proxy_view<arsenal>, int>);
 static_assert(CanAimSugar<proxy_view<arsenal>, double>);
 static_assert(CanAimSugar<proxy_view<arsenal>, short>);
 static_assert(!CanAimSugar<proxy_view<arsenal>, long>);
+
+// Cross-level overloads: `armory`'s two-argument `issue` joins the
+// inherited pair on derived handles, and an upcast handle sees only the
+// base's set. In the `api`, the derived forwarder hides the inherited ones
+// until a using-declaration merges them (see the `armory` fixture), the
+// same convention as sibling collisions, and forgetting it is caught: the
+// validation probe drives the base slots by natural name through the base
+// boilerplate, where the hidden forwarders fail to resolve.
+//
+// Diagnostics on record (clang 22, captured 2026-07-10). Removing the
+// `using arsenal::api::issue;` from `armory::api` fails at the validating
+// registration with "no matching member function for call to 'issue'" at
+// `t.issue(rifles)` and `t.issue()` in `arsenal::boilerplate` (the
+// candidate note names the two-argument `armory` forwarder: "requires 2
+// non-object arguments, but 1 was provided"); any sugar call sites using
+// the hidden overloads fail the same way. Before the chain relaxation,
+// declaring `armory`'s `issue(int, int)` at all detonated with the
+// phase-7 message ("a method name may recur within one facade only as
+// overloads differing in arguments or constness, and never across an
+// extends chain").
+template<typename P, typename... As>
+concept CanIssueSugar = requires(P& p, As... as) { p.issue(as...); };
+static_assert(CanIssueSugar<proxy_view<armory>>);
+static_assert(CanIssueSugar<proxy_view<armory>, int>);
+static_assert(CanIssueSugar<proxy_view<armory>, int, int>);
+static_assert(!CanIssueSugar<proxy_view<arsenal>, int, int>);
 
 // Handles of a derived facade satisfy the base facade too (Rust: a `dyn
 // Derived` meets a `Base` bound).
@@ -1835,6 +1881,16 @@ TEST_CASE("Per-name overloads", "[proxy]") {
   CHECK(std::as_const(p).count() == 8);
   CHECK(p.call<"arsenal::issue">() == 7);
   p.lock();
+
+  // Overloads span levels: `armory`'s own two-argument `issue` dispatches
+  // alongside the inherited pair, by argument count unqualified and through
+  // each level's qualified spelling; an upcast handle sees only the base's
+  // set (the sugar probe is the `CanIssueSugar` static_asserts).
+  CHECK(p.issue(2, 3) == 1);
+  CHECK(p.call<"armory::issue">(1, 1) == 0);
+  CHECK(p.call<"arsenal::issue">(10) == -10);
+  proxy_view<arsenal> base_view = p;
+  CHECK(base_view.issue() == -11);
 
   auto sp = make_shared_proxy<arsenal, quartermaster>();
   CHECK(sp.issue() == 19);

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -1941,7 +1941,7 @@ TEST_CASE("Sibling method collisions", "[proxy]") {
   CHECK(ph.rounds_fired == 0);
   wc.call<"camera::reload">();
   CHECK(ph.film_wound == 1);
-  // Note that `wc.reload();` would be ambigous and fail at compile time.
+  // Note that `wc.reload();` would be ambiguous and fail at compile time.
   // In contrast, `ph.reload();` is unambiguous and works, because
   // `photographer` uses that name for the `gunslinger` binding.
 

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -18,12 +18,14 @@
 #include <concepts>
 #include <cstddef>
 #include <memory>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "corvid/meta/proxy.h"
+#include "corvid/meta/proxy_codegen.h"
 #include "catch2_main.h"
 
 using namespace std::literals;
@@ -1064,6 +1066,21 @@ static_assert(!prox::Extends<marshal, marshal>);
 // or redeclare an inherited one"; before the collision-rules rework, the
 // same shape failed 'unique_method_names' with "method names must be
 // unique across the facade and its extends bases".)
+// A facade is never a value: the deleted default constructor on `facade`
+// propagates, so declaring a `gunslinger` where a handle over one was meant
+// fails at the declaration. Handles stay constructible as always.
+//
+// Diagnostic on record (clang 22, captured 2026-07-10): `gunslinger g;`
+// fails with a single error, "call to implicitly-deleted default
+// constructor of 'gunslinger'", with notes walking to the cause ("default
+// constructor of 'gunslinger' is implicitly deleted because base class
+// 'prox::facade<...>' has a deleted default constructor" and "'facade' has
+// been explicitly marked deleted here").
+static_assert(!std::is_default_constructible_v<gunslinger>);
+static_assert(!std::is_default_constructible_v<posse_leader>);
+static_assert(std::is_default_constructible_v<proxy<gunslinger>>);
+static_assert(std::is_default_constructible_v<proxy_view<gunslinger>>);
+
 static_assert(Proxiable<texas_ranger, gunslinger>);
 static_assert(Proxiable<texas_ranger, marshal>);
 static_assert(Proxiable<texas_ranger, ranger>);
@@ -2623,6 +2640,207 @@ TEST_CASE("Shared ownership interop with std", "[proxy]") {
     CHECK(shared_inline.call<"gold">() == 2);
   }
   CHECK(stats.destroyed == stats.constructed);
+}
+
+TEST_CASE("Codegen", "[proxy]") {
+  // `prox::codegen<F>(os)` writes the canonical `api` and `boilerplate` for
+  // pasting into the facade body. The goldens pin every generated shape:
+  // value, void, and reference returns; const and noexcept flavors; overload
+  // sets; the const pair's trailing requires-clause; base `api` inheritance
+  // with the using-declarations that un-hide inherited names; redeclared
+  // forwarders for methods the inherited path does not cover (the
+  // single-path diamond shape); and the facade-wide `arg_N` numbering, one
+  // sequence spanning all methods (covered slots consume numbers, hence the
+  // gaps), so a rename after pasting hits the `api` and `boilerplate`
+  // together.
+  std::ostringstream oss;
+
+  // The plain facade: every return shape, a const method, one parameter.
+  constexpr std::string_view gunslinger_golden = R"(  struct api {
+    int fire(this auto&& self, int arg_1) {
+      return self.template call<"fire">(arg_1);
+    }
+    std::string describe(this const auto& self) {
+      return self.template call<"describe">();
+    }
+    void reload(this auto&& self) {
+      self.template call<"reload">();
+    }
+    int& shots(this auto&& self) {
+      return self.template call<"shots">();
+    }
+  };
+  template<typename T>
+  struct boilerplate: proxy_impl_base {
+    static int on(method_key<"fire">, T& t, int arg_1) {
+      return t.fire(arg_1);
+    }
+    static std::string on(method_key<"describe">, const T& t) {
+      return t.describe();
+    }
+    static void on(method_key<"reload">, T& t) {
+      t.reload();
+    }
+    static int& on(method_key<"shots">, T& t) {
+      return t.shots();
+    }
+  };
+)";
+  prox::codegen<gunslinger>(oss);
+  CHECK(oss.str() == gunslinger_golden);
+
+  // Noexcept flavors mark the forwarders and the bindings alike.
+  constexpr std::string_view hair_trigger_golden = R"(  struct api {
+    int fire(this auto&& self, int arg_1) noexcept {
+      return self.template call<"fire">(arg_1);
+    }
+    bool jams(this const auto& self) noexcept {
+      return self.template call<"jams">();
+    }
+  };
+  template<typename T>
+  struct boilerplate: proxy_impl_base {
+    static int on(method_key<"fire">, T& t, int arg_1) noexcept {
+      return t.fire(arg_1);
+    }
+    static bool on(method_key<"jams">, const T& t) noexcept {
+      return t.jams();
+    }
+  };
+)";
+  oss.str({});
+  prox::codegen<hair_trigger>(oss);
+  CHECK(oss.str() == hair_trigger_golden);
+
+  // Overload sets, including the const pair with its requires-clause.
+  constexpr std::string_view arsenal_golden = R"(  struct api {
+    int issue(this auto&& self, int arg_1) {
+      return self.template call<"issue">(arg_1);
+    }
+    int issue(this auto&& self) {
+      return self.template call<"issue">();
+    }
+    int aim(this auto&& self, int arg_2) {
+      return self.template call<"aim">(arg_2);
+    }
+    int aim(this auto&& self, double arg_3) {
+      return self.template call<"aim">(arg_3);
+    }
+    int& count(this auto&& self)
+    requires(requires {
+      { self.template call<"count">() } -> std::same_as<int&>;
+    })
+    {
+      return self.template call<"count">();
+    }
+    int count(this const auto& self) {
+      return self.template call<"count">();
+    }
+  };
+  template<typename T>
+  struct boilerplate: proxy_impl_base {
+    static int on(method_key<"issue">, T& t, int arg_1) {
+      return t.issue(arg_1);
+    }
+    static int on(method_key<"issue">, T& t) {
+      return t.issue();
+    }
+    static int on(method_key<"aim">, T& t, int arg_2) {
+      return t.aim(arg_2);
+    }
+    static int on(method_key<"aim">, T& t, double arg_3) {
+      return t.aim(arg_3);
+    }
+    static int& on(method_key<"count">, T& t) {
+      return t.count();
+    }
+    static int on(method_key<"count">, const T& t) {
+      return t.count();
+    }
+  };
+)";
+  oss.str({});
+  prox::codegen<arsenal>(oss);
+  CHECK(oss.str() == arsenal_golden);
+
+  // Extends with a cross-level overload: the base api is inherited by its
+  // C++ type name, the hidden inherited name is merged back with a using,
+  // and the numbering continues past the covered base slots.
+  constexpr std::string_view armory_golden = R"(  struct api: arsenal::api {
+    using arsenal::api::issue;
+    int issue(this auto&& self, int arg_4, int arg_5) {
+      return self.template call<"issue">(arg_4, arg_5);
+    }
+    void lock(this auto&& self) {
+      self.template call<"lock">();
+    }
+  };
+  template<typename T>
+  struct boilerplate: proxy_impl_base {
+    static int on(method_key<"issue">, T& t, int arg_4, int arg_5) {
+      return t.issue(arg_4, arg_5);
+    }
+    static void on(method_key<"lock">, T& t) {
+      t.lock();
+    }
+  };
+)";
+  oss.str({});
+  prox::codegen<armory>(oss);
+  CHECK(oss.str() == armory_golden);
+
+  // Two unrelated bases: the heavier one is inherited, the lighter one's
+  // methods are redeclared, and collided names get their usings. Note the
+  // base spelled by TYPE name (`gunslinger`), where a formal-name spelling
+  // would also have worked here but breaks for facades like
+  // `war_correspondent` itself, whose formal name is "correspondent".
+  constexpr std::string_view war_correspondent_golden =
+      R"(  struct api: gunslinger::api {
+    using gunslinger::api::fire;
+    using gunslinger::api::reload;
+    std::string fire(this const auto& self) {
+      return self.template call<"fire">();
+    }
+    void reload(this auto&& self) {
+      self.template call<"reload">();
+    }
+    std::string byline(this const auto& self) {
+      return self.template call<"byline">();
+    }
+  };
+  template<typename T>
+  struct boilerplate: proxy_impl_base {
+    static std::string on(method_key<"byline">, const T& t) {
+      return t.byline();
+    }
+  };
+)";
+  oss.str({});
+  prox::codegen<war_correspondent>(oss);
+  CHECK(oss.str() == war_correspondent_golden);
+
+  // The diamond, generated in the recommended single-path shape: inherit
+  // the heavier chain, redeclare the lighter sibling's own method. This
+  // matches the hand-written `posse_leader` api exactly.
+  constexpr std::string_view posse_leader_golden =
+      R"(  struct api: marshal::api {
+    int claim(this auto&& self, int arg_3) {
+      return self.template call<"claim">(arg_3);
+    }
+    void rally(this auto&& self) {
+      self.template call<"rally">();
+    }
+  };
+  template<typename T>
+  struct boilerplate: proxy_impl_base {
+    static void on(method_key<"rally">, T& t) {
+      t.rally();
+    }
+  };
+)";
+  oss.str({});
+  prox::codegen<posse_leader>(oss);
+  CHECK(oss.str() == posse_leader_golden);
 }
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -476,18 +476,26 @@ struct bounty_hunter
 // and only one `proxy_impl<gunslinger, T>` exists no matter the path (unlike a
 // C++ non-virtual diamond, which has duplicated subobjects).
 //
-// The `api` diamond does need the facade author's help: both base `api`s
-// inherit `gunslinger::api`, so the shared ancestor's forwarder names are
-// ambiguous by ordinary C++ member lookup until a using-declaration pulls in
-// one path. One line per shared-ancestor method, through either base.
+// The `api` diamond does need the facade author's help, and the recommended
+// shape is to build it along ONE path: inherit the heavier chain and
+// redeclare the lighter siblings' own forwarders. Inheriting every base
+// `api` also works, but costs a using-declaration per shared-ancestor
+// method (two subobjects of the same empty `api` type make plain member
+// lookup ambiguous until a using-declaration pulls in one path) plus one
+// padding word in every handle (same-type subobjects need distinct
+// addresses, which empty-base optimization cannot paper over). There is no
+// automatic merge to reach for: using-declarations cannot be pack-expanded
+// over arbitrary names before reflection, and virtual inheritance would put
+// a vbptr in every handle.
 struct posse_leader
     : prox::facade<prox::name<"posse_leader">, //
           prox::extends<marshal>,              //
           prox::extends<bounty_hunter>,        //
           prox::method<"rally", void()>> {     //
-  struct api: marshal::api, bounty_hunter::api {
-    using marshal::api::fire, marshal::api::describe, marshal::api::reload,
-        marshal::api::shots;
+  struct api: marshal::api {
+    int claim(this auto&& self, int bounties) {
+      return self.template call<"claim">(bounties);
+    }
     void rally(this auto&& self) { self.template call<"rally">(); }
   };
   template<typename T>
@@ -551,7 +559,7 @@ struct camera
 // resolution ever runs.
 //
 // For `fire`, whose signatures differ, the using-declarations merge the
-// forwarders into a working overload set;. For `reload`, whose signatures
+// forwarders into a working overload set. For `reload`, whose signatures
 // match, the merged set is ambiguous at any unqualified call, lazily, which is
 // the pinned model: the qualified key or an upcast disambiguates. There's no
 // point injecting either `reload` with using declarations.
@@ -612,17 +620,18 @@ struct photographer {
 // validation (see the facade comment), and the rest ride the boilerplates.
 template<prox::InChainOf<war_correspondent> F>
 consteval auto corvid_proxy_spec(F*, photographer*) {
-  if constexpr (std::same_as<F, camera>) {
-    struct as_camera: camera::boilerplate<photographer> {
-      using camera::boilerplate<photographer>::on;
-      static void on(method_key<"reload">, photographer& p) { p.wind(); }
-    };
-    return prox::make_proxy_spec<F, photographer, as_camera>();
-  } else if constexpr (std::same_as<F, war_correspondent>) {
-    return prox::make_proxy_spec<F, photographer, prox::api_check::off>();
-  } else {
-    return prox::make_proxy_spec<F, photographer>();
-  }
+  struct as_camera: camera::boilerplate<photographer> {
+    using camera::boilerplate<photographer>::on;
+    static void on(method_key<"reload">, photographer& p) { p.wind(); }
+  };
+  constexpr auto check =
+      std::same_as<F, war_correspondent>
+          ? prox::api_check::off
+          : prox::api_check::on;
+  if constexpr (std::same_as<F, camera>)
+    return prox::make_proxy_spec<F, photographer, as_camera, check>();
+  else
+    return prox::make_proxy_spec<F, photographer, check>();
 }
 
 // Lifetime accounting shared by the owning-proxy targets.
@@ -916,12 +925,11 @@ static_assert(Proxiable<trail_boss, bounty_hunter>);
 static_assert(Proxiable<trail_boss, gunslinger>);
 static_assert(prox::validate_api<posse_leader>());
 
-// The `api` diamond has one honest cost: the two empty `gunslinger::api`
-// subobjects are the same type, so the ABI must give them distinct
-// addresses, and the handle picks up a padding word that empty-base
-// optimization cannot remove. An author who cares can avoid it by
-// inheriting one path only and redeclaring the other base's own forwarders.
-static_assert(sizeof(proxy_view<posse_leader>) == 3 * sizeof(void*));
+// The single-path `api` keeps the diamond handle at two pointers. (When it
+// briefly inherited both base `api`s, the two same-type empty
+// `gunslinger::api` subobjects needed distinct addresses and the handle
+// measured three pointers; see the facade comment.)
+static_assert(sizeof(proxy_view<posse_leader>) == 2 * sizeof(void*));
 
 // Sibling collisions. The composition is legal outright (every facade
 // carries a name, so the qualified spelling is always available),

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -2569,6 +2569,15 @@ TEST_CASE("Downcasting a shared_proxy", "[proxy]") {
   // An empty handle downcasts to an empty handle.
   shared_proxy<gunslinger> nobody;
   CHECK(!nobody.try_downcast<marshal>());
+
+  // A moved-from handle is empty too, and downcasts to empty, even though
+  // it keeps a stale table pointer internally.
+  auto sm = make_shared_proxy<marshal, texas_ranger>();
+  shared_proxy<gunslinger> upcast_away{std::move(sm)};
+  REQUIRE(upcast_away);
+  CHECK(!sm); // NOLINT(bugprone-use-after-move): probing moved-from state.
+  // NOLINTNEXTLINE(bugprone-use-after-move): probing moved-from state.
+  CHECK(!sm.try_downcast<ranger>());
 }
 
 TEST_CASE("Cloning", "[proxy]") {

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -32,6 +32,13 @@ using namespace std::literals;
 using namespace corvid;
 using namespace corvid::meta::prox::literals;
 
+// The fixtures below form one western-themed world, reused across the feature
+// tiers.
+//
+// The "Test fixture map" section of corvid/meta/proxy.md diagrams the whole
+// hierarchy: every facade with its `extends` edges, plus the facade each
+// conforming type registers under and the registration route it takes.
+
 // The facade under test: mixes value returns, a const method, a void
 // mutator, and a reference return.
 //
@@ -1583,6 +1590,48 @@ TEST_CASE("Const view", "[proxy]") {
   CHECK(describe_it(cl) == "lawman"s);
   const_proxy_view<census> census_view{cl};
   CHECK(describe_it(census_view) == "lawman"s);
+}
+
+TEST_CASE("Empty handles propagate emptiness", "[proxy]") {
+  // Lending from an empty proxy yields an empty view, exactly as copying an
+  // empty view does; only calling through the result is undefined behavior.
+  // The same holds when the lend upcasts.
+  proxy<marshal> pm;
+  proxy_view<marshal> pv = pm;
+  CHECK(!pv);
+  const_proxy_view<marshal> cv = pm;
+  CHECK(!cv);
+  const proxy<marshal>& cpm = pm;
+  const_proxy_view<marshal> ccv = cpm;
+  CHECK(!ccv);
+  proxy_view<gunslinger> pvb = pm;
+  CHECK(!pvb);
+  const_proxy_view<gunslinger> cvb = pm;
+  CHECK(!cvb);
+  CHECK(!make_proxy_view<gunslinger>(pm));
+
+  // View-to-view upcasts of empty views yield empty views, along every
+  // route: mutable to mutable, const to const, and mutable to const, both
+  // same-facade and upcasting.
+  proxy_view<marshal> evm;
+  proxy_view<gunslinger> evb = evm;
+  CHECK(!evb);
+  const_proxy_view<marshal> ecm;
+  const_proxy_view<gunslinger> ecb = ecm;
+  CHECK(!ecb);
+  const_proxy_view<gunslinger> ecb2 = evm;
+  CHECK(!ecb2);
+  const_proxy_view<marshal> ecm2 = evm;
+  CHECK(!ecm2);
+
+  // Lending from an empty shared_proxy propagates the same way.
+  shared_proxy<marshal> sm;
+  proxy_view<marshal> svm = sm;
+  CHECK(!svm);
+  proxy_view<gunslinger> svb = sm;
+  CHECK(!svb);
+  const_proxy_view<gunslinger> scb = sm;
+  CHECK(!scb);
 }
 
 TEST_CASE("Generic code accepts concrete and erased alike", "[proxy]") {

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -17,6 +17,8 @@
 
 #include <concepts>
 #include <cstddef>
+#include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -43,7 +45,7 @@ using namespace corvid::meta::prox::literals;
 // member names line up. Being an ordinary inheritable class, it is also the
 // base for partial overrides (see `sheriff`). It is used when a class is
 // registered for a facade, but can be partially or fully overridden.
-// Inheriting `prox_impl` is optional sugar: it carries the `method_key`
+// Inheriting `proxy_impl_base` is optional sugar: it carries the `method_key`
 // alias, so the bindings spell it unqualified.
 //
 // With reflection, both the API and boilerplate will be generated
@@ -66,7 +68,7 @@ struct gunslinger
     int& shots(this auto&& self) { return self.template call<"shots">(); }
   };
   template<typename T>
-  struct boilerplate: prox_impl {
+  struct boilerplate: proxy_impl_base {
     static int on(method_key<"fire">, T& t, int rounds) {
       return t.fire(rounds);
     }
@@ -150,7 +152,7 @@ struct robber {
 
 // Note the name adaptation, including binding "shots" to a data member.
 consteval auto corvid_proxy_spec(gunslinger*, robber*) {
-  struct as_gunslinger: prox_impl {
+  struct as_gunslinger: proxy_impl_base {
     static int on(method_key<"fire">, robber& r, int rounds) {
       return r.shoot(rounds);
     }
@@ -263,7 +265,7 @@ struct hair_trigger
     }
   };
   template<typename T>
-  struct boilerplate: prox_impl {
+  struct boilerplate: proxy_impl_base {
     static int on(method_key<"fire">, T& t, int rounds) noexcept {
       return t.fire(rounds);
     }
@@ -282,7 +284,7 @@ consteval auto corvid_proxy_spec(hair_trigger*, lawman*) {
 // shapes otherwise line up. Registration is the act of opting in, not proof
 // of conformance.
 consteval auto corvid_proxy_spec(hair_trigger*, robber*) {
-  struct as_hair_trigger: prox_impl {
+  struct as_hair_trigger: proxy_impl_base {
     static int on(method_key<"fire">, robber& r, int rounds) {
       return r.shoot(rounds);
     }
@@ -303,7 +305,7 @@ struct mortar
     }
   };
   template<typename T>
-  struct boilerplate: prox_impl {
+  struct boilerplate: proxy_impl_base {
     static int on(method_key<"lob">, T& t, int shells) {
       return t.lob(shells);
     }
@@ -342,7 +344,7 @@ struct marshal
     }
   };
   template<typename T>
-  struct boilerplate: prox_impl {
+  struct boilerplate: proxy_impl_base {
     static bool on(method_key<"arrest">, T& t, int outlaws) {
       return t.arrest(outlaws);
     }
@@ -359,7 +361,7 @@ struct ranger
     int track(this const auto& self) { return self.template call<"track">(); }
   };
   template<typename T>
-  struct boilerplate: prox_impl {
+  struct boilerplate: proxy_impl_base {
     static int on(method_key<"track">, const T& t) { return t.track(); }
   };
 };
@@ -460,7 +462,7 @@ struct bounty_hunter
     }
   };
   template<typename T>
-  struct boilerplate: prox_impl {
+  struct boilerplate: proxy_impl_base {
     static int on(method_key<"claim">, T& t, int bounties) {
       return t.claim(bounties);
     }
@@ -499,7 +501,7 @@ struct posse_leader
     void rally(this auto&& self) { self.template call<"rally">(); }
   };
   template<typename T>
-  struct boilerplate: prox_impl {
+  struct boilerplate: proxy_impl_base {
     static void on(method_key<"rally">, T& t) { t.rally(); }
   };
 };
@@ -546,7 +548,7 @@ struct camera
     void reload(this auto&& self) { self.template call<"reload">(); }
   };
   template<typename T>
-  struct boilerplate: prox_impl {
+  struct boilerplate: proxy_impl_base {
     static std::string on(method_key<"fire">, const T& t) { return t.fire(); }
     static void on(method_key<"reload">, T& t) { t.reload(); }
   };
@@ -579,7 +581,7 @@ struct war_correspondent
     }
   };
   template<typename T>
-  struct boilerplate: prox_impl {
+  struct boilerplate: proxy_impl_base {
     static std::string on(method_key<"byline">, const T& t) {
       return t.byline();
     }
@@ -639,6 +641,7 @@ struct life_stats {
   int constructed{};
   int destroyed{};
   int moves{};
+  int copies{};
 };
 
 // `strongbox` is a move-only lifetime-counting target. `Pad` scales the
@@ -692,10 +695,50 @@ struct prox::proxy_impl<lockbox, T> {
   static int on(method_key<"gold">, const T& t) { return t.gold(); }
 };
 
-// Registration for every `strongbox` size, via a template hook.
+// `coffer` is `strongbox`'s copyable sibling, for the clone tests.
 template<std::size_t Pad>
-consteval auto corvid_proxy_spec(lockbox*, strongbox<Pad>*) {
-  return prox::make_proxy_spec<lockbox, strongbox<Pad>>();
+struct coffer {
+  explicit coffer(life_stats& stats) noexcept : stats_{&stats} {
+    ++stats_->constructed;
+  }
+  coffer(const coffer& other) noexcept
+      : stats_{other.stats_}, gold_{other.gold_} {
+    ++stats_->constructed;
+    ++stats_->copies;
+  }
+  coffer(coffer&& other) noexcept : stats_{other.stats_}, gold_{other.gold_} {
+    ++stats_->constructed;
+    ++stats_->moves;
+  }
+  coffer& operator=(const coffer&) = delete;
+  coffer& operator=(coffer&&) = delete;
+  ~coffer() { ++stats_->destroyed; }
+
+  int add(int nuggets) { return gold_ += nuggets; }
+  [[nodiscard]] int gold() const { return gold_; }
+
+  life_stats* stats_{};
+  int gold_{};
+  std::byte pad_[Pad]{};
+};
+
+// `vault` composes `lockbox` without adding methods of its own: a pure
+// aggregation level. The owning-upcast lifetime tests move targets through
+// it.
+struct vault
+    : prox::facade<prox::name<"vault">, //
+          prox::extends<lockbox>> {};
+
+// Registration for every `strongbox` and `coffer` size, via chain hooks
+// covering `vault` and `lockbox` alike.
+template<prox::InChainOf<vault> F, std::size_t Pad>
+consteval auto corvid_proxy_spec(F*, strongbox<Pad>*) {
+  return prox::make_proxy_spec<F, strongbox<Pad>>();
+}
+
+template<prox::InChainOf<vault> F, std::size_t Pad>
+consteval auto corvid_proxy_spec(F*, coffer<Pad>*) {
+  return prox::make_proxy_spec<F, coffer<Pad>>();
 }
 
 // One size fits the inline buffer exactly, the other forces the heap path.
@@ -703,6 +746,16 @@ using small_box = strongbox<4>;
 using big_box = strongbox<64>;
 static_assert(sizeof(small_box) <= proxy<lockbox>::sbo_size);
 static_assert(sizeof(big_box) > proxy<lockbox>::sbo_size);
+using small_coffer = coffer<4>;
+using big_coffer = coffer<64>;
+
+// Storage policies the tests exercise, against the default's two-pointer
+// buffer with heap fallback.
+namespace policies {
+constexpr proxy_policy big_sbo{.sbo_size = 96};
+constexpr proxy_policy sbo_only{.alloc = proxy_alloc::sbo_only};
+constexpr proxy_policy heap_only{.alloc = proxy_alloc::heap_only};
+} // namespace policies
 
 // Facade detection.
 static_assert(prox::Facade<gunslinger>);
@@ -850,7 +903,7 @@ struct census
 // Conformance here is a one-off carried impl: `census` exists only to serve
 // the const-view assertions, so it defines no boilerplate at all.
 consteval auto corvid_proxy_spec(census*, lawman*) {
-  struct as_census: prox_impl {
+  struct as_census: proxy_impl_base {
     static std::string on(method_key<"describe">, const lawman& l) {
       return l.describe();
     }
@@ -1002,6 +1055,110 @@ static_assert(
     !std::constructible_from<proxy_view<gunslinger>, const proxy<marshal>&>);
 static_assert(
     !std::constructible_from<proxy_view<gunslinger>, proxy<gunslinger>>);
+
+// Owning upcast: an rvalue proxy converts to a proxy of any facade its
+// facade extends, one or more levels up. Downcasts, lvalue sources, const
+// sources, and unrelated facades do not convert.
+static_assert(std::convertible_to<proxy<ranger>&&, proxy<marshal>>);
+static_assert(std::convertible_to<proxy<ranger>&&, proxy<gunslinger>>);
+static_assert(std::constructible_from<proxy<gunslinger>, proxy<marshal>&&>);
+static_assert(!std::constructible_from<proxy<ranger>, proxy<marshal>&&>);
+static_assert(!std::constructible_from<proxy<marshal>, proxy<ranger>&>);
+static_assert(!std::constructible_from<proxy<marshal>, const proxy<ranger>&&>);
+static_assert(!std::constructible_from<proxy<gunslinger>, proxy<lockbox>&&>);
+static_assert(Proxiable<small_box, vault>);
+static_assert(prox::Extends<vault, lockbox>);
+
+// Storage policies size the handle: a `heap_only` proxy carries no buffer,
+// so it is two words like a view, and a bigger buffer grows the handle.
+static_assert(
+    sizeof(proxy<lockbox, policies::heap_only>) == 2 * sizeof(void*));
+static_assert(
+    sizeof(proxy<lockbox, policies::big_sbo>) > sizeof(proxy<lockbox>));
+static_assert(proxy<lockbox, policies::big_sbo>::sbo_size == 96);
+
+// Policies never foreclose an rvalue conversion: the destination
+// accommodates whatever target arrives, changing its storage mode when its
+// own policy demands. Exactly the conversions that might change the mode
+// (or fail to, under sbo_only) are not noexcept; everything else, including
+// every same-policy move, is.
+static_assert(std::constructible_from<proxy<lockbox, policies::big_sbo>,
+    proxy<lockbox>&&>);
+static_assert(std::constructible_from<proxy<lockbox>,
+    proxy<lockbox, policies::big_sbo>&&>);
+static_assert(std::constructible_from<proxy<lockbox>,
+    proxy<lockbox, policies::heap_only>&&>);
+static_assert(std::constructible_from<proxy<lockbox, policies::heap_only>,
+    proxy<lockbox>&&>);
+static_assert(std::constructible_from<proxy<lockbox>,
+    proxy<lockbox, policies::sbo_only>&&>);
+static_assert(std::constructible_from<proxy<lockbox, policies::sbo_only>,
+    proxy<lockbox>&&>);
+static_assert(std::constructible_from<proxy<lockbox, policies::sbo_only>,
+    proxy<lockbox, policies::heap_only>&&>);
+static_assert(std::constructible_from<proxy<lockbox, policies::big_sbo>,
+    proxy<vault>&&>);
+static_assert(std::is_nothrow_constructible_v<proxy<lockbox>, proxy<vault>&&>);
+static_assert(std::is_nothrow_constructible_v<
+    proxy<lockbox, policies::big_sbo>, proxy<lockbox>&&>);
+static_assert(!std::is_nothrow_constructible_v<proxy<lockbox>,
+    proxy<lockbox, policies::big_sbo>&&>);
+static_assert(!std::is_nothrow_constructible_v<
+    proxy<lockbox, policies::heap_only>, proxy<lockbox>&&>);
+static_assert(
+    std::is_nothrow_constructible_v<proxy<lockbox, policies::heap_only>,
+        proxy<lockbox, policies::heap_only>&&>);
+static_assert(!std::is_nothrow_constructible_v<
+    proxy<lockbox, policies::sbo_only>, proxy<lockbox>&&>);
+static_assert(std::is_nothrow_constructible_v<
+    proxy<lockbox, policies::sbo_only>, proxy<lockbox, policies::sbo_only>&&>);
+
+// Downcasting exists on every owning proxy, priced in the tables rather
+// than the handle, and only toward a facade that strictly extends the
+// proxy's own; whether the birth ancestry actually contains the target
+// facade is `try_downcast`'s runtime answer.
+template<typename P, typename D>
+concept CanTryDowncast = requires(P p) {
+  std::move(p).template try_downcast<D>();
+};
+static_assert(CanTryDowncast<proxy<gunslinger>, ranger>);
+static_assert(CanTryDowncast<proxy<gunslinger, policies::heap_only>, ranger>);
+static_assert(!CanTryDowncast<proxy<gunslinger>, lockbox>);
+static_assert(!CanTryDowncast<proxy<gunslinger>, gunslinger>);
+
+// The shared proxy is copyable, where the unique-owning proxy is not; it
+// upcasts by copy, satisfies base-facade bounds like every handle, and stays
+// deep-const as an instance.
+static_assert(std::copyable<shared_proxy<gunslinger>>);
+static_assert(
+    std::convertible_to<shared_proxy<ranger>, shared_proxy<gunslinger>>);
+static_assert(
+    !std::constructible_from<shared_proxy<ranger>, shared_proxy<gunslinger>>);
+static_assert(Proxiable<shared_proxy<ranger>, gunslinger>);
+static_assert(CanFire<shared_proxy<gunslinger>>);
+static_assert(!CanFire<const shared_proxy<gunslinger>>);
+static_assert(CanDescribe<const shared_proxy<gunslinger>>);
+
+// Ownership converts one way: an rvalue proxy becomes shared, but shared
+// ownership cannot become unique again (there is no race-free way to
+// recover it, which is also why `std::shared_ptr` has no release), and a
+// weak proxy only ever observes a shared one.
+static_assert(
+    std::constructible_from<shared_proxy<gunslinger>, proxy<ranger>&&>);
+static_assert(
+    !std::constructible_from<shared_proxy<gunslinger>, proxy<ranger>&>);
+static_assert(
+    !std::constructible_from<proxy<gunslinger>, shared_proxy<gunslinger>&&>);
+static_assert(
+    !std::constructible_from<proxy<gunslinger>, shared_proxy<ranger>&&>);
+static_assert(
+    !std::constructible_from<weak_proxy<gunslinger>, proxy<gunslinger>&&>);
+
+// Weak proxies upcast among themselves, like every other handle; downcasts
+// do not exist.
+static_assert(std::convertible_to<weak_proxy<ranger>, weak_proxy<gunslinger>>);
+static_assert(
+    !std::constructible_from<weak_proxy<ranger>, weak_proxy<gunslinger>&&>);
 
 // The call-site vocabulary is exported to `corvid::meta`, so this file uses
 // the unqualified spellings throughout. Only authoring (facades, impls,
@@ -1584,6 +1741,508 @@ TEST_CASE("Heterogeneous ownership", "[proxy]") {
     roll_call += ' ';
   }
   CHECK(roll_call == "lawman robber "s);
+}
+
+TEST_CASE("Owning upcast", "[proxy]") {
+  // Moving a derived-facade proxy into a base-facade one transfers the
+  // target: same object, narrowed interface, source left empty.
+  auto pr = make_proxy<ranger, texas_ranger>();
+  pr.fire(3);
+  CHECK(pr.arrest(2));
+  proxy<marshal> pm = std::move(pr);
+  CHECK(!pr); // NOLINT(bugprone-use-after-move): probing moved-from state.
+  REQUIRE(pm);
+  CHECK(pm.shots() == 3);
+  CHECK(pm.arrest(1));
+
+  // A second hop reaches the grandparent; a single hop from `ranger` would
+  // work just as well.
+  proxy<gunslinger> pg = std::move(pm);
+  CHECK(!pm); // NOLINT(bugprone-use-after-move): probing moved-from state.
+  CHECK(pg.describe() == "texas_ranger"s);
+  CHECK(pg.shots() == 3);
+
+  // Upcast assignment goes through the same conversion.
+  auto fresh = make_proxy<ranger, texas_ranger>();
+  pg = std::move(fresh);
+  CHECK(pg.shots() == 0);
+
+  // An empty source yields an empty proxy.
+  proxy<ranger> empty_ranger;
+  proxy<gunslinger> pe = std::move(empty_ranger);
+  CHECK(!pe);
+}
+
+TEST_CASE("Owning upcast through a diamond", "[proxy]") {
+  // Both diamond paths reach the shared ancestor, and dispatch through the
+  // upcast proxies agrees with the derived one.
+  auto pl = make_proxy<posse_leader, trail_boss>();
+  pl.fire(2);
+  CHECK(pl.claim(1) == 1);
+  proxy<bounty_hunter> pb = std::move(pl);
+  CHECK(pb.shots() == 2);
+  CHECK(pb.claim(1) == 2);
+  proxy<gunslinger> pg = std::move(pb);
+  CHECK(pg.shots() == 2);
+  CHECK(pg.describe() == "trail_boss"s);
+}
+
+TEST_CASE("Owning upcast lifetimes", "[proxy]") {
+  life_stats stats;
+  if (true) {
+    // An inline target relocates, one move like any proxy move.
+    auto pv = make_proxy<vault, small_box>(stats);
+    CHECK(pv.call<"add">(5) == 5);
+    proxy<lockbox> pl = std::move(pv);
+    CHECK(stats.moves == 1);
+    CHECK(stats.constructed == 2);
+    CHECK(stats.destroyed == 1);
+    CHECK(pl.call<"gold">() == 5);
+  }
+  CHECK(stats.destroyed == stats.constructed);
+
+  life_stats heap_stats;
+  if (true) {
+    // A heap target moves by pointer steal, with no target activity.
+    auto pv = make_proxy<vault, big_box>(heap_stats);
+    CHECK(pv.call<"add">(7) == 7);
+    proxy<lockbox> pl = std::move(pv);
+    CHECK(heap_stats.moves == 0);
+    CHECK(heap_stats.constructed == 1);
+    CHECK(heap_stats.destroyed == 0);
+    CHECK(pl.call<"gold">() == 7);
+  }
+  CHECK(heap_stats.destroyed == heap_stats.constructed);
+}
+
+// Diagnostics on record: constructing an sbo_only proxy over an ineligible
+// target, e.g. `make_proxy<lockbox, big_box, policies::sbo_only>(stats)`,
+// fires a single clean error from the in-place constructor: "static
+// assertion failed due to requirement 'corvid::prox::proxy_policy{16, 8,
+// 1}.alloc != corvid::prox::proxy_alloc::sbo_only ||
+// details::sbo_fits(corvid::prox::proxy_policy{16, 8, 1})': the target is
+// not eligible for an sbo_only proxy's inline buffer".
+TEST_CASE("Storage policies", "[proxy]") {
+  // A buffer sized for `big_box` stores it inline, so moves relocate instead
+  // of stealing a heap pointer.
+  static_assert(sizeof(big_box) <= policies::big_sbo.sbo_size);
+  life_stats stats;
+  if (true) {
+    auto p = make_proxy<lockbox, big_box, policies::big_sbo>(stats);
+    CHECK(p.call<"add">(3) == 3);
+    auto q = std::move(p);
+    CHECK(stats.moves == 1);
+    CHECK(q.call<"gold">() == 3);
+  }
+  CHECK(stats.destroyed == stats.constructed);
+
+  // A heap_only proxy keeps even an SBO-eligible target on the heap, so its
+  // address is stable and moves steal the pointer.
+  life_stats heap_stats;
+  if (true) {
+    auto p = make_proxy<lockbox, small_box, policies::heap_only>(heap_stats);
+    CHECK(p.call<"add">(4) == 4);
+    auto q = std::move(p);
+    CHECK(heap_stats.moves == 0);
+    CHECK(heap_stats.constructed == 1);
+
+    // Converting to the default policy hands the heap target over intact.
+    proxy<lockbox> r = std::move(q);
+    CHECK(heap_stats.moves == 0);
+    CHECK(r.call<"gold">() == 4);
+  }
+  CHECK(heap_stats.destroyed == heap_stats.constructed);
+
+  // An sbo_only proxy accepts an eligible target; converting it into a
+  // default-policy proxy of a base facade upcasts and relocates in one move.
+  life_stats sbo_stats;
+  if (true) {
+    auto p = make_proxy<vault, small_box, policies::sbo_only>(sbo_stats);
+    CHECK(p.call<"add">(5) == 5);
+    proxy<lockbox> r = std::move(p);
+    CHECK(sbo_stats.moves == 1);
+    CHECK(r.call<"gold">() == 5);
+  }
+  CHECK(sbo_stats.destroyed == sbo_stats.constructed);
+
+  // An inline target arriving at a heap_only proxy re-boxes onto the heap
+  // (one move, upcasting in the same conversion); moves from then on are
+  // pointer steals.
+  life_stats rebox_stats;
+  if (true) {
+    auto p = make_proxy<vault, small_box>(rebox_stats);
+    CHECK(p.call<"add">(8) == 8);
+    proxy<lockbox, policies::heap_only> h = std::move(p);
+    CHECK(!p); // NOLINT(bugprone-use-after-move): probing moved-from state.
+    CHECK(rebox_stats.moves == 1);
+    CHECK(rebox_stats.constructed == 2);
+    CHECK(rebox_stats.destroyed == 1);
+    CHECK(h.call<"gold">() == 8);
+    auto h2 = std::move(h);
+    CHECK(rebox_stats.moves == 1);
+    CHECK(h2.call<"gold">() == 8);
+  }
+  CHECK(rebox_stats.destroyed == rebox_stats.constructed);
+
+  // Adoption accommodates per target, not per policy: from the same
+  // big-buffer source, an oversized inline target re-boxes onto the
+  // destination's heap while a small one relocates into its buffer and
+  // stays inline.
+  life_stats shrink_stats;
+  if (true) {
+    auto p = make_proxy<lockbox, big_box, policies::big_sbo>(shrink_stats);
+    p.call<"add">(2);
+    proxy<lockbox> d = std::move(p);
+    CHECK(shrink_stats.moves == 1);
+    CHECK(d.call<"gold">() == 2);
+    auto d2 = std::move(d);
+    CHECK(shrink_stats.moves == 1);
+    CHECK(d2.call<"gold">() == 2);
+  }
+  CHECK(shrink_stats.destroyed == shrink_stats.constructed);
+  life_stats fit_stats;
+  if (true) {
+    auto p = make_proxy<lockbox, small_box, policies::big_sbo>(fit_stats);
+    p.call<"add">(3);
+    proxy<lockbox> d = std::move(p);
+    CHECK(fit_stats.moves == 1);
+    auto d2 = std::move(d);
+    CHECK(fit_stats.moves == 2);
+    CHECK(d2.call<"gold">() == 3);
+  }
+  CHECK(fit_stats.destroyed == fit_stats.constructed);
+
+  // A heap target un-boxes into an sbo_only proxy's buffer when it fits,
+  // and throws when it cannot, leaving the source intact. `can_adopt`
+  // answers up front, so the throw is avoidable; only an sbo_only
+  // destination can ever refuse, and an empty source is always adoptable.
+  life_stats unbox_stats;
+  if (true) {
+    using sbo_proxy = proxy<lockbox, policies::sbo_only>;
+    auto p = make_proxy<lockbox, small_box, policies::heap_only>(unbox_stats);
+    p.call<"add">(4);
+    CHECK(sbo_proxy::can_adopt(p));
+    sbo_proxy s = std::move(p);
+    CHECK(unbox_stats.moves == 1);
+    CHECK(s.call<"gold">() == 4);
+    auto s2 = std::move(s);
+    CHECK(unbox_stats.moves == 2);
+    CHECK(s2.call<"gold">() == 4);
+
+    auto big = make_proxy<lockbox, big_box, policies::heap_only>(unbox_stats);
+    big.call<"add">(6);
+    CHECK(!sbo_proxy::can_adopt(big));
+    CHECK(proxy<lockbox>::can_adopt(big));
+    proxy<lockbox, policies::heap_only> no_target;
+    CHECK(sbo_proxy::can_adopt(no_target));
+    CHECK_THROWS_AS(sbo_proxy{std::move(big)}, std::length_error);
+    REQUIRE(big); // NOLINT(bugprone-use-after-move): kept whole on failure.
+    CHECK(big.call<"gold">() == 6);
+  }
+  CHECK(unbox_stats.destroyed == unbox_stats.constructed);
+}
+
+TEST_CASE("Downcasting a proxy", "[proxy]") {
+  // Every owning proxy remembers the facade its target was born as (in the
+  // owning table, not the handle), so an upcast can be undone, one level at
+  // a time or straight back down.
+  auto pr = make_proxy<ranger, texas_ranger>();
+  pr.fire(3);
+  proxy<gunslinger> pg = std::move(pr);
+  CHECK(pg.shots() == 3);
+  auto pm = std::move(pg).try_downcast<marshal>();
+  REQUIRE(pm);
+  CHECK(!pg); // NOLINT(bugprone-use-after-move): probing moved-from state.
+  CHECK(pm.arrest(2));
+  auto pr2 = std::move(pm).try_downcast<ranger>();
+  REQUIRE(pr2);
+  CHECK(!pm); // NOLINT(bugprone-use-after-move): probing moved-from state.
+  CHECK(pr2.track() == 2);
+  CHECK(pr2.shots() == 3);
+
+  // A downcast below the birth facade fails, and failure does not consume
+  // the source; the matching cast then succeeds. An empty source fails.
+  auto pc = make_proxy<marshal, constable>();
+  proxy<gunslinger> pg2 = std::move(pc);
+  auto too_deep = std::move(pg2).try_downcast<ranger>();
+  CHECK(!too_deep);
+  REQUIRE(pg2); // NOLINT(bugprone-use-after-move): kept whole on failure.
+  // NOLINTNEXTLINE(bugprone-use-after-move): the failed cast kept it whole.
+  auto pm2 = std::move(pg2).try_downcast<marshal>();
+  REQUIRE(pm2);
+  CHECK(pm2.arrest(1));
+  proxy<gunslinger> unborn;
+  auto still_empty = std::move(unborn).try_downcast<marshal>();
+  CHECK(!still_empty);
+
+  // Through a diamond, the common base can sidecast to either sibling.
+  auto pl = make_proxy<posse_leader, trail_boss>();
+  pl.fire(2);
+  proxy<gunslinger> pgun = std::move(pl);
+  auto pb = std::move(pgun).try_downcast<bounty_hunter>();
+  REQUIRE(pb);
+  CHECK(pb.claim(1) == 1);
+  CHECK(pb.shots() == 2);
+
+  // The birth is the facade the proxy was constructed as, not the concrete
+  // type's full conformance: a texas_ranger born mid-chain downcasts back
+  // to its birth facade but never past it, even though the type conforms
+  // further up.
+  auto born_mid = make_proxy<marshal, texas_ranger>();
+  proxy<gunslinger> pg3 = std::move(born_mid);
+  auto not_ranger = std::move(pg3).try_downcast<ranger>();
+  CHECK(!not_ranger);
+  REQUIRE(pg3); // NOLINT(bugprone-use-after-move): kept whole on failure.
+  // NOLINTNEXTLINE(bugprone-use-after-move): the failed cast kept it whole.
+  auto back_to_birth = std::move(pg3).try_downcast<marshal>();
+  REQUIRE(back_to_birth);
+  CHECK(back_to_birth.describe() == "texas_ranger"s);
+}
+
+TEST_CASE("Downcast lifetimes", "[proxy]") {
+  // The inline target relocates on each cast; everything balances.
+  life_stats stats;
+  if (true) {
+    auto pv = make_proxy<vault, small_box>(stats);
+    pv.call<"add">(4);
+    proxy<lockbox> pl = std::move(pv);
+    CHECK(stats.moves == 1);
+    auto back = std::move(pl).try_downcast<vault>();
+    REQUIRE(back);
+    CHECK(stats.moves == 2);
+    CHECK(back.call<"gold">() == 4);
+  }
+  CHECK(stats.destroyed == stats.constructed);
+
+  // The heap target's allocation is handed through untouched.
+  life_stats heap_stats;
+  if (true) {
+    auto pv = make_proxy<vault, big_box>(heap_stats);
+    pv.call<"add">(6);
+    proxy<lockbox> pl = std::move(pv);
+    auto back = std::move(pl).try_downcast<vault>();
+    REQUIRE(back);
+    CHECK(heap_stats.moves == 0);
+    CHECK(heap_stats.constructed == 1);
+    CHECK(back.call<"gold">() == 6);
+  }
+  CHECK(heap_stats.destroyed == heap_stats.constructed);
+
+  // Mode changes keep the birth memory usable: a mode-changing adoption
+  // lands on the table's other-mode sibling, which carries its own mode's
+  // ancestry. Re-boxing into heap_only, then downcasting (a steal);
+  // un-boxing into sbo_only, then downcasting (a relocation).
+  life_stats rebox_stats;
+  if (true) {
+    auto pv = make_proxy<vault, small_box>(rebox_stats);
+    pv.call<"add">(7);
+    proxy<lockbox, policies::heap_only> pl = std::move(pv);
+    CHECK(rebox_stats.moves == 1);
+    auto back = std::move(pl).try_downcast<vault>();
+    REQUIRE(back);
+    CHECK(rebox_stats.moves == 1);
+    CHECK(back.call<"gold">() == 7);
+  }
+  CHECK(rebox_stats.destroyed == rebox_stats.constructed);
+  life_stats unbox_stats;
+  if (true) {
+    auto pv = make_proxy<vault, small_box, policies::heap_only>(unbox_stats);
+    pv.call<"add">(9);
+    proxy<lockbox, policies::sbo_only> pl = std::move(pv);
+    CHECK(unbox_stats.moves == 1);
+    auto back = std::move(pl).try_downcast<vault>();
+    REQUIRE(back);
+    CHECK(unbox_stats.moves == 2);
+    CHECK(back.call<"gold">() == 9);
+  }
+  CHECK(unbox_stats.destroyed == unbox_stats.constructed);
+}
+
+TEST_CASE("Cloning", "[proxy]") {
+  // Cloneability is a runtime property of the erased target: `strongbox` is
+  // move-only, so its proxy answers no. An empty proxy clones to an empty
+  // proxy.
+  life_stats box_stats;
+  const auto locked = make_proxy<lockbox, small_box>(box_stats);
+  CHECK(!locked.can_clone());
+  proxy<lockbox> nothing;
+  CHECK(nothing.can_clone());
+  CHECK(!nothing.clone());
+
+  // Inline path: the clone copy-constructs into its own buffer, and the two
+  // targets are independent.
+  life_stats stats;
+  if (true) {
+    auto p = make_proxy<lockbox, small_coffer>(stats);
+    CHECK(p.can_clone());
+    p.call<"add">(9);
+    const auto q = p.clone();
+    CHECK(stats.copies == 1);
+    CHECK(q.call<"gold">() == 9);
+    p.call<"add">(1);
+    CHECK(p.call<"gold">() == 10);
+    CHECK(q.call<"gold">() == 9);
+  }
+  CHECK(stats.destroyed == stats.constructed);
+
+  // Heap path: the clone allocates its own copy. Cloning is const-clean, so
+  // a const proxy clones too (into a mutable clone, like copying a const
+  // value).
+  life_stats heap_stats;
+  if (true) {
+    const auto p = make_proxy<lockbox, big_coffer>(heap_stats);
+    auto q = p.clone();
+    CHECK(heap_stats.copies == 1);
+    CHECK(q.call<"add">(2) == 2);
+    CHECK(p.call<"gold">() == 0);
+  }
+  CHECK(heap_stats.destroyed == heap_stats.constructed);
+}
+
+TEST_CASE("unique_ptr interop", "[proxy]") {
+  life_stats stats;
+  if (true) {
+    // Moving a unique_ptr in adopts the allocation: no copy, no move, and
+    // the target's address stays stable even though it would fit inline.
+    auto up = std::make_unique<small_coffer>(stats);
+    const auto* address = up.get();
+    auto p = make_proxy<lockbox>(std::move(up));
+    CHECK(!up); // NOLINT(bugprone-use-after-move): probing moved-from state.
+    CHECK(stats.constructed == 1);
+    CHECK(stats.moves == 0);
+    CHECK(p.call<"add">(6) == 6);
+
+    // Moving the target out hands the exact allocation back.
+    auto out = p.extract<small_coffer>();
+    REQUIRE(out);
+    CHECK(!p);
+    CHECK(out.get() == address);
+    CHECK(out->gold() == 6);
+    CHECK(stats.moves == 0);
+  }
+  CHECK(stats.destroyed == stats.constructed);
+
+  life_stats sbo_stats;
+  if (true) {
+    // Extraction verifies the type at runtime: the wrong type comes back
+    // null and leaves the proxy intact. An inline target moves onto the
+    // heap; an empty proxy has nothing to extract.
+    auto p = make_proxy<lockbox, small_coffer>(sbo_stats);
+    p.call<"add">(3);
+    CHECK(!p.extract<big_coffer>());
+    CHECK(p);
+    auto out = p.extract<small_coffer>();
+    REQUIRE(out);
+    CHECK(!p);
+    CHECK(out->gold() == 3);
+    CHECK(sbo_stats.moves == 1);
+    CHECK(!p.extract<small_coffer>());
+  }
+  CHECK(sbo_stats.destroyed == sbo_stats.constructed);
+
+  // An sbo_only proxy un-boxes an adopted unique_ptr at construction, where
+  // the concrete type makes the fit a compile-time fact.
+  life_stats unbox_stats;
+  if (true) {
+    auto up = std::make_unique<small_coffer>(unbox_stats);
+    up->add(5);
+    auto p = make_proxy<lockbox, policies::sbo_only>(std::move(up));
+    CHECK(unbox_stats.moves == 1);
+    CHECK(p.call<"gold">() == 5);
+  }
+  CHECK(unbox_stats.destroyed == unbox_stats.constructed);
+}
+
+TEST_CASE("Shared ownership", "[proxy]") {
+  life_stats stats;
+  weak_proxy<lockbox> wk;
+  weak_proxy<vault> wexpired;
+  CHECK(!wk.lock());
+  if (true) {
+    auto sv = make_shared_proxy<vault, small_coffer>(stats);
+    REQUIRE(sv);
+    CHECK(sv.call<"add">(5) == 5);
+
+    // A copy, here upcasting as it goes, shares the one target rather than
+    // cloning it, and mutations are visible through every handle.
+    shared_proxy<lockbox> sl = sv;
+    CHECK(stats.constructed == 1);
+    CHECK(sl.call<"add">(1) == 6);
+    CHECK(sv.call<"gold">() == 6);
+
+    // Views lend from a shared proxy exactly as from an owning one.
+    proxy_view<lockbox> v = sv;
+    CHECK(v.call<"gold">() == 6);
+    const_proxy_view<lockbox> cv = std::as_const(sv);
+    CHECK(cv.call<"gold">() == 6);
+
+    // A weak proxy observes without owning; locking regains a shared owner.
+    wk = sv;
+    CHECK(!wk.expired());
+    auto locked = wk.lock();
+    REQUIRE(locked);
+    CHECK(locked.call<"gold">() == 6);
+
+    // Weak proxies also upcast among themselves, without locking.
+    weak_proxy<vault> wv = sv;
+    weak_proxy<lockbox> wl = wv;
+    auto relocked = wl.lock();
+    REQUIRE(relocked);
+    CHECK(relocked.call<"gold">() == 6);
+    wexpired = wv;
+  }
+  // Every owner is gone, so the target is too, exactly once, and the weak
+  // proxy answers accordingly.
+  CHECK(stats.constructed == 1);
+  CHECK(stats.destroyed == stats.constructed);
+  CHECK(wk.expired());
+  CHECK(!wk.lock());
+
+  // An expired weak proxy upcasts too (here by move), still observing the
+  // dead target; expiry stays lock's business.
+  weak_proxy<lockbox> from_expired = std::move(wexpired);
+  CHECK(from_expired.expired());
+  CHECK(!from_expired.lock());
+}
+
+TEST_CASE("Shared ownership interop with std", "[proxy]") {
+  // A unique_ptr converts into shared ownership on the way in.
+  auto up = std::make_unique<lawman>();
+  shared_proxy<gunslinger> sg{std::move(up)};
+  CHECK(sg.fire(2) == 2);
+
+  // Sharing with an outside shared_ptr keeps the object somewhere canonical:
+  // the typed holder and the erased handle see the same target.
+  auto sr = std::make_shared<robber>();
+  shared_proxy<gunslinger> sg2{sr};
+  CHECK(sg2.fire(3) == 3);
+  CHECK(sr->fired == 3);
+  sr->rearm();
+  CHECK(sg2.shots() == 0);
+
+  // An owning proxy converts into shared ownership, consuming the source: a
+  // heap target keeps its allocation (the owning table's destroy slot
+  // becomes the control block's deleter), an inline target moves onto the
+  // heap first, and either can upcast on the way.
+  life_stats stats;
+  if (true) {
+    auto heap_owner = make_proxy<vault, big_box>(stats);
+    heap_owner.call<"add">(4);
+    shared_proxy<lockbox> shared_heap{std::move(heap_owner)};
+    CHECK(!heap_owner); // NOLINT(bugprone-use-after-move): probing.
+    CHECK(stats.moves == 0);
+    CHECK(shared_heap.call<"gold">() == 4);
+    auto another = shared_heap;
+    CHECK(stats.constructed == 1);
+    CHECK(another.call<"gold">() == 4);
+
+    auto inline_owner = make_proxy<lockbox, small_box>(stats);
+    inline_owner.call<"add">(2);
+    shared_proxy<lockbox> shared_inline{std::move(inline_owner)};
+    CHECK(stats.moves == 1);
+    CHECK(shared_inline.call<"gold">() == 2);
+  }
+  CHECK(stats.destroyed == stats.constructed);
 }
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -1,0 +1,235 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <concepts>
+#include <string>
+#include <vector>
+
+#include "corvid/meta/proxy.h"
+#include "catch2_main.h"
+
+using namespace std::literals;
+using namespace corvid;
+using namespace corvid::meta::prox;
+
+// The facade under test: mixes value returns, a const method, a void
+// mutator, and a reference return.
+struct gunslinger
+    : facade<method<"fire", int(int)>, method<"describe", std::string() const>,
+          method<"reload", void()>, method<"shots", int&()>> {};
+
+// A type whose method names line up with the facade; conforms by
+// registration through the boilerplate impl.
+struct lawman {
+  int fire(int rounds) {
+    rounds_fired += rounds;
+    return rounds_fired;
+  }
+  [[nodiscard]] std::string describe() const {
+    (void)this;
+    return "lawman";
+  }
+  void reload() { rounds_fired = 0; }
+  int& shots() { return rounds_fired; }
+
+  int rounds_fired{};
+};
+
+// A type with the right shape but the wrong names; conforms through an
+// explicit impl, with no registration.
+struct robber {
+  int shoot(int rounds) {
+    fired += rounds;
+    return fired;
+  }
+  [[nodiscard]] std::string description() const {
+    (void)this;
+    return "robber";
+  }
+  void rearm() { fired = 0; }
+
+  int fired{};
+};
+
+// A type whose method names line up but which never opts in. Nominal
+// conformance means this must NOT be proxiable.
+struct cowboy {
+  int fire(int rounds) {
+    (void)this;
+    return rounds;
+  }
+  [[nodiscard]] std::string describe() const {
+    (void)this;
+    return "cowboy";
+  }
+  void reload() {}
+  int& shots() { return count; }
+
+  int count{};
+};
+
+// Registration for `lawman`: pure opt-in, one hook, no bindings.
+consteval auto corvid_proxy_spec(gunslinger*, lawman*) {
+  return make_proxy_spec<gunslinger, lawman>();
+}
+
+namespace corvid {
+
+// Boilerplate impl for `gunslinger`: written once by the facade author,
+// generic over any registered type whose member names line up.
+template<typename T>
+requires ProxyRegistered<gunslinger, T>
+struct proxy_impl<gunslinger, T> {
+  static int on(key<"fire">, T& t, int rounds) { return t.fire(rounds); }
+  static std::string on(key<"describe">, const T& t) { return t.describe(); }
+  static void on(key<"reload">, T& t) { t.reload(); }
+  static int& on(key<"shots">, T& t) { return t.shots(); }
+};
+
+// Custom impl for `robber`: a full specialization outranks the boilerplate
+// and needs no registration. Note the name adaptation, including binding
+// "shots" to a data member.
+template<>
+struct proxy_impl<gunslinger, robber> {
+  static int on(key<"fire">, robber& r, int rounds) { return r.shoot(rounds); }
+  static std::string on(key<"describe">, const robber& r) {
+    return r.description();
+  }
+  static void on(key<"reload">, robber& r) { r.rearm(); }
+  static int& on(key<"shots">, robber& r) { return r.fired; }
+};
+
+} // namespace corvid
+
+// Facade detection.
+static_assert(Facade<gunslinger>);
+static_assert(!Facade<lawman>);
+static_assert(!Facade<int>);
+
+// A method is-a key: usable anywhere its key is.
+static_assert(std::derived_from<method<"fire", int(int)>, key<"fire">>);
+static_assert(std::derived_from<method<"describe", std::string() const>,
+    key<"describe">>);
+static_assert(!std::derived_from<method<"fire", int(int)>, key<"reload">>);
+
+// Registration state: lawman is registered, robber conforms without
+// registration, cowboy neither registers nor conforms.
+static_assert(ProxyRegistered<gunslinger, lawman>);
+static_assert(!ProxyRegistered<gunslinger, robber>);
+static_assert(!ProxyRegistered<gunslinger, cowboy>);
+static_assert(std::same_as<decltype(proxy_spec_v<gunslinger, lawman>),
+    const proxy_spec<gunslinger, lawman>>);
+
+// Conformance: boilerplate via registration, explicit impl directly, and
+// matching names alone are NOT enough.
+//
+// Diagnostics on record (clang 22, captured 2026-07-08). Constructing
+// `proxy_view<gunslinger>` from an unregistered `cowboy` emits exactly one
+// error: "no matching constructor for initialization of
+// 'proxy_view<gunslinger>' ... candidate template ignored: constraints not
+// satisfied [with T = cowboy] ... because 'Proxiable<cowboy, gunslinger>'
+// evaluated to false ... because
+// 'details::info_t<gunslinger>::all_bound_v<gunslinger, cowboy>' evaluated
+// to false". Calling `pv.call<"missing">()` emits exactly one error:
+// "static assertion failed ... facade has no method with this name" (the
+// `if constexpr` in `call` discards the dispatch on that path, so the
+// assert is not followed by `std::get` index noise).
+static_assert(Proxiable<lawman, gunslinger>);
+static_assert(Proxiable<robber, gunslinger>);
+static_assert(!Proxiable<cowboy, gunslinger>);
+static_assert(!Proxiable<int, gunslinger>);
+
+// A view satisfies its own facade.
+static_assert(Proxiable<proxy_view<gunslinger>, gunslinger>);
+
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+
+TEST_CASE("Boilerplate impl through registration", "[proxy]") {
+  lawman l;
+  proxy_view<gunslinger> pv{l};
+
+  CHECK(pv.call<"fire">(3) == 3);
+  CHECK(pv.call<"fire">(2) == 5);
+  CHECK(l.rounds_fired == 5);
+  CHECK(pv.call<"describe">() == "lawman"s);
+
+  // Reference return: assign through the erased call.
+  pv.call<"shots">() = 42;
+  CHECK(l.rounds_fired == 42);
+
+  pv.call<"reload">();
+  CHECK(l.rounds_fired == 0);
+}
+
+TEST_CASE("Custom impl without registration", "[proxy]") {
+  robber r;
+  proxy_view<gunslinger> pv{r};
+
+  CHECK(pv.call<"fire">(6) == 6);
+  CHECK(r.fired == 6);
+  CHECK(pv.call<"describe">() == "robber"s);
+  CHECK(pv.call<"shots">() == 6);
+
+  pv.call<"reload">();
+  CHECK(r.fired == 0);
+}
+
+TEST_CASE("Heterogeneous dispatch", "[proxy]") {
+  lawman l;
+  robber r;
+  std::vector<proxy_view<gunslinger>> gang{l, r};
+
+  std::string roll_call;
+  for (const auto& pv : gang) {
+    pv.call<"fire">(2);
+    roll_call += pv.call<"describe">();
+    roll_call += ' ';
+  }
+  CHECK(roll_call == "lawman robber "s);
+  CHECK(l.rounds_fired == 2);
+  CHECK(r.fired == 2);
+
+  // Copies are shallow: both views alias the same target.
+  auto pv2 = gang[0];
+  pv2.call<"fire">(1);
+  CHECK(l.rounds_fired == 3);
+}
+
+TEST_CASE("Generic code accepts concrete and erased alike", "[proxy]") {
+  // Facade-constrained generic code: erase, then call. `Proxiable` is the
+  // trait bound for the static-dispatch half.
+  auto fire_twice = [](Proxiable<gunslinger> auto& g) {
+    auto pv = make_proxy_view<gunslinger>(g);
+    // In a template context the view's type is dependent, hence `template`.
+    pv.template call<"fire">(1);
+    return pv.template call<"fire">(1);
+  };
+
+  lawman l;
+  CHECK(fire_twice(l) == 2);
+
+  // Passing a view works too, and flattens rather than stacking a second
+  // indirection.
+  proxy_view<gunslinger> pv{l};
+  CHECK(fire_twice(pv) == 4);
+
+  // The library-provided view impl is also usable directly.
+  CHECK(prox::proxy_impl<gunslinger, proxy_view<gunslinger>>::on(
+            key<"describe">{}, pv) == "lawman"s);
+}
+
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -35,20 +35,29 @@ struct gunslinger
           prox::method<"reload", void()>,                //
           prox::method<"shots", int&()>> {};             //
 
-// Boilerplate impl for `gunslinger`: written once by the facade author,
-// generic over any registered type whose member names line up.
+// This base class for proxy_impl<gunslinger, T> would not normally be
+// necessary, but it's used for `sheriff`. It also wouldn't need `prox::method`
+// to be fully specified.
 template<typename T>
-requires prox::ProxyRegistered<gunslinger, T>
-struct prox::proxy_impl<gunslinger, T> {
-  static int on(method_key<"fire">, T& t, int rounds) {
+struct proxy_impl_gunslinger {
+  static int on(prox::method_key<"fire">, T& t, int rounds) {
     return t.fire(rounds);
   }
-  static std::string on(method_key<"describe">, const T& t) {
+  static std::string on(prox::method_key<"describe">, const T& t) {
     return t.describe();
   }
-  static void on(method_key<"reload">, T& t) { t.reload(); }
-  static int& on(method_key<"shots">, T& t) { return t.shots(); }
+  static void on(prox::method_key<"reload">, T& t) { t.reload(); }
+  static int& on(prox::method_key<"shots">, T& t) { return t.shots(); }
 };
+
+// Boilerplate impl for `gunslinger`: written once by the facade author,
+// generic over any registered type whose member names line up.
+//
+// Again, it would normally contain the guts of what's been moved to
+// `proxy_impl_gunslinger`.
+template<typename T>
+requires prox::ProxyRegistered<gunslinger, T>
+struct prox::proxy_impl<gunslinger, T>: proxy_impl_gunslinger<T> {};
 
 // A type whose method names line up with the facade; conforms by
 // registration through the boilerplate impl.
@@ -71,6 +80,14 @@ struct lawman {
 consteval auto corvid_proxy_spec(gunslinger*, lawman*) {
   return prox::make_proxy_spec<gunslinger, lawman>();
 }
+
+// Exactly like a lawman, but with a different name. Works automatically.
+struct deputy: public lawman {
+  [[nodiscard]] std::string describe() const {
+    (void)this;
+    return "deputy";
+  }
+};
 
 // A type with the right shape but the wrong names; conforms through an
 // explicit impl, with no registration.
@@ -102,6 +119,34 @@ struct prox::proxy_impl<gunslinger, robber> {
   }
   static void on(method_key<"reload">, robber& r) { r.rearm(); }
   static int& on(method_key<"shots">, robber& r) { return r.fired; }
+};
+
+// A type whose method names line up, with one exception: `shoot` instead of
+// `fire`. Uses a full specialization that inherits and overrides the
+// boilerplate impl.
+struct sheriff {
+  int shoot(int rounds) {
+    rounds_fired += rounds;
+    return rounds_fired;
+  }
+  [[nodiscard]] std::string describe() const {
+    (void)this;
+    return "sheriff";
+  }
+  void reload() { rounds_fired = 0; }
+  int& shots() { return rounds_fired; }
+
+  int rounds_fired{};
+};
+
+// Custom impl for `sheriff`: inherits the boilerplate and overrides the
+// one method whose name differs.
+template<>
+struct prox::proxy_impl<gunslinger, sheriff>: proxy_impl_gunslinger<sheriff> {
+  using proxy_impl_gunslinger<sheriff>::on;
+  static int on(method_key<"fire">, sheriff& s, int rounds) {
+    return s.shoot(rounds);
+  }
 };
 
 // A type whose method names line up but which never opts in. Nominal
@@ -140,7 +185,9 @@ static_assert(std::same_as<decltype("fire"_method), prox::method_key<"fire">>);
 // Registration state: lawman is registered, robber conforms without
 // registration, cowboy neither registers nor conforms.
 static_assert(prox::ProxyRegistered<gunslinger, lawman>);
+static_assert(prox::ProxyRegistered<gunslinger, deputy>);
 static_assert(!prox::ProxyRegistered<gunslinger, robber>);
+static_assert(!prox::ProxyRegistered<gunslinger, sheriff>);
 static_assert(!prox::ProxyRegistered<gunslinger, cowboy>);
 static_assert(std::same_as<decltype(prox::proxy_spec_v<gunslinger, lawman>),
     const prox::proxy_spec<gunslinger, lawman>>);
@@ -162,6 +209,7 @@ static_assert(std::same_as<decltype(prox::proxy_spec_v<gunslinger, lawman>),
 // also removes the noise.
 static_assert(prox::Proxiable<lawman, gunslinger>);
 static_assert(prox::Proxiable<robber, gunslinger>);
+static_assert(prox::Proxiable<sheriff, gunslinger>);
 static_assert(!prox::Proxiable<cowboy, gunslinger>);
 static_assert(!prox::Proxiable<int, gunslinger>);
 
@@ -203,6 +251,21 @@ TEST_CASE("Custom impl without registration", "[proxy]") {
 
   pv.call<"reload">();
   CHECK(r.fired == 0);
+}
+
+TEST_CASE("Partially-overridden boilerplate impl", "[proxy]") {
+  sheriff s;
+  prox::proxy_view<gunslinger> pv{s};
+
+  // The overriding binding: "fire" routes to `shoot`.
+  CHECK(pv.call<"fire">(4) == 4);
+  CHECK(s.rounds_fired == 4);
+
+  // The inherited boilerplate bindings still serve the rest.
+  CHECK(pv.call<"describe">() == "sheriff"s);
+  CHECK(pv.call<"shots">() == 4);
+  pv.call<"reload">();
+  CHECK(s.rounds_fired == 0);
 }
 
 TEST_CASE("Heterogeneous dispatch", "[proxy]") {

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -1113,10 +1113,11 @@ static_assert(!std::is_nothrow_constructible_v<
 static_assert(std::is_nothrow_constructible_v<
     proxy<lockbox, policies::sbo_only>, proxy<lockbox, policies::sbo_only>&&>);
 
-// Downcasting exists on every owning proxy, priced in the tables rather
-// than the handle, and only toward a facade that strictly extends the
-// proxy's own; whether the birth ancestry actually contains the target
-// facade is `try_downcast`'s runtime answer.
+// Downcasting exists on every owning proxy, both views, and the shared
+// proxy, priced in the tables rather than the handle, and only toward a
+// facade that strictly extends the handle's own; whether the birth ancestry
+// actually contains the target facade is `try_downcast`'s runtime answer. A
+// weak proxy deliberately has none: access goes through `lock()`.
 template<typename P, typename D>
 concept CanTryDowncast = requires(P p) {
   std::move(p).template try_downcast<D>();
@@ -1125,6 +1126,12 @@ static_assert(CanTryDowncast<proxy<gunslinger>, ranger>);
 static_assert(CanTryDowncast<proxy<gunslinger, policies::heap_only>, ranger>);
 static_assert(!CanTryDowncast<proxy<gunslinger>, lockbox>);
 static_assert(!CanTryDowncast<proxy<gunslinger>, gunslinger>);
+static_assert(CanTryDowncast<proxy_view<gunslinger>, ranger>);
+static_assert(CanTryDowncast<const_proxy_view<gunslinger>, ranger>);
+static_assert(CanTryDowncast<shared_proxy<gunslinger>, ranger>);
+static_assert(!CanTryDowncast<weak_proxy<gunslinger>, ranger>);
+static_assert(!CanTryDowncast<proxy_view<gunslinger>, gunslinger>);
+static_assert(!CanTryDowncast<shared_proxy<gunslinger>, lockbox>);
 
 // The shared proxy is copyable, where the unique-owning proxy is not; it
 // upcasts by copy, satisfies base-facade bounds like every handle, and stays
@@ -2058,13 +2065,128 @@ TEST_CASE("Downcast lifetimes", "[proxy]") {
   CHECK(unbox_stats.destroyed == unbox_stats.constructed);
 }
 
+TEST_CASE("Downcasting views", "[proxy]") {
+  // A view built directly over a target is born as its own facade: the
+  // upcast is undoable, and the result is a new view over the same target.
+  // The source is copied from, never consumed, so it stays usable; that is
+  // why the view flavor is const where the owning one is an rvalue method.
+  texas_ranger tex;
+  proxy_view<marshal> vm = tex;
+  proxy_view<gunslinger> vg = vm;
+  vg.fire(3);
+  auto back = vg.try_downcast<marshal>();
+  REQUIRE(back);
+  CHECK(back.arrest(2));
+  CHECK(tex.arrested == 2);
+  CHECK(vg.shots() == 3);
+
+  // The birth is the view's facade, so a downcast past it fails even though
+  // the type conforms further up; failure yields an empty view.
+  CHECK(!vg.try_downcast<ranger>());
+
+  // A view lent from an owning proxy inherits the owner's birth: this
+  // gunslinger view recovers the full ranger, which the directly built view
+  // above could not.
+  auto pr = make_proxy<ranger, texas_ranger>();
+  pr.arrest(4);
+  proxy_view<gunslinger> lent = pr;
+  auto vr = lent.try_downcast<ranger>();
+  REQUIRE(vr);
+  CHECK(vr.track() == 4);
+
+  // A view lent from a shared proxy inherits its birth the same way.
+  auto sp = make_shared_proxy<marshal, texas_ranger>();
+  proxy_view<gunslinger> vs = sp;
+  CHECK(vs.try_downcast<marshal>());
+  CHECK(!vs.try_downcast<ranger>());
+
+  // The const view downcasts to another const view, so mutability never
+  // reopens.
+  const_proxy_view<gunslinger> cg = vm;
+  auto cm = cg.try_downcast<marshal>();
+  REQUIRE(cm);
+  CHECK(cm.describe() == "texas_ranger"s);
+
+  // Through a diamond, a view of the common base sidecasts to either
+  // sibling.
+  trail_boss boss;
+  proxy_view<posse_leader> vp = boss;
+  proxy_view<gunslinger> vgun = vp;
+  auto vb = vgun.try_downcast<bounty_hunter>();
+  REQUIRE(vb);
+  CHECK(vb.claim(1) == 1);
+  auto vm2 = vgun.try_downcast<marshal>();
+  REQUIRE(vm2);
+  CHECK(vm2.arrest(1));
+
+  // An empty view downcasts to an empty view.
+  proxy_view<gunslinger> unbound;
+  CHECK(!unbound.try_downcast<marshal>());
+}
+
+TEST_CASE("Downcasting a shared_proxy", "[proxy]") {
+  // The lvalue flavor shares: the result is another owner of the one
+  // target, and the source keeps its own share, so the target outlives any
+  // subset of its owners.
+  life_stats stats;
+  if (true) {
+    auto sv = make_shared_proxy<vault, small_box>(stats);
+    sv.call<"add">(5);
+    shared_proxy<lockbox> sl = sv;
+    auto back = sl.try_downcast<vault>();
+    REQUIRE(back);
+    CHECK(back.call<"gold">() == 5);
+    back.call<"add">(1);
+    CHECK(sl.call<"gold">() == 6);
+    REQUIRE(sl);
+    sv = {};
+    sl = {};
+    CHECK(stats.destroyed == 0);
+    CHECK(back.call<"gold">() == 6);
+    CHECK(stats.constructed == 1);
+  }
+  CHECK(stats.destroyed == stats.constructed);
+
+  // The rvalue flavor transfers, consuming the source only on success: a
+  // cast past the birth fails and keeps the source whole.
+  shared_proxy<gunslinger> sg{make_proxy<marshal, texas_ranger>()};
+  auto too_deep = std::move(sg).try_downcast<ranger>();
+  CHECK(!too_deep);
+  REQUIRE(sg); // NOLINT(bugprone-use-after-move): kept whole on failure.
+  // NOLINTNEXTLINE(bugprone-use-after-move): the failed cast kept it whole.
+  auto back_down = std::move(sg).try_downcast<marshal>();
+  REQUIRE(back_down);
+  CHECK(!sg); // NOLINT(bugprone-use-after-move): probing moved-from state.
+  CHECK(back_down.arrest(2));
+
+  // A birth adopted from a consumed proxy carries over: born a ranger as a
+  // unique proxy, still a ranger after becoming shared.
+  auto pr = make_proxy<ranger, texas_ranger>();
+  pr.fire(3);
+  shared_proxy<gunslinger> shared_gun{std::move(pr)};
+  auto sr = shared_gun.try_downcast<ranger>();
+  REQUIRE(sr);
+  CHECK(sr.shots() == 3);
+  REQUIRE(shared_gun);
+  CHECK(shared_gun.shots() == 3);
+
+  // An empty handle downcasts to an empty handle.
+  shared_proxy<gunslinger> nobody;
+  CHECK(!nobody.try_downcast<marshal>());
+}
+
 TEST_CASE("Cloning", "[proxy]") {
   // Cloneability is a runtime property of the erased target: `strongbox` is
-  // move-only, so its proxy answers no. An empty proxy clones to an empty
-  // proxy.
+  // move-only, so its proxy answers no. Cloning it anyway is graceful: the
+  // clone is empty, no copy is attempted, and the source is untouched. An
+  // empty proxy clones to an empty proxy.
   life_stats box_stats;
-  const auto locked = make_proxy<lockbox, small_box>(box_stats);
+  auto locked = make_proxy<lockbox, small_box>(box_stats);
+  locked.call<"add">(5);
   CHECK(!locked.can_clone());
+  CHECK(!locked.clone());
+  CHECK(box_stats.copies == 0);
+  CHECK(locked.call<"gold">() == 5);
   proxy<lockbox> nothing;
   CHECK(nothing.can_clone());
   CHECK(!nothing.clone());


### PR DESCRIPTION
## Summary

Adds `corvid/meta/proxy.h`: registration-based runtime polymorphism through type-erased handles over facade definitions, without inheritance, vtable pointers in the target type, or macros.

The design, feature tour, internals walkthrough (with diagrams), and build retrospective are in `corvid/meta/proxy.md`, which is part of this PR and is the intended entry point. Highlights:

- Five handles: the owning `proxy` (inline SBO or heap storage, selected by policy), `proxy_view`/`const_proxy_view`, and `shared_proxy`/`weak_proxy` with `std::shared_ptr`/`std::unique_ptr` interop.
- Conformance is nominal, not structural: registering a (facade, type) pair through an ADL hook is the act of opting in, so types you do not own (including std types) can be conformed without modification.
- Facade composition via `extends<Base>`, with implicit upcasting, vtable-carried `try_downcast`, diamond collapse by facade identity, and per-name overload sets resolved by the compiler's own overload ranking, so `call<>` and the `api` member-call sugar cannot disagree.
- The `api` sugar is validated against the method list at registration (`validate_api`), and `prox::codegen<F>` (`corvid/meta/proxy_codegen.h`) generates the two hand-written artifacts, pinned by golden-master tests.

## Also in this PR

- `fixed_string.h` moved from `corvid/strings/` to `corvid/meta/`, fixing inverted layering (proxy sits below the strings band). Breaking spelling change: `corvid::strings::fixed_string` is now `corvid::meta::fixed_string`, also reachable as `corvid::fixed_string` since `meta` is an inline namespace. In-repo users (the enum headers, `fixed_string_utils.h`) were respelled.
- `corvid/meta/naming.h` gained `friendly_type_name`, the best-effort demangled type spelling that codegen emits.

## Testing

- `tests/portable/proxy_test.cpp`: 36 test cases covering every feature tier; the shared fixture world is diagrammed in proxy.md's "Test fixture map". Interesting compile-time diagnostics are captured verbatim as comments next to the assertions that pin them.
- Full suite 51/51 green; `proxy_test` also clean under clang-tidy and ASAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
