### PR TITLE
clangd nvcc-flag stripping and a clang-tidy false-positive sweep

### DIFF
--- a/.clangd.in
+++ b/.clangd.in
@@ -15,6 +15,13 @@ CompileFlags:
 If:
   PathMatch: [.*\.cpp, .*\.cc, .*\.cxx, .*\.hpp, .*\.hh, .*\.hxx, .*\.h]
 CompileFlags:
+  # A header has no entry of its own in compile_commands.json, so it inherits
+  # the command of whatever parent TU clangd picks. When that parent is a
+  # `.cu` file (as `arithmetic.h` is, reached through the CUDA game headers),
+  # the inherited nvcc command carries nvcc-only flags that clangd's embedded
+  # clang rejects as "unknown argument". Strip them here too. This is a no-op
+  # for real `.cpp`/`.cc` TUs, whose own commands never carry these flags.
+  Remove: [-forward-unknown-to-host-compiler, -ccbin=*, -arch=*]
   Add: [-xc++, -std=c++23, -stdlib=libc++, -fexperimental-library, -D_LIBCPP_NO_ABI_TAG, -Wall, -Wextra, -Werror, -Wno-unused-variable]
 
 ---

--- a/corvid/enums/sequence_enum.h
+++ b/corvid/enums/sequence_enum.h
@@ -186,11 +186,11 @@ template<SequentialEnum E>
     constexpr auto hi = seq_max_num_v<E>;
     static_assert(lo <= hi);
     constexpr auto size = seq_size_v<E>;
-    // NOLINTNEXTLINE(bugprone-signed-char-misuse): intentional sign extension
+    // NOLINTBEGIN(bugprone-signed-char-misuse): intentional sign extension
     constexpr auto lo64 = static_cast<uint64_t>(lo);
     constexpr auto hi64 = static_cast<uint64_t>(hi);
-    // NOLINTNEXTLINE(bugprone-signed-char-misuse): intentional sign extension
     const auto u64 = static_cast<uint64_t>(u);
+    // NOLINTEND(bugprone-signed-char-misuse)
 
     // Below the range: count down from `hi`, so `lo - 1` maps to `hi`.
     if (u < lo)

