### PR TITLE
Concurrency band review

### DIFF
--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -70,6 +70,7 @@ for domain in \
     "sentry.io" \
     "statsig.com" \
     "marketplace.visualstudio.com" \
+    "copilot-proxy.githubusercontent.com" \
     "vscode.blob.core.windows.net" \
     "update.code.visualstudio.com"\
     "embeddings.vscode-cdn.net"; do

--- a/corvid/concurrency.h
+++ b/corvid/concurrency.h
@@ -23,9 +23,9 @@
 //  jthread_stoppable_sleep - interruptible deadline sleep for `std::jthread`
 //  notifiable              - value guarded by mutex and condition variable
 //  owner_thread_dispatcher - dispatches callbacks to execute only in the
-//                            owning thread
-//  sync_lock               - `synchronizer`, `lock`, and `reverse_lock`
-//                            attestation idiom
+//                            owning thread (Linux-only)
+//  sync_lock               - `synchronizer`, `breakable_synchronizer`,
+//                            `lock`, and `reverse_lock` attestation idiom
 //  timeout_sweeper         - heap of (`expiration`, `callback`) pairs swept
 //                            by an external driver
 //  timeouts                - common types/constants shared by
@@ -39,7 +39,9 @@
 #include "concurrency/idle_timeout.h"
 #include "concurrency/jthread_stoppable_sleep.h"
 #include "concurrency/notifiable.h"
+#ifdef __linux__
 #include "concurrency/owner_thread_dispatcher.h"
+#endif
 #include "concurrency/sync_lock.h"
 #include "concurrency/timeout_sweeper.h"
 #include "concurrency/timeouts.h"

--- a/corvid/concurrency/idle_timeout.h
+++ b/corvid/concurrency/idle_timeout.h
@@ -266,9 +266,10 @@ private:
         return {};
       }
       const auto result = self->on_sweep(fired);
-      if (result.fire_idle) self->expire();
-      // Dropping the entry releases its claim on `scheduled_count_`.
+      // Dropping the entry releases its claim on `scheduled_count_`. We do
+      // this before expiring so that the `on_idle_` can restart.
       if (result.next_deadline == time_point_t{}) --self->scheduled_count_;
+      if (result.fire_idle) self->expire();
       return result.next_deadline;
     };
   }

--- a/corvid/concurrency/idle_timeout.h
+++ b/corvid/concurrency/idle_timeout.h
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #pragma once
-#include <cstdint>
+#include <cassert>
 #include <memory>
 #include <utility>
 
@@ -60,7 +60,7 @@ public:
   using sweeper_t = Sweeper;
   using callback_t = Sweeper::callback_t;
 
-  // Cancelation action invoked when the idle timer expires.
+  // Cancellation action invoked when the idle timer expires.
   using cancel_action_t = meta::fixed_function<32, void()>;
 
 #pragma endregion
@@ -74,7 +74,7 @@ public:
       : sweeper_{sweeper}, owner_{owner}, on_idle_{std::move(on_idle)},
         configured_{configured} {
     on_idle_once_ = &on_idle_;
-    assert(configured >= duration_t{});
+    assert((configured >= duration_t{}) && (configured <= max_timeout));
     assert(on_idle_);
   }
 
@@ -106,13 +106,15 @@ public:
   // sweep is scheduled for `infra::steady_now_clock::now() +
   // configured_timeout()` but will not trigger an expiration.
   //
-  // When `mode::stopped`, this will be a value in the past.
+  // When `mode::stopped`, this is zero.
   [[nodiscard]] time_point_t deadline() const noexcept { return deadline_; }
 
   // Current mode.
   [[nodiscard]] mode get_mode() const noexcept {
-    if (*deadline_ >= paused_expiration) return mode::paused;
-    if (*deadline_ <= steady_now_clock::now()) return mode::stopped;
+    const auto deadline_snapshot = *deadline_;
+    if ((scheduled_count_ == 0) || (deadline_snapshot == time_point_t{}))
+      return mode::stopped;
+    if (deadline_snapshot >= paused_expiration) return mode::paused;
     return mode::running;
   }
 