--- a/corvid/enums/sequence_enum.h
+++ b/corvid/enums/sequence_enum.h
@@ -157,6 +157,7 @@ template<SequentialEnum E>
 seq_residue(std::underlying_type_t<E> r) noexcept {
   static_assert(seq_actually_need_wrap_v<E>);
   constexpr auto size = seq_size_v<E>;
+  // NOLINTNEXTLINE(bugprone-signed-char-misuse): intentional sign extension
   auto mag = static_cast<uint64_t>(r);
   bool neg{};
   if constexpr (std::is_signed_v<decltype(r)>) {
@@ -185,8 +186,10 @@ template<SequentialEnum E>
     constexpr auto hi = seq_max_num_v<E>;
     static_assert(lo <= hi);
     constexpr auto size = seq_size_v<E>;
+    // NOLINTNEXTLINE(bugprone-signed-char-misuse): intentional sign extension
     constexpr auto lo64 = static_cast<uint64_t>(lo);
     constexpr auto hi64 = static_cast<uint64_t>(hi);
+    // NOLINTNEXTLINE(bugprone-signed-char-misuse): intentional sign extension
     const auto u64 = static_cast<uint64_t>(u);
 
     // Below the range: count down from `hi`, so `lo - 1` maps to `hi`.

--- a/corvid/infra/exception_firewalls.h
+++ b/corvid/infra/exception_firewalls.h
@@ -198,7 +198,8 @@ requires(
     (!details::has_logs_bit(logging, log_policy::on_failure_value) ||
         std::equality_comparable<std::decay_t<std::invoke_result_t<F>>>))
 [[nodiscard]] auto
-// NOLINTNEXTLINE(bugprone-exception-escape): never policy swallows all throws
+// noexcept only for `rethrow_policy::never`, where nothing escapes
+// NOLINTNEXTLINE(bugprone-exception-escape)
 try_or_log(F&& fn, std::decay_t<std::invoke_result_t<F>> failure_value = {},
     format_with_loc<const char*, const char*> msg =
         "exception {}: {}") noexcept(rethrow == rethrow_policy::never) {
@@ -242,7 +243,8 @@ template<log_policy logging = log_policy::on_either_error,
     rethrow_policy rethrow = rethrow_policy::never, std::invocable F>
 requires(!std::is_void_v<std::invoke_result_t<F>> &&
          std::equality_comparable<std::decay_t<std::invoke_result_t<F>>>)
-// NOLINTNEXTLINE(bugprone-exception-escape): never policy swallows all throws
+// noexcept only for `rethrow_policy::never`, where nothing escapes
+// NOLINTNEXTLINE(bugprone-exception-escape)
 [[nodiscard]] auto try_or_terminate(F&& fn,
     const std::decay_t<std::invoke_result_t<F>>& failure_value = {},
     format_with_loc<const char*, const char*> msg =

--- a/corvid/infra/exception_firewalls.h
+++ b/corvid/infra/exception_firewalls.h
@@ -198,6 +198,7 @@ requires(
     (!details::has_logs_bit(logging, log_policy::on_failure_value) ||
         std::equality_comparable<std::decay_t<std::invoke_result_t<F>>>))
 [[nodiscard]] auto
+// NOLINTNEXTLINE(bugprone-exception-escape): never policy swallows all throws
 try_or_log(F&& fn, std::decay_t<std::invoke_result_t<F>> failure_value = {},
     format_with_loc<const char*, const char*> msg =
         "exception {}: {}") noexcept(rethrow == rethrow_policy::never) {
@@ -241,8 +242,9 @@ template<log_policy logging = log_policy::on_either_error,
     rethrow_policy rethrow = rethrow_policy::never, std::invocable F>
 requires(!std::is_void_v<std::invoke_result_t<F>> &&
          std::equality_comparable<std::decay_t<std::invoke_result_t<F>>>)
+// NOLINTNEXTLINE(bugprone-exception-escape): never policy swallows all throws
 [[nodiscard]] auto try_or_terminate(F&& fn,
-    std::decay_t<std::invoke_result_t<F>> failure_value = {},
+    const std::decay_t<std::invoke_result_t<F>>& failure_value = {},
     format_with_loc<const char*, const char*> msg =
         "exception {}: {}") noexcept(rethrow == rethrow_policy::never) {
   auto result =

--- a/corvid/meta/proxy.h
+++ b/corvid/meta/proxy.h
@@ -1450,6 +1450,7 @@ struct vtable_builder_impl<std::tuple<Ss...>, std::tuple<Bs...>, OwnName> {
   // An unqualified key matches the method name alone; a qualified key
   // ("facade::method") also requires the qualifying facade's name.
   template<typename S, fixed_string Key>
+  // NOLINTNEXTLINE(bugprone-exception-escape): consteval, compile-time only
   static consteval bool slot_matches() noexcept {
     constexpr std::string_view k = Key.view();
     constexpr auto pos = k.find("::");


### PR DESCRIPTION
Cleans up IDE and clang-tidy noise that surfaced after the proxy (#74) and exception-firewall (#75) work landed. One real defect is fixed; the rest are documented suppressions of false positives, verified against the code. The codebase is C++23.

## clangd: strip nvcc-only flags from headers (`.clangd.in`)

A header has no entry of its own in `compile_commands.json`, so clangd parses it through whatever parent TU it picks. For headers reachable from the CUDA game code (e.g. `corvid/math/arithmetic.h`, pulled in via the `.cuh` headers), that parent is a `.cu` file whose command is an `nvcc` invocation. clangd's embedded clang then rejects the nvcc-only flags `-forward-unknown-to-host-compiler`, `-ccbin=*`, and `-arch=*` as "unknown argument". The `.cu`/`.cuh` block already stripped these; this adds the same `Remove:` to the header/cpp block. It is a no-op for real `.cpp`/`.cc` TUs, whose own commands never carry those flags.

## Fix: unnecessary value-param copy (`exception_firewalls.h`)

The value-returning `try_or_terminate` took `failure_value` by value but only reads it (compares with `==`, forwards it to `try_or_log`, which has its own by-value sink). Changed to `const &`, removing a per-call copy of the result type (e.g. `std::string`). The default `= {}` still binds a temporary. The other overload's by-value `failure_value` is left as is: `do_firewall` returns it on the failure path, so it genuinely needs the value.

## Suppress: `bugprone-exception-escape` false positives

- `slot_matches` in `corvid/meta/proxy.h` is `consteval`. It is evaluated only at compile time and has no runtime existence, so it cannot throw at runtime; the check flags it purely because the body calls `std::string_view::substr`.
- `try_or_log` and `try_or_terminate` in `exception_firewalls.h` are `noexcept(rethrow == rethrow_policy::never)`. In the flagged `never` instantiations, `do_firewall`'s `catch (const std::exception&) / catch (const char*) / catch (...)` fully swallow, and the only rethrow is `if constexpr (rethrow == rethrow_policy::attempt) ... throw;`, which is discarded. Nothing escapes.

## Suppress: `bugprone-signed-char-misuse` false positives (`sequence_enum.h`)

Three sites in the wrap math. The widening sign-extension is intentional and load-bearing: `seq_residue` casts to the full 64-bit two's-complement value and recovers the magnitude with `mag = 0 - mag` (correct even for the type minimum), and `make_safely` sign-extends `lo`/`u` consistently so the modular subtraction stays exact. The check's suggested "cast to `unsigned char` first" would break the arithmetic.

## Verification

`./cleanbuild.sh tidy` builds the full suite clean (exit 0) with zero clang-tidy warnings (down from 345 exception-escape, 9 value-param, 3 signed-char-misuse), and the three clangd diagnostics on `arithmetic.h` clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