@@ -124,7 +126,7 @@ public:
   // Syncs `active_timeout` if in `mode::running` (so the next deadline
   // reset uses the new value), but will not clear it.
   void configure(duration_t d) noexcept {
-    assert(d >= duration_t{});
+    assert((d >= duration_t{}) && (d <= max_timeout));
     configured_ = d;
     if (d == duration_t{}) return;
     auto expected = *active_;
@@ -224,14 +226,13 @@ public:
 #pragma endregion
 #pragma region Helpers
 private:
-  // Build the sweeper closure. Mints a fresh aliased `weak_ptr` each
-  // call; the lambda captures it by value (16 bytes), fitting
-  // `callback_t`. Reaches `expire` through the locked `self`.
   // Ensure the single sweeper entry is in flight, scheduling one at `expire`
-  // if not. An entry that is already in flight adapts to the current
-  // `deadline_` on its next fire, so there is nothing to do. Fails only when
-  // the sweeper refuses (it is closing); the claim is released so a later
-  // attempt can retry.
+  // if not.
+  //
+  // An entry that is already in flight adapts to the current `deadline_` on
+  // its next fire, so there is nothing to do. Fails only when the sweeper
+  // refuses (it is closing); the claim is released and the state unwinds to
+  // stopped, so the mode reads truthfully and a later attempt can retry.
   [[nodiscard]] bool ensure_scheduled(time_point_t expire) {
     auto expected = *scheduled_count_;
     if (expected != 0) return true;
@@ -239,9 +240,11 @@ private:
     if (!scheduled_count_.compare_exchange(expected, 1)) return true;
     if (sweeper_.schedule(expire, build_sweeper_cb())) return true;
     --scheduled_count_;
+    (void)stop();
     return false;
   }
 
+  // Build the sweeper closure.
   [[nodiscard]] callback_t build_sweeper_cb() {
     std::shared_ptr<idle_timeout> self_sp{owner_.shared_from_this(), this};
     return [weak = std::weak_ptr<idle_timeout>{std::move(self_sp)}](
@@ -255,7 +258,7 @@ private:
         return {};
       }
       const auto result = self->on_sweep(fired);
-      if (result.fire_idle && self->on_idle_) self->expire();
+      if (result.fire_idle) self->expire();
       // Dropping the entry releases its claim on `scheduled_count_`.
       if (result.next_deadline == time_point_t{}) --self->scheduled_count_;
       return result.next_deadline;
@@ -269,7 +272,7 @@ private:
 
   [[nodiscard]] sweep_result on_sweep(time_point_t fired) noexcept {
     // `mode::stopped`: we transitioned out from under the sweeper. Drop the
-    // entry; no rearm, no cancelation.
+    // entry; no rearm, no cancellation.
     if (*deadline_ == time_point_t{}) return {{}, false};
     // `mode::paused`: parked at the sentinel. The deadline is in the far
     // future, but we always set the next callback to the configured timeout
@@ -286,13 +289,13 @@ private:
       return {steady_now_clock::now() + configured_snapshot, false};
     }
     // `mode::running` and deadline reached: nobody restarted between the
-    // schedule and now. Fire the cancelation action and drop the entry.
+    // schedule and now. Fire the cancellation action and drop the entry.
     if (*deadline_ == fired) {
       deadline_ = time_point_t{};
       return {{}, true};
     }
     // `mode::running`, but deadline moved (`postpone` pushed it forward):
-    // rearm to the new deadline; do not fire the cancelation action.
+    // rearm to the new deadline; do not fire the cancellation action.
     return {*deadline_, false};
   }
 
@@ -309,8 +312,8 @@ private:
   // `std::weak_ptr` to the owner, so that the callback harmlessly fails if the
   // owner has been destroyed.
   //
-  // `on_idle_` is the cancelation action that is invoked when the idle timeout
-  // expires.
+  // `on_idle_` is the cancellation action that is invoked when the idle
+  // timeout expires.
   //
   // `on_idle_once_` is an atomic pointer to `on_idle_`, used to ensure that it
   // is invoked only once. It can be reset with `reset_expiration()`.

--- a/corvid/concurrency/idle_timeout.h
+++ b/corvid/concurrency/idle_timeout.h
@@ -28,13 +28,13 @@ namespace corvid { inline namespace concurrency {
 
 #pragma region idle_timeout
 
-// Mechanism for implementing a idle timeout for a given operation, providing a
-// full state machine over the duration and callbacks. The use case is to set
+// Mechanism for implementing an idle timeout for a given operation, providing
+// a full state machine over the duration and callbacks. The use case is to set
 // an idle timeout and keep postponing it as more work is accomplished.
 //
 // Works with a sweeper implementation (such as `timeout_sweeper`). Manages the
 // configured/active duration, current deadline, sweeper integration, and the
-// three-state machine that owners drive via `set_mode`.
+// three-state machine that owners drive via `set_mode` and its synonyms.
 //
 // Owner must inherit from `std::enable_shared_from_this`. The aliased
 // keepalive is built lazily on the first `set_mode` transition that requires
@@ -94,13 +94,17 @@ public:
   // Active timeout. Non-zero iff currently `mode::running`.
   [[nodiscard]] duration_t active_timeout() const noexcept { return active_; }
 
-  // Current deadline. When `mode::running`, this time was set to
-  // `infra::steady_now_clock::now() + active_timeout()` and used to schedule
-  // the next sweep. When `mode::paused`, this is at or past the sentinel value
+  // Current deadline.
+  //
+  // When `mode::running`, this time was set to `infra::steady_now_clock::now()
+  // + active_timeout()` and used to schedule the next sweep.
+  //
+  // When `mode::paused`, this is at or past the sentinel value
   // (`paused_expiration`) that signals the clipping behavior, so that the next
   // sweep is scheduled for `infra::steady_now_clock::now() +
-  // configured_timeout()` but will not trigger an expiration. When
-  // `mode::stopped`, this will be a value in the past.
+  // configured_timeout()` but will not trigger an expiration.
+  //
+  // When `mode::stopped`, this will be a value in the past.
   [[nodiscard]] time_point_t deadline() const noexcept { return deadline_; }
 
   // Current mode.
@@ -126,25 +130,37 @@ public:
     (void)active_.compare_exchange(expected, d);
   }
 
-  // Postpone the expiration after progress. Safe to call in any mode.
+  // Postpone the expiration after progress
+  //
+  // Safe to call in any mode, from any thread: a postpone that races `stop` or
+  // `pause` may be dropped, but can never resurrect a deadline they parked.
   void postpone() noexcept {
+    auto expected = *deadline_;
+    // Not running: nothing to postpone.
+    if ((expected == time_point_t{}) || (expected >= paused_expiration))
+      return;
+    // Determine how long to postpone; if it got zeroed out, we lost the race.
     const auto active_snapshot = *active_;
     if (active_snapshot == duration_t{}) return;
-    deadline_ = steady_now_clock::now() + active_snapshot;
+    // Postpone deadline. If someone else changed it, we lost the race.
+    (void)deadline_.compare_exchange(expected,
+        steady_now_clock::now() + active_snapshot);
   }
 
-  // Stop the timeout and cancel any pending entry. Idempotent. Safe to call in
-  // any mode. Leaves `configured_timeout` and `on_idle` intact so the timeout
-  // can be restarted later.
+  // Stop the timeout and cancel any pending entry.
+  //
+  // Idempotent. Safe to call in any mode. Leaves `configured_timeout` and
+  // `on_idle` intact so the timeout can be restarted later.
   [[nodiscard]] bool stop() noexcept {
     active_ = duration_t{};
     deadline_ = time_point_t{};
     return true;
   }
 
-  // Start the timeout that was stopped or paused. If already running, all it
-  // does is postpone once. Fails if `configured_timeout` is zero or it can't
-  // schedule.
+  // Start the timeout that was stopped or paused.
+  //
+  // If already running, all it does is postpone once. Fails if
+  // `configured_timeout` is zero or it can't schedule.
   [[nodiscard]] bool start() {
     const auto now_time = steady_now_clock::now();
     const auto was_stopped = (*deadline_ <= now_time);
@@ -244,12 +260,13 @@ private:
     if (*deadline_ >= paused_expiration) {
       // Defensive: configured was zeroed while paused, so the clip path
       // would compute `now + 0`, hot-looping. Collapse to Stopped.
-      if (*configured_ == duration_t{}) {
+      const auto configured_snapshot = *configured_;
+      if (configured_snapshot == duration_t{}) {
         deadline_ = time_point_t{};
         return {{}, false};
       }
       // Clip back to a near-future fire so we keep checking periodically.
-      return {steady_now_clock::now() + *configured_, false};
+      return {steady_now_clock::now() + configured_snapshot, false};
     }
     // `mode::running` and deadline reached: nobody restarted between the
     // schedule and now. Fire the cancelation action and drop the entry.
@@ -264,6 +281,34 @@ private:
 
 #pragma endregion
 #pragma region Data members
+
+  // Summary:
+  //
+  // `sweeper_` is the non-owning reference to the sweeper, and is used to call
+  // its `schedule` method to register the next callback.
+  //
+  // `owner_` is the non-owning reference to the object that owns this
+  // `idle_timeout` instance. This is used in `build_sweeper_cb` to create a
+  // `std::weak_ptr` to the owner, so that the callback harmlessly fails if the
+  // owner has been destroyed.
+  //
+  // `on_idle_` is the cancelation action that is invoked when the idle timeout
+  // expires.
+  //
+  // `on_idle_once_` is an atomic pointer to `on_idle_`, used to ensure that it
+  // is invoked only once. It can be reset with `reset_expiration()`.
+  //
+  // `configured_` is the configured timeout duration, which can be updated
+  // with `configure()`. This is used to set `active_` when starting.
+  //
+  // `active_` is the active timeout duration, which is non-zero only when in
+  // `mode::running`. It is used to compute the next deadline when postponing.
+  //
+  // `deadline_` is the current deadline for the idle timeout. When zero, the
+  // timeout is stopped. When running, it is set to `now() + active_`; with
+  // each `postpone`, it is set again, only using the current `now()` value.
+  // In paused mode, it is set to the sentinel value `paused_expiration`, which
+  // is a time point far in the future.
 
   sweeper_t& sweeper_;
   owner_t& owner_;

--- a/corvid/concurrency/idle_timeout.h
+++ b/corvid/concurrency/idle_timeout.h
@@ -21,6 +21,7 @@
 
 #include "../meta/fixed_function.h"
 #include "../infra/relaxed_atomic.h"
+#include "../infra/scope_exit.h"
 #include "timeout_sweeper.h"
 #include "timeouts.h"
 
@@ -230,18 +231,25 @@ private:
   // if not.
   //
   // An entry that is already in flight adapts to the current `deadline_` on
-  // its next fire, so there is nothing to do. Fails only when the sweeper
-  // refuses (it is closing); the claim is released and the state unwinds to
-  // stopped, so the mode reads truthfully and a later attempt can retry.
+  // its next fire, so there is nothing to do. Fails when the sweeper refuses
+  // (it is closing), and throws when building the callback or scheduling it
+  // does. Either way the claim is released and the state unwinds to stopped,
+  // so the mode reads truthfully and a later attempt can retry.
   [[nodiscard]] bool ensure_scheduled(time_point_t expire) {
     auto expected = *scheduled_count_;
     if (expected != 0) return true;
     // Claim the 0 -> 1 transition; losing means someone else just scheduled.
     if (!scheduled_count_.compare_exchange(expected, 1)) return true;
-    if (sweeper_.schedule(expire, build_sweeper_cb())) return true;
-    --scheduled_count_;
-    (void)stop();
-    return false;
+
+    // Every exit but success unwinds the claim, so a refusal and a throw
+    // leave the same state.
+    scope_exit unwind{[this]() noexcept {
+      --scheduled_count_;
+      (void)stop();
+    }};
+    if (!sweeper_.schedule(expire, build_sweeper_cb())) return false;
+    unwind.release();
+    return true;
   }
 
   // Build the sweeper closure.

--- a/corvid/concurrency/idle_timeout.h
+++ b/corvid/concurrency/idle_timeout.h
@@ -46,7 +46,9 @@ namespace corvid { inline namespace concurrency {
 // The `postpone` method is fully thread-safe. Past that, individual loads and
 // stores are atomic, but there is no serialization of concurrent mutators. To
 // put it another way, it is best to call these other methods from a single
-// thread.
+// thread. Mode changes must also be serialized against the sweeper's driver
+// (in practice, both already run on the loop thread); only `postpone` may
+// come from any thread.
 template<typename Owner, typename Sweeper = timeout_sweeper<>>
 class idle_timeout: public timeouts {
 #pragma region Types
@@ -159,20 +161,19 @@ public:
 
   // Start the timeout that was stopped or paused.
   //
-  // If already running, all it does is postpone once. Fails if
-  // `configured_timeout` is zero or it can't schedule.
+  // If a sweeper entry is already in flight (running, paused, or stopped but
+  // not yet swept), all this does is move the deadline; the entry adapts on
+  // its next fire (`mode::paused` -> `mode::running` may see up to one
+  // `configured_timeout` of slop). Fails if `configured_timeout` is zero or
+  // it can't schedule.
   [[nodiscard]] bool start() {
-    const auto now_time = steady_now_clock::now();
-    const auto was_stopped = (*deadline_ <= now_time);
     const auto configured_snapshot = *configured_;
     if (configured_snapshot == duration_t{}) return false;
     active_ = configured_snapshot;
-    const auto deadline_snapshot = now_time + configured_snapshot;
+    const auto deadline_snapshot =
+        steady_now_clock::now() + configured_snapshot;
     deadline_ = deadline_snapshot;
-    // Existing entry adapts on its next fire (`mode::paused` ->
-    // `mode::running` may see up to one `configured_timeout` of slop).
-    if (!was_stopped) return true;
-    return sweeper_.schedule(deadline_snapshot, build_sweeper_cb());
+    return ensure_scheduled(deadline_snapshot);
   }
 
   // Pause the timeout. If already paused, does nothing.
@@ -184,26 +185,19 @@ public:
   //
   // Fails if `configured_timeout` is zero or it can't schedule.
   [[nodiscard]] bool pause() {
-    const auto now_time = steady_now_clock::now();
-    const auto was_stopped = (*deadline_ <= now_time);
     const auto configured_snapshot = *configured_;
     if (configured_snapshot == duration_t{}) return false;
-    auto succeeded = true;
-    if (was_stopped) {
-      // From `mode::stopped`: bootstrap. Schedule a near-future fire so the
-      // clipping cycle starts, then revert to the sentinel.
-      const auto deadline_snapshot = now_time + configured_snapshot;
-      deadline_ = deadline_snapshot;
-      succeeded = sweeper_.schedule(deadline_snapshot, build_sweeper_cb());
-    }
     active_ = duration_t{};
+    // Park the sentinel BEFORE scheduling the bootstrap entry, so it can
+    // never match a real deadline and fire; it lands on the clip path.
     deadline_ = paused_expiration;
-    return succeeded;
+    return ensure_scheduled(steady_now_clock::now() + configured_snapshot);
   }
 
-  // Change the mode to start, stop, or pause the timeout. Returns `false` if
-  // `configured_timeout` is zero and `target` is not `mode::stopped`, or if
-  // scheduling a fresh sweeper entry fails.
+  // Change the mode to start, stop, or pause the timeout.
+  //
+  // Returns `false` if `configured_timeout` is zero and `target` is not
+  // `mode::stopped`, or if scheduling a fresh sweeper entry fails.
   [[nodiscard]] bool set_mode(mode target) {
     switch (target) {
     case mode::stopped: return stop();
@@ -233,14 +227,37 @@ private:
   // Build the sweeper closure. Mints a fresh aliased `weak_ptr` each
   // call; the lambda captures it by value (16 bytes), fitting
   // `callback_t`. Reaches `expire` through the locked `self`.
+  // Ensure the single sweeper entry is in flight, scheduling one at `expire`
+  // if not. An entry that is already in flight adapts to the current
+  // `deadline_` on its next fire, so there is nothing to do. Fails only when
+  // the sweeper refuses (it is closing); the claim is released so a later
+  // attempt can retry.
+  [[nodiscard]] bool ensure_scheduled(time_point_t expire) {
+    auto expected = *scheduled_count_;
+    if (expected != 0) return true;
+    // Claim the 0 -> 1 transition; losing means someone else just scheduled.
+    if (!scheduled_count_.compare_exchange(expected, 1)) return true;
+    if (sweeper_.schedule(expire, build_sweeper_cb())) return true;
+    --scheduled_count_;
+    return false;
+  }
+
   [[nodiscard]] callback_t build_sweeper_cb() {
     std::shared_ptr<idle_timeout> self_sp{owner_.shared_from_this(), this};
     return [weak = std::weak_ptr<idle_timeout>{std::move(self_sp)}](
                time_point_t fired) -> time_point_t {
       auto self = weak.lock();
       if (!self) return {};
+      // A duplicate in-flight entry (which should not happen) drains itself
+      // rather than shadowing the real one.
+      if (self->scheduled_count_ > 1) {
+        --self->scheduled_count_;
+        return {};
+      }
       const auto result = self->on_sweep(fired);
       if (result.fire_idle && self->on_idle_) self->expire();
+      // Dropping the entry releases its claim on `scheduled_count_`.
+      if (result.next_deadline == time_point_t{}) --self->scheduled_count_;
       return result.next_deadline;
     };
   }
@@ -309,6 +326,14 @@ private:
   // each `postpone`, it is set again, only using the current `now()` value.
   // In paused mode, it is set to the sentinel value `paused_expiration`, which
   // is a time point far in the future.
+  //
+  // `scheduled_count_` is the number of sweeper entries currently in flight
+  // for this instance: 0 or 1 in normal operation. Mutators claim the 0 -> 1
+  // transition before scheduling, and the sweeper callback decrements when it
+  // drops an entry, so restarting before a stopped entry is swept can never
+  // double-schedule. It is a counter rather than a flag to leave room for
+  // deliberately scheduling an earlier second entry (e.g. so a shortened
+  // timeout takes effect immediately), with the extra entry draining itself.
 
   sweeper_t& sweeper_;
   owner_t& owner_;
@@ -317,6 +342,7 @@ private:
   relaxed_atomic<duration_t> configured_;
   relaxed_atomic<duration_t> active_;
   relaxed_atomic<time_point_t> deadline_;
+  relaxed_atomic_int scheduled_count_;
 
 #pragma endregion
 };

--- a/corvid/concurrency/jthread_stoppable_sleep.h
+++ b/corvid/concurrency/jthread_stoppable_sleep.h
@@ -22,7 +22,6 @@
 #include <string_view>
 #include <string>
 #include <atomic>
-#include <thread>
 
 // We support both Windows and POSIX.
 #ifdef _WIN32
@@ -45,11 +44,12 @@ namespace corvid { inline namespace concurrency {
 
 // Interruptible deadline sleep for use with `std::jthread`.
 //
-// Wraps the workaround needed because libc++ does not yet implement the
-// stop-token overload of `std::condition_variable_any::wait_until`. The
-// pattern -- register a `std::stop_callback` that wakes the cv, then use
-// a regular `wait_until` with a stop-check predicate -- is encapsulated
-// here so callers don't have to repeat it.
+// A thin, named veneer over the stop-token overload of
+// `std::condition_variable_any::wait_until`: sleep until the deadline, wake
+// immediately when a stop is requested.
+//
+// Also home to `set_thread_name`, a small cross-platform thread-naming
+// helper used by the I/O loops.
 //
 // Usage:
 //
@@ -72,9 +72,8 @@ public:
   template<typename Clock, typename Duration>
   [[nodiscard]] bool until(std::stop_token st,
       const std::chrono::time_point<Clock, Duration>& deadline) {
-    std::stop_callback on_stop(st, [this] { cv_.notify_all(); });
     std::unique_lock lock(mutex_);
-    return cv_.wait_until(lock, deadline, [&st] {
+    return cv_.wait_until(lock, st, deadline, [&st] {
       return st.stop_requested();
     });
   }
@@ -100,7 +99,7 @@ public:
 #pragma region Data members
 private:
   std::mutex mutex_;
-  std::condition_variable cv_;
+  std::condition_variable_any cv_;
 
 #pragma endregion
 };

--- a/corvid/concurrency/notifiable.h
+++ b/corvid/concurrency/notifiable.h
@@ -89,7 +89,9 @@ concept atomic_like =
 //
 // Not copyable or movable (owns a `std::mutex`).
 //
-// Typical use, signaling a bool flag from another thread:
+// Typical use, signaling a bool flag from another thread. This example is
+// kept compiling and passing as the `LedeExample` case in
+// "notifiable_test.cpp"; change the two together.
 //
 //   // The `bool` type is deduced by CTAD, but could be explicitly specified.
 //   notifiable running{false};
@@ -107,7 +109,7 @@ concept atomic_like =
 // `T` may be a specialization of `std::atomic`. In that case, `get` skips the
 // mutex and delegates directly to `T::load`, so readers pay no locking cost
 // while writers still go through the mutex to ensure correct notification
-// ordering.
+// ordering. It also supports `relaxed_atomic` in the same way.
 //
 // When considering `notifiable<std::atomic<U>>` vs. `std::atomic<U>`'s own
 // `wait`/`notify_one`/`notify_all` interface (added in C++20), prefer the
@@ -122,10 +124,9 @@ class notifiable {
 public:
 #pragma region Construction
 
-  // Return type of `wait_until` / `wait_until_changed` / `wait_for` /
-  // `wait_for_changed`, and parameter type of `notify` / `notify_one`.
-  // For non-atomic `T` this is `T` itself; for `std::atomic<U>` it is `U`,
-  // since atomics are neither copyable nor movable.
+  // For non-atomic `T`, this is `T` itself; for `std::atomic<U>` or
+  // `relaxed_atomic`, it is `U`, since atomics are neither copyable nor
+  // movable.
   using value_t = details::notifiable_result<T>::type;
 
   static_assert(
@@ -187,7 +188,25 @@ public:
   }
 
 #pragma endregion
-#pragma region Reading
+#pragma region Accessors
+
+  // Set the value without waking waiters.
+  void set(value_t val)
+  requires(!details::atomic_like<T>)
+  {
+    std::scoped_lock lock(mutex_);
+    value_ = std::move(val);
+  }
+
+  // Set the value without locking or waking waiters.
+  void set(value_t val, std::memory_order order = std::memory_order::relaxed)
+  requires(details::atomic_like<T>)
+  {
+    if constexpr (is_specialization_of_v<T, std::atomic>)
+      value_.store(val, order);
+    else
+      value_->store(val, order);
+  }
 
   // Return a snapshot of the current value under lock.
   [[nodiscard]] T get() const
@@ -320,10 +339,12 @@ public:
 #pragma endregion
 #pragma region Helpers
 
-  // Read a `T` as a `value_t`. For `std::atomic<U>` or `relaxed_atomic<U>`,
-  // uses a `relaxed` load rather than the implicit conversion operator (which
-  // would be `seq_cst` for `std::atomic`). This is correct when called inside
-  // the mutex, which already provides the necessary ordering.
+  // Read a `T` as a `value_t`.
+  //
+  // For `std::atomic<U>` or `relaxed_atomic<U>`, uses a `relaxed` load rather
+  // than the `std::atomic` implicit conversion operator (which would be
+  // `seq_cst` for `std::atomic`). This is correct when called inside the
+  // mutex, which already provides the necessary ordering.
   [[nodiscard]] static value_t load_value(const T& v) {
     if constexpr (is_specialization_of_v<T, std::atomic>)
       return v.load(std::memory_order::relaxed);
@@ -343,6 +364,11 @@ private:
 
 #pragma endregion
 };
+
+// Deduce the payload type from the initial value, as in
+// `notifiable running{false};`.
+template<typename T>
+notifiable(T) -> notifiable<T>;
 
 #pragma endregion
 }}} // namespace corvid::concurrency::notifiable_ns

--- a/corvid/concurrency/owner_thread_dispatcher.h
+++ b/corvid/concurrency/owner_thread_dispatcher.h
@@ -305,7 +305,7 @@ protected:
   // NOLINTNEXTLINE(bugprone-exception-escape)
   [[nodiscard]] size_t execute_post_queue() noexcept {
     assert(is_loop_thread());
-    assert(!draining_);
+    assert(!draining_queue_);
     if (draining_queue_) return 0;
 
     // Atomically swap between the double-buffered queues.

--- a/corvid/concurrency/owner_thread_dispatcher.h
+++ b/corvid/concurrency/owner_thread_dispatcher.h
@@ -15,6 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #pragma once
+#include <algorithm>
 #include <atomic>
 #include <cassert>
 #include <concepts>
@@ -27,10 +28,12 @@
 #include <stdexcept>
 #include <thread>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "../meta/concepts.h"
 #include "../infra/exception_firewalls.h"
+#include "../infra/scope_exit.h"
 #include "../filesys/os_file.h"
 #include "../filesys/event_fd.h"
 #include "../infra/relaxed_atomic.h"
@@ -224,15 +227,34 @@ public:
   // another thread, posts before blocking the calling thread until it
   // completes.
   //
+  // Returns false without running `fn` when the post cannot be queued, and
+  // also when a shutdown discards the post before the loop thread reaches it.
+  // Otherwise the wait is unbounded, so the loop thread has to be consuming
+  // its post queue.
+  //
   // The use cases for this are very limited, but it's helpful for testing.
   [[nodiscard]] bool post_and_wait(PostedInvocable auto&& fn) {
     if (is_loop_thread()) return fn();
     bool result{};
     std::latch done{1};
 
-    if (post([fn = std::move(fn), &result, &done]() mutable -> bool {
-          result = fn();
+    // The guard rides along in the callback, ending the wait when the
+    // callback is destroyed. That covers being discarded by a shutdown as
+    // well as having run, at the cost of waking no earlier than the end of
+    // the drain that ran it.
+    //
+    // Copying the guard throws, so the queue must never copy the callback.
+    // Growth uses `move_if_noexcept`, which reaches for the copy only when
+    // the move can throw.
+    static_assert(std::is_nothrow_move_constructible_v<posted_fn> ||
+                      !std::is_copy_constructible_v<posted_fn>,
+        "posted_fn must be nothrow-movable, or the post queue would copy "
+        "callbacks when it grows");
+
+    if (post([fn = std::move(fn), &result, guard = scope_exit{[&done] {
           done.count_down();
+        }}]() mutable -> bool {
+          result = fn();
           return true;
         }))
       done.wait();

--- a/corvid/concurrency/owner_thread_dispatcher.h
+++ b/corvid/concurrency/owner_thread_dispatcher.h
@@ -185,7 +185,7 @@ public:
       active_queue.emplace_back(std::move(cbpost));
     }
     // On transition from empty, signal the `eventfd` to wake the loop thread.
-    if (was_empty) return wake_post_queue();
+    if (was_empty) (void)wake_post_queue();
 
     return true;
   }
@@ -210,6 +210,10 @@ public:
   // This only makes sense if the failure is retryable. Even so, we have a
   // finite retry count, which you can configure the default for in the
   // constructor.
+  //
+  // Returns true when `fn` succeeded inline or was queued for a later
+  // attempt, and false when it failed inline with no retries left or the post
+  // was refused, as it is after shutdown.
   [[nodiscard]] bool execute_or_post_with_retry(PostedInvocable auto&& fn,
       size_t retry_count = npos) {
     if (retry_count == npos) retry_count = default_retry_count_;
@@ -221,10 +225,9 @@ public:
     // This will always be executed in the loop thread, where it will run
     // once. It will only be queued again if it fails but there are more
     // retries.
-    (void)post([this, retry_count, fn = std::move(fn)]() mutable -> bool {
+    return post([this, retry_count, fn = std::move(fn)]() mutable -> bool {
       return execute_or_post_with_retry(std::move(fn), retry_count);
     });
-    return true;
   }
 
 #pragma endregion

--- a/corvid/concurrency/owner_thread_dispatcher.h
+++ b/corvid/concurrency/owner_thread_dispatcher.h
@@ -131,12 +131,19 @@ public:
   }
 
   // Force shutdown of resources. Idempotent.
+  //
+  // May be called from a posted callback, in which case the drain that is
+  // running it stops after it returns, discarding the rest of that batch.
   [[nodiscard]] bool shutdown() {
     if (current_loop_ != this) return false;
     std::scoped_lock lock(post_mutex_);
     if (!active_queue_.exchange(nullptr)) return false;
-    post_queues_[0].clear();
-    post_queues_[1].clear();
+
+    // A drain in progress owns the queue it is walking, so leave that one to
+    // it. Clearing it here would destroy the callback that is executing.
+    for (auto& queue : post_queues_)
+      if (&queue != draining_queue_) queue.clear();
+
     return true;
   }
 
@@ -285,12 +292,21 @@ protected:
   // callbacks executed. There is no reason to call this until after `post`
   // signals the `eventfd`, and it must only be called from the owning thread.
   //
+  // A callback must not call this again: a nested drain would take over the
+  // queue this one is walking. Doing so asserts, and returns zero without
+  // draining anything.
+  //
+  // A callback may call `shutdown`, which ends the drain after that callback
+  // returns. The rest of the batch is discarded and counts as unexecuted.
+  //
   // This is intentional: we want to fail on an exception in a callback
   // function.
   //
   // NOLINTNEXTLINE(bugprone-exception-escape)
   [[nodiscard]] size_t execute_post_queue() noexcept {
     assert(is_loop_thread());
+    assert(!draining_);
+    if (draining_queue_) return 0;
 
     // Atomically swap between the double-buffered queues.
     post_queue_t* pending{};
@@ -300,14 +316,22 @@ protected:
       auto* other =
           (pending == &post_queues_[0]) ? &post_queues_[1] : &post_queues_[0];
       active_queue_ = other;
+      draining_queue_ = pending;
     }
-
-    const auto count = pending->size();
 
     // Note that this method is marked `noexcept`, so if any callback throws,
     // we crash. This is because we have no reasonable alternative.
-    for (auto& fn : *pending) fn();
+    size_t count{};
+    for (auto& fn : *pending) {
+      if (!active_queue_) break; // A callback shut us down.
+      fn();
+      ++count;
+    }
+
+    // Clear before releasing the claim, so that a destructor reaching
+    // `shutdown` still finds this queue spoken for.
     pending->clear();
+    draining_queue_ = nullptr;
     return count;
   }
 
@@ -317,10 +341,24 @@ private:
 
 #pragma region Data members
 private:
+  // `wake_fd` is used to signal that `active_queue_` has work to do.
+  //
+  // `post_mutex_` protects the `post_queues_`.
+  //
+  // `active_queue_` is the queue that is currently being filled by `post`.
+  //
+  // `draining_queue_` is the queue that is currently being drained by
+  // `execute_post_queue`, only while it's being drained.
+  //
+  // `default_retry_count_` is the default number of times
+  // `execute_or_post_with_retry` will retry a failed callback before giving
+  // up.
+
   event_fd wake_fd_{event_fd::create()};
   mutable std::mutex post_mutex_;
   post_queue_t post_queues_[2];
   relaxed_atomic<post_queue_t*> active_queue_{&post_queues_[0]};
+  post_queue_t* draining_queue_{};
   relaxed_atomic_size_t default_retry_count_{3};
 
   // A thread can only have one active loop at a time.

--- a/corvid/concurrency/owner_thread_dispatcher.h
+++ b/corvid/concurrency/owner_thread_dispatcher.h
@@ -309,8 +309,8 @@ public:
     return std::max(post_queues_[0].capacity(), post_queues_[1].capacity());
   }
 
-#pragma region Child access
-protected:
+#pragma region Loop integration
+
   // Access `eventfd` to wait on for work in the post queue.
   const auto& wake_fd() const noexcept { return wake_fd_; }
 

--- a/corvid/concurrency/owner_thread_dispatcher.h
+++ b/corvid/concurrency/owner_thread_dispatcher.h
@@ -18,7 +18,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
-#include <functional>
 #include <latch>
 #include <memory>
 #include <mutex>
@@ -28,6 +27,7 @@
 #include <vector>
 
 #include "../meta/concepts.h"
+#include "../meta/fixed_function.h"
 #include "../infra/exception_firewalls.h"
 #include "../infra/scope_exit.h"
 #include "../filesys/event_fd.h"
@@ -37,6 +37,14 @@ namespace corvid { inline namespace concurrency {
 inline namespace owner_thread_dispatcherns {
 
 #pragma region owner_thread_dispatcher
+
+// Inline capacity of the `fixed_function` that callbacks are stored in, both
+// here and in the loops built on this class. Large enough for the captures
+// these callbacks carry in practice, which are a handle or two and a small
+// payload.
+namespace default_fixed_function {
+inline constexpr auto capacity = 384UZ;
+} // namespace default_fixed_function
 
 // Concept for `owner_thread_dispatcher::posted_fn` lambda in its stored form.
 // This is what the invocable in the post queue has to fit.
@@ -112,7 +120,8 @@ protected:
 // and therefore won't work with a raw function pointer.
 //
 // NOLINTBEGIN(bugprone-move-forwarding-reference)
-template<typename CB = std::function<bool()>>
+template<typename CB =
+             fixed_function<default_fixed_function::capacity, bool()>>
 class owner_thread_dispatcher: public owner_thread_claim {
 public:
 #pragma region Infrastructure
@@ -390,10 +399,6 @@ private:
 };
 
 // NOLINTEND(bugprone-move-forwarding-reference)
-
-namespace default_fixed_function {
-inline static constexpr auto capacity = 384UZ;
-} // namespace default_fixed_function
 
 #pragma endregion
 

--- a/corvid/concurrency/owner_thread_dispatcher.h
+++ b/corvid/concurrency/owner_thread_dispatcher.h
@@ -161,11 +161,16 @@ public:
 
   // Force shutdown of resources.
   //
-  // Idempotent. May be called from a posted callback, in which case the drain
-  // that is running it stops after it returns, discarding the rest of that
-  // batch.
+  // Idempotent, returning false when the shutdown already happened. May be
+  // called from a posted callback, in which case the drain that is running it
+  // stops after it returns, discarding the rest of that batch.
+  //
+  // Throws when called from any thread but the loop thread, which is a caller
+  // bug rather than a lost race.
   [[nodiscard]] bool shutdown() {
-    if (current_loop_ != this) return false;
+    if (current_loop_ != this)
+      throw std::logic_error{"Wrong owner_thread_dispatcher shut down thread"};
+
     std::scoped_lock lock(post_mutex_);
     if (!active_queue_.exchange(nullptr)) return false;
 

--- a/corvid/concurrency/owner_thread_dispatcher.h
+++ b/corvid/concurrency/owner_thread_dispatcher.h
@@ -16,17 +16,13 @@
 // limitations under the License.
 #pragma once
 #include <algorithm>
-#include <atomic>
 #include <cassert>
-#include <concepts>
 #include <cstddef>
-#include <exception>
 #include <functional>
 #include <latch>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
-#include <thread>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -34,7 +30,6 @@
 #include "../meta/concepts.h"
 #include "../infra/exception_firewalls.h"
 #include "../infra/scope_exit.h"
-#include "../filesys/os_file.h"
 #include "../filesys/event_fd.h"
 #include "../infra/relaxed_atomic.h"
 
@@ -46,12 +41,12 @@ inline namespace owner_thread_dispatcherns {
 // Concept for `owner_thread_dispatcher::posted_fn` lambda in its stored form.
 // This is what the invocable in the post queue has to fit.
 template<typename FN>
-concept StoredPostedInvocable =
-    MoveConsumable<FN> && std::is_invocable_r_v<bool, FN>;
+concept StoredPostedInvocable = std::is_invocable_r_v<bool, FN>;
 
 // Concept for `owner_thread_dispatcher::posted_fn` lambda as a parameter. This
-// is what the parameter to `post` has to fit: see `MoveConsumable` for
-// details.
+// is what a callback handed to `execute_or_post` and its relatives has to fit,
+// adding to the stored form only the requirement that it can be moved from:
+// see `MoveConsumable` for details.
 template<typename FN>
 concept PostedInvocable = MoveConsumable<FN> && StoredPostedInvocable<FN>;
 
@@ -123,7 +118,7 @@ public:
 #pragma region Infrastructure
 
   static_assert(StoredPostedInvocable<CB>,
-      "CB must be a PostedInvocable lambda type");
+      "CB must be a StoredPostedInvocable callback type");
 
   using posted_fn = CB;
   static constexpr size_t npos = -1;

--- a/corvid/concurrency/owner_thread_dispatcher.h
+++ b/corvid/concurrency/owner_thread_dispatcher.h
@@ -55,6 +55,21 @@ concept StoredPostedInvocable =
 template<typename FN>
 concept PostedInvocable = MoveConsumable<FN> && StoredPostedInvocable<FN>;
 
+// Records which dispatcher, if any, has claimed the current thread.
+//
+// The claim lives outside the template so that all callback types compete for
+// it. As a member of `owner_thread_dispatcher`, it would be a distinct
+// `thread_local` per instantiation, letting dispatchers with different
+// callback types each claim the same thread. It also carries the
+// `enable_shared_from_this` hookup, so a dispatcher needs only this one base.
+class owner_thread_claim
+    : public std::enable_shared_from_this<owner_thread_claim> {
+protected:
+  ~owner_thread_claim() = default;
+
+  inline static thread_local const owner_thread_claim* current_loop_{};
+};
+
 // Dispatches callbacks to execute only in the owning thread (aka the loop
 // thread) by queuing them when they're posted from another thread.
 //
@@ -103,8 +118,7 @@ concept PostedInvocable = MoveConsumable<FN> && StoredPostedInvocable<FN>;
 //
 // NOLINTBEGIN(bugprone-move-forwarding-reference)
 template<typename CB = std::function<bool()>>
-class owner_thread_dispatcher
-    : public std::enable_shared_from_this<owner_thread_dispatcher<CB>> {
+class owner_thread_dispatcher: public owner_thread_claim {
 public:
 #pragma region Infrastructure
 
@@ -114,9 +128,11 @@ public:
   using posted_fn = CB;
   static constexpr size_t npos = -1;
 
-  // Construct with initial sizes for post queues and default retry count. See
-  // `queue_high_watermark` for tuning. The constructing thread becomes the
-  // loop thread; only one instance per thread is permitted (debug-asserted).
+  // Construct with initial sizes for post queues and default retry count.
+  //
+  // See `queue_high_watermark` for tuning. The constructing thread becomes the
+  // loop thread. Throws `std::logic_error` when that thread already has a
+  // dispatcher, whatever its callback type.
   explicit owner_thread_dispatcher(size_t post_queue_reserve = 32UZ,
       size_t default_retry_count = npos) {
     if (current_loop_)
@@ -130,10 +146,11 @@ public:
     post_queues_[1].reserve(post_queue_reserve);
   }
 
-  // Force shutdown of resources. Idempotent.
+  // Force shutdown of resources.
   //
-  // May be called from a posted callback, in which case the drain that is
-  // running it stops after it returns, discarding the rest of that batch.
+  // Idempotent. May be called from a posted callback, in which case the drain
+  // that is running it stops after it returns, discarding the rest of that
+  // batch.
   [[nodiscard]] bool shutdown() {
     if (current_loop_ != this) return false;
     std::scoped_lock lock(post_mutex_);
@@ -151,8 +168,7 @@ public:
     try_or_terminate([&] {
       if (current_loop_ != this)
         throw std::logic_error{
-            "owner_thread_dispatcher destructed on a different thread than it "
-            "was created on"};
+            "owner_thread_dispatcher destructed on wrong thread"};
       (void)shutdown();
       current_loop_ = nullptr;
     });
@@ -275,9 +291,10 @@ public:
 #pragma endregion
 
   // Returns the current high-watermark for the post queues, which can be used
-  // to tune the constructor's `post_queue_reserve` parameter. In practice,
-  // vectors grow by doubling and never shrink, so in the steady state, there
-  // should be no allocations.
+  // to tune the constructor's `post_queue_reserve` parameter
+  //
+  // In practice, vectors grow by doubling and never shrink, so in the steady
+  // state, there should be no allocations.
   [[nodiscard]] size_t queue_high_watermark() const noexcept {
     std::scoped_lock lock(post_mutex_);
     return std::max(post_queues_[0].capacity(), post_queues_[1].capacity());
@@ -291,19 +308,19 @@ protected:
   // Signal eventfd to wake the loop thread.
   [[nodiscard]] bool wake_post_queue() noexcept { return wake_fd_.notify(); }
 
-  // Execute all pending callbacks in the post queue. Returns the number of
-  // callbacks executed. There is no reason to call this until after `post`
-  // signals the `eventfd`, and it must only be called from the owning thread.
+  // Execute all pending callbacks in the post queue.
+  //
+  // Returns the number of callbacks executed. There is no reason to call this
+  // until after `post` signals the `eventfd`, and it must only be called from
+  // the owning thread.
   //
   // A callback must not call this again: a nested drain would take over the
   // queue this one is walking. Doing so asserts, and returns zero without
   // draining anything.
   //
   // A callback may call `shutdown`, which ends the drain after that callback
-  // returns. The rest of the batch is discarded and counts as unexecuted.
-  //
-  // This is intentional: we want to fail on an exception in a callback
-  // function.
+  // returns. The rest of the batch is discarded and counts as unexecuted. This
+  // is intentional: we want to fail on an exception in a callback function.
   //
   // NOLINTNEXTLINE(bugprone-exception-escape)
   [[nodiscard]] size_t execute_post_queue() noexcept {
@@ -343,7 +360,9 @@ private:
   using post_queue_t = std::vector<posted_fn>;
 
 #pragma region Data members
-private:
+
+  // Summary:
+  //
   // `wake_fd` is used to signal that `active_queue_` has work to do.
   //
   // `post_mutex_` protects the `post_queues_`.
@@ -354,8 +373,7 @@ private:
   // `execute_post_queue`, only while it's being drained.
   //
   // `default_retry_count_` is the default number of times
-  // `execute_or_post_with_retry` will retry a failed callback before giving
-  // up.
+  // `execute_or_post_with_retry` will retry a failed callback.
 
   event_fd wake_fd_{event_fd::create()};
   mutable std::mutex post_mutex_;
@@ -363,9 +381,6 @@ private:
   relaxed_atomic<post_queue_t*> active_queue_{&post_queues_[0]};
   post_queue_t* draining_queue_{};
   relaxed_atomic_size_t default_retry_count_{3};
-
-  // A thread can only have one active loop at a time.
-  inline static thread_local const owner_thread_dispatcher* current_loop_{};
 
 #pragma endregion
 };

--- a/corvid/concurrency/owner_thread_dispatcher.h
+++ b/corvid/concurrency/owner_thread_dispatcher.h
@@ -132,18 +132,27 @@ public:
   //
   // See `queue_high_watermark` for tuning. The constructing thread becomes the
   // loop thread. Throws `std::logic_error` when that thread already has a
-  // dispatcher, whatever its callback type.
+  // dispatcher, whatever its callback type, and `std::runtime_error` when the
+  // wake `eventfd` could not be created. A construction that throws for any
+  // reason leaves the thread unclaimed.
   explicit owner_thread_dispatcher(size_t post_queue_reserve = 32UZ,
       size_t default_retry_count = npos) {
     if (current_loop_)
       throw std::logic_error{
           "another owner_thread_dispatcher already exists on this thread"};
 
+    if (!wake_fd_)
+      throw std::runtime_error{
+          "owner_thread_dispatcher could not create its wake eventfd"};
+
     if (default_retry_count != npos)
       default_retry_count_ = default_retry_count;
-    current_loop_ = this;
+
     post_queues_[0].reserve(post_queue_reserve);
     post_queues_[1].reserve(post_queue_reserve);
+
+    // Don't claim until fully constructed.
+    current_loop_ = this;
   }
 
   // Force shutdown of resources.

--- a/corvid/concurrency/sync_lock.h
+++ b/corvid/concurrency/sync_lock.h
@@ -74,7 +74,7 @@ private:
 // Reversed lock. Unlocks on construction, relocks on destruction.
 //
 // This class is largely internal. The normal way to use it is to call
-// `reverse` on a `lock`.
+// `lock_reverse` on a `lock`.
 class [[nodiscard]] reverse_lock final {
 public:
 #pragma region Construction
@@ -101,7 +101,8 @@ public:
     return old;
   }
 
-  [[nodiscard]] operator bool() const noexcept { return sync_; }
+  // Whether a `synchronizer` is associated.
+  [[nodiscard]] explicit operator bool() const noexcept { return sync_; }
 
 #pragma endregion
 #pragma region Data members
@@ -143,19 +144,38 @@ private:
 //
 // You can use a `breakable_synchronizer` if you want the ability to disable
 // locking once the object is frozen. And if you need to reverse the lock
-// within a scope, use `reverse`.
+// within a scope, use `lock_reverse`.
 //
 // All methods are `const` and all members are `mutable` because thread
 // safety is needed regardless of constness.
 //
-// class thread_safe_container {
-//   synchronizer sync;
-// public:
-//   void do_something(int x, int y, const lock& attestation = {}) {
-//     attestation(sync);
-//     // Do something with x and y, but use the same lock.
-//     do_something_else(x + 2, y - 2, attestation);
-//     [...]
+// This example is kept compiling and passing as the `LedeExample` case in
+// "sync_lock_test.cpp"; change the two together.
+//
+//   class thread_safe_container {
+//   public:
+//     synchronizer sync;
+//
+//     void do_something(int x, int y, const lock& attestation = {}) {
+//       attestation(sync);
+//       // Work with x and y under the lock, then call a sibling method,
+//       // passing the same attestation instead of letting it default.
+//       do_something_else(x + 2, y - 2, attestation);
+//     }
+//
+//     void do_something_else(int x, int y, const lock& attestation = {}) {
+//       attestation(sync);
+//       total_ += x + y;
+//     }
+//
+//     int total(const lock& attestation = {}) const {
+//       attestation(sync);
+//       return total_;
+//     }
+//
+//   private:
+//     int total_{};
+//   };
 //
 // Note again how, in the above case, the caller could make a named `lock`
 // object, constructing it on the instance's public `sync` member. This lets

--- a/corvid/concurrency/timeout_sweeper.h
+++ b/corvid/concurrency/timeout_sweeper.h
@@ -28,6 +28,9 @@
 #include "../infra/exception_firewalls.h"
 
 namespace corvid { inline namespace concurrency {
+
+using namespace std::chrono_literals;
+
 #pragma region timeout_sweeper
 
 // A min-heap of (`expiration`, `callback`) pairs, swept by an external driver
@@ -117,12 +120,17 @@ public:
   timeout_sweeper& operator=(const timeout_sweeper&) = delete;
   timeout_sweeper& operator=(timeout_sweeper&&) = delete;
 
-  // Mark the sweeper as closing (further `schedule` calls are rejected) and
-  // drain anything still in the heap by invoking every remaining callback
-  // once.
+  // Destruct, invoking any pending timeouts now.
+  //
+  // Marks the sweeper as closing, so that further `schedule` calls are
+  // rejected, and drains the heap by ticking just short of
+  // `paused_expiration`. Every real deadline is expired, so running timeouts
+  // get their final invocation, while entries parked at (or past) the pause
+  // sentinel are discarded without one. As a result, paused means paused, even
+  // through destruction.
   ~timeout_sweeper() {
     closing_ = true;
-    try_or_terminate([&] { tick(time_point_t::max()); });
+    try_or_terminate([&] { tick(paused_expiration - 1s); });
   }
 
 #pragma endregion

--- a/corvid/concurrency/timeout_sweeper.h
+++ b/corvid/concurrency/timeout_sweeper.h
@@ -17,6 +17,7 @@
 #pragma once
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <functional>
 #include <mutex>
 #include <type_traits>
@@ -63,27 +64,28 @@ using namespace std::chrono_literals;
 // state change (extend, pause, resume) is a single write to `read_expiration_`
 // with no further call into the sweeper.
 //
+// This example is kept compiling and passing as the `LedeExample` case in
+// "timeout_sweeper_test.cpp"; change the two together.
+//
 //   using sweeper_t = timeout_sweeper<>;
-//   // Initial registration. Set a real deadline, register, then mark as
-//   // paused so the first real read activity will trigger a rearm.
-//   conn->read_expiration_ = infra::steady_now_clock::now() +
-//          conn->read_timeout_;
+//   // Initial registration. Set a real deadline, then register.
+//   conn->read_expiration_ = steady_now_clock::now() + conn->read_timeout_;
 //   sweeper.schedule(conn->read_expiration_,
 //       [weak_conn = std::weak_ptr{conn}](sweeper_t::time_point_t expire)
 //           -> sweeper_t::time_point_t {
 //         auto conn = weak_conn.lock();
 //         if (!conn) return {};
-//         auto current = conn->read_expiration_;
+//         auto current = *conn->read_expiration_;
 //         if (current == expire) { conn->close(); return {}; }
 //         // Only needed in callback when timer can be logically paused.
-//         if (current == infra::steady_now_clock::paused_expiration)
-//           current = infra::steady_now_clock::now() + conn->read_timeout_;
+//         if (current == sweeper_t::paused_expiration)
+//           current = steady_now_clock::now() + conn->read_timeout_;
 //         return current;
 //       });
 //   // Logically pause. It will rearm every read_timeout_, without ever
 //   // triggering. Setting read_expiration_ to an actual value will
 //   // unpause. You can then re-pause at any time.
-//   read_expiration_ = sweeper_t::paused_expiration;
+//   conn->read_expiration_ = sweeper_t::paused_expiration;
 //
 // The default callback storage is `std::function`. Callers that want to
 // avoid the heap allocation can specialize on a `fixed_function` sized to
@@ -113,7 +115,7 @@ public:
 #pragma endregion
 #pragma region Construction
 
-  timeout_sweeper() { heap_.reserve(64); };
+  timeout_sweeper() { heap_.reserve(64); }
 
   timeout_sweeper(const timeout_sweeper&) = delete;
   timeout_sweeper(timeout_sweeper&&) = delete;
@@ -168,16 +170,18 @@ public:
   // Callbacks are invoked outside the internal lock; a non-zero return value
   // causes the callback to be re-inserted at the returned time.
   //
-  // Intended to be called from a single driver thread.
-  bool tick(time_point_t now) {
+  // Returns the number of callbacks invoked. Intended to be called from a
+  // single driver thread.
+  size_t tick(time_point_t now) {
+    size_t invoked{};
     for (;;) {
       callback_t callback;
       time_point_t expire;
 
       if (std::scoped_lock lock(mutex_); true) {
         // Stop when the heap is empty or the next entry hasn't expired yet.
-        if (heap_.empty()) return true;
-        if (heap_.front().expire > now) return true;
+        if (heap_.empty()) return invoked;
+        if (heap_.front().expire > now) return invoked;
 
         // Move next entry to back and extract it.
         std::pop_heap(heap_.begin(), heap_.end());
@@ -188,6 +192,7 @@ public:
 
       // Note how we pass `expire`, not `now`.
       const auto next = callback(expire);
+      ++invoked;
 
       // Short-circuit the rearm path during shutdown so the drain terminates.
       if (next == time_point_t{} || closing_) continue;

--- a/corvid/concurrency/timeout_sweeper.h
+++ b/corvid/concurrency/timeout_sweeper.h
@@ -130,6 +130,13 @@ public:
 
   // Discard all registered entries without invoking their callbacks.
   // Thread-safe.
+  //
+  // This clears the heap as it stands at this instant; it does not prevent new
+  // registrations. In particular, a callback that is executing concurrently
+  // was already popped, so it is not discarded and may re-register itself
+  // through its return value. That is by design: callbacks run outside the
+  // lock, there is deliberately no way to cancel a specific entry, and it is
+  // each callback's job to detect its own irrelevance.
   void clear() noexcept {
     std::scoped_lock lock(mutex_);
     heap_.clear();

--- a/corvid/concurrency/timeouts.h
+++ b/corvid/concurrency/timeouts.h
@@ -38,11 +38,22 @@ public:
     running, // Timeout will trigger.
   };
 
-  // Sentinel value used to enter logical pause mode. One decade shy of
-  // `time_point_t::max`, leaving ample headroom against overflow when
-  // arithmetic is done on it.
+  // Sentinel value.
+  //
+  // Used to enter logical pause mode. One decade shy of `time_point_t::max`,
+  // leaving ample headroom against overflow when arithmetic is done on it.
   static constexpr steady_now_clock::time_point_t paused_expiration{
       steady_now_clock::time_point_t::max() - std::chrono::years{10}};
+
+  // Upper bound for a timeout duration.
+  //
+  // The span from a fixed stand-in for the present up to `paused_expiration`,
+  // so that `now() + duration` can neither overflow nor land in the sentinel
+  // band.
+  static constexpr steady_now_clock::duration_t max_timeout =
+      std::chrono::duration_cast<steady_now_clock::duration_t>(
+          paused_expiration -
+          (steady_now_clock::time_point_t{} + std::chrono::years{50}));
 
 #pragma endregion
 };

--- a/corvid/concurrency/timer_fuse.h
+++ b/corvid/concurrency/timer_fuse.h
@@ -110,6 +110,10 @@ public:
             const timer_fuse<T>&>,
         "payload must be invocable with `const timer_fuse<T>&` and return "
         "`bool`");
+    static_assert(
+        std::is_copy_constructible_v<std::remove_cvref_t<decltype(payload)>>,
+        "payload must be copy-constructible: the wheel stores callbacks in "
+        "`std::function`");
 
     // Check before touching `seq`: a failed arm must not fizzle the
     // previously armed fuse. Exact, because an oversized delay is

--- a/corvid/concurrency/timer_fuse.h
+++ b/corvid/concurrency/timer_fuse.h
@@ -110,10 +110,6 @@ public:
             const timer_fuse<T>&>,
         "payload must be invocable with `const timer_fuse<T>&` and return "
         "`bool`");
-    static_assert(
-        std::is_copy_constructible_v<std::remove_cvref_t<decltype(payload)>>,
-        "payload must be copy-constructible: the wheel stores callbacks in "
-        "`std::function`");
 
     // Check before touching `seq`: a failed arm must not fizzle the
     // previously armed fuse. Exact, because an oversized delay is

--- a/corvid/concurrency/timer_fuse.h
+++ b/corvid/concurrency/timer_fuse.h
@@ -99,7 +99,8 @@ public:
   // `payload` must be invocable as `bool(const timer_fuse<T>&)`.
   //
   // Returns false if `delay` exceeds the wheel's schedulable range; the
-  // caller should use `timers` instead for delays above ~60 s.
+  // caller should use `timers` instead for delays above ~60 s. A failed call
+  // has no side effects: any previously armed fuse stays armed.
   [[nodiscard]] static bool set_timeout(timing_wheel& wheel,
       std::atomic_uint64_t& seq, resource_weak_ptr_t resource_weak,
       timing_wheel::duration_t delay, auto&& payload) {
@@ -109,6 +110,11 @@ public:
             const timer_fuse<T>&>,
         "payload must be invocable with `const timer_fuse<T>&` and return "
         "`bool`");
+
+    // Check before touching `seq`: a failed arm must not fizzle the
+    // previously armed fuse. Exact, because an oversized delay is
+    // `schedule`'s only failure condition and `max_delay` is immutable.
+    if (delay > wheel.max_delay()) return false;
 
     const auto target = ++seq;
     timer_fuse<T> fuse{std::move(resource_weak), seq, target};

--- a/corvid/concurrency/timers.h
+++ b/corvid/concurrency/timers.h
@@ -16,10 +16,10 @@
 // limitations under the License.
 #pragma once
 
+#include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <functional>
-#include <limits>
-#include <map>
 #include <memory>
 #include <queue>
 #include <string>
@@ -54,7 +54,7 @@ using timer_event_ptr = std::shared_ptr<timer_event>;
 // reference, is valid only during the invocation.
 struct timer_invocation {
   // Access to the timers object that scheduled this event. Useful for
-  // scheduling follow-up events as well accessing the current time.
+  // scheduling follow-up events as well as accessing the current time.
   timers_ptr originating_timers;
 
   // The event, which was created in `timers::set` and is reused across
@@ -65,7 +65,7 @@ struct timer_invocation {
   // call. Contains a snapshot of the namesake in `timer_event`.
   size_t invocation_count{};
 
-  // When the event was scheduled to run, which will be at or after
+  // When the event was scheduled to run, which will be at or before
   // `tick_time`.
   time_point_t scheduled_time;
 
@@ -280,9 +280,9 @@ public:
   //
   // If `repeat_in` is zero, the event will be one-shot. If it's negative, then
   // it's malformed and therefore canceled. Note that you cannot repeat over
-  // and over again by passing a zero `repeat_in`. You can either pass the min
-  // or take control over rescheduling through the return value of the
-  // callback.
+  // and over again by passing a zero `repeat_in`. You can either pass a small
+  // positive interval, such as `1ms`, or take control over rescheduling
+  // through the return value of the callback.
   //
   // If `stop_at` isn't specified and the event is recurring, the event will
   // repeat indefinitely (or until canceled). If it is specified and is before
@@ -308,9 +308,9 @@ public:
   //
   // If `repeat_in` is zero, the event will be one-shot. If it's negative, then
   // it's malformed and therefore canceled. Note that you cannot repeat over
-  // and over again by passing a zero `repeat_in`. You can either pass the min
-  // or take control over rescheduling through the return value of the
-  // callback.
+  // and over again by passing a zero `repeat_in`. You can either pass a small
+  // positive interval, such as `1ms`, or take control over rescheduling
+  // through the return value of the callback.
   //
   // If `stop_in` is specified and is before `start_in`, it's canceled.
   auto set(duration_t start_in, timer_callback_t callback,
@@ -374,7 +374,7 @@ public:
       ++callbacks_invoked;
       invocation.invocation_count = ++event.invocation_count;
       time_point_t next_at{};
-      if (auto reverse_lock = attestation.lock_reverse()) {
+      if (auto rev_lock = attestation.lock_reverse()) {
         next_at = event.callback(invocation);
       }
 
@@ -387,8 +387,9 @@ public:
       invocation.now = get_now(attestation);
 
       // If no time specified, calculate it. Note how we add `repeat_in` to
-      // `get_now`, not `callback_now`, so that it's the interval between
-      // returns, not calls.
+      // the fresh `now` fetched after the callback returned, not to the
+      // pre-callback timestamp, so that it's the interval between returns,
+      // not calls.
       if (next_at == time_point_t{} && event.repeat_in != duration_t::max())
         next_at = invocation.now + event.repeat_in;
 

--- a/corvid/concurrency/timers.h
+++ b/corvid/concurrency/timers.h
@@ -99,9 +99,13 @@ struct timer_invocation {
 // This does not make it a recurring event, though. As soon as you return zero,
 // the event will be canceled.
 //
-// Scheduling in the past means it will be called back on the next tick.
-// Scheduling after `stop_at` cancels it, so you can return max to cancel. (You
-// can also cancel by explicitly setting the tombstone.)
+// The returned time must be in the future to keep the event alive. Returning
+// max cancels, as does any time at or after `stop_at`. Less obviously, a time
+// at or before the current time also cancels: this is what makes returning
+// zero cancel a one-shot, and it means a past time is never deferred to the
+// next tick. To run again as soon as possible, return a small future
+// increment, such as `i.now + 1ms`. (You can also cancel by explicitly setting
+// the tombstone.)
 using timer_callback_t = std::function<time_point_t(const timer_invocation&)>;
 
 // Callback to get the current time. Does not need to be reentrant, but must

--- a/corvid/concurrency/timers.h
+++ b/corvid/concurrency/timers.h
@@ -361,7 +361,10 @@ public:
       // because we care about the current time, not when the tick started. We
       // could have already called other callbacks that took a while.
       invocation.now = get_now(attestation);
-      if (event.stop_at <= invocation.now) continue;
+      if (event.stop_at <= invocation.now) {
+        (void)event.canceled.kill();
+        continue;
+      }
 
       // Set up invocation fully and invoke outside of the lock.
       ++callbacks_invoked;

--- a/corvid/concurrency/timing_wheel.h
+++ b/corvid/concurrency/timing_wheel.h
@@ -151,14 +151,19 @@ public:
   // Returns false if `delay` exceeds `(slot_count - 1) * tick_interval`; use
   // `timers` for longer delays, or chain callbacks. Delays below
   // `tick_interval` are clamped up to one tick (fires on the next `tick` call,
-  // not the current one, to avoid re-entrancy). The `delay` represents the
-  // minimum time before the callback fires; actual firing time is rounded to
-  // the next slot boundary after that, and only occurs after all previous
-  // callbacks have fired.
+  // not the current one, to avoid re-entrancy).
+  //
+  // Precision is one slot: `delay` is rounded up to a whole number of slots,
+  // measured from the most recent tick rather than from this call. Relative
+  // to the call, firing can therefore land up to one `tick_interval` early or
+  // late, plus any backlog of previously due callbacks.
   [[nodiscard]] bool schedule(eventfn callback, duration_t delay) {
     if (delay > max_delay()) return false;
     delay = std::max(delay, tick_interval_);
-    const auto ticks_ahead = static_cast<size_t>(delay / tick_interval_);
+    // Round up: the delay is a minimum, so a partial slot costs a whole one.
+    // No overflow risk: `delay` is bounded by `max_delay`.
+    const auto ticks_ahead = static_cast<size_t>(
+        (delay + tick_interval_ - duration_t{1}) / tick_interval_);
 
     std::scoped_lock lock(mutex_);
     const auto target = (current_slot_ + ticks_ahead) % slots_.size();

--- a/corvid/concurrency/timing_wheel.h
+++ b/corvid/concurrency/timing_wheel.h
@@ -308,12 +308,17 @@ private:
   void run(const std::stop_token& st) {
     jthread_stoppable_sleep::set_thread_name("wheel");
 
+    // Own the wheel locally: on the self-destruction path, the destructor
+    // detaches this thread from inside a callback and the runner dies before
+    // the loop finishes, so `this` must not be touched past this point.
+    const auto wheel = wheel_;
+
     // Kill the wheel's tombstone immediately when a stop is requested, so
     // any in-progress `tick` bails at the next callback boundary.
-    std::stop_callback on_stop(st, [this] { (void)wheel_->stop(); });
+    std::stop_callback on_stop(st, [wheel] { (void)wheel->stop(); });
     jthread_stoppable_sleep sleep;
-    while (!sleep.until(st, wheel_->next_tick_time()))
-      wheel_->tick(std::chrono::steady_clock::now());
+    while (!sleep.until(st, wheel->next_tick_time()))
+      wheel->tick(std::chrono::steady_clock::now());
   }
 
 #pragma endregion

--- a/corvid/concurrency/timing_wheel.h
+++ b/corvid/concurrency/timing_wheel.h
@@ -123,9 +123,9 @@ public:
   // `slot_count` must be at least 2. `tick_interval` must be at least 500000ns
   // (the minimum reliable resolution of `nanosleep` on Linux). `start_time`
   // defaults to the current time; pass an explicit value for testing with a
-  // fake clock. The maximum schedulable delay is `(slot_count
-  // - 1) * tick_interval`. Throws `std::invalid_argument` if either
-  // constraint is violated.
+  // fake clock. The maximum schedulable delay is `max_delay()`, one tick short
+  // of a full revolution. Throws `std::invalid_argument` if either constraint
+  // is violated.
   explicit timing_wheel(size_t slot_count = default_slot_count,
       duration_t tick_interval = default_tick_interval,
       time_point_t start_time = std::chrono::steady_clock::now())

--- a/corvid/concurrency/timing_wheel.h
+++ b/corvid/concurrency/timing_wheel.h
@@ -16,11 +16,12 @@
 // limitations under the License.
 #pragma once
 #include <algorithm>
-#include <cassert>
 #include <chrono>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <stdexcept>
+#include <stop_token>
 #include <thread>
 #include <vector>
 
@@ -39,8 +40,9 @@ using namespace std::chrono_literals;
 
 // Single-level timing wheel with configurable precision (100ms by default).
 //
-// Schedules `std::function<void()>` callbacks and fires them at the
-// appropriate time. That is all it does. It has no concept of IDs,
+// Schedules `eventfn` callbacks (`std::function<bool()>`; the return value is
+// ignored) and fires them at the appropriate time. That is all it does. It has
+// no concept of IDs,
 // cancellation tokens, targets, or delivery channels -- those are the
 // caller's concern.
 //
@@ -58,29 +60,34 @@ using namespace std::chrono_literals;
 // Maximum delay: `(slot_count - 1) * tick_interval`. `schedule` returns false
 // if the delay exceeds this. For longer delays, use `timers` instead.
 //
-// Example (serving suggestion -- one way to handle write timeouts):
+// Example (serving suggestion; one way to handle write timeouts). Here `conn`
+// is a `std::shared_ptr` to a connection holding a `std::atomic<uint64_t>
+// write_id_`, `loop` is an I/O loop whose `post` runs a callback on the loop
+// thread, and `wheel` is a `timing_wheel` (typically `*runner.wheel()`).
+//
+// This example is kept compiling and passing as the `LedeExample` case in
+// "timing_wheel_test.cpp"; change the two together.
 //
 //   // Caller generates IDs, captures them and any other context into the
 //   // closure, and performs liveness checks inside the callback.
-//
 //   static std::atomic<uint64_t> next_id{1};
-//   uint64_t id = next_id.fetch_add(1);
-//   conn.write_id_.store(id);
+//   const auto id = next_id.fetch_add(1);
+//   conn->write_id_.store(id);
 //
-//   runner.wheel().schedule(
-//       [id, &loop, conn_weak = weak_ptr<epoll_stream_conn>{conn}] {
-//           // Deliver result on the loop thread.
-//           loop.post([id, conn_weak] {
-//               auto c = conn_weak.lock();
-//               if (!c || c->write_id_.load() != id) return true; // stale
-//               c->handle_write_timeout();
-//               return true;
-//           });
+//   const auto scheduled = wheel.schedule(
+//       [id, &loop, conn_weak = std::weak_ptr{conn}] {
+//         // Deliver the result on the loop thread.
+//         return loop.post([id, conn_weak] {
+//           auto c = conn_weak.lock();
+//           if (!c || c->write_id_.load() != id) return true; // Stale.
+//           c->handle_write_timeout();
+//           return true;
+//         });
 //       },
 //       10s);
 //
-//   // On write completion -- stales any pending callback:
-//   conn.write_id_.store(0);
+//   // On write completion, store zero to stale any pending callback:
+//   conn->write_id_.store(0);
 //
 class timing_wheel {
 public:
@@ -111,12 +118,14 @@ public:
 #pragma region Construction
 
   // Construct a timing wheel with `slot_count` slots and `tick_interval`
-  // precision, starting from `start_time`. `slot_count` must be at least 2.
-  // `tick_interval` must be at least 500000ns (the minimum reliable resolution
-  // of `nanosleep` on Linux). `start_time` defaults to the current wall time;
-  // pass an explicit value for testing with a fake clock. The maximum
-  // schedulable delay is `(slot_count - 1) * tick_interval`.
-  // Throws `std::invalid_argument` if either constraint is violated.
+  // precision, starting from `start_time`.
+  //
+  // `slot_count` must be at least 2. `tick_interval` must be at least 500000ns
+  // (the minimum reliable resolution of `nanosleep` on Linux). `start_time`
+  // defaults to the current time; pass an explicit value for testing with a
+  // fake clock. The maximum schedulable delay is `(slot_count
+  // - 1) * tick_interval`. Throws `std::invalid_argument` if either
+  // constraint is violated.
   explicit timing_wheel(size_t slot_count = default_slot_count,
       duration_t tick_interval = default_tick_interval,
       time_point_t start_time = std::chrono::steady_clock::now())

--- a/corvid/concurrency/tombstone.h
+++ b/corvid/concurrency/tombstone.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <atomic>
+#include <concepts>
 
 namespace corvid { inline namespace concurrency {
 
@@ -106,7 +107,12 @@ public:
   }
 
   // Decrement if not dead.
-  tombstone_of& operator--() noexcept {
+  //
+  // A decrement that lands on `final_v` kills the tombstone; counting down to
+  // death is intended usage. If already dead, does nothing.
+  tombstone_of& operator--() noexcept
+  requires(!std::same_as<value_type, bool>)
+  {
     auto expected = value_.load(std::memory_order::acquire);
     while (expected != final_v) {
       if (value_.compare_exchange_weak(expected, expected - 1,
@@ -117,7 +123,12 @@ public:
   }
 
   // Increment if not dead.
-  tombstone_of& operator++() noexcept {
+  //
+  // An increment that lands on `final_v` kills the tombstone; counting up to
+  // death is intended usage. If already dead, does nothing.
+  tombstone_of& operator++() noexcept
+  requires(!std::same_as<value_type, bool>)
+  {
     auto expected = value_.load(std::memory_order::acquire);
     while (expected != final_v) {
       if (value_.compare_exchange_weak(expected, expected + 1,

--- a/corvid/containers/utils/interval.h
+++ b/corvid/containers/utils/interval.h
@@ -373,9 +373,13 @@ private:
     return self.pair_.second;
   }
 
-  [[nodiscard]] static constexpr U as_u(V v) { return static_cast<U>(v); }
-  [[nodiscard]] static constexpr V as_v(U u) { return static_cast<V>(u); }
-  [[nodiscard]] static constexpr uu_t as_uu(U u) {
+  [[nodiscard]] static constexpr U as_u(V v) noexcept {
+    return static_cast<U>(v);
+  }
+  [[nodiscard]] static constexpr V as_v(U u) noexcept {
+    return static_cast<V>(u);
+  }
+  [[nodiscard]] static constexpr uu_t as_uu(U u) noexcept {
     return static_cast<uu_t>(u);
   }
 

--- a/corvid/containers/utils/object_pool.h
+++ b/corvid/containers/utils/object_pool.h
@@ -47,6 +47,11 @@ concept IsNoOpCb = std::is_same_v<no_op_cb, std::remove_cvref_t<FN>>;
 
 // Width of the per-slot generation counter used for stale-token detection, or
 // `none` to disable versioning entirely.
+//
+// Counter storage rounds up to the next integer width, so `bits24` occupies
+// the same four bytes per slot as `bits32`; what it narrows is the generation
+// field in packed tokens (an 8-bit index plus a 24-bit generation fits in 32
+// bits).
 enum class generation_size : uint8_t {
   none = 0,
   bits8 = 8,

--- a/corvid/infra/scope_exit.h
+++ b/corvid/infra/scope_exit.h
@@ -17,6 +17,7 @@
 #pragma once
 #include <cstdint>
 #include <exception>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
 
@@ -93,7 +94,12 @@ public:
     if constexpr (Kind != scope_kind::success) fn();
   }
 
-  scope_guard(const scope_guard&) = delete;
+  // A guard cannot be copied, but we pretend that it can for the purpose of
+  // satisfying `std::function`'s requirements. So long as the `std::function`
+  // instance that a guard is bound into is only moved, everything is fine.
+  // Otherwise, we throw.
+  scope_guard(const scope_guard&) : exit_function_(do_refuse_copy()) {}
+
   scope_guard& operator=(const scope_guard&) = delete;
   scope_guard& operator=(scope_guard&&) = delete;
 
@@ -136,6 +142,14 @@ public:
 #pragma endregion
 #pragma region Helpers
 private:
+  // Refuse a copy, from the member initializer of the copy constructor.
+  //
+  // Throwing from there, rather than from the body, means `EF` is never
+  // copied and need not even be copyable.
+  [[noreturn]] static EF do_refuse_copy() {
+    throw std::logic_error{"scope guard cannot be copied"};
+  }
+
   // Pick the initializer for `exit_function_`. Forward `fn` when that
   // construction cannot throw, or when there is no lvalue alternative, and
   // otherwise pass the lvalue, so that a throwing copy leaves `fn` intact for

--- a/corvid/proto/epoll/epoll_loop.h
+++ b/corvid/proto/epoll/epoll_loop.h
@@ -116,8 +116,8 @@ private:
 // instance must be constructed and destructed on the loop thread; use
 // `epoll_loop_runner` to satisfy this automatically.
 class epoll_loop
-    : public concurrency::owner_thread_dispatcher<fixed_function<
-          concurrency::default_fixed_function::capacity, bool()>> {
+    : public owner_thread_dispatcher<
+          fixed_function<default_fixed_function::capacity, bool()>> {
   enum class allow : bool { ctor };
 
 #pragma region Types
@@ -125,9 +125,8 @@ public:
   // Maximum number of events retrieved per `epoll_wait` call.
   static constexpr auto max_events = 64UZ;
 
-  using posted_fn_t =
-      fixed_function<concurrency::default_fixed_function::capacity, bool()>;
-  using parent = concurrency::owner_thread_dispatcher<posted_fn_t>;
+  using posted_fn_t = fixed_function<default_fixed_function::capacity, bool()>;
+  using parent = owner_thread_dispatcher<posted_fn_t>;
 
 #pragma endregion
 #pragma region Infrastructure

--- a/corvid/proto/epoll/epoll_loop.h
+++ b/corvid/proto/epoll/epoll_loop.h
@@ -115,9 +115,7 @@ private:
 // `epoll_loop::make`. Per the `owner_thread_dispatcher` contract, the
 // instance must be constructed and destructed on the loop thread; use
 // `epoll_loop_runner` to satisfy this automatically.
-class epoll_loop
-    : public owner_thread_dispatcher<
-          fixed_function<default_fixed_function::capacity, bool()>> {
+class epoll_loop: public owner_thread_dispatcher<> {
   enum class allow : bool { ctor };
 
 #pragma region Types
@@ -125,8 +123,7 @@ public:
   // Maximum number of events retrieved per `epoll_wait` call.
   static constexpr auto max_events = 64UZ;
 
-  using posted_fn_t = fixed_function<default_fixed_function::capacity, bool()>;
-  using parent = owner_thread_dispatcher<posted_fn_t>;
+  using parent = owner_thread_dispatcher<>;
 
 #pragma endregion
 #pragma region Infrastructure

--- a/corvid/proto/io_uring/classes.md
+++ b/corvid/proto/io_uring/classes.md
@@ -198,9 +198,9 @@ classDiagram
 
 | Class | File | Relationships |
 | ----- | ---- | ------------- |
-| [iou_basic_loop&lt;...&gt;](iou_loop.h#L226) | iou_loop.h | Inherits `owner_thread_dispatcher<posted_fn>`. Owns `iou_ring`, the buffer pools (by `shared_ptr`), a `timeout_sweeper`, and a completion-callback pool. `iou_loop = iou_basic_loop<>` ([L1759](iou_loop.h#L1759)). |
-| [iou_basic_loop_runner&lt;...&gt;](iou_loop.h#L1771) | iou_loop.h | Owns an `iou_basic_loop` and runs it on a dedicated thread. `iou_loop_runner = iou_basic_loop_runner<>` ([L1946](iou_loop.h#L1946)). |
-| [bound_timeout / bound_endpoint / bound_msghdr](iou_loop.h#L77) | iou_loop.h | `address_forwarder` helpers binding extra parameters onto a submit call. |
+| [iou_basic_loop&lt;...&gt;](iou_loop.h#L223) | iou_loop.h | Inherits `owner_thread_dispatcher<posted_fn>`. Owns `iou_ring`, the buffer pools (by `shared_ptr`), a `timeout_sweeper`, and a completion-callback pool. `iou_loop = iou_basic_loop<>` ([L1746](iou_loop.h#L1746)). |
+| [iou_basic_loop_runner&lt;...&gt;](iou_loop.h#L1758) | iou_loop.h | Owns an `iou_basic_loop` and runs it on a dedicated thread. `iou_loop_runner = iou_basic_loop_runner<>` ([L1927](iou_loop.h#L1927)). |
+| [bound_timeout / bound_endpoint / bound_msghdr](iou_loop.h#L79) | iou_loop.h | `address_forwarder` helpers binding extra parameters onto a submit call. |
 
 ### Connection and session abstractions
 

--- a/corvid/proto/io_uring/iou_loop.h
+++ b/corvid/proto/io_uring/iou_loop.h
@@ -158,11 +158,6 @@ concept AnyCompletionInvocable =
     CompletionInvocable<FN> || EndpointCompletionInvocable<FN> ||
     BufCompletionInvocable<FN> || MsgHdrCompletionInvocable<FN>;
 
-// Concept for `iou_loop::posted_fn` lambda.
-template<typename FN>
-concept PostedInvocable =
-    MoveConsumable<FN> && std::is_invocable_r_v<bool, FN>;
-
 // Callback scheduled via `post` to run on the loop thread. These are used to
 // force single-threading of ring access.
 using posted_fn = fixed_function<default_fixed_function::capacity, bool()>;

--- a/corvid/proto/io_uring/iou_loop.h
+++ b/corvid/proto/io_uring/iou_loop.h
@@ -237,7 +237,6 @@ public:
   // Timeouts. (io_uring-specific)
   using duration_t = std::chrono::nanoseconds;
   static constexpr duration_t default_run_once_timeout = 10ms;
-  static constexpr duration_t default_post_and_wait_poll_interval = 100ms;
   static constexpr size_t default_max_pending_sqes{RING_SIZE / 4};
 
   // Expiration. (`timeout_sweeper`-specific)
@@ -329,8 +328,6 @@ public:
   // Note: The flags for the ring require that all SQEs be issued from the same
   // thread, and optimizes completions for the single-issuer case.
   explicit iou_basic_loop(allow,
-      duration_t post_and_wait_poll_interval =
-          default_post_and_wait_poll_interval,
       size_t max_pending_sqes = default_max_pending_sqes,
       size_t udp_provided_size = buf_pool_t::hugepage_size,
       block_size udp_provided_buf_size = block_size::kb002,
@@ -345,8 +342,7 @@ public:
             iou_setup_flags::setup_single_issuer |
                 iou_setup_flags::setup_defer_taskrun |
                 iou_setup_flags::setup_submit_all},
-        max_pending_sqes_{max_pending_sqes},
-        post_and_wait_poll_interval_{post_and_wait_poll_interval} {
+        max_pending_sqes_{max_pending_sqes} {
     if (!buf_pool_->register_with(ring_))
       throw std::system_error{errno, std::system_category(),
           "io_uring_register_buffers"};
@@ -384,16 +380,14 @@ public:
 
   // Create a heap-allocated `iou_basic_loop` managed by `std::shared_ptr`.
   [[nodiscard]] static std::shared_ptr<iou_basic_loop>
-  make(duration_t post_and_wait_poll_interval =
-           default_post_and_wait_poll_interval,
-      size_t max_pending_sqes = default_max_pending_sqes,
+  make(size_t max_pending_sqes = default_max_pending_sqes,
       size_t udp_provided_size = buf_pool_t::hugepage_size,
       block_size udp_provided_buf_size = block_size::kb002,
       size_t tcp_provided_size = buf_pool_t::hugepage_size,
       block_size tcp_provided_buf_size = block_size::kb004) {
-    return std::make_shared<iou_basic_loop>(allow::ctor,
-        post_and_wait_poll_interval, max_pending_sqes, udp_provided_size,
-        udp_provided_buf_size, tcp_provided_size, tcp_provided_buf_size);
+    return std::make_shared<iou_basic_loop>(allow::ctor, max_pending_sqes,
+        udp_provided_size, udp_provided_buf_size, tcp_provided_size,
+        tcp_provided_buf_size);
   }
 
   // Block until `run` is active. Returns false on timeout.
@@ -1744,7 +1738,6 @@ private:
 
   size_t max_pending_sqes_{};
   size_t pending_sqe_count_{};
-  const duration_t post_and_wait_poll_interval_;
 
 #pragma endregion
 };
@@ -1768,15 +1761,12 @@ public:
       iou_basic_loop<RING_SIZE, SLOT_COUNT, BUF_POOL_SIZE, BUF_POOL_MIN_BLOCK>;
 
   explicit iou_basic_loop_runner(
-      std::chrono::nanoseconds post_and_wait_poll_interval =
-          loop_t::default_post_and_wait_poll_interval,
       size_t udp_provided_size = loop_t::buf_pool_t::hugepage_size,
       block_size udp_provided_buf_size = block_size::kb002,
       size_t tcp_provided_size = loop_t::buf_pool_t::hugepage_size,
       block_size tcp_provided_buf_size = block_size::kb004)
-      : state_{std::make_shared<runner_state>(post_and_wait_poll_interval,
-            udp_provided_size, udp_provided_buf_size, tcp_provided_size,
-            tcp_provided_buf_size)},
+      : state_{std::make_shared<runner_state>(udp_provided_size,
+            udp_provided_buf_size, tcp_provided_size, tcp_provided_buf_size)},
         thread_{[state = state_](const std::stop_token& st) {
           run(st, state);
         }} {
@@ -1849,13 +1839,11 @@ private:
   // handle when the handle is destroyed on the loop thread (a
   // self-destroy path that would otherwise be a use-after-free).
   struct runner_state {
-    explicit runner_state(std::chrono::nanoseconds ppi, size_t ups,
-        block_size ubs, size_t tps, block_size tbs)
-        : post_and_wait_poll_interval{ppi}, udp_provided_size{ups},
-          udp_provided_buf_size{ubs}, tcp_provided_size{tps},
-          tcp_provided_buf_size{tbs} {}
+    explicit runner_state(size_t ups, block_size ubs, size_t tps,
+        block_size tbs)
+        : udp_provided_size{ups}, udp_provided_buf_size{ubs},
+          tcp_provided_size{tps}, tcp_provided_buf_size{tbs} {}
 
-    const std::chrono::nanoseconds post_and_wait_poll_interval;
     const size_t udp_provided_size;
     const block_size udp_provided_buf_size;
     const size_t tcp_provided_size;
@@ -1871,10 +1859,9 @@ private:
   run(const std::stop_token& st, const std::shared_ptr<runner_state>& state) {
     jthread_stoppable_sleep::set_thread_name("iouring");
     try {
-      auto loop = loop_t::make(state->post_and_wait_poll_interval,
-          loop_t::default_max_pending_sqes, state->udp_provided_size,
-          state->udp_provided_buf_size, state->tcp_provided_size,
-          state->tcp_provided_buf_size);
+      auto loop = loop_t::make(loop_t::default_max_pending_sqes,
+          state->udp_provided_size, state->udp_provided_buf_size,
+          state->tcp_provided_size, state->tcp_provided_buf_size);
       if (std::scoped_lock lock(state->startup_mutex); true)
         state->loop = loop;
       state->started.notify(true);

--- a/corvid/proto/io_uring/iou_loop.h
+++ b/corvid/proto/io_uring/iou_loop.h
@@ -241,7 +241,7 @@ public:
   static constexpr size_t default_max_pending_sqes{RING_SIZE / 4};
 
   // Expiration. (`timeout_sweeper`-specific)
-  using sweeper_t = concurrency::timeout_sweeper<expiration_fn>;
+  using sweeper_t = timeout_sweeper<expiration_fn>;
   using expiration_time_point_t = sweeper_t::time_point_t;
   using expiration_duration_t = sweeper_t::duration_t;
 

--- a/tests/linux/owner_thread_dispatcher_test.cpp
+++ b/tests/linux/owner_thread_dispatcher_test.cpp
@@ -134,11 +134,14 @@ TEST_CASE("MoveOnlyCallback", "[OwnerThreadDispatcher]") {
   owner_thread_dispatcher<> dispatcher;
   int value{0};
 
+  // Posted outside the CHECK, which would move the capture inside a macro
+  // that the analyzer reads as looping.
   auto owned = std::make_unique<int>(42);
-  CHECK(dispatcher.post([&value, owned = std::move(owned)] {
+  const auto posted = dispatcher.post([&value, owned = std::move(owned)] {
     value = *owned;
     return true;
-  }));
+  });
+  CHECK(posted);
 
   CHECK(dispatcher.execute_post_queue() == 1U);
   CHECK(value == 42);

--- a/tests/linux/owner_thread_dispatcher_test.cpp
+++ b/tests/linux/owner_thread_dispatcher_test.cpp
@@ -16,12 +16,16 @@
 // limitations under the License.
 
 #include <atomic>
+#include <chrono>
+#include <memory>
+#include <semaphore>
 #include <thread>
 
 #include "corvid/concurrency.h"
 #include "catch2_main.h"
 
 using namespace corvid;
+using namespace std::chrono_literals;
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 // NOLINTBEGIN(bugprone-derived-method-shadowing-base-method)
@@ -169,6 +173,57 @@ TEST_CASE("PostAndWait_OffLoopThread", "[OwnerThreadDispatcher]") {
   CHECK(executed == 1U);
   CHECK(result);
   CHECK(count.load() == 1);
+}
+#pragma endregion
+
+#pragma region PostAndWait_ShutdownReleasesWaiter
+
+TEST_CASE("PostAndWait_ShutdownReleasesWaiter", "[OwnerThreadDispatcher]") {
+  // A shutdown discards the queued callback without running it, and the
+  // waiter is released anyway, reporting failure.
+  //
+  // A regression strands the waiter thread permanently, so the state that
+  // thread reports through is heap-owned: the timeout below reports a failure
+  // and abandons it, rather than hanging the suite on a join that can never
+  // finish.
+  struct waiter_state {
+    relaxed_atomic_bool result{true};
+    relaxed_atomic_int count{0};
+    std::binary_semaphore finished{0};
+  };
+  auto state = std::make_unique<waiter_state>();
+  OwnerThreadTestDispatcher dispatcher;
+
+  std::thread t{[&dispatcher, s = state.get()] {
+    s->result = dispatcher.post_and_wait([s]() -> bool {
+      ++s->count;
+      return true;
+    });
+    s->finished.release();
+  }};
+
+  // Spin until the callback is queued, which the wake signal proves because
+  // `post` raises it only after adding to the queue.
+  event_fd::counter_t val{};
+  while (!dispatcher.wake_fd().read(val)) std::this_thread::yield();
+
+  CHECK(dispatcher.shutdown());
+
+  // Wildly generous: the whole suite runs in well under a second.
+  const auto released = state->finished.try_acquire_for(20s);
+  CHECK(released);
+  if (!released) {
+    // A stranded waiter reads nothing but `state` on the way out, so leaking
+    // that is enough. The dispatcher is left to die normally here, which
+    // keeps this thread usable by the rest of the file.
+    t.detach();
+    [[maybe_unused]] auto* leaked = state.release();
+    return;
+  }
+
+  t.join();
+  CHECK_FALSE(state->result);
+  CHECK(state->count == 0);
 }
 #pragma endregion
 

--- a/tests/linux/owner_thread_dispatcher_test.cpp
+++ b/tests/linux/owner_thread_dispatcher_test.cpp
@@ -126,6 +126,25 @@ TEST_CASE("PostAndExecute", "[OwnerThreadDispatcher]") {
 }
 
 #pragma endregion
+#pragma region MoveOnlyCallback
+
+TEST_CASE("MoveOnlyCallback", "[OwnerThreadDispatcher]") {
+  // A callback may own what it captures. The default callback type stores
+  // move-only lambdas, which a `std::function` could not.
+  owner_thread_dispatcher<> dispatcher;
+  int value{0};
+
+  auto owned = std::make_unique<int>(42);
+  CHECK(dispatcher.post([&value, owned = std::move(owned)] {
+    value = *owned;
+    return true;
+  }));
+
+  CHECK(dispatcher.execute_post_queue() == 1U);
+  CHECK(value == 42);
+}
+
+#pragma endregion
 #pragma region ExecutePostQueue_Empty
 
 TEST_CASE("ExecutePostQueue_Empty", "[OwnerThreadDispatcher]") {

--- a/tests/linux/owner_thread_dispatcher_test.cpp
+++ b/tests/linux/owner_thread_dispatcher_test.cpp
@@ -328,6 +328,29 @@ TEST_CASE("DoubleBuffer", "[OwnerThreadDispatcher]") {
 }
 
 #pragma endregion
+#pragma region ShutdownFailureModes
+
+TEST_CASE("ShutdownFailureModes", "[OwnerThreadDispatcher]") {
+  // Losing the race to whoever shut it down first is a false return. Calling
+  // from off the loop thread is a caller bug, and says so.
+  owner_thread_dispatcher<> dispatcher;
+  CHECK(dispatcher.shutdown());
+  CHECK_FALSE(dispatcher.shutdown());
+
+  relaxed_atomic_bool refused{false};
+  std::thread t{[&] {
+    try {
+      (void)dispatcher.shutdown();
+    }
+    catch (const std::logic_error&) {
+      refused = true;
+    }
+  }};
+  t.join();
+  CHECK(refused);
+}
+
+#pragma endregion
 #pragma region ShutdownFromCallback
 
 TEST_CASE("ShutdownFromCallback", "[OwnerThreadDispatcher]") {

--- a/tests/linux/owner_thread_dispatcher_test.cpp
+++ b/tests/linux/owner_thread_dispatcher_test.cpp
@@ -338,8 +338,8 @@ TEST_CASE("WakeFd", "[OwnerThreadDispatcher]") {
 
   (void)dispatcher.execute_post_queue();
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ExecuteOrPostWithRetry_Success
 
 TEST_CASE("ExecuteOrPostWithRetry_Success", "[OwnerThreadDispatcher]") {

--- a/tests/linux/owner_thread_dispatcher_test.cpp
+++ b/tests/linux/owner_thread_dispatcher_test.cpp
@@ -31,25 +31,6 @@ using namespace corvid;
 using namespace std::chrono_literals;
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
-// NOLINTBEGIN(bugprone-derived-method-shadowing-base-method)
-
-class OwnerThreadTestDispatcher: public owner_thread_dispatcher<> {
-public:
-  using parent = owner_thread_dispatcher<>;
-
-  OwnerThreadTestDispatcher(size_t max_pending = 16UZ) : parent(max_pending) {}
-
-  [[nodiscard]] size_t execute_post_queue() {
-    // Expose `execute_post_queue` for testing.
-    return parent::execute_post_queue();
-  }
-
-  [[nodiscard]] const auto& wake_fd() const noexcept {
-    return parent::wake_fd();
-  }
-};
-
-// NOLINTEND(bugprone-derived-method-shadowing-base-method)
 
 #pragma region IsLoopThread
 
@@ -125,7 +106,7 @@ TEST_CASE("ThrowingConstructorLeavesThreadUnclaimed",
 
 TEST_CASE("PostAndExecute", "[OwnerThreadDispatcher]") {
   // `post` queues callbacks; `execute_post_queue` drains and returns count.
-  OwnerThreadTestDispatcher dispatcher;
+  owner_thread_dispatcher<> dispatcher;
   int count{0};
   CHECK(dispatcher.post([&count]() mutable -> bool {
     ++count;
@@ -149,7 +130,7 @@ TEST_CASE("PostAndExecute", "[OwnerThreadDispatcher]") {
 
 TEST_CASE("ExecutePostQueue_Empty", "[OwnerThreadDispatcher]") {
   // Empty queue returns 0 and does not crash.
-  OwnerThreadTestDispatcher dispatcher;
+  owner_thread_dispatcher<> dispatcher;
   CHECK(dispatcher.execute_post_queue() == 0U);
 }
 
@@ -158,7 +139,7 @@ TEST_CASE("ExecutePostQueue_Empty", "[OwnerThreadDispatcher]") {
 
 TEST_CASE("ExecuteOrPost_OnLoopThread", "[OwnerThreadDispatcher]") {
   // On the loop thread `execute_or_post` runs inline without queuing.
-  OwnerThreadTestDispatcher dispatcher;
+  owner_thread_dispatcher<> dispatcher;
   int count{0};
   auto ok = dispatcher.execute_or_post([&count]() -> bool {
     ++count;
@@ -174,7 +155,7 @@ TEST_CASE("ExecuteOrPost_OnLoopThread", "[OwnerThreadDispatcher]") {
 
 TEST_CASE("ExecuteOrPost_OffLoopThread", "[OwnerThreadDispatcher]") {
   // From a non-loop thread `execute_or_post` posts without executing inline.
-  OwnerThreadTestDispatcher dispatcher;
+  owner_thread_dispatcher<> dispatcher;
   relaxed_atomic_int count{0};
   std::thread t{[&] {
     (void)dispatcher.execute_or_post([&count]() -> bool {
@@ -194,7 +175,7 @@ TEST_CASE("ExecuteOrPost_OffLoopThread", "[OwnerThreadDispatcher]") {
 
 TEST_CASE("PostAndWait_OnLoopThread", "[OwnerThreadDispatcher]") {
   // On the loop thread `post_and_wait` executes the callback directly.
-  OwnerThreadTestDispatcher dispatcher;
+  owner_thread_dispatcher<> dispatcher;
   int count{0};
   auto ok = dispatcher.post_and_wait([&count]() -> bool {
     ++count;
@@ -211,7 +192,7 @@ TEST_CASE("PostAndWait_OnLoopThread", "[OwnerThreadDispatcher]") {
 TEST_CASE("PostAndWait_OffLoopThread", "[OwnerThreadDispatcher]") {
   // From a non-loop thread `post_and_wait` blocks until the loop thread
   // drains the queue.
-  OwnerThreadTestDispatcher dispatcher;
+  owner_thread_dispatcher<> dispatcher;
   bool result{false};
   std::atomic<int> count{0};
 
@@ -251,7 +232,7 @@ TEST_CASE("PostAndWait_ShutdownReleasesWaiter", "[OwnerThreadDispatcher]") {
     std::binary_semaphore finished{0};
   };
   auto state = std::make_unique<waiter_state>();
-  OwnerThreadTestDispatcher dispatcher;
+  owner_thread_dispatcher<> dispatcher;
 
   std::thread t{[&dispatcher, s = state.get()] {
     s->result = dispatcher.post_and_wait([s]() -> bool {
@@ -290,7 +271,7 @@ TEST_CASE("PostAndWait_ShutdownReleasesWaiter", "[OwnerThreadDispatcher]") {
 
 TEST_CASE("QueueHighWatermark", "[OwnerThreadDispatcher]") {
   // `queue_high_watermark` reflects the maximum capacity seen.
-  OwnerThreadTestDispatcher dispatcher{4};
+  owner_thread_dispatcher<> dispatcher{4};
   CHECK(dispatcher.queue_high_watermark() >= 4U);
   for (auto ndx = 0; ndx < 8; ++ndx)
     CHECK(dispatcher.post([]() -> bool { return true; }));
@@ -304,7 +285,7 @@ TEST_CASE("QueueHighWatermark", "[OwnerThreadDispatcher]") {
 TEST_CASE("DoubleBuffer", "[OwnerThreadDispatcher]") {
   // Callbacks posted during `execute_post_queue` go into the inactive buffer
   // and are deferred to the next drain.
-  OwnerThreadTestDispatcher dispatcher;
+  owner_thread_dispatcher<> dispatcher;
   int first{0};
   int second{0};
 
@@ -334,7 +315,7 @@ TEST_CASE("ShutdownFromCallback", "[OwnerThreadDispatcher]") {
   // A callback may shut the dispatcher down. The drain running it stops
   // there, so the rest of the batch neither runs nor counts, and the queue it
   // was walking survives long enough for that callback to return.
-  OwnerThreadTestDispatcher dispatcher;
+  owner_thread_dispatcher<> dispatcher;
   int before{0};
   int after{0};
   std::string tag;
@@ -381,7 +362,7 @@ TEST_CASE("ShutdownFromCallback", "[OwnerThreadDispatcher]") {
 
 TEST_CASE("WakeFd", "[OwnerThreadDispatcher]") {
   // `wake_fd` is signaled exactly once when the queue transitions from empty.
-  OwnerThreadTestDispatcher dispatcher;
+  owner_thread_dispatcher<> dispatcher;
 
   // No signal before any post.
   CHECK_FALSE(dispatcher.wake_fd().read().has_value());
@@ -402,7 +383,7 @@ TEST_CASE("WakeFd", "[OwnerThreadDispatcher]") {
 
 TEST_CASE("ExecuteOrPostWithRetry_Success", "[OwnerThreadDispatcher]") {
   // On the loop thread, fn succeeds immediately; returns true without posting.
-  OwnerThreadTestDispatcher dispatcher;
+  owner_thread_dispatcher<> dispatcher;
   int calls{0};
   auto ok = dispatcher.execute_or_post_with_retry(
       [&calls]() mutable -> bool {
@@ -420,7 +401,7 @@ TEST_CASE("ExecuteOrPostWithRetry_Success", "[OwnerThreadDispatcher]") {
 
 TEST_CASE("ExecuteOrPostWithRetry_ExhaustedRetry", "[OwnerThreadDispatcher]") {
   // With retry_count=0 and a fn that always fails, returns false immediately.
-  OwnerThreadTestDispatcher dispatcher;
+  owner_thread_dispatcher<> dispatcher;
   int calls{0};
   auto ok = dispatcher.execute_or_post_with_retry(
       [&calls]() mutable -> bool {
@@ -438,7 +419,7 @@ TEST_CASE("ExecuteOrPostWithRetry_ExhaustedRetry", "[OwnerThreadDispatcher]") {
 
 TEST_CASE("ExecuteOrPostWithRetry_Retry", "[OwnerThreadDispatcher]") {
   // fn fails the first time; the retry posted to the queue succeeds.
-  OwnerThreadTestDispatcher dispatcher;
+  owner_thread_dispatcher<> dispatcher;
   int attempts{0};
   auto ok = dispatcher.execute_or_post_with_retry(
       [&attempts]() mutable -> bool {
@@ -458,7 +439,7 @@ TEST_CASE("ExecuteOrPostWithRetry_Retry", "[OwnerThreadDispatcher]") {
 
 TEST_CASE("ExecuteOrPostWithRetry_OffLoopThread", "[OwnerThreadDispatcher]") {
   // From a non-loop thread, fn is never called inline; it is always posted.
-  OwnerThreadTestDispatcher dispatcher;
+  owner_thread_dispatcher<> dispatcher;
   relaxed_atomic_int calls{0};
   std::thread t{[&] {
     (void)dispatcher.execute_or_post_with_retry([&calls]() -> bool {
@@ -478,7 +459,7 @@ TEST_CASE("ExecuteOrPostWithRetry_OffLoopThread", "[OwnerThreadDispatcher]") {
 TEST_CASE("ExecuteOrPostWithRetry_AfterShutdown", "[OwnerThreadDispatcher]") {
   // After shutdown, nothing can be queued, so a callback that needs the queue
   // fails instead of reporting a success that never happens.
-  OwnerThreadTestDispatcher dispatcher;
+  owner_thread_dispatcher<> dispatcher;
   CHECK(dispatcher.shutdown());
 
   // Inline execution still works, since it doesn't touch the queue.

--- a/tests/linux/owner_thread_dispatcher_test.cpp
+++ b/tests/linux/owner_thread_dispatcher_test.cpp
@@ -19,6 +19,7 @@
 #include <chrono>
 #include <memory>
 #include <semaphore>
+#include <string>
 #include <thread>
 
 #include "corvid/concurrency.h"
@@ -269,6 +270,55 @@ TEST_CASE("DoubleBuffer", "[OwnerThreadDispatcher]") {
 }
 #pragma endregion
 
+#pragma region ShutdownFromCallback
+
+TEST_CASE("ShutdownFromCallback", "[OwnerThreadDispatcher]") {
+  // A callback may shut the dispatcher down. The drain running it stops
+  // there, so the rest of the batch neither runs nor counts, and the queue it
+  // was walking survives long enough for that callback to return.
+  OwnerThreadTestDispatcher dispatcher;
+  int before{0};
+  int after{0};
+  std::string tag;
+
+  CHECK(dispatcher.post([&before]() -> bool {
+    ++before;
+    return true;
+  }));
+
+  // The owned string is read back after the shutdown, so that a shutdown
+  // which destroyed this callback mid-flight would be a use-after-free rather
+  // than something that happens to work. It is long enough to be heap
+  // allocated rather than held inline.
+  CHECK(dispatcher.post(
+      [&dispatcher, &tag, owned = std::string(64, 'x')]() -> bool {
+        const auto ok = dispatcher.shutdown();
+        tag = owned;
+        return ok;
+      }));
+
+  CHECK(dispatcher.post([&after]() -> bool {
+    ++after;
+    return true;
+  }));
+
+  CHECK(dispatcher.execute_post_queue() == 2U);
+  CHECK(before == 1);
+  CHECK(after == 0);
+  CHECK(tag == std::string(64, 'x'));
+
+  // Shutdown is complete: nothing more can be queued or drained.
+  CHECK_FALSE(dispatcher.post([]() -> bool { return true; }));
+  CHECK(dispatcher.execute_post_queue() == 0U);
+}
+
+// Draining from inside a callback asserts, so it cannot be probed here. The
+// call would be:
+//
+//   (void)dispatcher.post(
+//       [&dispatcher]() -> bool { return dispatcher.execute_post_queue(); });
+
+#pragma endregion
 #pragma region WakeFd
 
 TEST_CASE("WakeFd", "[OwnerThreadDispatcher]") {

--- a/tests/linux/owner_thread_dispatcher_test.cpp
+++ b/tests/linux/owner_thread_dispatcher_test.cpp
@@ -80,6 +80,47 @@ TEST_CASE("OneInstancePerThread", "[OwnerThreadDispatcher]") {
 }
 
 #pragma endregion
+#pragma region ThrowingConstructorLeavesThreadUnclaimed
+
+TEST_CASE("ThrowingConstructorLeavesThreadUnclaimed",
+    "[OwnerThreadDispatcher]") {
+  // A constructor that throws never runs its destructor, so it must not have
+  // claimed the thread yet. Reserving past `max_size` is the cheap way to make
+  // it throw, since that is checked before anything is allocated.
+  //
+  // This runs on its own thread so that a regression fails here instead of
+  // stranding the claim on the main thread, where every later case would
+  // inherit the failure.
+  using dispatcher_t = owner_thread_dispatcher<>;
+  relaxed_atomic_bool refused{false};
+  relaxed_atomic_bool stranded{false};
+  relaxed_atomic_bool reclaimed{false};
+
+  std::thread t{[&] {
+    try {
+      dispatcher_t doomed{dispatcher_t::npos};
+    }
+    catch (const std::length_error&) {
+      refused = true;
+    }
+
+    // The thread is still available to the next dispatcher.
+    try {
+      dispatcher_t dispatcher;
+      reclaimed = dispatcher.is_loop_thread();
+    }
+    catch (const std::logic_error&) {
+      stranded = true;
+    }
+  }};
+  t.join();
+
+  CHECK(refused);
+  CHECK_FALSE(stranded);
+  CHECK(reclaimed);
+}
+
+#pragma endregion
 #pragma region PostAndExecute
 
 TEST_CASE("PostAndExecute", "[OwnerThreadDispatcher]") {

--- a/tests/linux/owner_thread_dispatcher_test.cpp
+++ b/tests/linux/owner_thread_dispatcher_test.cpp
@@ -413,6 +413,47 @@ TEST_CASE("ExecuteOrPostWithRetry_OffLoopThread", "[OwnerThreadDispatcher]") {
   (void)dispatcher.execute_post_queue();
   CHECK(calls == 1);
 }
+
+#pragma endregion
+#pragma region ExecuteOrPostWithRetry_AfterShutdown
+
+TEST_CASE("ExecuteOrPostWithRetry_AfterShutdown", "[OwnerThreadDispatcher]") {
+  // After shutdown, nothing can be queued, so a callback that needs the queue
+  // fails instead of reporting a success that never happens.
+  OwnerThreadTestDispatcher dispatcher;
+  CHECK(dispatcher.shutdown());
+
+  // Inline execution still works, since it doesn't touch the queue.
+  int calls{0};
+  CHECK(dispatcher.execute_or_post_with_retry([&calls] {
+    ++calls;
+    return true;
+  }));
+  CHECK(calls == 1);
+
+  // The retry has nowhere to go, even though retries remain.
+  calls = 0;
+  CHECK_FALSE(dispatcher.execute_or_post_with_retry(
+      [&calls] {
+        ++calls;
+        return false;
+      },
+      2));
+  CHECK(calls == 1);
+
+  // Off the loop thread, there is nothing but the queue.
+  relaxed_atomic_int off_thread_calls{0};
+  relaxed_atomic_bool ok{true};
+  std::thread t{[&] {
+    ok = dispatcher.execute_or_post_with_retry([&off_thread_calls] {
+      ++off_thread_calls;
+      return true;
+    });
+  }};
+  t.join();
+  CHECK_FALSE(ok);
+  CHECK(off_thread_calls == 0);
+}
 #pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/linux/owner_thread_dispatcher_test.cpp
+++ b/tests/linux/owner_thread_dispatcher_test.cpp
@@ -19,10 +19,12 @@
 #include <chrono>
 #include <memory>
 #include <semaphore>
+#include <stdexcept>
 #include <string>
 #include <thread>
 
 #include "corvid/concurrency.h"
+#include "corvid/meta/fixed_function.h"
 #include "catch2_main.h"
 
 using namespace corvid;
@@ -61,8 +63,23 @@ TEST_CASE("IsLoopThread", "[OwnerThreadDispatcher]") {
   t.join();
   CHECK_FALSE(other_is_loop);
 }
-#pragma endregion
 
+#pragma endregion
+#pragma region OneInstancePerThread
+
+TEST_CASE("OneInstancePerThread", "[OwnerThreadDispatcher]") {
+  // The thread is claimed by the dispatcher, not by the callback type, so a
+  // second one is refused even when it stores its callbacks differently.
+  using fixed_dispatcher = owner_thread_dispatcher<fixed_function<64, bool()>>;
+  owner_thread_dispatcher<> dispatcher;
+  CHECK_THROWS_AS(owner_thread_dispatcher<>{}, std::logic_error);
+  CHECK_THROWS_AS(fixed_dispatcher{}, std::logic_error);
+
+  // The failed claims left the original one intact.
+  CHECK(dispatcher.is_loop_thread());
+}
+
+#pragma endregion
 #pragma region PostAndExecute
 
 TEST_CASE("PostAndExecute", "[OwnerThreadDispatcher]") {
@@ -85,8 +102,8 @@ TEST_CASE("PostAndExecute", "[OwnerThreadDispatcher]") {
   CHECK(executed == 3U);
   CHECK(count == 3);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ExecutePostQueue_Empty
 
 TEST_CASE("ExecutePostQueue_Empty", "[OwnerThreadDispatcher]") {
@@ -94,8 +111,8 @@ TEST_CASE("ExecutePostQueue_Empty", "[OwnerThreadDispatcher]") {
   OwnerThreadTestDispatcher dispatcher;
   CHECK(dispatcher.execute_post_queue() == 0U);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ExecuteOrPost_OnLoopThread
 
 TEST_CASE("ExecuteOrPost_OnLoopThread", "[OwnerThreadDispatcher]") {
@@ -110,8 +127,8 @@ TEST_CASE("ExecuteOrPost_OnLoopThread", "[OwnerThreadDispatcher]") {
   CHECK(count == 1);
   CHECK(dispatcher.execute_post_queue() == 0U);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ExecuteOrPost_OffLoopThread
 
 TEST_CASE("ExecuteOrPost_OffLoopThread", "[OwnerThreadDispatcher]") {
@@ -130,8 +147,8 @@ TEST_CASE("ExecuteOrPost_OffLoopThread", "[OwnerThreadDispatcher]") {
   CHECK(executed == 1U);
   CHECK(count == 1);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region PostAndWait_OnLoopThread
 
 TEST_CASE("PostAndWait_OnLoopThread", "[OwnerThreadDispatcher]") {
@@ -146,8 +163,8 @@ TEST_CASE("PostAndWait_OnLoopThread", "[OwnerThreadDispatcher]") {
   CHECK(count == 1);
   CHECK(dispatcher.execute_post_queue() == 0U);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region PostAndWait_OffLoopThread
 
 TEST_CASE("PostAndWait_OffLoopThread", "[OwnerThreadDispatcher]") {
@@ -175,8 +192,8 @@ TEST_CASE("PostAndWait_OffLoopThread", "[OwnerThreadDispatcher]") {
   CHECK(result);
   CHECK(count.load() == 1);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region PostAndWait_ShutdownReleasesWaiter
 
 TEST_CASE("PostAndWait_ShutdownReleasesWaiter", "[OwnerThreadDispatcher]") {
@@ -226,8 +243,8 @@ TEST_CASE("PostAndWait_ShutdownReleasesWaiter", "[OwnerThreadDispatcher]") {
   CHECK_FALSE(state->result);
   CHECK(state->count == 0);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region QueueHighWatermark
 
 TEST_CASE("QueueHighWatermark", "[OwnerThreadDispatcher]") {
@@ -239,8 +256,8 @@ TEST_CASE("QueueHighWatermark", "[OwnerThreadDispatcher]") {
   (void)dispatcher.execute_post_queue();
   CHECK(dispatcher.queue_high_watermark() >= 8U);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region DoubleBuffer
 
 TEST_CASE("DoubleBuffer", "[OwnerThreadDispatcher]") {
@@ -268,8 +285,8 @@ TEST_CASE("DoubleBuffer", "[OwnerThreadDispatcher]") {
   CHECK(count2 == 1U);
   CHECK(second == 1);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ShutdownFromCallback
 
 TEST_CASE("ShutdownFromCallback", "[OwnerThreadDispatcher]") {
@@ -356,8 +373,8 @@ TEST_CASE("ExecuteOrPostWithRetry_Success", "[OwnerThreadDispatcher]") {
   CHECK(calls == 1);
   CHECK(dispatcher.execute_post_queue() == 0U);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ExecuteOrPostWithRetry_ExhaustedRetry
 
 TEST_CASE("ExecuteOrPostWithRetry_ExhaustedRetry", "[OwnerThreadDispatcher]") {
@@ -374,8 +391,8 @@ TEST_CASE("ExecuteOrPostWithRetry_ExhaustedRetry", "[OwnerThreadDispatcher]") {
   CHECK(calls == 1);
   CHECK(dispatcher.execute_post_queue() == 0U);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ExecuteOrPostWithRetry_Retry
 
 TEST_CASE("ExecuteOrPostWithRetry_Retry", "[OwnerThreadDispatcher]") {
@@ -394,8 +411,8 @@ TEST_CASE("ExecuteOrPostWithRetry_Retry", "[OwnerThreadDispatcher]") {
   (void)dispatcher.execute_post_queue();
   CHECK(attempts == 2); // Retry succeeded.
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ExecuteOrPostWithRetry_OffLoopThread
 
 TEST_CASE("ExecuteOrPostWithRetry_OffLoopThread", "[OwnerThreadDispatcher]") {
@@ -454,6 +471,7 @@ TEST_CASE("ExecuteOrPostWithRetry_AfterShutdown", "[OwnerThreadDispatcher]") {
   CHECK_FALSE(ok);
   CHECK(off_thread_calls == 0);
 }
+
 #pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/idle_timeout_test.cpp
+++ b/tests/portable/idle_timeout_test.cpp
@@ -642,5 +642,24 @@ TEST_CASE("LateTickStartActsAsPostpone", "[IdleTimeout]") {
 }
 
 #pragma endregion
+#pragma region FailedStartLeavesNothingClaimed
+
+TEST_CASE("FailedStartLeavesNothingClaimed", "[IdleTimeout]") {
+  // Starting before any `shared_ptr` owns the owner cannot build the sweeper
+  // callback, so it throws. The timeout has to unwind to stopped: a start
+  // that half-succeeded would report success from then on while scheduling
+  // nothing, silencing the timeout for good.
+  sweeper sw;
+  test_owner unowned{sw, dur{100ms}};
+
+  CHECK_THROWS_AS((void)unowned.idle.start(), std::bad_weak_ptr);
+  CHECK(unowned.idle.get_mode() == mode::stopped);
+
+  // Still honest on a second attempt, rather than claiming success.
+  CHECK_THROWS_AS((void)unowned.idle.start(), std::bad_weak_ptr);
+  CHECK(sw.empty());
+}
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/idle_timeout_test.cpp
+++ b/tests/portable/idle_timeout_test.cpp
@@ -21,6 +21,7 @@
 #include "catch2_main.h"
 
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include <thread>
 #include <vector>
@@ -38,6 +39,10 @@ using mode = timeouts::mode;
 // steady-clock epoch. Tests drive the clock through `clk::set_fake_now` and
 // by passing the desired `now` to `sweeper::tick` directly.
 static tp T(int ms) { return tp{} + std::chrono::milliseconds{ms}; }
+
+// The duration cap leaves centuries of usable range below the pause
+// sentinel.
+static_assert(timeouts::max_timeout > std::chrono::years{100});
 
 #pragma region Fixture
 
@@ -548,6 +553,9 @@ TEST_CASE("StopStartKeepsSingleEntry", "[IdleTimeout]") {
 
   clk::set_fake_now(T(50));
   CHECK(o->idle.stop());
+  // Stopped reads truthfully even while the old entry awaits its last look.
+  CHECK((static_cast<int>(o->idle.get_mode())) ==
+        (static_cast<int>(mode::stopped)));
   CHECK(o->idle.start());
   CHECK(sw.size() == 1U); // Pre-fix: 2.
 
@@ -613,8 +621,12 @@ TEST_CASE("LateTickStartActsAsPostpone", "[IdleTimeout]") {
   CHECK(o->idle.start());
   CHECK(sw.size() == 1U);
 
-  // Deadline T100 passes with no tick; restart at T150.
+  // Deadline T100 passes with no tick. The mode still reads running: the
+  // entry is live and will chase or fire on the next sweep (pre-fix, a past
+  // deadline misreported as stopped).
   clk::set_fake_now(T(150));
+  CHECK((static_cast<int>(o->idle.get_mode())) ==
+        (static_cast<int>(mode::running)));
   CHECK(o->idle.start());
   CHECK(sw.size() == 1U); // Pre-fix: 2.
 

--- a/tests/portable/idle_timeout_test.cpp
+++ b/tests/portable/idle_timeout_test.cpp
@@ -20,7 +20,10 @@
 
 #include "catch2_main.h"
 
+#include <atomic>
 #include <memory>
+#include <thread>
+#include <vector>
 
 using namespace std::chrono_literals;
 using namespace corvid::concurrency;
@@ -481,6 +484,53 @@ TEST_CASE("SweepAndExpireFireOnce", "[IdleTimeout]") {
   sw.tick(T(300));
   CHECK(o->idle_count == 2);
   CHECK(sw.empty());
+}
+
+#pragma endregion
+#pragma region PostponeCannotResurrectStop
+
+TEST_CASE("PostponeCannotResurrectStop", "[IdleTimeout]") {
+  // Threads hammering `postpone` race the main thread's `stop`: the CAS in
+  // `postpone` must never resurrect a deadline that `stop` just parked. The
+  // teeth are probabilistic; pre-fix, the unconditional read-then-store pair
+  // trips this within a few hundred rounds.
+  sweeper sw;
+  auto fake_clock = clk::fake_now_scope();
+  auto o = make_owner(sw, 100ms);
+  clk::set_fake_now(T(0));
+  std::atomic_bool running{true};
+  std::atomic_int ready{0};
+  int failed_starts = 0;
+  int resurrected = 0;
+
+  if (true) {
+    constexpr auto postponer_count = 4;
+    std::vector<std::jthread> postponers;
+    postponers.reserve(postponer_count);
+    for (auto ndx = 0; ndx < postponer_count; ++ndx)
+      postponers.emplace_back([&] {
+        ++ready;
+        while (running.load(std::memory_order::relaxed)) o->idle.postpone();
+      });
+
+    // Don't start racing until every postponer is actually spinning.
+    while (ready.load() < postponer_count) std::this_thread::yield();
+
+    for (auto round = 0; round < 10'000; ++round) {
+      if (!o->idle.start()) ++failed_starts;
+      if (!o->idle.stop()) ++failed_starts;
+      // Once `stop` returns, no in-flight `postpone` may land: a CAS armed
+      // with the pre-stop deadline fails against the zero, and one armed
+      // after the zero bails out before the CAS. Spin briefly so a stale
+      // store from the racing window cannot slip in after a single read.
+      for (auto spin = 0; spin < 16; ++spin)
+        if (o->idle.deadline() != tp{}) ++resurrected;
+    }
+    running = false;
+  }
+
+  CHECK(failed_starts == 0);
+  CHECK(resurrected == 0);
 }
 
 #pragma endregion

--- a/tests/portable/idle_timeout_test.cpp
+++ b/tests/portable/idle_timeout_test.cpp
@@ -534,5 +534,101 @@ TEST_CASE("PostponeCannotResurrectStop", "[IdleTimeout]") {
 }
 
 #pragma endregion
+#pragma region StopStartKeepsSingleEntry
+
+TEST_CASE("StopStartKeepsSingleEntry", "[IdleTimeout]") {
+  // Restarting before the stopped entry is swept must not schedule a second
+  // entry; the in-flight one adapts to the new deadline.
+  sweeper sw;
+  auto fake_clock = clk::fake_now_scope();
+  auto o = make_owner(sw, 100ms);
+  clk::set_fake_now(T(0));
+  CHECK(o->idle.start());
+  CHECK(sw.size() == 1U);
+
+  clk::set_fake_now(T(50));
+  CHECK(o->idle.stop());
+  CHECK(o->idle.start());
+  CHECK(sw.size() == 1U); // Pre-fix: 2.
+
+  // The entry fires at its original registration, sees the moved deadline
+  // (T150), and chases it instead of dropping or expiring.
+  clk::set_fake_now(T(100));
+  sw.tick(T(100));
+  CHECK(o->idle_count == 0);
+  CHECK(sw.size() == 1U);
+
+  // At the restarted deadline it fires exactly once and drains.
+  clk::set_fake_now(T(150));
+  sw.tick(T(150));
+  CHECK(o->idle_count == 1);
+  CHECK(sw.empty());
+}
+
+#pragma endregion
+#pragma region StopPauseCyclesDontLeak
+
+TEST_CASE("StopPauseCyclesDontLeak", "[IdleTimeout]") {
+  // stop -> pause used to bootstrap a fresh clip entry each cycle while the
+  // old one clipped forever, leaking one permanent entry per cycle. The
+  // claim counter keeps it at exactly one.
+  sweeper sw;
+  auto fake_clock = clk::fake_now_scope();
+  auto o = make_owner(sw, 100ms);
+  clk::set_fake_now(T(0));
+  CHECK(o->idle.pause());
+  CHECK(sw.size() == 1U);
+
+  for (auto round = 0; round < 3; ++round) {
+    CHECK(o->idle.stop());
+    CHECK(o->idle.pause());
+  }
+  CHECK(sw.size() == 1U); // Pre-fix: 4.
+
+  // Clipping continues on the single entry, without firing.
+  clk::set_fake_now(T(100));
+  sw.tick(T(100));
+  CHECK(sw.size() == 1U);
+  CHECK(o->idle_count == 0);
+
+  // Stopped for good: the entry drains on its next fire.
+  CHECK(o->idle.stop());
+  clk::set_fake_now(T(200));
+  sw.tick(T(200));
+  CHECK(sw.empty());
+  CHECK(o->idle_count == 0);
+}
+
+#pragma endregion
+#pragma region LateTickStartActsAsPostpone
+
+TEST_CASE("LateTickStartActsAsPostpone", "[IdleTimeout]") {
+  // A deadline in the past does not mean the entry was swept: a start in
+  // that gap must not schedule a duplicate, and the late fire must chase the
+  // moved deadline rather than expire.
+  sweeper sw;
+  auto fake_clock = clk::fake_now_scope();
+  auto o = make_owner(sw, 100ms);
+  clk::set_fake_now(T(0));
+  CHECK(o->idle.start());
+  CHECK(sw.size() == 1U);
+
+  // Deadline T100 passes with no tick; restart at T150.
+  clk::set_fake_now(T(150));
+  CHECK(o->idle.start());
+  CHECK(sw.size() == 1U); // Pre-fix: 2.
+
+  // The late sweep sees the moved deadline (T250) and chases it.
+  sw.tick(T(150));
+  CHECK(o->idle_count == 0);
+  CHECK(sw.size() == 1U);
+
+  clk::set_fake_now(T(250));
+  sw.tick(T(250));
+  CHECK(o->idle_count == 1);
+  CHECK(sw.empty());
+}
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/idle_timeout_test.cpp
+++ b/tests/portable/idle_timeout_test.cpp
@@ -642,6 +642,52 @@ TEST_CASE("LateTickStartActsAsPostpone", "[IdleTimeout]") {
 }
 
 #pragma endregion
+#pragma region RestartFromIdleAction
+
+namespace {
+// Owner whose idle action restarts the timeout, the natural "warn, then keep
+// waiting" shape.
+struct restart_owner: std::enable_shared_from_this<restart_owner> {
+  int idle_count{};
+  bool restart_ok{};
+  idle_timeout<restart_owner> idle;
+
+  restart_owner(sweeper& sw, dur configured)
+      : idle{sw, *this, idle_timeout<restart_owner>::cancel_action_t{[this] {
+               ++idle_count;
+               idle.reset_expiration();
+               restart_ok = idle.start();
+             }},
+            configured} {}
+};
+} // namespace
+
+TEST_CASE("RestartFromIdleAction", "[IdleTimeout]") {
+  // Firing leaves the timeout stopped, so the idle action may start it again.
+  // The entry releases its claim before the action runs, giving the restart
+  // one to take; otherwise the restart would report success while quietly
+  // adopting the entry that is about to be dropped.
+  sweeper sw;
+  auto fake_clock = clk::fake_now_scope();
+  clk::set_fake_now(T(0));
+  auto o = std::make_shared<restart_owner>(sw, dur{100ms});
+  CHECK(o->idle.start());
+  CHECK(sw.size() == 1U);
+
+  clk::set_fake_now(T(100));
+  sw.tick(T(100));
+  CHECK(o->idle_count == 1);
+  CHECK(o->restart_ok);
+  CHECK(o->idle.get_mode() == mode::running);
+  CHECK(sw.size() == 1U);
+
+  // The restarted timeout keeps its own schedule, firing a window later.
+  clk::set_fake_now(T(200));
+  sw.tick(T(200));
+  CHECK(o->idle_count == 2);
+}
+
+#pragma endregion
 #pragma region FailedStartLeavesNothingClaimed
 
 TEST_CASE("FailedStartLeavesNothingClaimed", "[IdleTimeout]") {

--- a/tests/portable/infra_scope_exit_test.cpp
+++ b/tests/portable/infra_scope_exit_test.cpp
@@ -257,5 +257,54 @@ TEST_CASE("Throwing construction", "[ScopeExit][ScopeFail][ScopeSuccess]") {
   }
 }
 #pragma endregion
+#pragma region CopyRefused
+
+// A guard claims to be copyable so that a lambda holding one can be stored in
+// a `std::function`, which requires a copy-constructible target even when it
+// never copies.
+static_assert(std::is_copy_constructible_v<scope_exit<void (*)()>>);
+static_assert(std::is_copy_constructible_v<scope_fail<void (*)()>>);
+static_assert(std::is_copy_constructible_v<scope_success<void (*)()>>);
+
+namespace {
+// Exit function that can be moved but not copied.
+struct move_only_fn {
+  std::unique_ptr<int> owned;
+  void operator()() const noexcept {}
+};
+} // namespace
+
+// The claim holds even for an exit function that cannot itself be copied,
+// because the refusal happens before the exit function is touched.
+static_assert(!std::is_copy_constructible_v<move_only_fn>);
+static_assert(std::is_copy_constructible_v<scope_exit<move_only_fn>>);
+
+TEST_CASE("Copy refused", "[ScopeExit]") {
+  // Reaching a copy throws, and the guard that was copied from is left armed
+  // and fires exactly once.
+  int calls = 0;
+  if (true) {
+    scope_exit guard{[&calls]() noexcept { ++calls; }};
+    // Taking the guard by value is what makes the copy, and it keeps the
+    // attempt inside an expression Catch2 can handle. The by-value parameter
+    // is the subject of the test, not an oversight.
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    const auto copy_guard = [](auto) {};
+    CHECK_THROWS_AS(copy_guard(guard), std::logic_error);
+    CHECK(calls == 0);
+  }
+  CHECK(calls == 1);
+
+  // Moving is still the supported way to relocate a guard, and disarms the
+  // source rather than duplicating the call.
+  int moved_calls = 0;
+  if (true) {
+    scope_exit guard{[&moved_calls]() noexcept { ++moved_calls; }};
+    auto other = std::move(guard);
+    CHECK(moved_calls == 0);
+  }
+  CHECK(moved_calls == 1);
+}
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/infra_scope_exit_test.cpp
+++ b/tests/portable/infra_scope_exit_test.cpp
@@ -295,6 +295,18 @@ TEST_CASE("Copy refused", "[ScopeExit]") {
   }
   CHECK(calls == 1);
 
+  // The refusal holds even when the exit function itself cannot be copied,
+  // which is why it is thrown from the member initializer rather than the
+  // body. Nothing else instantiates that copy constructor: the trait above
+  // inspects only its declaration, so a regression that copied the exit
+  // function would break this block's build rather than fail an assertion.
+  if (true) {
+    scope_exit move_only_guard{move_only_fn{std::make_unique<int>(1)}};
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    const auto copy_guard = [](auto) {};
+    CHECK_THROWS_AS(copy_guard(move_only_guard), std::logic_error);
+  }
+
   // Moving is still the supported way to relocate a guard, and disarms the
   // source rather than duplicating the call.
   int moved_calls = 0;

--- a/tests/portable/jthread_stoppable_sleep_test.cpp
+++ b/tests/portable/jthread_stoppable_sleep_test.cpp
@@ -1,0 +1,82 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <stop_token>
+#include <thread>
+
+#include "corvid/concurrency/jthread_stoppable_sleep.h"
+
+#include "catch2_main.h"
+
+using namespace std::chrono_literals;
+using namespace corvid::concurrency;
+
+#pragma region PreRequestedStop
+
+TEST_CASE("PreRequestedStop", "[JthreadStoppableSleep]") {
+  // A stop requested before the call returns true without sleeping.
+  jthread_stoppable_sleep sleep;
+  std::stop_source src;
+  src.request_stop();
+  CHECK(sleep.until(src.get_token(), std::chrono::steady_clock::now() + 1h));
+}
+
+#pragma endregion
+#pragma region PastDeadline
+
+TEST_CASE("PastDeadline", "[JthreadStoppableSleep]") {
+  // An already-elapsed deadline returns false immediately when no stop was
+  // requested.
+  jthread_stoppable_sleep sleep;
+  std::stop_source src;
+  CHECK_FALSE(
+      sleep.until(src.get_token(), std::chrono::steady_clock::now() - 1s));
+}
+
+#pragma endregion
+#pragma region StopWakesSleeper
+
+TEST_CASE("StopWakesSleeper", "[JthreadStoppableSleep]") {
+  // A stop from another thread wakes the sleeper long before the deadline.
+  // The healthy path finishes in microseconds; the far-off deadline and the
+  // elapsed check exist so a lost wakeup fails loudly (and slowly) instead
+  // of passing at the deadline, where the predicate would also be true.
+  jthread_stoppable_sleep sleep;
+  bool stopped_early = false;
+  const auto begin = std::chrono::steady_clock::now();
+  if (true) {
+    std::jthread worker{[&](const std::stop_token& st) {
+      stopped_early = sleep.until(st, begin + 10s);
+    }};
+    // The jthread destructor requests stop and joins.
+  }
+  CHECK(stopped_early);
+  CHECK((std::chrono::steady_clock::now() - begin) < 5s);
+}
+
+#pragma endregion
+#pragma region SetThreadName
+
+TEST_CASE("SetThreadName", "[JthreadStoppableSleep]") {
+  // Smoke: naming the current thread neither fails nor crashes, with a name
+  // long enough to exercise the POSIX 15-character truncation.
+  jthread_stoppable_sleep::set_thread_name("sleep-test-name-quite-long");
+  SUCCEED();
+}
+
+#pragma endregion

--- a/tests/portable/notifiable_test.cpp
+++ b/tests/portable/notifiable_test.cpp
@@ -15,6 +15,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <atomic>
+#include <chrono>
+#include <concepts>
+#include <functional>
+#include <string>
+#include <string_view>
 #include <thread>
 
 #include "corvid/concurrency/notifiable.h"
@@ -367,6 +373,118 @@ TEST_CASE("RelaxedAtomic", "[Notifiable]") {
     CHECK_FALSE(n.wait_for_changed(1ms));
   }
 }
+#pragma endregion
+#pragma region LedeExample
+
+TEST_CASE("LedeExample", "[Notifiable]") {
+  // Keeps the class comment's sample compiling and passing; change the two
+  // together. The `bool` is deduced by CTAD via the deduction guide.
+  notifiable running{false};
+  static_assert(std::same_as<decltype(running), notifiable<bool>>);
+
+  // Setter thread:
+  std::jthread setter{[&] { running.notify(true); }};
+
+  // Waiting thread:
+  running.wait_until_value(true);
+  CHECK(running.get() == true);
+}
+
+#pragma endregion
+#pragma region SetLockFree
+
+TEST_CASE("SetLockFree", "[Notifiable]") {
+  // `set` is the lock-free counterpart of `get`: it stores without waking
+  // waiters, honoring the requested order on either payload flavor.
+  notifiable<std::atomic<int>> a{1};
+  a.set(2);
+  CHECK(a.get() == 2);
+  a.set(3, std::memory_order::release);
+  CHECK(a.get(std::memory_order::acquire) == 3);
+
+  notifiable<relaxed_atomic<int>> r{1};
+  r.set(2);
+  CHECK(r.get() == 2);
+  r.set(3, std::memory_order::release);
+  CHECK(r.get(std::memory_order::acquire) == 3);
+
+  // A waiter entering after the store still observes it: predicates read
+  // the current value on entry even though `set` wakes nobody.
+  CHECK(a.wait_for_value(0ms, 3));
+}
+
+#pragma endregion
+#pragma region SetLocked
+
+TEST_CASE("SetLocked", "[Notifiable]") {
+  // The non-atomic `set` stores under the lock without waking waiters; a
+  // waiter entering afterward still observes the value on entry.
+  notifiable<int> n{1};
+  n.set(2);
+  CHECK(n.get() == 2);
+  CHECK(n.wait_for_value(0ms, 2));
+
+  notifiable<std::string> s{"abc"};
+  s.set("xyz");
+  CHECK(s.get() == "xyz");
+}
+
+#pragma endregion
+#pragma region NotifyOne
+
+TEST_CASE("NotifyOne", "[Notifiable]") {
+  // The single-waiter forms: set or modify, then wake one waiter.
+  notifiable<int> n{0};
+  if (true) {
+    std::jthread waiter{[&] { n.wait_until_value(1); }};
+    n.notify_one(1);
+  }
+  CHECK(n.get() == 1);
+
+  if (true) {
+    std::jthread waiter{[&] { n.wait_until_value(3); }};
+    n.modify_and_notify_one([](int& v) { v += 2; });
+  }
+  CHECK(n.get() == 3);
+}
+
+#pragma endregion
+#pragma region ZeroArgWaitUntilChanged
+
+TEST_CASE("ZeroArgWaitUntilChanged", "[Notifiable]") {
+  // The zero-argument form captures the "before" value inside the lock, so
+  // the notifier keeps notifying until the waiter reports success: the safe
+  // pattern when entry order is not guaranteed.
+  notifiable<int> n{0};
+  std::atomic_bool done{false};
+  int observed = 0;
+  if (true) {
+    std::jthread waiter{[&] {
+      observed = n.wait_until_changed();
+      done = true;
+    }};
+    auto next = 0;
+    while (!done.load()) {
+      n.notify(++next);
+      std::this_thread::yield();
+    }
+  }
+  CHECK(observed != 0);
+}
+
+#pragma endregion
+#pragma region HeterogeneousTarget
+
+TEST_CASE("HeterogeneousTarget", "[Notifiable]") {
+  // The comparison target may be any type `T` compares with, such as
+  // `std::string_view` against `notifiable<std::string>`.
+  notifiable<std::string> s{"abc"};
+  CHECK(s.wait_for_value(0ms, std::string_view{"abc"}));
+  s.notify("xyz");
+  s.wait_until_value(std::string_view{"xyz"});
+  CHECK(s.get() == "xyz");
+}
+
 #pragma endregion
 
 // NOLINTEND(performance-unnecessary-copy-initialization)

--- a/tests/portable/object_pool_test.cpp
+++ b/tests/portable/object_pool_test.cpp
@@ -535,14 +535,17 @@ TEST_CASE("TokenAsInt", "[ObjectPool]") {
 
     // Bit set above the packed span. This pool packs an 8-bit index plus a
     // 32-bit generation, so bit 40 is the first foreign one.
-    object_pool<int, 4>::token overflow{(1ULL << 40) | 2ULL};
+    constexpr auto index_bits = sizeof(object_pool<int, 4>::index_t) * 8;
+    object_pool<int, 4>::token overflow{
+        (1ULL << (index_bits + gen32_t::bits)) | 2ULL};
     CHECK_FALSE(overflow);
 
     // Borrow bit set in the generation field (the field's top bit, at bit 39
     // here).
     auto b = pool.borrow();
     object_pool<int, 4>::token h{b};
-    object_pool<int, 4>::token forged{h.as_int() | (1ULL << 39)};
+    object_pool<int, 4>::token forged{
+        h.as_int() | (uint64_t{gen32_t::borrow_bit} << index_bits)};
     CHECK_FALSE(forged);
 
     // A zero generation field passes validation (a post-shutdown mint can

--- a/tests/portable/object_pool_test.cpp
+++ b/tests/portable/object_pool_test.cpp
@@ -551,7 +551,7 @@ TEST_CASE("TokenAsInt", "[ObjectPool]") {
     // A zero generation field passes validation (a post-shutdown mint can
     // produce it), but generation 0 is reserved as invalid and never borrows.
     object_pool<int, 4>::token zero_gen{2ULL};
-    CHECK(zero_gen.is_valid());
+    CHECK(zero_gen);
     CHECK_FALSE(zero_gen.borrow(pool));
   }
 
@@ -713,7 +713,7 @@ TEST_CASE("Shutdown", "[ObjectPool]") {
     object_pool<int, 1>::token tok{std::move(h)};
     // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
     CHECK_FALSE(h); // emptied even though the detach failed
-    CHECK(tok.is_valid());
+    CHECK(tok);
     CHECK_FALSE(tok.borrow(pool));
     // The minted token carries the sealed generation 0, which never matches:
     // pre-fix, this resolved to a live pointer into the sealed slot.

--- a/tests/portable/optional_ptr_test.cpp
+++ b/tests/portable/optional_ptr_test.cpp
@@ -181,7 +181,7 @@ TEST_CASE("Smart", "[OptionalPtrTest]") {
     CHECK(q == test);
 
     // * auto p{qo.get()};
-    auto p{std::move(qo.get())};
+    auto p{std::move(qo).get()};
 
     auto l = [&test]() {
       return optional_ptr{std::make_unique<std::string>(test)};

--- a/tests/portable/sync_lock_test.cpp
+++ b/tests/portable/sync_lock_test.cpp
@@ -1,0 +1,213 @@
+// Corvid: A general-purpose modern C++ library extending std.
+// https://github.com/stevensudit/Corvid
+//
+// Copyright 2022-2026 Steven Sudit
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdexcept>
+#include <thread>
+#include <utility>
+
+// The umbrella, not just sync_lock.h: on Windows this doubles as a compile
+// pin that the Linux-only dispatcher include stays properly guarded.
+#include "corvid/concurrency.h"
+
+#include "catch2_main.h"
+
+using namespace corvid::concurrency;
+
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+
+#pragma region LedeExample
+
+namespace {
+// The container from the `lock` class comment's example. This test keeps the
+// code sample in "sync_lock.h" compiling and passing; change the two
+// together.
+class thread_safe_container {
+public:
+  synchronizer sync;
+
+  void do_something(int x, int y, const lock& attestation = {}) {
+    attestation(sync);
+    // Work with x and y under the lock, then call a sibling method,
+    // passing the same attestation instead of letting it default.
+    do_something_else(x + 2, y - 2, attestation);
+  }
+
+  void do_something_else(int x, int y, const lock& attestation = {}) {
+    attestation(sync);
+    total_ += x + y;
+  }
+
+  int total(const lock& attestation = {}) const {
+    attestation(sync);
+    return total_;
+  }
+
+private:
+  int total_{};
+};
+} // namespace
+
+TEST_CASE("LedeExample", "[SyncLock]") {
+  thread_safe_container c;
+
+  // Defaulted attestation: each outer call takes its own lock; the nested
+  // call reuses it instead of deadlocking.
+  c.do_something(1, 2);
+  CHECK(c.total() == 3);
+
+  // A caller-held lock spans multiple calls.
+  lock att{c.sync};
+  c.do_something(10, 20, att);
+  CHECK(c.total(att) == 33);
+}
+
+#pragma endregion
+#pragma region LockAttestation
+
+TEST_CASE("LockAttestation", "[SyncLock]") {
+  synchronizer sync;
+
+  // Default-constructed lock is unbound; the first attestation call binds
+  // and locks, and repeating it is a no-op.
+  lock att;
+  CHECK_FALSE(static_cast<bool>(att));
+  att(sync);
+  CHECK(static_cast<bool>(att));
+  att(sync);
+  CHECK(static_cast<bool>(att));
+
+  // Attesting a different synchronizer under the same lock throws.
+  synchronizer other;
+  CHECK_THROWS_AS(att(other), std::logic_error);
+
+  // The failed mix leaves the original association intact.
+  CHECK(static_cast<bool>(att));
+}
+
+#pragma endregion
+#pragma region LockMoveAndRelease
+
+TEST_CASE("LockMoveAndRelease", "[SyncLock]") {
+  synchronizer sync;
+
+  lock att{sync};
+  lock moved{std::move(att)};
+  // Moved-from lock is defined unbound.
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  CHECK_FALSE(static_cast<bool>(att));
+  CHECK(static_cast<bool>(moved));
+
+  lock target;
+  target = std::move(moved);
+  // Moved-from lock is defined unbound.
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  CHECK_FALSE(static_cast<bool>(moved));
+  CHECK(static_cast<bool>(target));
+
+  // `release` detaches ownership without unlocking; the caller now owns the
+  // held lock and must unlock through the returned synchronizer.
+  const auto* released = target.release();
+  CHECK(released == &sync);
+  CHECK_FALSE(static_cast<bool>(target));
+  released->unlock();
+}
+
+#pragma endregion
+#pragma region ReverseLock
+
+TEST_CASE("ReverseLock", "[SyncLock]") {
+  synchronizer sync;
+  lock att{sync};
+
+  {
+    auto rev = att.lock_reverse();
+    CHECK(static_cast<bool>(rev));
+
+    // The reverse genuinely unlocked: another thread can take the lock and
+    // finish. Join-based, no timing assumptions.
+    bool acquired = false;
+    std::jthread probe{[&] {
+      lock inner{sync};
+      acquired = true;
+    }};
+    probe.join();
+    CHECK(acquired);
+  }
+
+  // `rev` relocked on destruction; `att` still attests and unlocks at scope
+  // end.
+  CHECK(static_cast<bool>(att));
+}
+
+#pragma endregion
+#pragma region ReverseLockMoveAndRelease
+
+TEST_CASE("ReverseLockMoveAndRelease", "[SyncLock]") {
+  synchronizer sync;
+
+  // Reversing an unbound lock is a clean no-op.
+  {
+    lock unbound;
+    auto rev = unbound.lock_reverse();
+    CHECK_FALSE(static_cast<bool>(rev));
+  }
+
+  lock att{sync};
+  auto rev = att.lock_reverse();
+  auto moved = std::move(rev);
+  // Moved-from reverse_lock is defined empty.
+  // NOLINTNEXTLINE(bugprone-use-after-move)
+  CHECK_FALSE(static_cast<bool>(rev));
+  CHECK(static_cast<bool>(moved));
+
+  // `release` detaches, so nobody relocks on destruction; restore the lock
+  // by hand to keep `att`'s eventual unlock balanced.
+  const auto* released = moved.release();
+  CHECK(released == &sync);
+  released->lock();
+}
+
+#pragma endregion
+#pragma region BreakableSynchronizer
+
+TEST_CASE("BreakableSynchronizer", "[SyncLock]") {
+  breakable_synchronizer bs;
+
+  // Live: converts to a real synchronizer, which a lock can take.
+  CHECK_FALSE(bs.is_disabled());
+  const synchronizer* live = bs;
+  CHECK(live);
+  {
+    lock att{live};
+    CHECK(static_cast<bool>(att));
+  }
+
+  // Disabled: converts to null, and locking through it is a clean no-op.
+  bs.disable();
+  CHECK(bs.is_disabled());
+  const synchronizer* frozen = bs;
+  CHECK_FALSE(frozen);
+  lock att{frozen};
+  CHECK_FALSE(static_cast<bool>(att));
+  lock late;
+  late(frozen);
+  CHECK_FALSE(static_cast<bool>(late));
+}
+
+#pragma endregion
+
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/timeout_sweeper_test.cpp
+++ b/tests/portable/timeout_sweeper_test.cpp
@@ -214,6 +214,31 @@ TEST_CASE("DestructorDrains", "[TimeoutSweeper]") {
 }
 
 #pragma endregion
+#pragma region DestructorSkipsParkedEntries
+
+TEST_CASE("DestructorSkipsParkedEntries", "[TimeoutSweeper]") {
+  // The destructor drains by ticking just short of `paused_expiration`:
+  // entries at real deadlines get their final invocation, while an entry
+  // parked at the pause sentinel is discarded without one. Paused means
+  // paused, even through destruction.
+  int running_calls{};
+  int parked_calls{};
+  {
+    sweeper s;
+    s.schedule(T(100), [&](tp) -> tp {
+      ++running_calls;
+      return {};
+    });
+    s.schedule(sweeper::paused_expiration, [&](tp) -> tp {
+      ++parked_calls;
+      return {};
+    });
+  }
+  CHECK(running_calls == 1);
+  CHECK(parked_calls == 0); // Under a tick(max) drain, this would be 1.
+}
+
+#pragma endregion
 #pragma region DestructorShortCircuitsRearm
 
 TEST_CASE("DestructorShortCircuitsRearm", "[TimeoutSweeper]") {

--- a/tests/portable/timeout_sweeper_test.cpp
+++ b/tests/portable/timeout_sweeper_test.cpp
@@ -214,6 +214,78 @@ TEST_CASE("DestructorDrains", "[TimeoutSweeper]") {
 }
 
 #pragma endregion
+#pragma region LedeExample
+
+namespace {
+// The connection type from the class comment's example. This test keeps the
+// code sample in timeout_sweeper.h compiling and passing; change the two
+// together.
+struct example_conn {
+  corvid::relaxed_atomic<sweeper::time_point_t> read_expiration_;
+  sweeper::duration_t read_timeout_{100ms};
+  bool closed{};
+  void close() { closed = true; }
+};
+} // namespace
+
+TEST_CASE("LedeExample", "[TimeoutSweeper]") {
+  using sweeper_t = sweeper;
+  using clk = corvid::steady_now_clock;
+  auto fake_clock = clk::fake_now_scope();
+  clk::set_fake_now(T(0));
+  sweeper_t sw;
+  auto conn = std::make_shared<example_conn>();
+
+  // Initial registration. Set a real deadline, then register.
+  conn->read_expiration_ = steady_now_clock::now() + conn->read_timeout_;
+  sw.schedule(*conn->read_expiration_,
+      [weak_conn = std::weak_ptr{conn}](
+          sweeper_t::time_point_t expire) -> sweeper_t::time_point_t {
+        auto conn = weak_conn.lock();
+        if (!conn) return {};
+        auto current = *conn->read_expiration_;
+        if (current == expire) {
+          conn->close();
+          return {};
+        }
+        // Only needed in callback when timer can be logically paused.
+        if (current == sweeper_t::paused_expiration)
+          current = steady_now_clock::now() + conn->read_timeout_;
+        return current;
+      });
+  CHECK(sw.size() == 1U);
+
+  // Extend: a single write to the expiration, no sweeper call. The entry
+  // chases the moved deadline on its next fire instead of closing.
+  conn->read_expiration_ = T(150);
+  clk::set_fake_now(T(100));
+  CHECK(sw.tick(T(100)) == 1U);
+  CHECK_FALSE(conn->closed);
+  CHECK(sw.size() == 1U);
+
+  // Logically pause: the entry clips forward every `read_timeout_` without
+  // ever triggering.
+  conn->read_expiration_ = sweeper_t::paused_expiration;
+  clk::set_fake_now(T(150));
+  CHECK(sw.tick(T(150)) == 1U);
+  CHECK_FALSE(conn->closed);
+  CHECK(sw.size() == 1U);
+
+  // Nothing due yet: a tick invokes nothing.
+  CHECK(sw.tick(T(200)) == 0U);
+
+  // Unpause by setting a real deadline; when it arrives untouched, the
+  // connection closes and the entry drops.
+  conn->read_expiration_ = T(300);
+  clk::set_fake_now(T(250));
+  CHECK(sw.tick(T(250)) == 1U); // Clip entry chases the new deadline.
+  clk::set_fake_now(T(300));
+  CHECK(sw.tick(T(300)) == 1U);
+  CHECK(conn->closed);
+  CHECK(sw.empty());
+}
+
+#pragma endregion
 #pragma region DestructorSkipsParkedEntries
 
 TEST_CASE("DestructorSkipsParkedEntries", "[TimeoutSweeper]") {

--- a/tests/portable/timerfuse_test.cpp
+++ b/tests/portable/timerfuse_test.cpp
@@ -163,12 +163,29 @@ TEST_CASE("ExceedMaxDelay", "[TimerFuse]") {
   // `set_timeout` returns false when the delay exceeds the wheel's range.
   // With slot_count=2 and tick_interval=1ms, max delay = 1ms.
   auto resource = std::make_shared<FakeResource>();
-  timing_wheel wheel{2, 1ms};
+  auto t0 = std::chrono::steady_clock::now();
+  timing_wheel wheel{2, 1ms, t0};
 
+  bool fired{false};
+  bool saw_resource{false};
+  CHECK(timer_fuse<FakeResource>::set_timeout(wheel, resource->seq, resource,
+      1ms, [&](const timer_fuse<FakeResource>& f) -> bool {
+        fired = true;
+        saw_resource = (f.get_if_armed() != nullptr);
+        return true;
+      }));
+
+  // The failed arm reports false and has no side effects: the sequencer is
+  // untouched, so the earlier fuse stays armed instead of fizzling.
   auto ok = timer_fuse<FakeResource>::set_timeout(wheel, resource->seq,
       resource, 2ms,
       [](const timer_fuse<FakeResource>&) -> bool { return true; });
   CHECK_FALSE(ok);
+  CHECK(resource->seq == 1U); // Pre-fix: 2, and the first fuse fizzled.
+
+  wheel.tick(t0 + 2ms);
+  CHECK(fired);
+  CHECK(saw_resource);
 }
 
 #pragma endregion

--- a/tests/portable/timerfuse_test.cpp
+++ b/tests/portable/timerfuse_test.cpp
@@ -34,6 +34,14 @@ struct FakeResource {
   int value{42};
 };
 
+// Payload for the plain-function case, which needs somewhere to report from.
+int fired_value{};
+
+[[nodiscard]] bool payload_fired(const timer_fuse<FakeResource>& fuse) {
+  if (auto r = fuse.get_if_armed()) fired_value = r->value;
+  return true;
+}
+
 #pragma region TimerFuse_Default
 
 TEST_CASE("Default", "[TimerFuse]") {
@@ -189,21 +197,21 @@ TEST_CASE("ExceedMaxDelay", "[TimerFuse]") {
 }
 
 #pragma endregion
-#pragma region TimerFuse_PayloadCopyable
+#pragma region TimerFuse_PlainFunctionPayload
 
-TEST_CASE("PayloadCopyable", "[TimerFuse]") {
-  // The payload is stored in `std::function`, so it must be
-  // copy-constructible; a move-only payload fails the static_assert with a
-  // readable message instead of erroring deep inside std internals.
-  // Uncomment to verify the rejection:
-  //
-  // auto resource = std::make_shared<FakeResource>();
-  // timing_wheel wheel{2, 1ms};
-  // (void)timer_fuse<FakeResource>::set_timeout(wheel, resource->seq,
-  //     resource, 1ms,
-  //     [p = std::make_unique<int>(0)](
-  //         const timer_fuse<FakeResource>&) -> bool { return true; });
-  SUCCEED();
+TEST_CASE("PlainFunctionPayload", "[TimerFuse]") {
+  // A payload named as a plain function, not a lambda, is accepted: it decays
+  // to a function pointer on capture. The function type itself is not
+  // copy-constructible, which is why `set_timeout` cannot screen payloads on
+  // that trait.
+  auto resource = std::make_shared<FakeResource>();
+  auto t0 = std::chrono::steady_clock::now();
+  timing_wheel wheel{4, 1ms, t0};
+
+  CHECK(timer_fuse<FakeResource>::set_timeout(wheel, resource->seq, resource,
+      1ms, payload_fired));
+  wheel.tick(t0 + 4ms);
+  CHECK(fired_value == 42);
 }
 
 #pragma endregion

--- a/tests/portable/timerfuse_test.cpp
+++ b/tests/portable/timerfuse_test.cpp
@@ -189,5 +189,23 @@ TEST_CASE("ExceedMaxDelay", "[TimerFuse]") {
 }
 
 #pragma endregion
+#pragma region TimerFuse_PayloadCopyable
+
+TEST_CASE("PayloadCopyable", "[TimerFuse]") {
+  // The payload is stored in `std::function`, so it must be
+  // copy-constructible; a move-only payload fails the static_assert with a
+  // readable message instead of erroring deep inside std internals.
+  // Uncomment to verify the rejection:
+  //
+  // auto resource = std::make_shared<FakeResource>();
+  // timing_wheel wheel{2, 1ms};
+  // (void)timer_fuse<FakeResource>::set_timeout(wheel, resource->seq,
+  //     resource, 1ms,
+  //     [p = std::make_unique<int>(0)](
+  //         const timer_fuse<FakeResource>&) -> bool { return true; });
+  SUCCEED();
+}
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/timers_test.cpp
+++ b/tests/portable/timers_test.cpp
@@ -82,6 +82,31 @@ TEST_CASE("StopAtExpires", "[TimersTest]") {
 }
 
 #pragma endregion
+#pragma region ReturnPastTimeCancels
+
+TEST_CASE("ReturnPastTimeCancels", "[TimersTest]") {
+  auto now = make_time(100);
+  auto t = timers::make("test");
+  t->set_clock_callback([&]() { return now; });
+  size_t cnt{};
+
+  // Returning a time at or before the current time cancels the event; a
+  // past time is never deferred to the next tick.
+  auto ev = t->set(25ms, [&](const timer_invocation& i) -> time_point_t {
+    ++cnt;
+    return i.now;
+  });
+  now += 25ms;
+  CHECK(t->tick() == 1U);
+  CHECK(cnt == 1U);
+  CHECK(ev->canceled);
+
+  now += 25ms;
+  CHECK(t->tick() == 0U);
+  CHECK(cnt == 1U);
+}
+
+#pragma endregion
 
 #pragma region OneShot
 

--- a/tests/portable/timers_test.cpp
+++ b/tests/portable/timers_test.cpp
@@ -42,6 +42,47 @@ static time_point_t make_time(int ms) {
   return time_point_t{} + milliseconds{ms};
 }
 
+#pragma region StopAtExpires
+
+TEST_CASE("StopAtExpires", "[TimersTest]") {
+  auto now = make_time(100);
+  auto t = timers::make("test");
+  t->set_clock_callback([&]() { return now; });
+  size_t cnt{};
+
+  // Recurring event, allowed to run only until 100ms from now.
+  auto ev = t->set(
+      25ms,
+      [&](const timer_invocation&) -> time_point_t {
+        ++cnt;
+        return {};
+      },
+      25ms, 100ms);
+  CHECK_FALSE(ev->canceled);
+
+  // The driver stalls past `stop_at`: the event pops expired, never fires,
+  // and its tombstone is killed so pollers observe the cancelation.
+  now += 150ms;
+  CHECK(t->tick() == 0U);
+  CHECK(cnt == 0U);
+  CHECK(ev->canceled); // Pre-fix: stayed false forever.
+
+  // Born dead: `stop_at` before `start_at` is DOA and never scheduled.
+  auto doa = t->set(
+      50ms,
+      [&](const timer_invocation&) -> time_point_t {
+        ++cnt;
+        return {};
+      },
+      {}, 25ms);
+  CHECK(doa->canceled);
+  now += 100ms;
+  CHECK(t->tick() == 0U);
+  CHECK(cnt == 0U);
+}
+
+#pragma endregion
+
 #pragma region OneShot
 
 TEST_CASE("OneShot", "[TimersTest]") {

--- a/tests/portable/timing_wheel_test.cpp
+++ b/tests/portable/timing_wheel_test.cpp
@@ -30,7 +30,6 @@ using namespace std::chrono_literals;
 using namespace corvid::concurrency;
 
 using tp = timing_wheel::time_point_t;
-using dur = timing_wheel::duration_t;
 
 // Construct a time_point at `ms` milliseconds past the epoch.
 static tp T(int ms) { return tp{} + std::chrono::milliseconds{ms}; }
@@ -42,9 +41,9 @@ static tp T(int ms) { return tp{} + std::chrono::milliseconds{ms}; }
 TEST_CASE("CtorValidation", "[TimingWheel]") {
   // Constraints from the constructor doc: slot_count >= 2 and tick_interval
   // >= 500000ns (which at millisecond granularity means >= 1ms).
-  CHECK_THROWS_AS(timing_wheel(1, dur{100}, T(0)), std::invalid_argument);
-  CHECK_THROWS_AS(timing_wheel(2, dur{0}, T(0)), std::invalid_argument);
-  CHECK_NOTHROW(timing_wheel(2, dur{1}, T(0)));
+  CHECK_THROWS_AS(timing_wheel(1, 100ms, T(0)), std::invalid_argument);
+  CHECK_THROWS_AS(timing_wheel(2, 0ms, T(0)), std::invalid_argument);
+  CHECK_NOTHROW(timing_wheel(2, 1ms, T(0)));
 }
 
 #pragma endregion
@@ -52,7 +51,7 @@ TEST_CASE("CtorValidation", "[TimingWheel]") {
 
 TEST_CASE("BasicFire", "[TimingWheel]") {
   // Schedule at 200ms; should not fire at 100ms but should fire at 200ms.
-  timing_wheel wheel(600, dur{100}, T(0));
+  timing_wheel wheel(600, 100ms, T(0));
   int fired = 0;
 
   CHECK(wheel.schedule(
@@ -78,7 +77,7 @@ TEST_CASE("BasicFire", "[TimingWheel]") {
 
 TEST_CASE("NotFiredEarly", "[TimingWheel]") {
   // Verify no premature fire.
-  timing_wheel wheel(600, dur{100}, T(0));
+  timing_wheel wheel(600, 100ms, T(0));
   int fired = 0;
 
   CHECK(wheel.schedule(
@@ -101,7 +100,7 @@ TEST_CASE("NotFiredEarly", "[TimingWheel]") {
 
 TEST_CASE("MultiSlot", "[TimingWheel]") {
   // Three entries at 100/200/300ms; exactly one fires per 100ms tick.
-  timing_wheel wheel(600, dur{100}, T(0));
+  timing_wheel wheel(600, 100ms, T(0));
   int count = 0;
 
   CHECK(wheel.schedule(
@@ -136,7 +135,7 @@ TEST_CASE("MultiSlot", "[TimingWheel]") {
 
 TEST_CASE("TickSkip", "[TimingWheel]") {
   // A single tick jump drains all three slots at once.
-  timing_wheel wheel(600, dur{100}, T(0));
+  timing_wheel wheel(600, 100ms, T(0));
   int count = 0;
 
   CHECK(wheel.schedule(
@@ -167,7 +166,7 @@ TEST_CASE("TickSkip", "[TimingWheel]") {
 
 TEST_CASE("TickTooEarly", "[TimingWheel]") {
   // Ticks separated by less than 100ms are no-ops.
-  timing_wheel wheel(600, dur{100}, T(0));
+  timing_wheel wheel(600, 100ms, T(0));
   int fired = 0;
 
   CHECK(wheel.schedule(
@@ -190,7 +189,7 @@ TEST_CASE("TickTooEarly", "[TimingWheel]") {
 
 TEST_CASE("ZeroDelay", "[TimingWheel]") {
   // Zero delay is clamped to one tick; fires on the next tick, not current.
-  timing_wheel wheel(600, dur{100}, T(0));
+  timing_wheel wheel(600, 100ms, T(0));
   int fired = 0;
 
   CHECK(wheel.schedule(
@@ -198,7 +197,7 @@ TEST_CASE("ZeroDelay", "[TimingWheel]") {
               ++fired;
               return true;
             },
-            dur{0}) == true);
+            0ms) == true);
 
   // Should not fire synchronously.
   CHECK(fired == 0);
@@ -213,7 +212,7 @@ TEST_CASE("ZeroDelay", "[TimingWheel]") {
 TEST_CASE("OverflowFails", "[TimingWheel]") {
   // A delay exceeding the wheel range is rejected; returns false.
   // Use slot_count=10 so the max is 900ms.
-  timing_wheel wheel(10, dur{100}, T(0));
+  timing_wheel wheel(10, 100ms, T(0));
   int fired = 0;
 
   // 10 seconds far exceeds the 900ms maximum: schedule fails.
@@ -242,7 +241,7 @@ TEST_CASE("OverflowFails", "[TimingWheel]") {
 
 TEST_CASE("SameSlotMultiple", "[TimingWheel]") {
   // Five callbacks in the same slot all fire together.
-  timing_wheel wheel(600, dur{100}, T(0));
+  timing_wheel wheel(600, 100ms, T(0));
   int count = 0;
 
   for (auto ndx = 0; ndx < 5; ++ndx)
@@ -263,7 +262,7 @@ TEST_CASE("SameSlotMultiple", "[TimingWheel]") {
 TEST_CASE("RingWrap", "[TimingWheel]") {
   // Advance near the end of the ring; a new entry wraps around to slot 0.
   // slot_count=10: slots 0..9, max delay = 900ms.
-  timing_wheel wheel(10, dur{100}, T(0));
+  timing_wheel wheel(10, 100ms, T(0));
   int fired = 0;
 
   // Advance 8 slots: current_slot becomes 8, last_tick = T(800).
@@ -289,7 +288,7 @@ TEST_CASE("RingWrap", "[TimingWheel]") {
 
 TEST_CASE("ScheduleDuringTick", "[TimingWheel]") {
   // A callback that calls schedule() places the new entry in a future slot.
-  timing_wheel wheel(600, dur{100}, T(0));
+  timing_wheel wheel(600, 100ms, T(0));
   int first = 0;
   int second = 0;
 
@@ -320,7 +319,7 @@ TEST_CASE("ScheduleDuringTick", "[TimingWheel]") {
 
 TEST_CASE("CallbackOwnsMeta", "[TimingWheel]") {
   // The callback closure owns all its own metadata (simulated ID + target).
-  timing_wheel wheel(600, dur{100}, T(0));
+  timing_wheel wheel(600, 100ms, T(0));
 
   // Simulate a caller-owned ID scheme.
   uint64_t active_id{42};
@@ -362,7 +361,7 @@ TEST_CASE("CallbackOwnsMeta", "[TimingWheel]") {
 
 TEST_CASE("StopAbortsTick", "[TimingWheel]") {
   // Calling stop() during tick() prevents remaining callbacks from firing.
-  timing_wheel wheel(600, dur{100}, T(0));
+  timing_wheel wheel(600, 100ms, T(0));
   int count = 0;
 
   // Schedule five callbacks in the same slot; the first one calls stop().
@@ -386,7 +385,7 @@ TEST_CASE("StopAbortsTick", "[TimingWheel]") {
 TEST_CASE("NonMultipleDelayRoundsUp", "[TimingWheel]") {
   // A delay that is not a slot multiple rounds UP to the next boundary:
   // 150ms on a 100ms wheel must not fire at the 100ms tick.
-  timing_wheel wheel(600, dur{100}, T(0));
+  timing_wheel wheel(600, 100ms, T(0));
   int fired = 0;
 
   CHECK(wheel.schedule(
@@ -423,7 +422,7 @@ struct example_loop {
 } // namespace
 
 TEST_CASE("LedeExample", "[TimingWheel]") {
-  timing_wheel wheel(600, dur{100}, T(0));
+  timing_wheel wheel(600, 100ms, T(0));
   example_loop loop;
   auto conn = std::make_shared<example_conn>();
 

--- a/tests/portable/timing_wheel_test.cpp
+++ b/tests/portable/timing_wheel_test.cpp
@@ -15,7 +15,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <atomic>
+#include <cstdint>
 #include <latch>
+#include <memory>
+#include <stdexcept>
 #include <thread>
 
 #include "corvid/concurrency/timing_wheel.h"
@@ -33,6 +37,17 @@ static tp T(int ms) { return tp{} + std::chrono::milliseconds{ms}; }
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region CtorValidation
+
+TEST_CASE("CtorValidation", "[TimingWheel]") {
+  // Constraints from the constructor doc: slot_count >= 2 and tick_interval
+  // >= 500000ns (which at millisecond granularity means >= 1ms).
+  CHECK_THROWS_AS(timing_wheel(1, dur{100}, T(0)), std::invalid_argument);
+  CHECK_THROWS_AS(timing_wheel(2, dur{0}, T(0)), std::invalid_argument);
+  CHECK_NOTHROW(timing_wheel(2, dur{1}, T(0)));
+}
+
+#pragma endregion
 #pragma region BasicFire
 
 TEST_CASE("BasicFire", "[TimingWheel]") {
@@ -386,6 +401,81 @@ TEST_CASE("NonMultipleDelayRoundsUp", "[TimingWheel]") {
 
   wheel.tick(T(200));
   CHECK(fired == 1);
+}
+
+#pragma endregion
+#pragma region LedeExample
+
+namespace {
+// The connection and loop types from the class comment's example. This test
+// keeps the code sample in "timing_wheel.h" compiling and passing; change the
+// two together.
+struct example_conn {
+  std::atomic<uint64_t> write_id_;
+  int timeouts_handled{};
+  void handle_write_timeout() { ++timeouts_handled; }
+};
+
+// Stands in for an I/O loop: runs the posted callback inline.
+struct example_loop {
+  bool post(const auto& cb) { return cb(); }
+};
+} // namespace
+
+TEST_CASE("LedeExample", "[TimingWheel]") {
+  timing_wheel wheel(600, dur{100}, T(0));
+  example_loop loop;
+  auto conn = std::make_shared<example_conn>();
+
+  // Caller generates IDs, captures them and any other context into the
+  // closure, and performs liveness checks inside the callback.
+  static std::atomic<uint64_t> next_id{1};
+  const auto id = next_id.fetch_add(1);
+  conn->write_id_.store(id);
+
+  const auto scheduled = wheel.schedule(
+      [id, &loop, conn_weak = std::weak_ptr{conn}] {
+        // Deliver the result on the loop thread.
+        return loop.post([id, conn_weak] {
+          auto c = conn_weak.lock();
+          if (!c || c->write_id_.load() != id) return true; // Stale.
+          c->handle_write_timeout();
+          return true;
+        });
+      },
+      10s);
+  CHECK(scheduled);
+
+  // The write never completes, so the callback finds the ID live and handles
+  // the timeout.
+  wheel.tick(T(9'900));
+  CHECK(conn->timeouts_handled == 0);
+  wheel.tick(T(10'000));
+  CHECK(conn->timeouts_handled == 1);
+
+  // Re-arm; this time the write completes before the timeout, staling the
+  // pending callback.
+  {
+    const auto id = next_id.fetch_add(1);
+    conn->write_id_.store(id);
+    const auto scheduled = wheel.schedule(
+        [id, &loop, conn_weak = std::weak_ptr{conn}] {
+          return loop.post([id, conn_weak] {
+            auto c = conn_weak.lock();
+            if (!c || c->write_id_.load() != id) return true; // Stale.
+            c->handle_write_timeout();
+            return true;
+          });
+        },
+        10s);
+    CHECK(scheduled);
+  }
+
+  // On write completion, store zero to stale any pending callback:
+  conn->write_id_.store(0);
+
+  wheel.tick(T(20'100));
+  CHECK(conn->timeouts_handled == 1); // Unchanged: the callback was stale.
 }
 
 #pragma endregion

--- a/tests/portable/timing_wheel_test.cpp
+++ b/tests/portable/timing_wheel_test.cpp
@@ -15,6 +15,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <latch>
+#include <thread>
+
 #include "corvid/concurrency/timing_wheel.h"
 
 #include "catch2_main.h"
@@ -360,6 +363,45 @@ TEST_CASE("StopAbortsTick", "[TimingWheel]") {
 
   // Only the first callback fires before the tombstone is seen.
   CHECK(count == 1);
+}
+
+#pragma endregion
+#pragma region RunnerLifecycle
+
+TEST_CASE("RunnerLifecycle", "[TimingWheel]") {
+  // The runner drives the wheel from its own thread; destruction joins.
+  std::latch fired{1};
+  timing_wheel_runner runner{8, 1ms};
+  CHECK(runner.wheel()->schedule(
+            [&] {
+              fired.count_down();
+              return true;
+            },
+            1ms) == true);
+  fired.wait();
+}
+
+#pragma endregion
+#pragma region RunnerSelfDestruct
+
+TEST_CASE("RunnerSelfDestruct", "[TimingWheel]") {
+  // A callback may destroy the runner from the wheel thread itself (the
+  // epoll_http_server last-reference path): the destructor detaches instead
+  // of self-joining, and `run` must finish on its own copy of the wheel
+  // without touching the dead runner. ASAN is the real teeth here; without
+  // the local wheel copy in `run`, this is a deterministic use-after-free.
+  std::latch done{1};
+  auto* runner = new timing_wheel_runner{8, 1ms};
+  CHECK(runner->wheel()->schedule(
+            [&] {
+              delete runner;
+              done.count_down();
+              return true;
+            },
+            1ms) == true);
+  done.wait();
+  // Give the detached thread a beat to unwind before the test ends.
+  std::this_thread::sleep_for(20ms);
 }
 
 #pragma endregion

--- a/tests/portable/timing_wheel_test.cpp
+++ b/tests/portable/timing_wheel_test.cpp
@@ -366,6 +366,29 @@ TEST_CASE("StopAbortsTick", "[TimingWheel]") {
 }
 
 #pragma endregion
+#pragma region NonMultipleDelayRoundsUp
+
+TEST_CASE("NonMultipleDelayRoundsUp", "[TimingWheel]") {
+  // A delay that is not a slot multiple rounds UP to the next boundary:
+  // 150ms on a 100ms wheel must not fire at the 100ms tick.
+  timing_wheel wheel(600, dur{100}, T(0));
+  int fired = 0;
+
+  CHECK(wheel.schedule(
+            [&] {
+              ++fired;
+              return true;
+            },
+            150ms) == true);
+
+  wheel.tick(T(100));
+  CHECK(fired == 0); // Pre-fix: fired here, 50ms early.
+
+  wheel.tick(T(200));
+  CHECK(fired == 1);
+}
+
+#pragma endregion
 #pragma region RunnerLifecycle
 
 TEST_CASE("RunnerLifecycle", "[TimingWheel]") {

--- a/tests/portable/tombstone_test.cpp
+++ b/tests/portable/tombstone_test.cpp
@@ -81,5 +81,50 @@ TEST_CASE("Kill", "[TombStone]") {
 }
 
 #pragma endregion
+#pragma region TombStone_Countdown
+
+// Probe for the stepping operators. The template parameter is load-bearing:
+// a requires-expression with no dependent names hard-errors instead of
+// yielding false.
+template<typename TS>
+constexpr bool can_step_v = requires(TS& t) {
+  ++t;
+  --t;
+};
+
+TEST_CASE("Countdown", "[TombStone]") {
+  // Counting down to `final_v` kills the tombstone by design; once dead, it
+  // stays dead and further steps are no-ops.
+  tombstone_of<int, 0, 3> t;
+  CHECK_FALSE(t.dead());
+  --t;
+  --t;
+  CHECK_FALSE(t.dead());
+  CHECK(t.get() == 1);
+
+  // The step that lands on the final value kills.
+  --t;
+  CHECK(t.dead());
+
+  // Dead stays dead: neither direction moves it.
+  --t;
+  ++t;
+  CHECK(t.dead());
+  CHECK(t.get() == 0);
+
+  // An increment can also land on death.
+  tombstone_of<int, 2, 0> u;
+  ++u;
+  CHECK_FALSE(u.dead());
+  ++u;
+  CHECK(u.dead());
+
+  // For the `bool` tombstone, stepping is pointless (both directions would
+  // land on death), so the operators are constrained away.
+  static_assert(can_step_v<tombstone_of<int, 0, 3>>);
+  static_assert(!can_step_v<tombstone>);
+}
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)


### PR DESCRIPTION
The `concurrency` module's turn in the module-by-module review of `corvid/`.
Behavior fixes where the review found real defects, doc corrections where the
docs described something the code did not do, and a large test expansion:
1,304 added lines across 13 test files against 546 in the library.

## `owner_thread_dispatcher`

The bulk of the work, and the source of most of the behavior changes.

- `post_and_wait` could block forever. `post` returning true means only that
  the callback was queued, and `shutdown` clears the queues without running
  them, so a discarded callback never counted the latch down. The posted
  callback now carries a `scope_exit` guard that releases the waiter when the
  callback is destroyed, so the discarded and executed paths both wake it; an
  abandoned waiter returns false because its result was never assigned.
- `shutdown` from inside a posted callback was undefined behavior, since it
  cleared the vector the drain was walking, destroying the callback mid-call.
  A drain now records the queue it owns and `shutdown` leaves that one alone,
  stopping the drain after the running callback returns. The rest of the batch
  is discarded and no longer counts as executed, so the return value is the
  number actually run. A nested drain asserts and drains nothing.
- `execute_or_post_with_retry` discarded the result of its `post` and returned
  true regardless, so after a shutdown every call reported success for work
  that was dropped. It now returns what `post` returned, which makes the
  io_uring submit family's existing failure paths reachable.
- The one-instance-per-thread claim lived in the class template, so it was one
  `thread_local` per callback type and two dispatchers with different callback
  types could each claim the same thread, starving each other's queue. The
  claim moved to a non-template base that also carries the
  `enable_shared_from_this` hookup, so there is one claim per thread and still
  only one base.
- The constructor claimed the thread before the queue reservations, which can
  throw. Since a constructor that throws runs no destructor, the claim was
  stranded and that thread could never host a dispatcher again. It now claims
  last, and refuses to construct at all when the wake `eventfd` was not
  created.
- `shutdown` returned false both for losing the race to an earlier shutdown
  and for being called from the wrong thread. The lost race stays false; the
  wrong thread now throws `std::logic_error`.
- The default callback type is now `fixed_function` rather than
  `std::function`, which is what both loops already specified by hand. The
  concepts only require a callback that can be moved from, but `std::function`
  demands copy-constructibility, so the default instantiation rejected
  move-only callables the concepts advertised.
- `wake_fd`, `wake_post_queue`, and `execute_post_queue` are public. The class
  documented itself as working equally well as a member, which was not
  possible while an owner could neither drain the queue nor register the wake
  fd.
- `StoredPostedInvocable` required `MoveConsumable`, which is a
  parameter-binding constraint and vacuously true of a stored type, making it
  identical to `PostedInvocable`. The stored form is now invocability alone.

## Other classes

- `timing_wheel::schedule` truncated the delay to whole slots, so anything not
  landing exactly on a boundary fired up to one tick early even though the
  delay is documented as a minimum. It now rounds up. The runner's thread also
  takes its own `shared_ptr` to the wheel, since the self-destruction path
  destroys the runner from inside a callback.
- `timer_fuse::set_timeout` incremented the sequencer before discovering the
  delay was unschedulable, which fizzled the previously armed fuse on a call
  that reported failure and changed nothing else. It now checks first.
- `timeout_sweeper`'s destructor ticked to `time_point_t::max()`, firing
  entries parked at the pause sentinel. It now ticks to just short of that
  sentinel, so paused stays paused through destruction. `tick` returns the
  number of callbacks invoked rather than an unconditional true.
- `timers` did not kill the tombstone of an event dropped for being past
  `stop_at`.
- `idle_timeout` tracks its single sweeper entry through a claim counter
  rather than inferring liveness by comparing the deadline against the current
  time, which is what let mode transitions duplicate or lose entries. Mode
  reads from the claim, `postpone` is a compare-exchange that cannot resurrect
  a deadline that `stop` or `pause` parked, and a failed schedule unwinds to
  stopped so the mode reads truthfully.
- `tombstone_of`'s `++` and `--` are constrained away from `bool`.
- `notifiable` gained `set` and a deduction guide.
- `jthread_stoppable_sleep` now calls the stop-token overload of
  `std::condition_variable_any::wait_until`, which libc++ implements. The
  hand-rolled `std::stop_callback` workaround it wrapped is gone.
- `scope_exit`'s copy constructor throws instead of being deleted, so a guard
  can live inside a `std::function`, which requires a copy constructor it
  never calls. This file belongs to the already-merged infra band; it is here
  because the `post_and_wait` fix needs it.
- `concurrency.h` gates `owner_thread_dispatcher` behind `__linux__`. It is
  built on `eventfd`.
- `iou_loop` loses `post_and_wait_poll_interval`, dead since its own polling
  `post_and_wait` was replaced by the dispatcher's in #59.

## Tests

Every behavior fix above has a test that fails without it. Four headers now
carry lede examples that are compiled and run as `LedeExample` cases
(`notifiable`, `sync_lock`, `timing_wheel`, `timeout_sweeper`), so an example
that drifts from the API breaks the build.

Verified on Linux with clang and libc++: full suite 73/73, clang-tidy clean,
and the dispatcher fixes re-checked under ASAN with asserts live, each by
reverting the fix and confirming the intended failure.

This is a C++23 codebase, so constructs like deducing `this` (`interval`'s
`lo`/`hi`) and `UZ` literals are intentional.

Unrelated one-liner along for the ride: `.devcontainer/init-firewall.sh` gains
an allowlist entry for the Copilot proxy.
