### PR TITLE
Repair split-line NOLINT directives and clear the warnings they hid

### DIFF
--- a/corvid/ecs/component_scene.h
+++ b/corvid/ecs/component_scene.h
@@ -454,6 +454,11 @@ private:
       using self_t = std::remove_reference_t<decltype(self)>;
       // Scan all storages with `component_t == C`; the per-selector check in
       // `for_all` guarantees exactly one contains the entity.
+      //
+      // Both branches dereference a pointer that the analyzer cannot prove
+      // non-null, since it is the caller's guarantee above that makes it so.
+      // The asserts stand in for that narrow contract.
+      // NOLINTBEGIN(clang-analyzer-core.uninitialized.UndefReturn)
       if constexpr (std::is_const_v<self_t>) {
         const C* result{};
         [&]<size_t... Is>(std::index_sequence<Is...>) {
@@ -483,6 +488,7 @@ private:
         assert(result);
         return *result; // C&
       }
+      // NOLINTEND(clang-analyzer-core.uninitialized.UndefReturn)
     }
   }
 

--- a/tests/linux/epoll_tests.cpp
+++ b/tests/linux/epoll_tests.cpp
@@ -123,13 +123,14 @@ TEST_CASE("Create", "[Epoll]") {
 
 #pragma region Move
 
+// The moved-from source going invalid is what these blocks assert.
+// NOLINTBEGIN(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
 TEST_CASE("Move", "[Epoll]") {
   // Move constructor transfers ownership; source becomes invalid.
   if (true) {
     auto a = epoll::create();
     const auto h = a.handle();
     epoll b{std::move(a)};
-    // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
     CHECK_FALSE(a.is_open());
     CHECK(b.is_open());
     CHECK(b.handle() == h);
@@ -141,7 +142,6 @@ TEST_CASE("Move", "[Epoll]") {
     auto b = epoll::create();
     const auto h = a.handle();
     b = std::move(a);
-    // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
     CHECK_FALSE(a.is_open());
     CHECK(b.is_open());
     CHECK(b.handle() == h);
@@ -157,6 +157,7 @@ TEST_CASE("Move", "[Epoll]") {
     CHECK(a.handle() == h);
   }
 }
+// NOLINTEND(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
 
 #pragma endregion
 
@@ -265,13 +266,14 @@ TEST_CASE("Lifecycle", "[EventFd]") {
 
 #pragma region EventFd_Move
 
+// The moved-from source going invalid is what these blocks assert.
+// NOLINTBEGIN(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
 TEST_CASE("Move", "[EventFd]") {
   // Move constructor transfers ownership; source becomes invalid.
   if (true) {
     auto a = event_fd::create();
     const auto h = a.handle();
     event_fd b{std::move(a)};
-    // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
     CHECK_FALSE(a.is_open());
     CHECK(b.is_open());
     CHECK(b.handle() == h);
@@ -283,7 +285,6 @@ TEST_CASE("Move", "[EventFd]") {
     auto b = event_fd::create();
     const auto h = a.handle();
     b = std::move(a);
-    // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
     CHECK_FALSE(a.is_open());
     CHECK(b.is_open());
     CHECK(b.handle() == h);
@@ -299,6 +300,7 @@ TEST_CASE("Move", "[EventFd]") {
     CHECK(a.handle() == h);
   }
 }
+// NOLINTEND(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
 
 #pragma endregion
 

--- a/tests/portable/charconv_wrapper_test.cpp
+++ b/tests/portable/charconv_wrapper_test.cpp
@@ -198,6 +198,7 @@ TEST_CASE("WideInt", "[charconv]") {
 #pragma region Float
 
 TEST_CASE("FloatCharMatchesStd", "[charconv]") {
+  // NOLINTNEXTLINE(modernize-use-std-numbers): test data, not pi.
   const double vals[]{0.0, 1.0, -1.0, 3.14159, -2.5, 1e10, 1e-10, 123456.789};
   for (double v : vals) {
     std::array<char, 64> a{};
@@ -211,6 +212,7 @@ TEST_CASE("FloatCharMatchesStd", "[charconv]") {
 }
 
 TEST_CASE("FloatRoundTrip", "[charconv]") {
+  // NOLINTNEXTLINE(modernize-use-std-numbers): test data, not pi.
   const double vals[]{0.0, 1.0, -1.0, 3.141592653589793, -2.5, 1e10, 1e-10,
       6.022e23};
 

--- a/tests/portable/charconv_wrapper_test.cpp
+++ b/tests/portable/charconv_wrapper_test.cpp
@@ -27,8 +27,7 @@
 using namespace std::literals;
 using namespace corvid;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 
 // Format `value` to a `std::string` with our `int_to_chars`.
 template<std::integral T>
@@ -57,7 +56,7 @@ TEST_CASE("IntToChars", "[charconv]") {
     const int64_t svals[]{0, 1, -1, 7, -7, 42, -42, 255, 256, 1000, -1000,
         65535, 2147483647, -2147483648, 9223372036854775807LL,
         (-9223372036854775807LL - 1)};
-    const uint64_t uvals[]{0u, 1u, 255u, 256u, 65535u, 4294967295u,
+    const uint64_t uvals[]{0U, 1U, 255U, 256U, 65535U, 4294967295U,
         18446744073709551615ULL};
     for (auto base : bases) {
       for (int64_t v : svals) CHECK(ours_int(v, base) == theirs_int(v, base));
@@ -141,8 +140,10 @@ TEST_CASE("IntFromChars", "[charconv]") {
   }
 
   SECTION("accepts upper- and lowercase digits above base 10") {
-    int outl = 0, outu = 0;
-    auto l = "ff"sv, u = "FF"sv;
+    int outl = 0;
+    int outu = 0;
+    auto l = "ff"sv;
+    auto u = "FF"sv;
     (void)strings::int_from_chars(l.data(), l.data() + l.size(), outl, 16);
     (void)strings::int_from_chars(u.data(), u.data() + u.size(), outu, 16);
     CHECK(outl == 255);
@@ -176,7 +177,7 @@ TEST_CASE("WideInt", "[charconv]") {
   };
   for (auto base : {2, 10, 16, 36}) {
     widen_check(int64_t{-123456789}, base);
-    widen_check(uint64_t{9876543210u}, base);
+    widen_check(uint64_t{9876543210U}, base);
   }
 
   // char16_t round-trip.
@@ -199,7 +200,8 @@ TEST_CASE("WideInt", "[charconv]") {
 TEST_CASE("FloatCharMatchesStd", "[charconv]") {
   const double vals[]{0.0, 1.0, -1.0, 3.14159, -2.5, 1e10, 1e-10, 123456.789};
   for (double v : vals) {
-    std::array<char, 64> a{}, b{};
+    std::array<char, 64> a{};
+    std::array<char, 64> b{};
     auto [pa, ea] = strings::float_to_chars(a.data(), a.data() + a.size(), v);
     auto [pb, eb] = std::to_chars(b.data(), b.data() + b.size(), v);
     CHECK(ea == std::errc{});
@@ -291,5 +293,4 @@ TEST_CASE("FloatPrecisionClip", "[charconv]") {
 
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/circular_buffer_test.cpp
+++ b/tests/portable/circular_buffer_test.cpp
@@ -25,8 +25,7 @@
 using namespace std::literals;
 using namespace corvid;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 
 #pragma region Construction
 
@@ -648,5 +647,4 @@ TEST_CASE("Format", "[CircularBufferTest]") {
 
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/circular_buffer_test.cpp
+++ b/tests/portable/circular_buffer_test.cpp
@@ -249,6 +249,9 @@ TEST_CASE("At", "[CircularBufferTest]") {
 TEST_CASE("ZeroCapacity", "[CircularBufferTest]") {
   // A zero-capacity buffer, however obtained, is both empty and full at
   // once: the `try_` forms fail cleanly and `at` throws.
+  // The last caller below deliberately probes a moved-from buffer, and the
+  // analyzer attributes that to every method reached through here.
+  // NOLINTBEGIN(clang-analyzer-cplusplus.Move)
   auto probe = [](circular_buffer<int>& cb) {
     CHECK(cb.capacity() == 0U);
     CHECK(cb.empty());
@@ -258,6 +261,7 @@ TEST_CASE("ZeroCapacity", "[CircularBufferTest]") {
     CHECK_FALSE(cb.try_emplace_back(1));
     CHECK_THROWS_AS((void)cb.at(0), std::out_of_range);
   };
+  // NOLINTEND(clang-analyzer-cplusplus.Move)
 
   // Default-constructed.
   if (true) {

--- a/tests/portable/containers_test.cpp
+++ b/tests/portable/containers_test.cpp
@@ -48,8 +48,8 @@ consteval auto corvid_enum_spec(small_id_t*) {
   return corvid::enums::sequence::make_sequence_enum_spec<small_id_t, "">();
 }
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+// NOLINTBEGIN(readability-function-size)
 
 #pragma region TransparentTest_General
 
@@ -1188,26 +1188,26 @@ TEST_CASE("Basic", "[HashCombiner]") {
   // Default seed is zero; explicit seed is respected.
   if (true) {
     hash_combiner h;
-    CHECK(h.value() == 0u);
-    CHECK(static_cast<size_t>(h) == 0u);
+    CHECK(h.value() == 0U);
+    CHECK(static_cast<size_t>(h) == 0U);
   }
   if (true) {
-    hash_combiner h{42u};
-    CHECK(h.value() == 42u);
+    hash_combiner h{42U};
+    CHECK(h.value() == 42U);
   }
 
   // Combining a non-zero hash into seed 0 must produce a non-zero result.
   if (true) {
     hash_combiner h;
-    h.combine_hash(1u);
-    CHECK(h.value() != 0u);
+    h.combine_hash(1U);
+    CHECK(h.value() != 0U);
   }
 
   // `combine` hashes a typed value and folds it in.
   if (true) {
     hash_combiner h;
     h.combine(123);
-    CHECK(h.value() != 0u);
+    CHECK(h.value() != 0U);
   }
 
   // Order of combination must matter.
@@ -1256,5 +1256,5 @@ TEST_CASE("Basic", "[HashCombiner]") {
 }
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/containers_test.cpp
+++ b/tests/portable/containers_test.cpp
@@ -461,13 +461,13 @@ TEST_CASE("Extended", "[StrongType]") {
     CHECK(fn == "John"s);
     CHECK(fn == fn);
     // Test spaceship, both heterogeneous and homogeneous.
-    CHECK(fn <=> fn == std::strong_ordering::equal);
-    CHECK(fn <=> fn2 == std::strong_ordering::greater);
-    CHECK(fn2 <=> fn == std::strong_ordering::less);
-    CHECK(fn <=> "John"s == std::strong_ordering::equal);
-    CHECK(fn <=> "Zoe"s == std::strong_ordering::less);
-    CHECK("Zoe"s <=> fn == std::strong_ordering::greater);
-    CHECK("John"s <=> fn == std::strong_ordering::equal);
+    CHECK((fn <=> fn) == std::strong_ordering::equal);
+    CHECK((fn <=> fn2) == std::strong_ordering::greater);
+    CHECK((fn2 <=> fn) == std::strong_ordering::less);
+    CHECK((fn <=> "John"s) == std::strong_ordering::equal);
+    CHECK((fn <=> "Zoe"s) == std::strong_ordering::less);
+    CHECK(("Zoe"s <=> fn) == std::strong_ordering::greater);
+    CHECK(("John"s <=> fn) == std::strong_ordering::equal);
     // Test homogeneous comparisons.
     CHECK_FALSE(fn == fn2);
     CHECK(fn != fn2);
@@ -477,13 +477,13 @@ TEST_CASE("Extended", "[StrongType]") {
     CHECK(fn >= fn2);
     // Test heterogeneous comparisons.
     CHECK(fn == "John"s);
-    CHECK(fn <=> "John"s == std::strong_ordering::equal);
+    CHECK((fn <=> "John"s) == std::strong_ordering::equal);
     CHECK_FALSE(fn != "John"s);
     CHECK(fn < "Zoe"s);
     CHECK(fn <= "John"s);
     CHECK(fn > "Adam"s);
     CHECK(fn >= "John"s);
-    CHECK("John"s <=> fn == std::strong_ordering::equal);
+    CHECK(("John"s <=> fn) == std::strong_ordering::equal);
     CHECK("John"s == fn);
     CHECK_FALSE("John"s != fn);
     CHECK("Zoe"s > fn);

--- a/tests/portable/containers_test.cpp
+++ b/tests/portable/containers_test.cpp
@@ -442,8 +442,11 @@ TEST_CASE("Extended", "[StrongType]") {
     CHECK(fn->at(0) == 'J');
     CHECK(fn->front() == 'J');
     CHECK(fn->back() == 'n');
+    // The accessor itself is what is under test here.
+    // NOLINTBEGIN(readability-redundant-string-cstr)
     CHECK(std::string_view{fn->data()} == "John");
     CHECK(std::string_view{fn->c_str()} == "John");
+    // NOLINTEND(readability-redundant-string-cstr)
     std::string s;
     for (auto c : fn) s += c;
     CHECK(s == "John");
@@ -1070,6 +1073,10 @@ struct throwing_scoped_value_test {
   throwing_scoped_value_test& operator=(
       const throwing_scoped_value_test&) = default;
 
+  // This fixture exists to exercise a throwing move, so the throw is the
+  // subject rather than a defect, and marking it noexcept would defeat it.
+  // NOLINTBEGIN(bugprone-exception-escape)
+  // NOLINTBEGIN(performance-noexcept-move-constructor)
   throwing_scoped_value_test(throwing_scoped_value_test&& other) {
     if (other.throw_on_move) throw std::runtime_error("move failed");
     value = std::move(other.value);
@@ -1082,6 +1089,8 @@ struct throwing_scoped_value_test {
     throw_on_move = other.throw_on_move;
     return *this;
   }
+  // NOLINTEND(performance-noexcept-move-constructor)
+  // NOLINTEND(bugprone-exception-escape)
 };
 
 inline void swap(throwing_scoped_value_test& lhs,

--- a/tests/portable/cstring_view_test.cpp
+++ b/tests/portable/cstring_view_test.cpp
@@ -28,8 +28,8 @@ using namespace std::literals;
 using namespace corvid;
 using namespace corvid::literals;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+// NOLINTBEGIN(readability-function-size)
 
 #pragma region Construction
 
@@ -507,5 +507,5 @@ TEST_CASE("Env", "[CStringViewTest]") {
 
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/cstring_view_test.cpp
+++ b/tests/portable/cstring_view_test.cpp
@@ -199,6 +199,7 @@ TEST_CASE("Construction", "[CStringViewTest]") {
   }
   // Construct string_view on empty string_view.
   if (true) {
+    // NOLINTNEXTLINE(readability-redundant-string-init): non-null empty.
     std::string_view sv("");
     CHECK(sv.data() != nullptr);
     std::string_view v{sv};
@@ -208,6 +209,7 @@ TEST_CASE("Construction", "[CStringViewTest]") {
   }
   // Construct cstring_view on empty string_view.
   if (true) {
+    // NOLINTNEXTLINE(readability-redundant-string-init): non-null empty.
     std::string_view svbad("");
     CHECK(svbad.data() != nullptr);
     CHECK_THROWS_AS((cstring_view(svbad)), std::length_error);

--- a/tests/portable/ecs_test.cpp
+++ b/tests/portable/ecs_test.cpp
@@ -598,6 +598,7 @@ TEST_CASE("RowAccess", "[ArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     CHECK(a.add(id0, 7, 2.0F));
     auto row = a[id0];
+    // NOLINTNEXTLINE(performance-move-const-arg): move is the subject.
     auto moved = std::move(row);
     CHECK(moved.index() == 0U);
     CHECK(moved.component<int>() == 7);
@@ -3746,6 +3747,7 @@ TEST_CASE("ChunkBoundary", "[ChunkedArchetypeStorage]") {
 
   auto make_ids = [&](reg_t& r, int n) {
     std::vector<reg_t::id_t> ids;
+    ids.reserve(n);
     for (auto ndx = 0; ndx < n; ++ndx)
       ids.push_back(r.create_id(staging, ndx * 10));
     return ids;
@@ -3761,6 +3763,8 @@ TEST_CASE("ChunkBoundary", "[ChunkedArchetypeStorage]") {
     CHECK(a.size() == 4U);
     for (auto ndx = 0; ndx < 4; ++ndx) {
       CHECK(a[ids[ndx]].component<int>() == (ndx + 1));
+      // The explicit cast is deliberate and correct.
+      // NOLINTNEXTLINE(modernize-use-integer-sign-comparison)
       CHECK(r.get_location(ids[ndx]).ndx == size_t(ndx));
     }
   }
@@ -3788,6 +3792,8 @@ TEST_CASE("ChunkBoundary", "[ChunkedArchetypeStorage]") {
     // Remaining entities are all in chunk 0; indices 0-3 intact.
     for (auto ndx = 0; ndx < 4; ++ndx) {
       CHECK(a.contains(ids[ndx]));
+      // The explicit cast is deliberate and correct.
+      // NOLINTNEXTLINE(modernize-use-integer-sign-comparison)
       CHECK(r.get_location(ids[ndx]).ndx == size_t(ndx));
     }
   }
@@ -6613,8 +6619,8 @@ TEST_CASE("ForEach", "[ArchetypeScene]") {
       return true;
     });
     CHECK(seen.size() == 2U);
-    CHECK(std::find(seen.begin(), seen.end(), h1.id()) != seen.end());
-    CHECK(std::find(seen.begin(), seen.end(), h2.id()) != seen.end());
+    CHECK(std::ranges::find(seen, h1.id()) != seen.end());
+    CHECK(std::ranges::find(seen, h2.id()) != seen.end());
   }
 
   // for_each on a const scene yields const component references.

--- a/tests/portable/ecs_test.cpp
+++ b/tests/portable/ecs_test.cpp
@@ -27,8 +27,8 @@
 using namespace std::literals;
 using namespace corvid;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+// NOLINTBEGIN(readability-function-size)
 
 using int_stable_ids = stable_ids<int>;
 
@@ -124,7 +124,7 @@ TEST_CASE("Add", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 42, 1.0f));
+    CHECK(a.add(id0, 42, 1.0F));
     CHECK(a.size() == 1U);
     CHECK_FALSE(a.empty());
     CHECK(a.contains(id0));
@@ -140,9 +140,9 @@ TEST_CASE("Add", "[ArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK(a.add(id1, 2, 2.0f));
-    CHECK(a.add(id2, 3, 3.0f));
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK(a.add(id1, 2, 2.0F));
+    CHECK(a.add(id2, 3, 3.0F));
     CHECK(a.size() == 3U);
     CHECK(r.get_location(id0).ndx == 0U);
     CHECK(r.get_location(id1).ndx == 1U);
@@ -155,8 +155,8 @@ TEST_CASE("Add", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     arch_t b{r, store_id_t{2}};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK_FALSE(b.add(id0, 2, 2.0f)); // id0 not in staging
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK_FALSE(b.add(id0, 2, 2.0F)); // id0 not in staging
     CHECK(b.size() == 0U);
   }
 
@@ -165,7 +165,7 @@ TEST_CASE("Add", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto h = r.create_handle(staging, 10);
-    CHECK(a.add(h, 99, 1.5f));
+    CHECK(a.add(h, 99, 1.5F));
     CHECK(a.size() == 1U);
     CHECK(a.contains(h));
   }
@@ -176,7 +176,7 @@ TEST_CASE("Add", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto h = r.create_handle(staging, 10);
     r.erase(h);
-    CHECK_FALSE(a.add(h, 99, 1.5f));
+    CHECK_FALSE(a.add(h, 99, 1.5F));
     CHECK(a.size() == 0U);
   }
 
@@ -184,7 +184,7 @@ TEST_CASE("Add", "[ArchetypeStorage]") {
   if (true) {
     reg_t r;
     arch_t a{r, sid};
-    auto h = a.add_new(42, 7, 2.0f);
+    auto h = a.add_new(42, 7, 2.0F);
     CHECK(r.is_valid(h));
     CHECK(r[h.id()] == 42);
     CHECK(a.size() == 1U);
@@ -196,7 +196,7 @@ TEST_CASE("Add", "[ArchetypeStorage]") {
   if (true) {
     reg_t r{id_t{0}};
     arch_t a{r, sid};
-    auto h = a.add_new(10, 1, 1.0f);
+    auto h = a.add_new(10, 1, 1.0F);
     CHECK_FALSE(r.is_valid(h));
     CHECK(a.size() == 0U);
   }
@@ -206,9 +206,9 @@ TEST_CASE("Add", "[ArchetypeStorage]") {
   if (true) {
     reg_t r;
     arch_t a{r, sid, 1};
-    auto h0 = a.add_new(10, 1, 1.0f);
+    auto h0 = a.add_new(10, 1, 1.0F);
     CHECK(r.is_valid(h0));
-    auto h1 = a.add_new(20, 2, 2.0f);
+    auto h1 = a.add_new(20, 2, 2.0F);
     CHECK_FALSE(r.is_valid(h1));
     CHECK(a.size() == 1U);
     CHECK(r.size() == 1U); // second entity cleaned up by RAII owner
@@ -221,7 +221,7 @@ TEST_CASE("Add", "[ArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     CHECK(a.add(id0, 7));
     CHECK(a[id0].template component<int>() == 7);
-    CHECK(a[id0].template component<float>() == 0.0f);
+    CHECK(a[id0].template component<float>() == 0.0F);
   }
 
   // add with all components omitted: all are default-constructed.
@@ -231,7 +231,7 @@ TEST_CASE("Add", "[ArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     CHECK(a.add(id0));
     CHECK(a[id0].template component<int>() == 0);
-    CHECK(a[id0].template component<float>() == 0.0f);
+    CHECK(a[id0].template component<float>() == 0.0F);
   }
 
   // add_new with one trailing component omitted: it is default-constructed.
@@ -241,7 +241,7 @@ TEST_CASE("Add", "[ArchetypeStorage]") {
     auto h = a.add_new(42, 7);
     CHECK(r.is_valid(h));
     CHECK(a[h.id()].template component<int>() == 7);
-    CHECK(a[h.id()].template component<float>() == 0.0f);
+    CHECK(a[h.id()].template component<float>() == 0.0F);
   }
 
   // add_new with all components omitted: all are default-constructed.
@@ -251,7 +251,7 @@ TEST_CASE("Add", "[ArchetypeStorage]") {
     auto h = a.add_new(42);
     CHECK(r.is_valid(h));
     CHECK(a[h.id()].template component<int>() == 0);
-    CHECK(a[h.id()].template component<float>() == 0.0f);
+    CHECK(a[h.id()].template component<float>() == 0.0F);
   }
 
   // contains(id) returns false for entity in staging, true after add.
@@ -260,7 +260,7 @@ TEST_CASE("Add", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     CHECK_FALSE(a.contains(id0));
-    CHECK(a.add(id0, 1, 1.0f));
+    CHECK(a.add(id0, 1, 1.0F));
     CHECK(a.contains(id0));
   }
 
@@ -290,7 +290,7 @@ TEST_CASE("Remove", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 1, 1.0f));
+    CHECK(a.add(id0, 1, 1.0F));
     CHECK(a.remove(id0));
     CHECK(a.size() == 0U);
     CHECK_FALSE(a.contains(id0));
@@ -311,7 +311,7 @@ TEST_CASE("Remove", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto h = r.create_handle(staging, 10);
-    CHECK(a.add(h, 1, 1.0f));
+    CHECK(a.add(h, 1, 1.0F));
     CHECK(a.remove(h));
     CHECK(r.is_valid(h));
     CHECK(a.size() == 0U);
@@ -333,9 +333,9 @@ TEST_CASE("Remove", "[ArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK(a.add(id1, 2, 2.0f));
-    CHECK(a.add(id2, 3, 3.0f));
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK(a.add(id1, 2, 2.0F));
+    CHECK(a.add(id2, 3, 3.0F));
     a.remove_all();
     CHECK(a.size() == 0U);
     CHECK(r.is_valid(id0));
@@ -353,9 +353,9 @@ TEST_CASE("Remove", "[ArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK(a.add(id1, 2, 2.0f));
-    CHECK(a.add(id2, 3, 3.0f));
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK(a.add(id1, 2, 2.0F));
+    CHECK(a.add(id2, 3, 3.0F));
     // Removing index 0 swaps id2 (last) into slot 0.
     CHECK(a.remove(id0));
     CHECK(a.size() == 2U);
@@ -380,7 +380,7 @@ TEST_CASE("Erase", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 1, 1.0f));
+    CHECK(a.add(id0, 1, 1.0F));
     CHECK(a.erase(id0));
     CHECK(a.size() == 0U);
     CHECK_FALSE(r.is_valid(id0));
@@ -400,7 +400,7 @@ TEST_CASE("Erase", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto h = r.create_handle(staging, 10);
-    CHECK(a.add(h, 1, 1.0f));
+    CHECK(a.add(h, 1, 1.0F));
     CHECK(a.erase(h));
     CHECK_FALSE(r.is_valid(h));
     CHECK(a.size() == 0U);
@@ -422,9 +422,9 @@ TEST_CASE("Erase", "[ArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK(a.add(id1, 2, 2.0f));
-    CHECK(a.add(id2, 3, 3.0f));
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK(a.add(id1, 2, 2.0F));
+    CHECK(a.add(id2, 3, 3.0F));
     a.clear();
     CHECK(a.size() == 0U);
     CHECK_FALSE(r.is_valid(id0));
@@ -439,9 +439,9 @@ TEST_CASE("Erase", "[ArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 11, 1.1f));
-    CHECK(a.add(id1, 22, 2.2f));
-    CHECK(a.add(id2, 33, 3.3f));
+    CHECK(a.add(id0, 11, 1.1F));
+    CHECK(a.add(id1, 22, 2.2F));
+    CHECK(a.add(id2, 33, 3.3F));
     // Erase id0 at index 0: id2 (index 2) swaps into index 0.
     CHECK(a.erase(id0));
     CHECK(a.size() == 2U);
@@ -468,7 +468,7 @@ TEST_CASE("RowAccess", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 42, 1.0f));
+    CHECK(a.add(id0, 42, 1.0F));
     auto row = a[id0];
     CHECK(row.index() == 0U);
     CHECK(row.id() == id0);
@@ -479,10 +479,10 @@ TEST_CASE("RowAccess", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 42, 2.0f));
+    CHECK(a.add(id0, 42, 2.0F));
     auto row = a[id0];
     CHECK(row.component<int>() == 42);
-    CHECK(row.component<float>() == 2.0f);
+    CHECK(row.component<float>() == 2.0F);
     row.component<int>() = 99;
     CHECK(row.component<int>() == 99);
   }
@@ -492,10 +492,10 @@ TEST_CASE("RowAccess", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 42, 3.0f));
+    CHECK(a.add(id0, 42, 3.0F));
     auto row = a[id0];
     CHECK(row.component<0>() == 42);
-    CHECK(row.component<1>() == 3.0f);
+    CHECK(row.component<1>() == 3.0F);
     row.component<0>() = 77;
     CHECK(row.component<0>() == 77);
   }
@@ -505,11 +505,11 @@ TEST_CASE("RowAccess", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 10, 1.0f));
+    CHECK(a.add(id0, 10, 1.0F));
     auto row = a[id0];
     auto [i, f] = row.components();
     CHECK(i == 10);
-    CHECK(f == 1.0f);
+    CHECK(f == 1.0F);
     i = 100; // mutates actual data via reference
     CHECK(a[id0].component<int>() == 100);
   }
@@ -519,13 +519,13 @@ TEST_CASE("RowAccess", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 42, 4.0f));
+    CHECK(a.add(id0, 42, 4.0F));
     const auto& ca = a;
     auto row = ca[id0];
     CHECK(row.index() == 0U);
     CHECK(row.id() == id0);
     CHECK(row.component<int>() == 42);
-    CHECK(row.component<float>() == 4.0f);
+    CHECK(row.component<float>() == 4.0F);
   }
 
   // row_view::component<Index>() const access by index.
@@ -533,11 +533,11 @@ TEST_CASE("RowAccess", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 5, 2.0f));
+    CHECK(a.add(id0, 5, 2.0F));
     const auto& ca = a;
     auto row = ca[id0];
     CHECK(row.component<0>() == 5);
-    CHECK(row.component<1>() == 2.0f);
+    CHECK(row.component<1>() == 2.0F);
   }
 
   // row_view::components() returns tuple of const references.
@@ -545,11 +545,11 @@ TEST_CASE("RowAccess", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 7, 3.0f));
+    CHECK(a.add(id0, 7, 3.0F));
     const auto& ca = a;
     auto [i, f] = ca[id0].components();
     CHECK(i == 7);
-    CHECK(f == 3.0f);
+    CHECK(f == 3.0F);
   }
 
   // row_lens::get_owner() refers back to the owning archetype_storage.
@@ -557,7 +557,7 @@ TEST_CASE("RowAccess", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 1, 1.0f));
+    CHECK(a.add(id0, 1, 1.0F));
     auto row = a[id0];
     CHECK(&row.get_owner() == &a);
   }
@@ -568,8 +568,8 @@ TEST_CASE("RowAccess", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 11, 1.0f));
-    CHECK(a.add(id1, 22, 2.0f));
+    CHECK(a.add(id0, 11, 1.0F));
+    CHECK(a.add(id1, 22, 2.0F));
     CHECK(a[id0].component<int>() == 11);
     CHECK(a[id1].component<int>() == 22);
     CHECK(a[id0].id() == id0);
@@ -581,7 +581,7 @@ TEST_CASE("RowAccess", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 42, 1.0f));
+    CHECK(a.add(id0, 42, 1.0F));
     auto row = a[id0];
     auto copy = row; // copy construction
     CHECK(copy.index() == 0U);
@@ -596,7 +596,7 @@ TEST_CASE("RowAccess", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 7, 2.0f));
+    CHECK(a.add(id0, 7, 2.0F));
     auto row = a[id0];
     auto moved = std::move(row);
     CHECK(moved.index() == 0U);
@@ -608,7 +608,7 @@ TEST_CASE("RowAccess", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 55, 3.0f));
+    CHECK(a.add(id0, 55, 3.0F));
     const auto& ca = a;
     auto row = ca[id0];
     auto copy = row; // copy construction
@@ -635,8 +635,8 @@ TEST_CASE("ComponentAccess", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK(a.add(id1, 2, 2.0f));
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK(a.add(id1, 2, 2.0F));
     CHECK(a.size() == 2U);
     CHECK(a[id0].component<int>() == 1);
     CHECK(a[id1].component<int>() == 2);
@@ -649,10 +649,10 @@ TEST_CASE("ComponentAccess", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 42, 5.0f));
+    CHECK(a.add(id0, 42, 5.0F));
     const auto& ca = a;
     CHECK(ca.size() == 1U);
-    CHECK(ca[id0].component<float>() == 5.0f);
+    CHECK(ca[id0].component<float>() == 5.0F);
   }
 
   // component<Index>() access by index, mutable and const.
@@ -660,9 +660,9 @@ TEST_CASE("ComponentAccess", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 7, 4.0f));
+    CHECK(a.add(id0, 7, 4.0F));
     CHECK(a[id0].component<0>() == 7);
-    CHECK(a[id0].component<1>() == 4.0f);
+    CHECK(a[id0].component<1>() == 4.0F);
     a[id0].component<0>() = 77;
     CHECK(a[id0].component<0>() == 77);
   }
@@ -672,10 +672,10 @@ TEST_CASE("ComponentAccess", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 3, 3.0f));
+    CHECK(a.add(id0, 3, 3.0F));
     auto [i, f] = a[id0].components();
     CHECK(i == 3);
-    CHECK(f == 3.0f);
+    CHECK(f == 3.0F);
     i = 33;
     CHECK(a[id0].component<int>() == 33);
   }
@@ -685,11 +685,11 @@ TEST_CASE("ComponentAccess", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 6, 6.0f));
+    CHECK(a.add(id0, 6, 6.0F));
     const auto& ca = a;
     auto [i, f] = ca[id0].components();
     CHECK(i == 6);
-    CHECK(f == 6.0f);
+    CHECK(f == 6.0F);
   }
 }
 
@@ -719,9 +719,9 @@ TEST_CASE("Limit", "[ArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK(a.add(id1, 2, 2.0f));
-    CHECK_FALSE(a.add(id2, 3, 3.0f)); // at limit
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK(a.add(id1, 2, 2.0F));
+    CHECK_FALSE(a.add(id2, 3, 3.0F)); // at limit
     CHECK(a.size() == 2U);
   }
 
@@ -730,7 +730,7 @@ TEST_CASE("Limit", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 1, 1.0f));
+    CHECK(a.add(id0, 1, 1.0F));
     CHECK(a.set_limit(2U));
     CHECK(a.limit() == 2U);
   }
@@ -741,8 +741,8 @@ TEST_CASE("Limit", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK(a.add(id1, 2, 2.0f));
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK(a.add(id1, 2, 2.0F));
     CHECK_FALSE(a.set_limit(1U));
     CHECK(a.limit() == *id_t::invalid); // unchanged
   }
@@ -751,9 +751,9 @@ TEST_CASE("Limit", "[ArchetypeStorage]") {
   if (true) {
     reg_t r;
     arch_t a{r, sid, 1};
-    auto h0 = a.add_new(10, 1, 1.0f);
+    auto h0 = a.add_new(10, 1, 1.0F);
     CHECK(r.is_valid(h0));
-    auto h1 = a.add_new(20, 2, 2.0f); // fails: archetype full
+    auto h1 = a.add_new(20, 2, 2.0F); // fails: archetype full
     CHECK_FALSE(r.is_valid(h1));
     CHECK(a.size() == 1U);
     CHECK(r.size() == 1U);
@@ -779,8 +779,8 @@ TEST_CASE("SwapAndMove", "[ArchetypeStorage]") {
     arch_t b{r, sid2};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 11, 1.0f));
-    CHECK(b.add(id1, 22, 2.0f));
+    CHECK(a.add(id0, 11, 1.0F));
+    CHECK(b.add(id1, 22, 2.0F));
     swap(a, b);
     // After swap, a holds what b had and vice versa, including store_ids.
     CHECK(a.store_id() == sid2);
@@ -797,7 +797,7 @@ TEST_CASE("SwapAndMove", "[ArchetypeStorage]") {
     arch_t a{r, sid1};
     a.reserve(100);
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 1, 1.0f));
+    CHECK(a.add(id0, 1, 1.0F));
     a.shrink_to_fit();
     CHECK(a.size() == 1U);
     CHECK((a.capacity()) < (100U));
@@ -810,7 +810,7 @@ TEST_CASE("SwapAndMove", "[ArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     {
       arch_t a{r, sid1};
-      CHECK(a.add(id0, 42, 1.0f));
+      CHECK(a.add(id0, 42, 1.0F));
       arch_t b{std::move(a)};
       CHECK(b.size() == 1U);
       CHECK(b.store_id() == sid1);
@@ -827,7 +827,7 @@ TEST_CASE("SwapAndMove", "[ArchetypeStorage]") {
     {
       arch_t a{r, sid1};
       arch_t b{r, sid2};
-      CHECK(a.add(id0, 7, 7.0f));
+      CHECK(a.add(id0, 7, 7.0F));
       b = std::move(a);
       CHECK(b.size() == 1U);
       CHECK(b.store_id() == sid1);
@@ -843,8 +843,8 @@ TEST_CASE("SwapAndMove", "[ArchetypeStorage]") {
     auto id1 = r.create_id(staging, 20);
     {
       arch_t a{r, sid1};
-      CHECK(a.add(id0, 1, 1.0f));
-      CHECK(a.add(id1, 2, 2.0f));
+      CHECK(a.add(id0, 1, 1.0F));
+      CHECK(a.add(id1, 2, 2.0F));
     } // destructor fires
     CHECK_FALSE(r.is_valid(id0));
     CHECK_FALSE(r.is_valid(id1));
@@ -869,9 +869,9 @@ TEST_CASE("Iterator", "[ArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK(a.add(id1, 2, 2.0f));
-    CHECK(a.add(id2, 3, 3.0f));
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK(a.add(id1, 2, 2.0F));
+    CHECK(a.add(id2, 3, 3.0F));
     int sum = 0;
     for (auto row : a) sum += row.component<int>();
     CHECK(sum == 6);
@@ -883,12 +883,12 @@ TEST_CASE("Iterator", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 10, 1.0f));
-    CHECK(a.add(id1, 20, 2.0f));
+    CHECK(a.add(id0, 10, 1.0F));
+    CHECK(a.add(id1, 20, 2.0F));
     const auto& ca = a;
-    float fsum = 0.0f;
+    float fsum = 0.0F;
     for (const auto& row : ca) fsum += row.component<float>();
-    CHECK(fsum == 3.0f);
+    CHECK(fsum == 3.0F);
   }
 
   // Mutating components via iterator is reflected in storage.
@@ -897,8 +897,8 @@ TEST_CASE("Iterator", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 1, 0.0f));
-    CHECK(a.add(id1, 2, 0.0f));
+    CHECK(a.add(id0, 1, 0.0F));
+    CHECK(a.add(id1, 2, 0.0F));
     for (auto row : a) row.component<int>() *= 10;
     CHECK(a[id0].component<int>() == 10);
     CHECK(a[id1].component<int>() == 20);
@@ -910,8 +910,8 @@ TEST_CASE("Iterator", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 0, 0.0f));
-    CHECK(a.add(id1, 0, 0.0f));
+    CHECK(a.add(id0, 0, 0.0F));
+    CHECK(a.add(id1, 0, 0.0F));
     auto it = a.begin();
     CHECK(it->id() == id0);
     ++it;
@@ -926,8 +926,8 @@ TEST_CASE("Iterator", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 5, 0.0f));
-    CHECK(a.add(id1, 6, 0.0f));
+    CHECK(a.add(id0, 5, 0.0F));
+    CHECK(a.add(id1, 6, 0.0F));
     auto it = a.end();
     --it;
     CHECK((*it).component<int>() == 6);
@@ -950,11 +950,11 @@ TEST_CASE("Iterator", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 7, 1.5f));
-    float fsum = 0.0f;
+    CHECK(a.add(id0, 7, 1.5F));
+    float fsum = 0.0F;
     for (auto it = a.cbegin(); it != a.cend(); ++it)
       fsum += it->component<float>();
-    CHECK(fsum == 1.5f);
+    CHECK(fsum == 1.5F);
     static_assert(
         std::is_same_v<decltype(a.cbegin()), arch_t::const_iterator>);
   }
@@ -977,8 +977,8 @@ TEST_CASE("EraseIf", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK(a.add(id1, 2, 2.0f));
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK(a.add(id1, 2, 2.0F));
     auto cnt = a.erase_if([](const auto&) { return false; });
     CHECK(cnt == 0U);
     CHECK(a.size() == 2U);
@@ -992,8 +992,8 @@ TEST_CASE("EraseIf", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK(a.add(id1, 2, 2.0f));
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK(a.add(id1, 2, 2.0F));
     auto cnt = a.erase_if([](const auto&) { return true; });
     CHECK(cnt == 2U);
     CHECK(a.size() == 0U);
@@ -1009,9 +1009,9 @@ TEST_CASE("EraseIf", "[ArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 11, 1.0f));
-    CHECK(a.add(id1, 22, 2.0f));
-    CHECK(a.add(id2, 33, 3.0f));
+    CHECK(a.add(id0, 11, 1.0F));
+    CHECK(a.add(id1, 22, 2.0F));
+    CHECK(a.add(id2, 33, 3.0F));
     // Erase entities whose int component is odd.
     auto cnt = a.erase_if([](const auto& row) {
       return row.template component<int>() % 2 != 0;
@@ -1032,7 +1032,7 @@ TEST_CASE("EraseIf", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 1, 1.0f));
+    CHECK(a.add(id0, 1, 1.0F));
     auto cnt = a.erase_if([](const auto&) { return true; });
     CHECK(cnt == 1U);
     CHECK(a.size() == 0U);
@@ -1046,9 +1046,9 @@ TEST_CASE("EraseIf", "[ArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 10, 1.0f));
-    CHECK(a.add(id1, 20, 2.0f));
-    CHECK(a.add(id2, 30, 3.0f));
+    CHECK(a.add(id0, 10, 1.0F));
+    CHECK(a.add(id1, 20, 2.0F));
+    CHECK(a.add(id2, 30, 3.0F));
     auto cnt = a.erase_if_component<int>([](int val, auto) {
       return val > 15;
     });
@@ -1066,11 +1066,11 @@ TEST_CASE("EraseIf", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 5, 1.0f));
-    CHECK(a.add(id1, 5, 9.0f));
+    CHECK(a.add(id0, 5, 1.0F));
+    CHECK(a.add(id1, 5, 9.0F));
     // Component at index 1 is float; erase where float > 5.
     auto cnt = a.erase_if_component<1>([](float val, auto) {
-      return val > 5.0f;
+      return val > 5.0F;
     });
     CHECK(cnt == 1U);
     CHECK(a.size() == 1U);
@@ -1312,7 +1312,8 @@ TEST_CASE("Basic", "[StableId]") {
 
   // swap exchanges containers.
   if (true) {
-    V a, b;
+    V a;
+    V b;
     (void)a.push_back(1);
     (void)a.push_back(2);
     (void)b.push_back(100);
@@ -1727,7 +1728,8 @@ TEST_CASE("Fifo", "[StableId]") {
 
   // swap exchanges the complete FIFO free-list state between containers.
   if (true) {
-    V a, b;
+    V a;
+    V b;
     (void)a.push_back(10); // a: id 0
     (void)a.push_back(20); // a: id 1
     a.erase(id_t{0});      // a free list: [0]
@@ -2252,13 +2254,13 @@ TEST_CASE("Basic", "[MonoArchetypeStorage]") {
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
     CHECK(s.size() == 2U);
-    CHECK(s[id0] == 1.0f);
-    CHECK(s[id1] == 2.0f);
-    CHECK(s.at(id0) == 1.0f);
-    CHECK(s.at(id1) == 2.0f);
+    CHECK(s[id0] == 1.0F);
+    CHECK(s[id1] == 2.0F);
+    CHECK(s.at(id0) == 1.0F);
+    CHECK(s.at(id1) == 2.0F);
   }
 
   // Const access.
@@ -2266,10 +2268,10 @@ TEST_CASE("Basic", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(s.add(id0, 3.14f));
+    CHECK(s.add(id0, 3.14F));
     const auto& cs = s;
-    CHECK(cs[id0] == 3.14f);
-    CHECK(cs.at(id0) == 3.14f);
+    CHECK(cs[id0] == 3.14F);
+    CHECK(cs.at(id0) == 3.14F);
   }
 
   // Mutable access via operator[].
@@ -2277,9 +2279,9 @@ TEST_CASE("Basic", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(s.add(id0, 1.0f));
-    s[id0] = 99.0f;
-    CHECK(s[id0] == 99.0f);
+    CHECK(s.add(id0, 1.0F));
+    s[id0] = 99.0F;
+    CHECK(s[id0] == 99.0F);
   }
 
   // contains by ID.
@@ -2288,7 +2290,7 @@ TEST_CASE("Basic", "[MonoArchetypeStorage]") {
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
     CHECK_FALSE(s.contains(id0));
-    CHECK(s.add(id0, 1.0f));
+    CHECK(s.add(id0, 1.0F));
     CHECK(s.contains(id0));
     CHECK_FALSE(s.contains(id_t{99}));
   }
@@ -2305,7 +2307,7 @@ TEST_CASE("Basic", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(s.add(id0, 1.0f));
+    CHECK(s.add(id0, 1.0F));
     const auto loc = r.get_location(id0);
     CHECK(*loc.store_id == *sid);
     CHECK(loc.ndx == 0U);
@@ -2316,18 +2318,18 @@ TEST_CASE("Basic", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(s.add(id0, 1.0f));
-    CHECK_FALSE(s.add(id0, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK_FALSE(s.add(id0, 2.0F));
   }
 
   // add_new creates entity and adds component; returns its handle.
   if (true) {
     reg_t r;
     storage_t s{r, sid};
-    auto h0 = s.add_new(1.0f, 42);
+    auto h0 = s.add_new(1.0F, 42);
     CHECK(bool(h0));
     CHECK(s.size() == 1U);
-    CHECK(s[h0.id()] == 1.0f);
+    CHECK(s[h0.id()] == 1.0F);
     CHECK(r[h0.id()] == 42);
     CHECK(s.contains(h0));
     const auto loc = r.get_location(h0);
@@ -2338,9 +2340,9 @@ TEST_CASE("Basic", "[MonoArchetypeStorage]") {
   if (true) {
     reg_t r;
     storage_t s{r, sid};
-    auto h0 = s.add_new(5.5f);
+    auto h0 = s.add_new(5.5F);
     CHECK(bool(h0));
-    CHECK(s[h0.id()] == 5.5f);
+    CHECK(s[h0.id()] == 5.5F);
     CHECK(r[h0.id()] == 0);
   }
 
@@ -2356,9 +2358,9 @@ TEST_CASE("Basic", "[MonoArchetypeStorage]") {
   if (true) {
     reg_t r;
     storage_t s{r, sid};
-    auto h0 = s.add_new(42, 2.5f);
+    auto h0 = s.add_new(42, 2.5F);
     CHECK(bool(h0));
-    CHECK(s[h0.id()] == 2.5f);
+    CHECK(s[h0.id()] == 2.5F);
     CHECK(r[h0.id()] == 42);
   }
 
@@ -2368,7 +2370,7 @@ TEST_CASE("Basic", "[MonoArchetypeStorage]") {
     storage_t s{r, sid};
     auto h0 = s.add_new(99);
     CHECK(bool(h0));
-    CHECK(s[h0.id()] == 0.0f);
+    CHECK(s[h0.id()] == 0.0F);
     CHECK(r[h0.id()] == 99);
   }
 
@@ -2400,9 +2402,9 @@ TEST_CASE("Handle", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto h = r.create_handle(staging, 10);
-    CHECK(s.add(h, 1.0f));
+    CHECK(s.add(h, 1.0F));
     CHECK(s.size() == 1U);
-    CHECK(s[h.id()] == 1.0f);
+    CHECK(s[h.id()] == 1.0F);
   }
 
   // add by invalid handle returns false.
@@ -2411,7 +2413,7 @@ TEST_CASE("Handle", "[MonoArchetypeStorage]") {
     storage_t s{r, sid};
     auto h = r.create_handle(staging, 10);
     r.erase(h);
-    CHECK_FALSE(s.add(h, 1.0f));
+    CHECK_FALSE(s.add(h, 1.0F));
   }
 
   // contains by handle.
@@ -2420,7 +2422,7 @@ TEST_CASE("Handle", "[MonoArchetypeStorage]") {
     storage_t s{r, sid};
     auto h = r.create_handle(staging, 10);
     CHECK_FALSE(s.contains(h));
-    CHECK(s.add(h, 1.0f));
+    CHECK(s.add(h, 1.0F));
     CHECK(s.contains(h));
   }
 
@@ -2429,7 +2431,7 @@ TEST_CASE("Handle", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto h = r.create_handle(staging, 10);
-    CHECK(s.add(h, 1.0f));
+    CHECK(s.add(h, 1.0F));
     auto eid = h.id();
     (void)s.erase(eid);
     CHECK_FALSE(s.contains(h));
@@ -2440,10 +2442,10 @@ TEST_CASE("Handle", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto h = r.create_handle(staging, 10);
-    CHECK(s.add(h, 3.14f));
-    CHECK(s.at(h) == 3.14f);
-    s.at(h) = 99.0f;
-    CHECK(s.at(h) == 99.0f);
+    CHECK(s.add(h, 3.14F));
+    CHECK(s.at(h) == 3.14F);
+    s.at(h) = 99.0F;
+    CHECK(s.at(h) == 99.0F);
   }
 
   // at by handle const.
@@ -2451,9 +2453,9 @@ TEST_CASE("Handle", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto h = r.create_handle(staging, 10);
-    CHECK(s.add(h, 3.14f));
+    CHECK(s.add(h, 3.14F));
     const auto& cs = s;
-    CHECK(cs.at(h) == 3.14f);
+    CHECK(cs.at(h) == 3.14F);
   }
 
   // at by invalid handle throws.
@@ -2469,7 +2471,7 @@ TEST_CASE("Handle", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto h = r.create_handle(staging, 10);
-    CHECK(s.add(h, 1.0f));
+    CHECK(s.add(h, 1.0F));
     CHECK(s.remove(h));
     CHECK(s.empty());
     CHECK(r.is_valid(h));
@@ -2490,7 +2492,7 @@ TEST_CASE("Handle", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto h = r.create_handle(staging, 10);
-    CHECK(s.add(h, 1.0f));
+    CHECK(s.add(h, 1.0F));
     CHECK(s.erase(h));
     CHECK(s.empty());
     CHECK_FALSE(r.is_valid(h));
@@ -2523,7 +2525,7 @@ TEST_CASE("Remove", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(s.add(id0, 1.0f));
+    CHECK(s.add(id0, 1.0F));
     CHECK(s.remove(id0));
     CHECK_FALSE(s.contains(id0));
     CHECK(s.empty());
@@ -2546,14 +2548,14 @@ TEST_CASE("Remove", "[MonoArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
-    CHECK(s.add(id2, 3.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
+    CHECK(s.add(id2, 3.0F));
     CHECK(s.remove(id0));
     CHECK(s.size() == 2U);
-    CHECK(s[id2] == 3.0f);
+    CHECK(s[id2] == 3.0F);
     CHECK(r.get_location(id2).ndx == 0U);
-    CHECK(s[id1] == 2.0f);
+    CHECK(s[id1] == 2.0F);
     CHECK(r.get_location(id1).ndx == 1U);
   }
 
@@ -2563,11 +2565,11 @@ TEST_CASE("Remove", "[MonoArchetypeStorage]") {
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
     CHECK(s.remove(id1));
     CHECK(s.size() == 1U);
-    CHECK(s[id0] == 1.0f);
+    CHECK(s[id0] == 1.0F);
   }
 
   // Remove allows re-add.
@@ -2575,10 +2577,10 @@ TEST_CASE("Remove", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(s.add(id0, 1.0f));
+    CHECK(s.add(id0, 1.0F));
     CHECK(s.remove(id0));
-    CHECK(s.add(id0, 99.0f));
-    CHECK(s[id0] == 99.0f);
+    CHECK(s.add(id0, 99.0F));
+    CHECK(s[id0] == 99.0F);
   }
 }
 
@@ -2601,9 +2603,9 @@ TEST_CASE("RemoveAll", "[MonoArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
-    CHECK(s.add(id2, 3.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
+    CHECK(s.add(id2, 3.0F));
     s.remove_all();
     CHECK(s.empty());
     CHECK(r.is_valid(id0));
@@ -2625,10 +2627,10 @@ TEST_CASE("RemoveAll", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(s.add(id0, 1.0f));
+    CHECK(s.add(id0, 1.0F));
     s.remove_all();
-    CHECK(s.add(id0, 99.0f));
-    CHECK(s[id0] == 99.0f);
+    CHECK(s.add(id0, 99.0F));
+    CHECK(s[id0] == 99.0F);
   }
 }
 
@@ -2650,7 +2652,7 @@ TEST_CASE("Erase", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(s.add(id0, 1.0f));
+    CHECK(s.add(id0, 1.0F));
     CHECK(s.erase(id0));
     CHECK(s.empty());
     CHECK_FALSE(r.is_valid(id0));
@@ -2662,13 +2664,13 @@ TEST_CASE("Erase", "[MonoArchetypeStorage]") {
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
     CHECK(s.erase(id0));
     CHECK(s.size() == 1U);
     CHECK_FALSE(r.is_valid(id0));
     CHECK(r.is_valid(id1));
-    CHECK(s[id1] == 2.0f);
+    CHECK(s[id1] == 2.0F);
     CHECK(r.get_location(id1).ndx == 0U);
   }
 
@@ -2700,10 +2702,10 @@ TEST_CASE("EraseIf", "[MonoArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 5.0f));
-    CHECK(s.add(id2, 10.0f));
-    auto cnt = s.erase_if([](float val, auto) { return val > 3.0f; });
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 5.0F));
+    CHECK(s.add(id2, 10.0F));
+    auto cnt = s.erase_if([](float val, auto) { return val > 3.0F; });
     CHECK(cnt == 2U);
     CHECK(s.size() == 1U);
     CHECK(s.contains(id0));
@@ -2716,7 +2718,7 @@ TEST_CASE("EraseIf", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(s.add(id0, 1.0f));
+    CHECK(s.add(id0, 1.0F));
     auto cnt = s.erase_if([](float, auto) { return false; });
     CHECK(cnt == 0U);
     CHECK(s.size() == 1U);
@@ -2750,9 +2752,9 @@ TEST_CASE("Clear", "[MonoArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
-    CHECK(s.add(id2, 3.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
+    CHECK(s.add(id2, 3.0F));
     s.clear();
     CHECK(s.empty());
     CHECK_FALSE(r.is_valid(id0));
@@ -2789,8 +2791,8 @@ TEST_CASE("SwapAndMove", "[MonoArchetypeStorage]") {
     storage_t s2{r, sid2};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(s1.add(id0, 1.0f));
-    CHECK(s2.add(id1, 2.0f));
+    CHECK(s1.add(id0, 1.0F));
+    CHECK(s2.add(id1, 2.0F));
     s1.swap(s2);
     CHECK(*s1.store_id() == *sid2);
     CHECK(*s2.store_id() == *sid1);
@@ -2815,10 +2817,10 @@ TEST_CASE("SwapAndMove", "[MonoArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     {
       storage_t s1{r, sid1};
-      CHECK(s1.add(id0, 1.0f));
+      CHECK(s1.add(id0, 1.0F));
       storage_t s2{std::move(s1)};
       CHECK(s2.size() == 1U);
-      CHECK(s2[id0] == 1.0f);
+      CHECK(s2[id0] == 1.0F);
       CHECK(*s2.store_id() == *sid1);
     }
     CHECK_FALSE(r.is_valid(id0));
@@ -2830,11 +2832,11 @@ TEST_CASE("SwapAndMove", "[MonoArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     {
       storage_t s1{r, sid1};
-      CHECK(s1.add(id0, 1.0f));
+      CHECK(s1.add(id0, 1.0F));
       storage_t s2;
       s2 = std::move(s1);
       CHECK(s2.size() == 1U);
-      CHECK(s2[id0] == 1.0f);
+      CHECK(s2[id0] == 1.0F);
     }
     CHECK_FALSE(r.is_valid(id0));
   }
@@ -2846,8 +2848,8 @@ TEST_CASE("SwapAndMove", "[MonoArchetypeStorage]") {
     auto id1 = r.create_id(staging, 20);
     {
       storage_t s{r, sid1};
-      CHECK(s.add(id0, 1.0f));
-      CHECK(s.add(id1, 2.0f));
+      CHECK(s.add(id0, 1.0F));
+      CHECK(s.add(id1, 2.0F));
     } // destructor fires
     CHECK_FALSE(r.is_valid(id0));
     CHECK_FALSE(r.is_valid(id1));
@@ -2889,8 +2891,8 @@ TEST_CASE("LimitAndReserve", "[MonoArchetypeStorage]") {
     CHECK(s.limit() == 5U);
     CHECK(s.empty());
     auto id0 = r.create_id(staging, 10);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s[id0] == 1.0f);
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s[id0] == 1.0F);
   }
 
   // Constructor with limit enforces on add.
@@ -2899,8 +2901,8 @@ TEST_CASE("LimitAndReserve", "[MonoArchetypeStorage]") {
     storage_t s{r, sid, 1};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(s.add(id0, 1.0f));
-    CHECK_FALSE(s.add(id1, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK_FALSE(s.add(id1, 2.0F));
   }
 
   // Constructor with default limit and reserve=true is a no-op reserve.
@@ -2927,9 +2929,9 @@ TEST_CASE("LimitAndReserve", "[MonoArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
-    CHECK_FALSE(s.add(id2, 3.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
+    CHECK_FALSE(s.add(id2, 3.0F));
     CHECK(s.size() == 2U);
     // id2 should still be in staging.
     CHECK(r.is_valid(id2));
@@ -2943,8 +2945,8 @@ TEST_CASE("LimitAndReserve", "[MonoArchetypeStorage]") {
     CHECK(s.set_limit(1));
     auto h0 = r.create_handle(staging, 10);
     auto h1 = r.create_handle(staging, 20);
-    CHECK(s.add(h0, 1.0f));
-    CHECK_FALSE(s.add(h1, 2.0f));
+    CHECK(s.add(h0, 1.0F));
+    CHECK_FALSE(s.add(h1, 2.0F));
     CHECK(s.size() == 1U);
   }
 
@@ -2953,9 +2955,9 @@ TEST_CASE("LimitAndReserve", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     CHECK(s.set_limit(1));
-    auto h0 = s.add_new(1.0f, 10);
+    auto h0 = s.add_new(1.0F, 10);
     CHECK(bool(h0));
-    auto h1 = s.add_new(2.0f, 20);
+    auto h1 = s.add_new(2.0F, 20);
     CHECK_FALSE(bool(h1));
     CHECK(s.size() == 1U);
     // The failed add_new should have cleaned up the entity it created.
@@ -2968,8 +2970,8 @@ TEST_CASE("LimitAndReserve", "[MonoArchetypeStorage]") {
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
     CHECK_FALSE(s.set_limit(1));
     CHECK(s.limit() == *id_t::invalid); // unchanged
   }
@@ -2979,7 +2981,7 @@ TEST_CASE("LimitAndReserve", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(s.add(id0, 1.0f));
+    CHECK(s.add(id0, 1.0F));
     CHECK(s.set_limit(1));
     CHECK(s.limit() == 1U);
   }
@@ -2992,11 +2994,11 @@ TEST_CASE("LimitAndReserve", "[MonoArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
-    CHECK_FALSE(s.add(id2, 3.0f)); // at limit
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
+    CHECK_FALSE(s.add(id2, 3.0F)); // at limit
     CHECK(s.remove(id0));
-    CHECK(s.add(id2, 3.0f)); // now succeeds
+    CHECK(s.add(id2, 3.0F)); // now succeeds
     CHECK(s.size() == 2U);
   }
 
@@ -3006,7 +3008,7 @@ TEST_CASE("LimitAndReserve", "[MonoArchetypeStorage]") {
     storage_t s{r, sid};
     CHECK(s.set_limit(0));
     auto id0 = r.create_id(staging, 10);
-    CHECK_FALSE(s.add(id0, 1.0f));
+    CHECK_FALSE(s.add(id0, 1.0F));
   }
 
   // Raising the limit allows more adds.
@@ -3016,10 +3018,10 @@ TEST_CASE("LimitAndReserve", "[MonoArchetypeStorage]") {
     CHECK(s.set_limit(1));
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(s.add(id0, 1.0f));
-    CHECK_FALSE(s.add(id1, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK_FALSE(s.add(id1, 2.0F));
     CHECK(s.set_limit(2));
-    CHECK(s.add(id1, 2.0f));
+    CHECK(s.add(id1, 2.0F));
     CHECK(s.size() == 2U);
   }
 
@@ -3029,10 +3031,10 @@ TEST_CASE("LimitAndReserve", "[MonoArchetypeStorage]") {
     storage_t s{r, sid};
     s.reserve(100);
     auto id0 = r.create_id(staging, 10);
-    CHECK(s.add(id0, 1.0f));
+    CHECK(s.add(id0, 1.0F));
     s.shrink_to_fit();
     CHECK(s.size() == 1U);
-    CHECK(s[id0] == 1.0f);
+    CHECK(s[id0] == 1.0F);
   }
 
   // shrink_to_fit on empty storage.
@@ -3083,13 +3085,13 @@ TEST_CASE("Iterator", "[MonoArchetypeStorage]") {
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
     auto it = s.begin();
-    CHECK(*it == 1.0f);
+    CHECK(*it == 1.0F);
     CHECK(it.id() == id0);
     ++it;
-    CHECK(*it == 2.0f);
+    CHECK(*it == 2.0F);
     CHECK(it.id() == id1);
     ++it;
     CHECK(it == s.end());
@@ -3100,9 +3102,9 @@ TEST_CASE("Iterator", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(s.add(id0, 1.0f));
-    *s.begin() = 99.0f;
-    CHECK(s[id0] == 99.0f);
+    CHECK(s.add(id0, 1.0F));
+    *s.begin() = 99.0F;
+    CHECK(s[id0] == 99.0F);
   }
 
   // Const iteration.
@@ -3110,10 +3112,10 @@ TEST_CASE("Iterator", "[MonoArchetypeStorage]") {
     reg_t r;
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(s.add(id0, 3.14f));
+    CHECK(s.add(id0, 3.14F));
     const auto& cs = s;
     auto it = cs.begin();
-    CHECK(*it == 3.14f);
+    CHECK(*it == 3.14F);
     CHECK(it.id() == id0);
   }
 
@@ -3124,12 +3126,12 @@ TEST_CASE("Iterator", "[MonoArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
-    CHECK(s.add(id2, 3.0f));
-    float sum = 0.0f;
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
+    CHECK(s.add(id2, 3.0F));
+    float sum = 0.0F;
     for (auto val : s) sum += val;
-    CHECK(sum == 6.0f);
+    CHECK(sum == 6.0F);
   }
 
   // Range-for with id() access via explicit iterator.
@@ -3138,8 +3140,8 @@ TEST_CASE("Iterator", "[MonoArchetypeStorage]") {
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
     std::vector<id_t> ids;
     for (auto it = s.begin(); it != s.end(); ++it) ids.push_back(it.id());
     CHECK(ids.size() == 2U);
@@ -3154,18 +3156,18 @@ TEST_CASE("Iterator", "[MonoArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
-    CHECK(s.add(id2, 3.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
+    CHECK(s.add(id2, 3.0F));
     auto it = s.begin();
-    CHECK(it[0] == 1.0f);
-    CHECK(it[2] == 3.0f);
+    CHECK(it[0] == 1.0F);
+    CHECK(it[2] == 3.0F);
     auto it2 = it + 2;
-    CHECK(*it2 == 3.0f);
+    CHECK(*it2 == 3.0F);
     CHECK(it2.id() == id2);
     CHECK((it2 - it) == 2);
     it2 -= 1;
-    CHECK(*it2 == 2.0f);
+    CHECK(*it2 == 2.0F);
   }
 
   // Comparison operators.
@@ -3174,8 +3176,8 @@ TEST_CASE("Iterator", "[MonoArchetypeStorage]") {
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
     auto a = s.begin();
     auto b = s.begin() + 1;
     CHECK(a < b);
@@ -3190,15 +3192,15 @@ TEST_CASE("Iterator", "[MonoArchetypeStorage]") {
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
     auto it = s.begin();
     auto prev = it++;
-    CHECK(*prev == 1.0f);
-    CHECK(*it == 2.0f);
+    CHECK(*prev == 1.0F);
+    CHECK(*it == 2.0F);
     auto next = it--;
-    CHECK(*next == 2.0f);
-    CHECK(*it == 1.0f);
+    CHECK(*next == 2.0F);
+    CHECK(*it == 1.0F);
   }
 
   // n + iterator (commutative).
@@ -3207,10 +3209,10 @@ TEST_CASE("Iterator", "[MonoArchetypeStorage]") {
     storage_t s{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
     auto it = 1 + s.begin();
-    CHECK(*it == 2.0f);
+    CHECK(*it == 2.0F);
   }
 }
 
@@ -3299,7 +3301,7 @@ TEST_CASE("Add", "[ChunkedArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 42, 1.0f));
+    CHECK(a.add(id0, 42, 1.0F));
     CHECK(a.size() == 1U);
     CHECK(a.contains(id0));
     auto loc = r.get_location(id0);
@@ -3313,8 +3315,8 @@ TEST_CASE("Add", "[ChunkedArchetypeStorage]") {
     arch_t a{r, sid};
     arch_t b{r, store_id_t{2}};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK_FALSE(b.add(id0, 2, 2.0f));
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK_FALSE(b.add(id0, 2, 2.0F));
   }
 
   // add(handle) succeeds for valid staging handle.
@@ -3322,7 +3324,7 @@ TEST_CASE("Add", "[ChunkedArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto h = r.create_handle(staging, 10);
-    CHECK(a.add(h, 99, 1.5f));
+    CHECK(a.add(h, 99, 1.5F));
     CHECK(a.contains(h));
   }
 
@@ -3332,14 +3334,14 @@ TEST_CASE("Add", "[ChunkedArchetypeStorage]") {
     arch_t a{r, sid};
     auto h = r.create_handle(staging, 10);
     r.erase(h);
-    CHECK_FALSE(a.add(h, 1, 1.0f));
+    CHECK_FALSE(a.add(h, 1, 1.0F));
   }
 
   // add_new creates and adds entity atomically.
   if (true) {
     reg_t r;
     arch_t a{r, sid};
-    auto h = a.add_new(42, 7, 2.0f);
+    auto h = a.add_new(42, 7, 2.0F);
     CHECK(r.is_valid(h));
     CHECK(r[h.id()] == 42);
     CHECK(a.contains(h));
@@ -3353,9 +3355,9 @@ TEST_CASE("Add", "[ChunkedArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK(a.add(id1, 2, 2.0f));
-    CHECK_FALSE(a.add(id2, 3, 3.0f));
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK(a.add(id1, 2, 2.0F));
+    CHECK_FALSE(a.add(id2, 3, 3.0F));
     CHECK(a.size() == 2U);
   }
 
@@ -3365,8 +3367,8 @@ TEST_CASE("Add", "[ChunkedArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK(a.add(id1, 2, 2.0f));
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK(a.add(id1, 2, 2.0F));
     CHECK_FALSE(a.set_limit(1U));
     CHECK(a.set_limit(3U));
     CHECK(a.limit() == 3U);
@@ -3379,7 +3381,7 @@ TEST_CASE("Add", "[ChunkedArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     CHECK(a.add(id0, 7));
     CHECK(a[id0].template component<int>() == 7);
-    CHECK(a[id0].template component<float>() == 0.0f);
+    CHECK(a[id0].template component<float>() == 0.0F);
   }
 
   // add with all components omitted: all are default-constructed.
@@ -3389,7 +3391,7 @@ TEST_CASE("Add", "[ChunkedArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     CHECK(a.add(id0));
     CHECK(a[id0].template component<int>() == 0);
-    CHECK(a[id0].template component<float>() == 0.0f);
+    CHECK(a[id0].template component<float>() == 0.0F);
   }
 
   // add_new with one trailing component omitted: it is default-constructed.
@@ -3399,7 +3401,7 @@ TEST_CASE("Add", "[ChunkedArchetypeStorage]") {
     auto h = a.add_new(42, 7);
     CHECK(r.is_valid(h));
     CHECK(a[h.id()].template component<int>() == 7);
-    CHECK(a[h.id()].template component<float>() == 0.0f);
+    CHECK(a[h.id()].template component<float>() == 0.0F);
   }
 
   // add_new with all components omitted: all are default-constructed.
@@ -3409,7 +3411,7 @@ TEST_CASE("Add", "[ChunkedArchetypeStorage]") {
     auto h = a.add_new(42);
     CHECK(r.is_valid(h));
     CHECK(a[h.id()].template component<int>() == 0);
-    CHECK(a[h.id()].template component<float>() == 0.0f);
+    CHECK(a[h.id()].template component<float>() == 0.0F);
   }
 }
 
@@ -3429,7 +3431,7 @@ TEST_CASE("RemoveAndErase", "[ChunkedArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 1, 1.0f));
+    CHECK(a.add(id0, 1, 1.0F));
     CHECK(a.remove(id0));
     CHECK(a.size() == 0U);
     CHECK(r.is_valid(id0));
@@ -3442,8 +3444,8 @@ TEST_CASE("RemoveAndErase", "[ChunkedArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK(a.add(id1, 2, 2.0f));
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK(a.add(id1, 2, 2.0F));
     a.remove_all();
     CHECK(a.size() == 0U);
     CHECK(r.is_valid(id0));
@@ -3457,7 +3459,7 @@ TEST_CASE("RemoveAndErase", "[ChunkedArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 1, 1.0f));
+    CHECK(a.add(id0, 1, 1.0F));
     CHECK(a.erase(id0));
     CHECK(a.size() == 0U);
     CHECK_FALSE(r.is_valid(id0));
@@ -3468,7 +3470,7 @@ TEST_CASE("RemoveAndErase", "[ChunkedArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto h = r.create_handle(staging, 10);
-    CHECK(a.add(h, 1, 1.0f));
+    CHECK(a.add(h, 1, 1.0F));
     CHECK(a.erase(h));
     CHECK_FALSE(r.is_valid(h));
     CHECK_FALSE(a.erase(h));
@@ -3480,8 +3482,8 @@ TEST_CASE("RemoveAndErase", "[ChunkedArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK(a.add(id1, 2, 2.0f));
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK(a.add(id1, 2, 2.0F));
     a.clear();
     CHECK(a.size() == 0U);
     CHECK_FALSE(r.is_valid(id0));
@@ -3493,7 +3495,7 @@ TEST_CASE("RemoveAndErase", "[ChunkedArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto h = r.create_handle(staging, 10);
-    CHECK(a.add(h, 5, 5.0f));
+    CHECK(a.add(h, 5, 5.0F));
     CHECK(a.remove(h));
     CHECK(a.size() == 0U);
     CHECK(r.is_valid(h));
@@ -3510,9 +3512,9 @@ TEST_CASE("RemoveAndErase", "[ChunkedArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 11, 1.1f));
-    CHECK(a.add(id1, 22, 2.2f));
-    CHECK(a.add(id2, 33, 3.3f));
+    CHECK(a.add(id0, 11, 1.1F));
+    CHECK(a.add(id1, 22, 2.2F));
+    CHECK(a.add(id2, 33, 3.3F));
     CHECK(a.erase(id0)); // id2 swaps into slot 0
     CHECK(a.size() == 2U);
     CHECK(a[id2].id() == id2);
@@ -3539,12 +3541,12 @@ TEST_CASE("RowAndIterator", "[ChunkedArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 42, 2.0f));
+    CHECK(a.add(id0, 42, 2.0F));
     auto row = a[id0];
     CHECK(row.index() == 0U);
     CHECK(row.id() == id0);
     CHECK(row.component<int>() == 42);
-    CHECK(row.component<float>() == 2.0f);
+    CHECK(row.component<float>() == 2.0F);
     row.component<int>() = 99;
     CHECK(a[id0].component<int>() == 99);
   }
@@ -3554,9 +3556,9 @@ TEST_CASE("RowAndIterator", "[ChunkedArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 5, 3.0f));
+    CHECK(a.add(id0, 5, 3.0F));
     CHECK(a[id0].component<0>() == 5);
-    CHECK(a[id0].component<1>() == 3.0f);
+    CHECK(a[id0].component<1>() == 3.0F);
     a[id0].component<0>() = 77;
     CHECK(a[id0].component<0>() == 77);
   }
@@ -3566,7 +3568,7 @@ TEST_CASE("RowAndIterator", "[ChunkedArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 10, 1.0f));
+    CHECK(a.add(id0, 10, 1.0F));
     auto [i, f] = a[id0].components();
     CHECK(i == 10);
     i = 100;
@@ -3578,11 +3580,11 @@ TEST_CASE("RowAndIterator", "[ChunkedArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 7, 4.0f));
+    CHECK(a.add(id0, 7, 4.0F));
     const auto& ca = a;
     auto [i, f] = ca[id0].components();
     CHECK(i == 7);
-    CHECK(f == 4.0f);
+    CHECK(f == 4.0F);
   }
 
   // Range-based for over mutable storage.
@@ -3592,9 +3594,9 @@ TEST_CASE("RowAndIterator", "[ChunkedArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 1, 0.0f));
-    CHECK(a.add(id1, 2, 0.0f));
-    CHECK(a.add(id2, 3, 0.0f));
+    CHECK(a.add(id0, 1, 0.0F));
+    CHECK(a.add(id1, 2, 0.0F));
+    CHECK(a.add(id2, 3, 0.0F));
     int sum = 0;
     for (auto row : a) sum += row.component<int>();
     CHECK(sum == 6);
@@ -3606,12 +3608,12 @@ TEST_CASE("RowAndIterator", "[ChunkedArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 0, 1.0f));
-    CHECK(a.add(id1, 0, 2.0f));
+    CHECK(a.add(id0, 0, 1.0F));
+    CHECK(a.add(id1, 0, 2.0F));
     const auto& ca = a;
-    float fsum = 0.0f;
+    float fsum = 0.0F;
     for (const auto& row : ca) fsum += row.component<float>();
-    CHECK(fsum == 3.0f);
+    CHECK(fsum == 3.0F);
   }
 
   // Bidirectional iterator.
@@ -3620,8 +3622,8 @@ TEST_CASE("RowAndIterator", "[ChunkedArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 5, 0.0f));
-    CHECK(a.add(id1, 6, 0.0f));
+    CHECK(a.add(id0, 5, 0.0F));
+    CHECK(a.add(id1, 6, 0.0F));
     auto it = a.end();
     --it;
     CHECK((*it).component<int>() == 6);
@@ -3643,8 +3645,8 @@ TEST_CASE("RowAndIterator", "[ChunkedArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 1, 0.0f));
-    CHECK(a.add(id1, 2, 0.0f));
+    CHECK(a.add(id0, 1, 0.0F));
+    CHECK(a.add(id1, 2, 0.0F));
     for (auto row : a) row.component<int>() *= 10;
     CHECK(a[id0].component<int>() == 10);
     CHECK(a[id1].component<int>() == 20);
@@ -3655,11 +3657,11 @@ TEST_CASE("RowAndIterator", "[ChunkedArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 7, 1.5f));
-    float fsum = 0.0f;
+    CHECK(a.add(id0, 7, 1.5F));
+    float fsum = 0.0F;
     for (auto it = a.cbegin(); it != a.cend(); ++it)
       fsum += it->component<float>();
-    CHECK(fsum == 1.5f);
+    CHECK(fsum == 1.5F);
     static_assert(
         std::is_same_v<decltype(a.cbegin()), arch_t::const_iterator>);
   }
@@ -3683,9 +3685,9 @@ TEST_CASE("EraseIf", "[ChunkedArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 11, 1.0f));
-    CHECK(a.add(id1, 22, 2.0f));
-    CHECK(a.add(id2, 33, 3.0f));
+    CHECK(a.add(id0, 11, 1.0F));
+    CHECK(a.add(id1, 22, 2.0F));
+    CHECK(a.add(id2, 33, 3.0F));
     auto cnt = a.erase_if([](const auto& row) {
       return row.template component<int>() % 2 != 0;
     });
@@ -3704,9 +3706,9 @@ TEST_CASE("EraseIf", "[ChunkedArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 10, 1.0f));
-    CHECK(a.add(id1, 20, 2.0f));
-    CHECK(a.add(id2, 30, 3.0f));
+    CHECK(a.add(id0, 10, 1.0F));
+    CHECK(a.add(id1, 20, 2.0F));
+    CHECK(a.add(id2, 30, 3.0F));
     auto cnt = a.erase_if_component<int>([](int v, auto) { return v > 15; });
     CHECK(cnt == 2U);
     CHECK(a.size() == 1U);
@@ -3720,9 +3722,9 @@ TEST_CASE("EraseIf", "[ChunkedArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 5, 1.0f));
-    CHECK(a.add(id1, 5, 9.0f));
-    auto cnt = a.erase_if_component<1>([](float v, auto) { return v > 5.0f; });
+    CHECK(a.add(id0, 5, 1.0F));
+    CHECK(a.add(id1, 5, 9.0F));
+    auto cnt = a.erase_if_component<1>([](float v, auto) { return v > 5.0F; });
     CHECK(cnt == 1U);
     CHECK(a.size() == 1U);
     CHECK(r.is_valid(id0));
@@ -3993,8 +3995,8 @@ TEST_CASE("Basic", "[ArchetypeScene]") {
   // store_new_entity inserts into the chosen storage.
   if (true) {
     two_storage_scene_t s;
-    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 2.f},
-        Velocity{3.f, 4.f});
+    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{1.F, 2.F},
+        Velocity{3.F, 4.F});
     CHECK(h);
     CHECK(s.size() == 1U);
     CHECK_FALSE(s.empty());
@@ -4002,8 +4004,8 @@ TEST_CASE("Basic", "[ArchetypeScene]") {
     CHECK(s.storage<scene_sid_t{2}>().size() == 0U);
     // Component values round-trip correctly.
     auto row = s.storage<scene_sid_t{1}>()[h.id()];
-    CHECK(row.component<Position>().x == 1.f);
-    CHECK(row.component<Velocity>().vx == 3.f);
+    CHECK(row.component<Position>().x == 1.F);
+    CHECK(row.component<Velocity>().vx == 3.F);
   }
 
   // store_new_entity by tuple type: SID inferred from tuple_t.
@@ -4011,21 +4013,21 @@ TEST_CASE("Basic", "[ArchetypeScene]") {
     two_storage_scene_t s;
     // `tuple<Position, Velocity>` is unique to storage 1.
     auto h1 = s.store_new_entity({},
-        std::tuple<Position, Velocity>{Position{1.f, 2.f},
-            Velocity{3.f, 4.f}});
+        std::tuple<Position, Velocity>{Position{1.F, 2.F},
+            Velocity{3.F, 4.F}});
     CHECK(h1);
     CHECK(s.storage<scene_sid_t{1}>().contains(h1.id()));
     auto row1 = s.storage<scene_sid_t{1}>()[h1.id()];
-    CHECK(row1.component<Position>().x == 1.f);
-    CHECK(row1.component<Velocity>().vx == 3.f);
+    CHECK(row1.component<Position>().x == 1.F);
+    CHECK(row1.component<Velocity>().vx == 3.F);
     // `tuple<Position, Velocity, Health>` is unique to storage 2.
     auto h2 = s.store_new_entity({},
-        std::tuple<Position, Velocity, Health>{Position{5.f, 6.f}, Velocity{},
+        std::tuple<Position, Velocity, Health>{Position{5.F, 6.F}, Velocity{},
             Health{42}});
     CHECK(h2);
     CHECK(s.storage<scene_sid_t{2}>().contains(h2.id()));
     auto row2 = s.storage<scene_sid_t{2}>()[h2.id()];
-    CHECK(row2.component<Position>().x == 5.f);
+    CHECK(row2.component<Position>().x == 5.F);
     CHECK(row2.component<Health>().hp == 42);
     CHECK(s.size() == 2U);
   }
@@ -4054,9 +4056,9 @@ TEST_CASE("EraseRemove", "[ArchetypeScene]") {
   if (true) {
     two_storage_scene_t s;
     auto h0 =
-        s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 0.f}, Velocity{});
+        s.store_new_entity<scene_sid_t{1}>({}, Position{1.F, 0.F}, Velocity{});
     auto h1 =
-        s.store_new_entity<scene_sid_t{1}>({}, Position{2.f, 0.f}, Velocity{});
+        s.store_new_entity<scene_sid_t{1}>({}, Position{2.F, 0.F}, Velocity{});
     auto id0 = h0.id();
     CHECK(s.erase_entity(id0));
     CHECK(id0 == scene_reg_t::id_t::invalid); // invalidated on success
@@ -4135,8 +4137,8 @@ TEST_CASE("Migrate_Manual", "[ArchetypeScene]") {
   // Promote from arch_pv to arch_pvh, providing a new Health component.
   if (true) {
     two_storage_scene_t s;
-    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 2.f},
-        Velocity{3.f, 4.f});
+    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{1.F, 2.F},
+        Velocity{3.F, 4.F});
     auto id = h.id();
     CHECK(s.storage<scene_sid_t{1}>().contains(id));
 
@@ -4151,16 +4153,16 @@ TEST_CASE("Migrate_Manual", "[ArchetypeScene]") {
     CHECK(s.storage<scene_sid_t{2}>().contains(id));
     // Component values preserved and new one set.
     auto row = s.storage<scene_sid_t{2}>()[id];
-    CHECK(row.component<Position>().x == 1.f);
-    CHECK(row.component<Velocity>().vx == 3.f);
+    CHECK(row.component<Position>().x == 1.F);
+    CHECK(row.component<Velocity>().vx == 3.F);
     CHECK(row.component<Health>().hp == 99);
   }
 
   // Migrate via handle overload.
   if (true) {
     two_storage_scene_t s;
-    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{5.f, 6.f},
-        Velocity{7.f, 8.f});
+    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{5.F, 6.F},
+        Velocity{7.F, 8.F});
     auto build2 = [](const auto& row) {
       return std::tuple<Position, Velocity, Health>{
           row.template component<Position>(),
@@ -4196,16 +4198,16 @@ TEST_CASE("Migrate_Auto", "[ArchetypeScene]") {
   // Health). Health should be default-constructed (hp=100).
   if (true) {
     two_storage_scene_t s;
-    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 2.f},
-        Velocity{3.f, 4.f});
+    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{1.F, 2.F},
+        Velocity{3.F, 4.F});
     auto id = h.id();
     bool ok_promote = s.migrate_entity(id, scene_sid_t{2});
     CHECK(ok_promote);
     CHECK_FALSE(s.storage<scene_sid_t{1}>().contains(id));
     CHECK(s.storage<scene_sid_t{2}>().contains(id));
     auto row = s.storage<scene_sid_t{2}>()[id];
-    CHECK(row.component<Position>().x == 1.f);
-    CHECK(row.component<Velocity>().vx == 3.f);
+    CHECK(row.component<Position>().x == 1.F);
+    CHECK(row.component<Velocity>().vx == 3.F);
     CHECK(row.component<Health>().hp == 100); // default-constructed
   }
 
@@ -4213,23 +4215,23 @@ TEST_CASE("Migrate_Auto", "[ArchetypeScene]") {
   // are copied.
   if (true) {
     two_storage_scene_t s;
-    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{5.f, 6.f},
-        Velocity{7.f, 8.f}, Health{42});
+    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{5.F, 6.F},
+        Velocity{7.F, 8.F}, Health{42});
     auto id = h.id();
     bool ok_demote = s.migrate_entity(id, scene_sid_t{1});
     CHECK(ok_demote);
     CHECK_FALSE(s.storage<scene_sid_t{2}>().contains(id));
     CHECK(s.storage<scene_sid_t{1}>().contains(id));
     auto row = s.storage<scene_sid_t{1}>()[id];
-    CHECK(row.component<Position>().x == 5.f);
-    CHECK(row.component<Velocity>().vx == 7.f);
+    CHECK(row.component<Position>().x == 5.F);
+    CHECK(row.component<Velocity>().vx == 7.F);
   }
 
   // Auto-migrate via handle overload.
   if (true) {
     two_storage_scene_t s;
     auto h =
-        s.store_new_entity<scene_sid_t{1}>({}, Position{9.f, 0.f}, Velocity{});
+        s.store_new_entity<scene_sid_t{1}>({}, Position{9.F, 0.F}, Velocity{});
     bool ok_h = s.migrate_entity(h, scene_sid_t{2});
     CHECK(ok_h);
     CHECK(s.storage<scene_sid_t{2}>().contains(h.id()));
@@ -4239,8 +4241,8 @@ TEST_CASE("Migrate_Auto", "[ArchetypeScene]") {
   // components default-constructed.
   if (true) {
     three_storage_scene_t s;
-    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 1.f},
-        Velocity{2.f, 2.f});
+    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{1.F, 1.F},
+        Velocity{2.F, 2.F});
     auto id = h.id();
     bool ok_cross = s.migrate_entity(id, scene_sid_t{3}); // arch_pv -> arch_h
     CHECK(ok_cross);
@@ -4401,8 +4403,8 @@ TEST_CASE("MultiStorage", "[ArchetypeScene]") {
     three_storage_scene_t s;
     // Add entities to each of the three storages.
     auto h0 =
-        s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 0.f}, Velocity{});
-    auto h1 = s.store_new_entity<scene_sid_t{2}>({}, Position{2.f, 0.f},
+        s.store_new_entity<scene_sid_t{1}>({}, Position{1.F, 0.F}, Velocity{});
+    auto h1 = s.store_new_entity<scene_sid_t{2}>({}, Position{2.F, 0.F},
         Velocity{}, Health{50});
     auto h2 = s.store_new_entity<scene_sid_t{3}>({}, Health{75});
     CHECK(s.size() == 3U);
@@ -4447,10 +4449,10 @@ TEST_CASE("MixedStorages", "[ArchetypeScene]") {
   // add_new into each storage type; size() sums all three.
   if (true) {
     mixed_scene_t s;
-    auto h0 = s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 2.f},
-        Velocity{3.f, 4.f});
+    auto h0 = s.store_new_entity<scene_sid_t{1}>({}, Position{1.F, 2.F},
+        Velocity{3.F, 4.F});
     auto h1 = s.store_new_entity<scene_sid_t{2}>({}, Health{50});
-    auto h2 = s.store_new_entity<scene_sid_t{3}>({}, Position{5.f, 6.f});
+    auto h2 = s.store_new_entity<scene_sid_t{3}>({}, Position{5.F, 6.F});
     CHECK(h0);
     CHECK(h1);
     CHECK(h2);
@@ -4460,9 +4462,9 @@ TEST_CASE("MixedStorages", "[ArchetypeScene]") {
     CHECK(s.storage<scene_sid_t{3}>().size() == 1U);
     // Component values round-trip correctly through each storage type.
     CHECK((s.storage<scene_sid_t{1}>()[h0.id()].component<Position>().x) ==
-          (1.f));
+          (1.F));
     CHECK(s.storage<scene_sid_t{2}>()[h1.id()].component<Health>().hp == 50);
-    CHECK(s.storage<scene_sid_t{3}>()[h2.id()].x == 5.f);
+    CHECK(s.storage<scene_sid_t{3}>()[h2.id()].x == 5.F);
   }
 
   // erase_entity dispatches to the correct storage regardless of type.
@@ -4484,15 +4486,15 @@ TEST_CASE("MixedStorages", "[ArchetypeScene]") {
   // Position is copied; Velocity is dropped (not in dst).
   if (true) {
     mixed_scene_t s;
-    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{7.f, 8.f},
-        Velocity{9.f, 10.f});
+    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{7.F, 8.F},
+        Velocity{9.F, 10.F});
     auto id = h.id();
     bool ok = s.migrate_entity(id, scene_sid_t{3});
     CHECK(ok);
     CHECK_FALSE(s.storage<scene_sid_t{1}>().contains(id));
     CHECK(s.storage<scene_sid_t{3}>().contains(id));
     // Position carried over; mono_archetype_storage's direct C& access works.
-    CHECK(s.storage<scene_sid_t{3}>()[id].x == 7.f);
+    CHECK(s.storage<scene_sid_t{3}>()[id].x == 7.F);
   }
 
   // Migrate chunked_h (Health) -> comp_pos (Position).
@@ -4505,22 +4507,22 @@ TEST_CASE("MixedStorages", "[ArchetypeScene]") {
     CHECK(ok);
     CHECK_FALSE(s.storage<scene_sid_t{2}>().contains(id));
     CHECK(s.storage<scene_sid_t{3}>().contains(id));
-    CHECK(s.storage<scene_sid_t{3}>()[id].x == 0.f); // default Position{}.x
+    CHECK(s.storage<scene_sid_t{3}>()[id].x == 0.F); // default Position{}.x
   }
 
   // Migrate comp_pos (Position) -> arch_pv (Position, Velocity).
   // Position is copied; Velocity is default-constructed.
   if (true) {
     mixed_scene_t s;
-    auto h = s.store_new_entity<scene_sid_t{3}>({}, Position{3.f, 4.f});
+    auto h = s.store_new_entity<scene_sid_t{3}>({}, Position{3.F, 4.F});
     auto id = h.id();
     bool ok = s.migrate_entity(id, scene_sid_t{1});
     CHECK(ok);
     CHECK_FALSE(s.storage<scene_sid_t{3}>().contains(id));
     CHECK(s.storage<scene_sid_t{1}>().contains(id));
     auto row = s.storage<scene_sid_t{1}>()[id];
-    CHECK(row.component<Position>().x == 3.f);
-    CHECK(row.component<Velocity>().vx == 0.f); // default-constructed
+    CHECK(row.component<Position>().x == 3.F);
+    CHECK(row.component<Velocity>().vx == 0.F); // default-constructed
   }
 
   // clear() empties all three storage types.
@@ -4552,10 +4554,10 @@ TEST_CASE("At", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 42, 1.5f));
+    CHECK(a.add(id0, 42, 1.5F));
     auto row = a.at(id0);
     CHECK(row.component<int>() == 42);
-    CHECK(row.component<float>() == 1.5f);
+    CHECK(row.component<float>() == 1.5F);
     row.component<int>() = 99;
     CHECK(a[id0].component<int>() == 99);
   }
@@ -4565,11 +4567,11 @@ TEST_CASE("At", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 7, 2.0f));
+    CHECK(a.add(id0, 7, 2.0F));
     const auto& ca = a;
     auto row = ca.at(id0);
     CHECK(row.component<int>() == 7);
-    CHECK(row.component<float>() == 2.0f);
+    CHECK(row.component<float>() == 2.0F);
   }
 
   // at(id_t) throws std::out_of_range when entity is not in this storage.
@@ -4587,14 +4589,14 @@ TEST_CASE("At", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto h = r.create_handle(staging, 5);
-    CHECK(a.add(h.id(), 3, 0.5f));
+    CHECK(a.add(h.id(), 3, 0.5F));
     auto row = a.at(h);
     CHECK(row.component<int>() == 3);
-    row.component<float>() = 9.9f;
-    CHECK(a[h.id()].component<float>() == 9.9f);
+    row.component<float>() = 9.9F;
+    CHECK(a[h.id()].component<float>() == 9.9F);
     const auto& ca = a;
     auto crow = ca.at(h);
-    CHECK(crow.component<float>() == 9.9f);
+    CHECK(crow.component<float>() == 9.9F);
   }
 
   // at(handle_t) throws std::invalid_argument for an invalid handle.
@@ -4613,7 +4615,7 @@ TEST_CASE("At", "[ArchetypeStorage]") {
     arch_t a1{r, sid};
     arch_t a2{r, store_id_t{2}};
     auto h = r.create_handle(staging, 5);
-    CHECK(a1.add(h.id(), 1, 1.0f));
+    CHECK(a1.add(h.id(), 1, 1.0F));
     CHECK_THROWS_AS(a2.at(h), std::invalid_argument);
     const auto& ca2 = a2;
     CHECK_THROWS_AS(ca2.at(h), std::invalid_argument);
@@ -4638,9 +4640,9 @@ TEST_CASE("RemoveIf", "[ArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 11, 1.0f));
-    CHECK(a.add(id1, 22, 2.0f));
-    CHECK(a.add(id2, 33, 3.0f));
+    CHECK(a.add(id0, 11, 1.0F));
+    CHECK(a.add(id1, 22, 2.0F));
+    CHECK(a.add(id2, 33, 3.0F));
     auto cnt = a.remove_if([](const auto& row) {
       return row.template component<int>() % 2 != 0;
     });
@@ -4662,7 +4664,7 @@ TEST_CASE("RemoveIf", "[ArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 5, 0.5f));
+    CHECK(a.add(id0, 5, 0.5F));
     auto cnt = a.remove_if([](const auto&) { return false; });
     CHECK(cnt == 0U);
     CHECK(a.size() == 1U);
@@ -4675,15 +4677,15 @@ TEST_CASE("RemoveIf", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 1, 1.0f));
-    CHECK(a.add(id1, 2, 2.0f));
+    CHECK(a.add(id0, 1, 1.0F));
+    CHECK(a.add(id1, 2, 2.0F));
     auto cnt = a.remove_if([](const auto&) { return true; });
     CHECK(cnt == 2U);
     CHECK(a.size() == 0U);
     CHECK(r.is_valid(id0));
     CHECK(r.is_valid(id1));
     // Staged entities can be re-added.
-    CHECK(a.add(id0, 1, 1.0f));
+    CHECK(a.add(id0, 1, 1.0F));
     CHECK(a.size() == 1U);
   }
 
@@ -4694,9 +4696,9 @@ TEST_CASE("RemoveIf", "[ArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 10, 1.0f));
-    CHECK(a.add(id1, 20, 2.0f));
-    CHECK(a.add(id2, 30, 3.0f));
+    CHECK(a.add(id0, 10, 1.0F));
+    CHECK(a.add(id1, 20, 2.0F));
+    CHECK(a.add(id2, 30, 3.0F));
     auto cnt = a.remove_if_component<int>([](int v, auto) { return v > 15; });
     CHECK(cnt == 2U);
     CHECK(a.size() == 1U);
@@ -4713,10 +4715,10 @@ TEST_CASE("RemoveIf", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 5, 1.0f));
-    CHECK(a.add(id1, 5, 9.0f));
+    CHECK(a.add(id0, 5, 1.0F));
+    CHECK(a.add(id1, 5, 9.0F));
     auto cnt = a.remove_if_component<1>([](float v, auto) {
-      return v > 5.0f;
+      return v > 5.0F;
     });
     CHECK(cnt == 1U);
     CHECK(a.size() == 1U);
@@ -4743,8 +4745,8 @@ TEST_CASE("IteratorPostIncDec", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 1, 0.0f));
-    CHECK(a.add(id1, 2, 0.0f));
+    CHECK(a.add(id0, 1, 0.0F));
+    CHECK(a.add(id1, 2, 0.0F));
     auto it = a.begin();
     auto prev = it++;
     CHECK((*prev).component<int>() == 1);
@@ -4760,8 +4762,8 @@ TEST_CASE("IteratorPostIncDec", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 5, 0.0f));
-    CHECK(a.add(id1, 6, 0.0f));
+    CHECK(a.add(id0, 5, 0.0F));
+    CHECK(a.add(id1, 6, 0.0F));
     auto it = a.end();
     auto prev = it--;
     CHECK(prev == a.end());
@@ -4778,8 +4780,8 @@ TEST_CASE("IteratorPostIncDec", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 7, 0.0f));
-    CHECK(a.add(id1, 8, 0.0f));
+    CHECK(a.add(id0, 7, 0.0F));
+    CHECK(a.add(id1, 8, 0.0F));
     const auto& ca = a;
     auto it = ca.begin();
     auto prev = it++;
@@ -4793,8 +4795,8 @@ TEST_CASE("IteratorPostIncDec", "[ArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 3, 0.0f));
-    CHECK(a.add(id1, 4, 0.0f));
+    CHECK(a.add(id0, 3, 0.0F));
+    CHECK(a.add(id1, 4, 0.0F));
     const auto& ca = a;
     auto it = ca.end();
     auto prev = it--;
@@ -4819,7 +4821,7 @@ TEST_CASE("At", "[ChunkedArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 42, 1.5f));
+    CHECK(a.add(id0, 42, 1.5F));
     auto row = a.at(id0);
     CHECK(row.component<int>() == 42);
     row.component<int>() = 99;
@@ -4831,7 +4833,7 @@ TEST_CASE("At", "[ChunkedArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 7, 2.0f));
+    CHECK(a.add(id0, 7, 2.0F));
     const auto& ca = a;
     auto row = ca.at(id0);
     CHECK(row.component<int>() == 7);
@@ -4852,7 +4854,7 @@ TEST_CASE("At", "[ChunkedArchetypeStorage]") {
     reg_t r;
     arch_t a{r, sid};
     auto h = r.create_handle(staging, 5);
-    CHECK(a.add(h.id(), 3, 0.5f));
+    CHECK(a.add(h.id(), 3, 0.5F));
     auto row = a.at(h);
     CHECK(row.component<int>() == 3);
     const auto& ca = a;
@@ -4889,9 +4891,9 @@ TEST_CASE("RemoveIf", "[ChunkedArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 11, 1.0f));
-    CHECK(a.add(id1, 22, 2.0f));
-    CHECK(a.add(id2, 33, 3.0f));
+    CHECK(a.add(id0, 11, 1.0F));
+    CHECK(a.add(id1, 22, 2.0F));
+    CHECK(a.add(id2, 33, 3.0F));
     auto cnt = a.remove_if([](const auto& row) {
       return row.template component<int>() % 2 != 0;
     });
@@ -4911,9 +4913,9 @@ TEST_CASE("RemoveIf", "[ChunkedArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
     auto id2 = r.create_id(staging, 30);
-    CHECK(a.add(id0, 10, 1.0f));
-    CHECK(a.add(id1, 20, 2.0f));
-    CHECK(a.add(id2, 30, 3.0f));
+    CHECK(a.add(id0, 10, 1.0F));
+    CHECK(a.add(id1, 20, 2.0F));
+    CHECK(a.add(id2, 30, 3.0F));
     auto cnt = a.remove_if_component<int>([](int v, auto) { return v > 15; });
     CHECK(cnt == 2U);
     CHECK(a.size() == 1U);
@@ -4928,10 +4930,10 @@ TEST_CASE("RemoveIf", "[ChunkedArchetypeStorage]") {
     arch_t a{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 5, 1.0f));
-    CHECK(a.add(id1, 5, 9.0f));
+    CHECK(a.add(id0, 5, 1.0F));
+    CHECK(a.add(id1, 5, 9.0F));
     auto cnt = a.remove_if_component<1>([](float v, auto) {
-      return v > 5.0f;
+      return v > 5.0F;
     });
     CHECK(cnt == 1U);
     CHECK(a.size() == 1U);
@@ -4956,9 +4958,9 @@ TEST_CASE("RowView", "[MonoArchetypeStorage]") {
     reg_t r;
     cs_t cs{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(cs.add(id0, 3.14f));
+    CHECK(cs.add(id0, 3.14F));
     const auto& ccs = cs;
-    CHECK(ccs[id0].component<float>() == 3.14f);
+    CHECK(ccs[id0].component<float>() == 3.14F);
   }
 
   // row_view::id() returns the entity ID.
@@ -4967,8 +4969,8 @@ TEST_CASE("RowView", "[MonoArchetypeStorage]") {
     cs_t cs{r, sid};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(cs.add(id0, 1.0f));
-    CHECK(cs.add(id1, 2.0f));
+    CHECK(cs.add(id0, 1.0F));
+    CHECK(cs.add(id1, 2.0F));
     const auto& ccs = cs;
     CHECK(ccs[id0].id() == id0);
     CHECK(ccs[id1].id() == id1);
@@ -4979,10 +4981,10 @@ TEST_CASE("RowView", "[MonoArchetypeStorage]") {
     reg_t r;
     cs_t cs{r, sid};
     auto id0 = r.create_id(staging, 10);
-    CHECK(cs.add(id0, 2.5f));
-    CHECK(cs.at(id0) == 2.5f);
-    cs.at(id0) = 9.9f;
-    CHECK(cs[id0] == 9.9f);
+    CHECK(cs.add(id0, 2.5F));
+    CHECK(cs.at(id0) == 2.5F);
+    cs.at(id0) = 9.9F;
+    CHECK(cs[id0] == 9.9F);
     // at(id_t) throws std::out_of_range for absent entity.
     auto id1 = r.create_id(staging, 20);
     CHECK_THROWS_AS(cs.at(id1), std::out_of_range);
@@ -4995,10 +4997,10 @@ TEST_CASE("RowView", "[MonoArchetypeStorage]") {
     reg_t r;
     cs_t cs{r, sid};
     auto h = r.create_handle(staging, 5);
-    CHECK(cs.add(h.id(), 7.0f));
-    CHECK(cs.at(h) == 7.0f);
+    CHECK(cs.add(h.id(), 7.0F));
+    CHECK(cs.at(h) == 7.0F);
     const auto& ccs = cs;
-    CHECK(ccs.at(h).component<float>() == 7.0f);
+    CHECK(ccs.at(h).component<float>() == 7.0F);
     CHECK(ccs.at(h).id() == h.id());
     reg_t::handle_t bad{};
     CHECK_THROWS_AS(cs.at(bad), std::invalid_argument);
@@ -5039,11 +5041,11 @@ TEST_CASE("StorageTypeAccess", "[ArchetypeScene]") {
   // Data is visible through both access paths after insertion.
   if (true) {
     two_storage_scene_t s;
-    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 2.f},
-        Velocity{3.f, 4.f});
+    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{1.F, 2.F},
+        Velocity{3.F, 4.F});
     const auto& st = s.storage<arch_pv_t>();
     CHECK(st.size() == 1U);
-    CHECK(st[h.id()].component<Position>().x == 1.f);
+    CHECK(st[h.id()].component<Position>().x == 1.F);
   }
 }
 
@@ -5080,8 +5082,8 @@ TEST_CASE("Tag", "[ArchetypeStorage]") {
     CHECK(sa.store_id() == scene_sid_t{1});
     CHECK(sb.store_id() == scene_sid_t{2});
     // Entities are inserted into and retrieved from the correct typed storage.
-    auto ha = s.store_new_entity<scene_sid_t{1}>({}, 10, 1.0f);
-    auto hb = s.store_new_entity<scene_sid_t{2}>({}, 20, 2.0f);
+    auto ha = s.store_new_entity<scene_sid_t{1}>({}, 10, 1.0F);
+    auto hb = s.store_new_entity<scene_sid_t{2}>({}, 20, 2.0F);
     CHECK(s.size() == 2U);
     CHECK(sa[ha.id()].component<int>() == 10);
     CHECK(sb[hb.id()].component<int>() == 20);
@@ -5145,8 +5147,8 @@ TEST_CASE("SwapAndMove", "[ChunkedArchetypeStorage]") {
     arch_t b{r, sid2};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 11, 1.0f));
-    CHECK(b.add(id1, 22, 2.0f));
+    CHECK(a.add(id0, 11, 1.0F));
+    CHECK(b.add(id1, 22, 2.0F));
     a.swap(b);
     CHECK(a.store_id() == sid2);
     CHECK(b.store_id() == sid1);
@@ -5163,8 +5165,8 @@ TEST_CASE("SwapAndMove", "[ChunkedArchetypeStorage]") {
     arch_t b{r, sid2};
     auto id0 = r.create_id(staging, 10);
     auto id1 = r.create_id(staging, 20);
-    CHECK(a.add(id0, 11, 1.0f));
-    CHECK(b.add(id1, 22, 2.0f));
+    CHECK(a.add(id0, 11, 1.0F));
+    CHECK(b.add(id1, 22, 2.0F));
     swap(a, b);
     CHECK(a.store_id() == sid2);
     CHECK(b.store_id() == sid1);
@@ -5178,7 +5180,7 @@ TEST_CASE("SwapAndMove", "[ChunkedArchetypeStorage]") {
     arch_t a{r, sid1};
     a.reserve(100);
     auto id0 = r.create_id(staging, 10);
-    CHECK(a.add(id0, 1, 1.0f));
+    CHECK(a.add(id0, 1, 1.0F));
     a.shrink_to_fit();
     CHECK(a.size() == 1U);
     CHECK((a.capacity()) < (100U));
@@ -5191,7 +5193,7 @@ TEST_CASE("SwapAndMove", "[ChunkedArchetypeStorage]") {
     auto id0 = r.create_id(staging, 10);
     {
       arch_t a{r, sid1};
-      CHECK(a.add(id0, 42, 1.0f));
+      CHECK(a.add(id0, 42, 1.0F));
       arch_t b{std::move(a)};
       CHECK(b.size() == 1U);
       CHECK(b.store_id() == sid1);
@@ -5208,7 +5210,7 @@ TEST_CASE("SwapAndMove", "[ChunkedArchetypeStorage]") {
     {
       arch_t a{r, sid1};
       arch_t b{r, sid2};
-      CHECK(a.add(id0, 7, 7.0f));
+      CHECK(a.add(id0, 7, 7.0F));
       b = std::move(a);
       CHECK(b.size() == 1U);
       CHECK(b.store_id() == sid1);
@@ -5224,8 +5226,8 @@ TEST_CASE("SwapAndMove", "[ChunkedArchetypeStorage]") {
     auto id1 = r.create_id(staging, 20);
     {
       arch_t a{r, sid1};
-      CHECK(a.add(id0, 1, 1.0f));
-      CHECK(a.add(id1, 2, 2.0f));
+      CHECK(a.add(id0, 1, 1.0F));
+      CHECK(a.add(id1, 2, 2.0F));
     } // destructor fires
     CHECK_FALSE(r.is_valid(id0));
     CHECK_FALSE(r.is_valid(id1));
@@ -5438,12 +5440,12 @@ TEST_CASE("Basic", "[ComponentStorage]") {
     cs_store_t s{r, cs_sid_t{1}};
     auto id0 = r.create_id({}, 10);
     auto id1 = r.create_id({}, 20);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
     CHECK(s.size() == 2U);
     CHECK_FALSE(s.empty());
-    CHECK(s[id0] == 1.0f);
-    CHECK(s[id1] == 2.0f);
+    CHECK(s[id0] == 1.0F);
+    CHECK(s[id1] == 2.0F);
   }
 
   // contains() returns true only for entities in this storage.
@@ -5452,7 +5454,7 @@ TEST_CASE("Basic", "[ComponentStorage]") {
     cs_store_t s{r, cs_sid_t{1}};
     auto id0 = r.create_id({}, 0);
     CHECK_FALSE(s.contains(id0));
-    CHECK(s.add(id0, 1.0f));
+    CHECK(s.add(id0, 1.0F));
     CHECK(s.contains(id0));
     CHECK_FALSE(s.contains(cs_id_t{99})); // out of range
   }
@@ -5461,7 +5463,7 @@ TEST_CASE("Basic", "[ComponentStorage]") {
   if (true) {
     cs_reg_t r;
     cs_store_t s{r, cs_sid_t{1}};
-    auto h = s.add_new(9.0f);
+    auto h = s.add_new(9.0F);
     CHECK(s.contains(h));
     cs_reg_t::handle_t bad{};
     CHECK_FALSE(s.contains(bad));
@@ -5475,20 +5477,20 @@ TEST_CASE("Basic", "[ComponentStorage]") {
     cs_reg_t r;
     cs_store_t s{r, cs_sid_t{1}};
     auto id0 = r.create_id({}, 0);
-    CHECK(s.add(id0, 1.0f));
-    CHECK_FALSE(s.add(id0, 2.0f)); // already in storage
+    CHECK(s.add(id0, 1.0F));
+    CHECK_FALSE(s.add(id0, 2.0F)); // already in storage
     CHECK(s.size() == 1U);
-    CHECK(s[id0] == 1.0f);
+    CHECK(s[id0] == 1.0F);
   }
 
   // add_new() creates entity and adds in one step.
   if (true) {
     cs_reg_t r;
     cs_store_t s{r, cs_sid_t{1}};
-    auto h = s.add_new({}, 3.14f);
+    auto h = s.add_new({}, 3.14F);
     CHECK(static_cast<bool>(h));
     CHECK(s.contains(h.id()));
-    CHECK(s[h.id()] == 3.14f);
+    CHECK(s[h.id()] == 3.14F);
   }
 
   // Mutable operator[] modifies in place.
@@ -5496,9 +5498,9 @@ TEST_CASE("Basic", "[ComponentStorage]") {
     cs_reg_t r;
     cs_store_t s{r, cs_sid_t{1}};
     auto id0 = r.create_id({}, 0);
-    CHECK(s.add(id0, 1.0f));
-    s[id0] = 99.0f;
-    CHECK(s[id0] == 99.0f);
+    CHECK(s.add(id0, 1.0F));
+    s[id0] = 99.0F;
+    CHECK(s[id0] == 99.0F);
   }
 
   // Const operator[] returns row_view.
@@ -5506,10 +5508,10 @@ TEST_CASE("Basic", "[ComponentStorage]") {
     cs_reg_t r;
     cs_store_t s{r, cs_sid_t{1}};
     auto id0 = r.create_id({}, 0);
-    CHECK(s.add(id0, 5.0f));
+    CHECK(s.add(id0, 5.0F));
     const auto& cs = s;
-    CHECK(cs[id0] == 5.0f);
-    CHECK(cs[id0].component<float>() == 5.0f);
+    CHECK(cs[id0] == 5.0F);
+    CHECK(cs[id0].component<float>() == 5.0F);
     CHECK(cs[id0].id() == id0);
   }
 
@@ -5519,8 +5521,8 @@ TEST_CASE("Basic", "[ComponentStorage]") {
     cs_store_t s{r, cs_sid_t{1}};
     auto id0 = r.create_id({}, 0);
     CHECK_THROWS_AS((void)s.at(id0), std::out_of_range);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.at(id0) == 1.0f);
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.at(id0) == 1.0F);
   }
 }
 
@@ -5538,13 +5540,13 @@ TEST_CASE("MultiStore", "[ComponentStorage]") {
 
     auto id0 = r.create_id({}, 0);
 
-    CHECK(s1.add(id0, 1.0f));
-    CHECK(s2.add(id0, 2.0f)); // same entity, second storage
+    CHECK(s1.add(id0, 1.0F));
+    CHECK(s2.add(id0, 2.0F)); // same entity, second storage
 
     CHECK(s1.contains(id0));
     CHECK(s2.contains(id0));
-    CHECK(s1[id0] == 1.0f);
-    CHECK(s2[id0] == 2.0f);
+    CHECK(s1[id0] == 1.0F);
+    CHECK(s2[id0] == 2.0F);
 
     // Entity remains valid and alive throughout.
     CHECK(r.is_valid(id0));
@@ -5556,9 +5558,9 @@ TEST_CASE("MultiStore", "[ComponentStorage]") {
     cs_store_t sa{r, cs_sid_t{1}};
     cs_store_t sb{r, cs_sid_t{2}};
 
-    auto h = sa.add_new({}, 10.0f);
+    auto h = sa.add_new({}, 10.0F);
     CHECK(static_cast<bool>(h));
-    CHECK(sb.add(h.id(), 20.0f));
+    CHECK(sb.add(h.id(), 20.0F));
 
     CHECK(sa.contains(h.id()));
     CHECK(sb.contains(h.id()));
@@ -5578,15 +5580,15 @@ TEST_CASE("Remove", "[ComponentStorage]") {
     cs_store_t s2{r, cs_sid_t{2}};
 
     auto id0 = r.create_id({}, 0);
-    CHECK(s1.add(id0, 1.0f));
-    CHECK(s2.add(id0, 2.0f));
+    CHECK(s1.add(id0, 1.0F));
+    CHECK(s2.add(id0, 2.0F));
 
     CHECK(s1.remove(id0));
 
     CHECK_FALSE(s1.contains(id0));
     CHECK(s2.contains(id0));
     CHECK(r.is_valid(id0)); // still alive in s2
-    CHECK(s2[id0] == 2.0f);
+    CHECK(s2[id0] == 2.0F);
   }
 
   // remove() from only storage sends entity to staging (still alive).
@@ -5595,15 +5597,15 @@ TEST_CASE("Remove", "[ComponentStorage]") {
     cs_store_t s{r, cs_sid_t{1}};
 
     auto id0 = r.create_id({}, 0);
-    CHECK(s.add(id0, 5.0f));
+    CHECK(s.add(id0, 5.0F));
     CHECK(s.remove(id0));
 
     CHECK_FALSE(s.contains(id0));
     CHECK(r.is_valid(id0)); // alive but staged
 
     // Can be re-added.
-    CHECK(s.add(id0, 7.0f));
-    CHECK(s[id0] == 7.0f);
+    CHECK(s.add(id0, 7.0F));
+    CHECK(s[id0] == 7.0F);
   }
 
   // remove() returns false for entity not in storage.
@@ -5620,8 +5622,8 @@ TEST_CASE("Remove", "[ComponentStorage]") {
     cs_store_t s{r, cs_sid_t{1}};
     auto id0 = r.create_id({}, 0);
     auto id1 = r.create_id({}, 0);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
     s.remove_all();
     CHECK(s.empty());
     CHECK(r.is_valid(id0));
@@ -5641,7 +5643,7 @@ TEST_CASE("Erase", "[ComponentStorage]") {
     cs_store_t s{r, cs_sid_t{1}};
 
     auto id0 = r.create_id({}, 0);
-    CHECK(s.add(id0, 5.0f));
+    CHECK(s.add(id0, 5.0F));
     CHECK(s.erase(id0));
 
     CHECK_FALSE(s.contains(id0));
@@ -5655,8 +5657,8 @@ TEST_CASE("Erase", "[ComponentStorage]") {
     cs_store_t s2{r, cs_sid_t{2}};
 
     auto id0 = r.create_id({}, 0);
-    CHECK(s1.add(id0, 1.0f));
-    CHECK(s2.add(id0, 2.0f));
+    CHECK(s1.add(id0, 1.0F));
+    CHECK(s2.add(id0, 2.0F));
     CHECK(s1.erase(id0)); // removes from s1 only
 
     CHECK_FALSE(s1.contains(id0));
@@ -5679,8 +5681,8 @@ TEST_CASE("Erase", "[ComponentStorage]") {
     cs_store_t s{r, cs_sid_t{1}};
     auto id0 = r.create_id({}, 0);
     auto id1 = r.create_id({}, 0);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
     s.clear();
     CHECK(s.empty());
     CHECK_FALSE(r.is_valid(id0));
@@ -5694,16 +5696,16 @@ TEST_CASE("Erase", "[ComponentStorage]") {
     auto id0 = r.create_id({}, 0);
     auto id1 = r.create_id({}, 0);
     auto id2 = r.create_id({}, 0);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
-    CHECK(s.add(id2, 3.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
+    CHECK(s.add(id2, 3.0F));
     CHECK(s.erase(id1)); // erase middle
     CHECK(s.size() == 2U);
     CHECK_FALSE(s.contains(id1));
     CHECK(s.contains(id0));
     CHECK(s.contains(id2));
-    CHECK(s[id0] == 1.0f);
-    CHECK(s[id2] == 3.0f);
+    CHECK(s[id0] == 1.0F);
+    CHECK(s[id2] == 3.0F);
   }
 }
 
@@ -5720,17 +5722,17 @@ TEST_CASE("EraseIf", "[ComponentStorage]") {
     auto id0 = r.create_id({}, 0);
     auto id1 = r.create_id({}, 0);
     auto id2 = r.create_id({}, 0);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
-    CHECK(s.add(id2, 3.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
+    CHECK(s.add(id2, 3.0F));
 
     const auto cnt = s.erase_if([](float v, cs_id_t) {
-      return v < 2.5f;
+      return v < 2.5F;
     }); // erases id0, id1
     CHECK(cnt == 2U);
     CHECK(s.size() == 1U);
     CHECK(s.contains(id2));
-    CHECK(s[id2] == 3.0f);
+    CHECK(s[id2] == 3.0F);
     CHECK_FALSE(r.is_valid(id0));
     CHECK_FALSE(r.is_valid(id1));
     CHECK(r.is_valid(id2));
@@ -5742,10 +5744,10 @@ TEST_CASE("EraseIf", "[ComponentStorage]") {
     cs_store_t s{r, cs_sid_t{1}};
     auto id0 = r.create_id({}, 0);
     auto id1 = r.create_id({}, 0);
-    CHECK(s.add(id0, 10.0f));
-    CHECK(s.add(id1, 20.0f));
+    CHECK(s.add(id0, 10.0F));
+    CHECK(s.add(id1, 20.0F));
 
-    const auto cnt = s.remove_if([](float v, cs_id_t) { return v < 15.0f; });
+    const auto cnt = s.remove_if([](float v, cs_id_t) { return v < 15.0F; });
     CHECK(cnt == 1U);
     CHECK(s.size() == 1U);
     CHECK_FALSE(s.contains(id0));
@@ -5761,14 +5763,14 @@ TEST_CASE("EraseIf", "[ComponentStorage]") {
     cs_store_t s1{r, cs_sid_t{1}};
     cs_store_t s2{r, cs_sid_t{2}};
     auto id0 = r.create_id({}, 0);
-    CHECK(s1.add(id0, 5.0f)); // will be erased from s1
-    CHECK(s2.add(id0, 9.0f)); // entity still lives here after erase_if
+    CHECK(s1.add(id0, 5.0F)); // will be erased from s1
+    CHECK(s2.add(id0, 9.0F)); // entity still lives here after erase_if
     const auto cnt = s1.erase_if([](float, cs_id_t) { return true; });
     CHECK(cnt == 1U);
     CHECK_FALSE(s1.contains(id0));
     CHECK(s2.contains(id0)); // entity survives in s2
     CHECK(r.is_valid(id0));  // not destroyed
-    CHECK(s2[id0] == 9.0f);
+    CHECK(s2[id0] == 9.0F);
   }
 }
 
@@ -5784,15 +5786,15 @@ TEST_CASE("Iterator", "[ComponentStorage]") {
     cs_store_t s{r, cs_sid_t{1}};
     auto id0 = r.create_id({}, 0);
     auto id1 = r.create_id({}, 0);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
 
-    float sum = 0.0f;
+    float sum = 0.0F;
     for (auto it = s.begin(); it != s.end(); ++it) {
       sum += *it;
       CHECK(r.is_valid(it.id()));
     }
-    CHECK(sum == 3.0f);
+    CHECK(sum == 3.0F);
   }
 
   // Range-for over mutable storage.
@@ -5800,9 +5802,9 @@ TEST_CASE("Iterator", "[ComponentStorage]") {
     cs_reg_t r;
     cs_store_t s{r, cs_sid_t{1}};
     auto id0 = r.create_id({}, 0);
-    CHECK(s.add(id0, 7.0f));
-    for (auto& c : s) c = 8.0f;
-    CHECK(s[id0] == 8.0f);
+    CHECK(s.add(id0, 7.0F));
+    for (auto& c : s) c = 8.0F;
+    CHECK(s[id0] == 8.0F);
   }
 
   // Const iterator.
@@ -5811,12 +5813,12 @@ TEST_CASE("Iterator", "[ComponentStorage]") {
     cs_store_t s{r, cs_sid_t{1}};
     auto id0 = r.create_id({}, 0);
     auto id1 = r.create_id({}, 0);
-    CHECK(s.add(id0, 3.0f));
-    CHECK(s.add(id1, 4.0f));
+    CHECK(s.add(id0, 3.0F));
+    CHECK(s.add(id1, 4.0F));
     const auto& cs = s;
-    float sum = 0.0f;
+    float sum = 0.0F;
     for (const auto& c : cs) sum += c;
-    CHECK(sum == 7.0f);
+    CHECK(sum == 7.0F);
   }
 
   // Random-access: arithmetic operators and operator[].
@@ -5825,13 +5827,13 @@ TEST_CASE("Iterator", "[ComponentStorage]") {
     cs_store_t s{r, cs_sid_t{1}};
     auto id0 = r.create_id({}, 0);
     auto id1 = r.create_id({}, 0);
-    CHECK(s.add(id0, 10.0f));
-    CHECK(s.add(id1, 20.0f));
+    CHECK(s.add(id0, 10.0F));
+    CHECK(s.add(id1, 20.0F));
 
     auto it = s.begin();
-    CHECK(it[0] == 10.0f);
-    CHECK(it[1] == 20.0f);
-    CHECK(*(it + 1) == 20.0f);
+    CHECK(it[0] == 10.0F);
+    CHECK(it[1] == 20.0F);
+    CHECK(*(it + 1) == 20.0F);
     CHECK((s.end() - s.begin()) == 2);
   }
 
@@ -5857,13 +5859,13 @@ TEST_CASE("IndexVariants", "[ComponentStorage]") {
     sorted_store_t s{r, cs_sid_t{1}};
     auto id0 = r.create_id({}, 0);
     auto id1 = r.create_id({}, 0);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
-    CHECK(s[id0] == 1.0f);
-    CHECK(s[id1] == 2.0f);
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
+    CHECK(s[id0] == 1.0F);
+    CHECK(s[id1] == 2.0F);
     CHECK(s.erase(id0));
     CHECK_FALSE(s.contains(id0));
-    CHECK(s[id1] == 2.0f);
+    CHECK(s[id1] == 2.0F);
   }
 
   // paged_sparse_index variant.
@@ -5874,10 +5876,10 @@ TEST_CASE("IndexVariants", "[ComponentStorage]") {
     paged_store_t s{r, cs_sid_t{1}};
     auto id0 = r.create_id({}, 0);
     auto id1 = r.create_id({}, 0);
-    CHECK(s.add(id0, 3.0f));
-    CHECK(s.add(id1, 4.0f));
-    CHECK(s[id0] == 3.0f);
-    CHECK(s[id1] == 4.0f);
+    CHECK(s.add(id0, 3.0F));
+    CHECK(s.add(id1, 4.0F));
+    CHECK(s[id0] == 3.0F);
+    CHECK(s[id1] == 4.0F);
     s.clear();
     CHECK(s.empty());
   }
@@ -5894,10 +5896,10 @@ TEST_CASE("IndexVariants", "[ComponentStorage]") {
     store_a_t sa{r, cs_sid_t{1}};
     store_b_t sb{r, cs_sid_t{2}};
     auto id0 = r.create_id({}, 0);
-    CHECK(sa.add(id0, 1.0f));
-    CHECK(sb.add(id0, 2.0f));
-    CHECK(sa[id0] == 1.0f);
-    CHECK(sb[id0] == 2.0f);
+    CHECK(sa.add(id0, 1.0F));
+    CHECK(sb.add(id0, 2.0F));
+    CHECK(sa[id0] == 1.0F);
+    CHECK(sb[id0] == 2.0F);
   }
 }
 
@@ -5983,14 +5985,14 @@ TEST_CASE("StoreEntity", "[ComponentScene]") {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
     auto id = h.id();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 2.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 2.0F));
     CHECK(s.storage<cs_scene_sid_t{1}>().contains(id));
     CHECK_FALSE(s.storage<cs_scene_sid_t{2}>().contains(id));
 
     CHECK(s.store_entity<cs_scene_sid_t{2}>(id, 42));
     CHECK(s.storage<cs_scene_sid_t{1}>().contains(id));
     CHECK(s.storage<cs_scene_sid_t{2}>().contains(id));
-    CHECK(s.storage<cs_scene_sid_t{1}>()[id] == 2.0f);
+    CHECK(s.storage<cs_scene_sid_t{1}>()[id] == 2.0F);
     CHECK(s.storage<cs_scene_sid_t{2}>()[id] == 42);
   }
 
@@ -5998,22 +6000,22 @@ TEST_CASE("StoreEntity", "[ComponentScene]") {
   if (true) {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h, 3.14f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h, 3.14F));
     CHECK(s.storage<cs_scene_sid_t{1}>().contains(h.id()));
 
     // store_entity with invalid handle returns false.
     cs_scene_reg_t::handle_t bad{};
-    CHECK_FALSE(s.store_entity<cs_scene_sid_t{1}>(bad, 1.0f));
+    CHECK_FALSE(s.store_entity<cs_scene_sid_t{1}>(bad, 1.0F));
   }
 
   // store_entity fails if entity is already in that storage.
   if (true) {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 1.0f));
-    CHECK_FALSE(s.store_entity<cs_scene_sid_t{1}>(h.id(), 2.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 1.0F));
+    CHECK_FALSE(s.store_entity<cs_scene_sid_t{1}>(h.id(), 2.0F));
     CHECK(s.storage<cs_scene_sid_t{1}>().size() == 1U);
-    CHECK(s.storage<cs_scene_sid_t{1}>()[h.id()] == 1.0f); // unchanged
+    CHECK(s.storage<cs_scene_sid_t{1}>()[h.id()] == 1.0F); // unchanged
   }
 
   // store_entity returns false when the target storage is at its limit.
@@ -6022,8 +6024,8 @@ TEST_CASE("StoreEntity", "[ComponentScene]") {
     CHECK(s.storage<cs_scene_sid_t{1}>().set_limit(1));
     auto ha = s.stage_new_entity();
     auto hb = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0f));
-    CHECK_FALSE(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 2.0f)); // at limit
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0F));
+    CHECK_FALSE(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 2.0F)); // at limit
     CHECK(s.storage<cs_scene_sid_t{1}>().size() == 1U);            // unchanged
     CHECK_FALSE(s.storage<cs_scene_sid_t{1}>().contains(hb.id()));
     CHECK(s.registry().is_valid(hb)); // entity still alive (staged)
@@ -6042,7 +6044,7 @@ TEST_CASE("RemoveErase", "[ComponentScene]") {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
     auto id = h.id();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 5.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 5.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(id, 7));
 
     CHECK(s.remove_entity<cs_scene_sid_t{1}>(id));
@@ -6056,7 +6058,7 @@ TEST_CASE("RemoveErase", "[ComponentScene]") {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
     auto id = h.id();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 9.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 9.0F));
     CHECK(s.remove_entity<cs_scene_sid_t{1}>(id));
     CHECK(s.storage<cs_scene_sid_t{1}>().size() == 0U);
     // Entity still alive (staged).
@@ -6083,7 +6085,7 @@ TEST_CASE("RemoveErase", "[ComponentScene]") {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
     auto id = h.id();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 1.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 1.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(id, 2));
 
     CHECK(s.erase_entity(id));
@@ -6109,7 +6111,7 @@ TEST_CASE("RemoveErase", "[ComponentScene]") {
   if (true) {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 3.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 3.0F));
     CHECK(s.erase_entity(h));
     CHECK_FALSE(static_cast<bool>(h));
     CHECK(s.size() == 0U);
@@ -6152,7 +6154,7 @@ TEST_CASE("EraseStaged", "[ComponentScene]") {
   if (true) {
     two_cs_scene_t s;
     auto h1 = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h1.id(), 1.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h1.id(), 1.0F));
     auto h2 = s.stage_new_entity(); // staged
     auto h3 = s.stage_new_entity(); // staged
     CHECK(s.size() == 3U);
@@ -6168,7 +6170,7 @@ TEST_CASE("EraseStaged", "[ComponentScene]") {
   if (true) {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 1.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 1.0F));
     CHECK(s.erase_staged_entities() == 0U);
   }
 
@@ -6177,7 +6179,7 @@ TEST_CASE("EraseStaged", "[ComponentScene]") {
     two_cs_scene_t s;
     auto h1 = s.stage_new_entity();
     auto h2 = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h1.id(), 1.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h1.id(), 1.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(h2.id(), 2));
     (void)s.stage_new_entity();
     s.clear(deallocation_policy::release);
@@ -6192,7 +6194,7 @@ TEST_CASE("EraseStaged", "[ComponentScene]") {
     two_cs_scene_t s;
     auto h1 = s.stage_new_entity();
     auto h2 = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h1.id(), 1.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h1.id(), 1.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(h2.id(), 2));
     (void)s.stage_new_entity();
     s.clear(deallocation_policy::preserve);
@@ -6218,7 +6220,7 @@ TEST_CASE("Destructor", "[ComponentScene]") {
     two_cs_scene_t s;
     auto h1 = s.stage_new_entity();
     auto h2 = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h1.id(), 1.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h1.id(), 1.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(h2.id(), 2));
     CHECK(s.size() == 2U);
     // Scope ends here; destructor runs clear() implicitly.
@@ -6245,7 +6247,7 @@ TEST_CASE("CreateHandleId", "[ArchetypeScene]") {
     auto h = s.stage_new_entity();
     CHECK(h);
     auto& st = s.storage<scene_sid_t{1}>();
-    CHECK(st.add(h.id(), Position{1.f, 2.f}, Velocity{3.f, 4.f}));
+    CHECK(st.add(h.id(), Position{1.F, 2.F}, Velocity{3.F, 4.F}));
     CHECK(s.size() == 1U);
     CHECK(st.contains(h.id()));
   }
@@ -6276,8 +6278,8 @@ TEST_CASE("AddNewRuntime", "[ArchetypeScene]") {
     CHECK(s.size() == 1U);
     CHECK(s.storage<scene_sid_t{1}>().contains(h.id()));
     auto row = s.storage<scene_sid_t{1}>()[h.id()];
-    CHECK(row.component<Position>().x == 0.f);
-    CHECK(row.component<Velocity>().vx == 0.f);
+    CHECK(row.component<Position>().x == 0.F);
+    CHECK(row.component<Velocity>().vx == 0.F);
   }
 
   // store_new_entity(store_id) targeting the second storage.
@@ -6315,7 +6317,7 @@ TEST_CASE("StoreEntity", "[ArchetypeScene]") {
     CHECK(s.store_entity(id, scene_sid_t{1}));
     CHECK(s.size() == 1U);
     CHECK(s.storage<scene_sid_t{1}>().contains(id));
-    CHECK(s.storage<scene_sid_t{1}>()[id].component<Position>().x == 0.f);
+    CHECK(s.storage<scene_sid_t{1}>()[id].component<Position>().x == 0.F);
   }
 
   // store_entity(id, store_id) targeting the second storage.
@@ -6344,11 +6346,11 @@ TEST_CASE("StoreEntity", "[ArchetypeScene]") {
     two_storage_scene_t s;
     auto h = s.stage_new_entity();
     auto id = h.id();
-    CHECK(s.store_entity<scene_sid_t{1}>(id, Position{3.f, 4.f},
-        Velocity{5.f, 6.f}));
+    CHECK(s.store_entity<scene_sid_t{1}>(id, Position{3.F, 4.F},
+        Velocity{5.F, 6.F}));
     CHECK(s.storage<scene_sid_t{1}>().contains(id));
-    CHECK(s.storage<scene_sid_t{1}>()[id].component<Position>().x == 3.f);
-    CHECK(s.storage<scene_sid_t{1}>()[id].component<Velocity>().vx == 5.f);
+    CHECK(s.storage<scene_sid_t{1}>()[id].component<Position>().x == 3.F);
+    CHECK(s.storage<scene_sid_t{1}>()[id].component<Velocity>().vx == 5.F);
   }
 
   // store_entity(id, tuple) infers the storage from the tuple type.
@@ -6357,8 +6359,8 @@ TEST_CASE("StoreEntity", "[ArchetypeScene]") {
     auto h = s.stage_new_entity();
     auto id = h.id();
     CHECK(s.store_entity(id,
-        std::tuple<Position, Velocity, Health>{Position{7.f, 8.f},
-            Velocity{9.f, 0.f}, Health{55}}));
+        std::tuple<Position, Velocity, Health>{Position{7.F, 8.F},
+            Velocity{9.F, 0.F}, Health{55}}));
     CHECK(s.storage<scene_sid_t{2}>().contains(id));
     CHECK(s.storage<scene_sid_t{2}>()[id].component<Health>().hp == 55);
   }
@@ -6383,10 +6385,10 @@ TEST_CASE("StoreEntity", "[ArchetypeScene]") {
   if (true) {
     two_storage_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<scene_sid_t{1}>(h, Position{1.f, 2.f},
-        Velocity{3.f, 4.f}));
+    CHECK(s.store_entity<scene_sid_t{1}>(h, Position{1.F, 2.F},
+        Velocity{3.F, 4.F}));
     CHECK((s.storage<scene_sid_t{1}>()[h.id()].component<Position>().x) ==
-          (1.f));
+          (1.F));
   }
 
   // store_entity<SID>(invalid handle, args) returns false.
@@ -6401,10 +6403,10 @@ TEST_CASE("StoreEntity", "[ArchetypeScene]") {
     two_storage_scene_t s;
     auto h = s.stage_new_entity();
     CHECK(s.store_entity(h,
-        std::tuple<Position, Velocity>{Position{2.f, 3.f}, Velocity{}}));
+        std::tuple<Position, Velocity>{Position{2.F, 3.F}, Velocity{}}));
     CHECK(s.storage<scene_sid_t{1}>().contains(h.id()));
     CHECK((s.storage<scene_sid_t{1}>()[h.id()].component<Position>().x) ==
-          (2.f));
+          (2.F));
   }
 
   // store_entity(invalid handle, tuple) returns false.
@@ -6434,11 +6436,11 @@ TEST_CASE("EntityLifecycle", "[ArchetypeScene]") {
   CHECK_FALSE(s.storage<scene_sid_t{2}>().contains(id));
 
   // Store: move the staged entity into storage 1.
-  CHECK(s.store_entity<scene_sid_t{1}>(id, Position{1.f, 2.f},
-      Velocity{3.f, 4.f}));
+  CHECK(s.store_entity<scene_sid_t{1}>(id, Position{1.F, 2.F},
+      Velocity{3.F, 4.F}));
   CHECK(s.size() == 1U);
   CHECK(s.storage<scene_sid_t{1}>().contains(id));
-  CHECK(s.storage<scene_sid_t{1}>()[id].component<Position>().x == 1.f);
+  CHECK(s.storage<scene_sid_t{1}>()[id].component<Position>().x == 1.F);
 
   // Remove: entity returns to staging; it remains valid but leaves storage 1.
   CHECK(s.remove_entity(id));
@@ -6447,8 +6449,8 @@ TEST_CASE("EntityLifecycle", "[ArchetypeScene]") {
   CHECK(s.registry().is_valid(id));
 
   // Re-store: put the same entity into storage 2.
-  CHECK(s.store_entity<scene_sid_t{2}>(id, Position{5.f, 6.f},
-      Velocity{7.f, 8.f}, Health{50}));
+  CHECK(s.store_entity<scene_sid_t{2}>(id, Position{5.F, 6.F},
+      Velocity{7.F, 8.F}, Health{50}));
   CHECK(s.size() == 1U);
   CHECK(s.storage<scene_sid_t{2}>().contains(id));
   CHECK(s.storage<scene_sid_t{2}>()[id].component<Health>().hp == 50);
@@ -6460,7 +6462,7 @@ TEST_CASE("EntityLifecycle", "[ArchetypeScene]") {
   CHECK(s.size() == 1U);
   CHECK_FALSE(s.storage<scene_sid_t{2}>().contains(id));
   CHECK(s.storage<scene_sid_t{1}>().contains(id));
-  CHECK(s.storage<scene_sid_t{1}>()[id].component<Position>().x == 5.f);
+  CHECK(s.storage<scene_sid_t{1}>()[id].component<Position>().x == 5.F);
 
   // Erase: entity is destroyed; handle becomes stale.
   CHECK(s.erase_entity(id));
@@ -6478,8 +6480,8 @@ TEST_CASE("MigrateEdgeCases", "[ArchetypeScene]") {
   // storage.
   if (true) {
     two_storage_scene_t s;
-    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 2.f},
-        Velocity{3.f, 4.f});
+    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{1.F, 2.F},
+        Velocity{3.F, 4.F});
     auto id = h.id();
     auto build = [](const auto&) {
       return std::tuple<Position, Velocity, Health>{};
@@ -6504,7 +6506,7 @@ TEST_CASE("MigrateEdgeCases", "[ArchetypeScene]") {
   // storage.
   if (true) {
     two_storage_scene_t s;
-    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{5.f, 0.f},
+    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{5.F, 0.F},
         Velocity{}, Health{77});
     auto id = h.id();
     CHECK(s.migrate_entity(id, scene_sid_t{2})); // same storage -- no-op
@@ -6530,13 +6532,13 @@ TEST_CASE("ForEach", "[ArchetypeScene]") {
   if (true) {
     three_storage_scene_t s;
     auto h1 =
-        s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 0.f}, Velocity{});
-    auto h2 = s.store_new_entity<scene_sid_t{2}>({}, Position{2.f, 0.f},
+        s.store_new_entity<scene_sid_t{1}>({}, Position{1.F, 0.F}, Velocity{});
+    auto h2 = s.store_new_entity<scene_sid_t{2}>({}, Position{2.F, 0.F},
         Velocity{}, Health{});
     (void)s.store_new_entity<scene_sid_t{3}>({}, Health{});
     // for_each<Position, Velocity> matches SID{1} and SID{2}, not SID{3}.
     int count = 0;
-    float sum = 0.f;
+    float sum = 0.F;
     s.for_each<Position, Velocity>([&](auto id, auto comps) {
       ++count;
       sum += std::get<0>(comps).x;
@@ -6544,7 +6546,7 @@ TEST_CASE("ForEach", "[ArchetypeScene]") {
       return true;
     });
     CHECK(count == 2);
-    CHECK(sum == 3.f); // 1.f + 2.f
+    CHECK(sum == 3.F); // 1.f + 2.f
     (void)h1;
     (void)h2;
   }
@@ -6568,28 +6570,28 @@ TEST_CASE("ForEach", "[ArchetypeScene]") {
   if (true) {
     three_storage_scene_t s;
     (void)s.store_new_entity<scene_sid_t{1}>({}, Position{}, Velocity{});
-    (void)s.store_new_entity<scene_sid_t{2}>({}, Position{9.f, 0.f},
+    (void)s.store_new_entity<scene_sid_t{2}>({}, Position{9.F, 0.F},
         Velocity{}, Health{});
     (void)s.store_new_entity<scene_sid_t{3}>({}, Health{});
     int count = 0;
-    float x_sum = 0.f;
+    float x_sum = 0.F;
     s.for_each<Position, Velocity, Health>([&](auto, auto comps) {
       ++count;
       x_sum += std::get<0>(comps).x;
       return true;
     });
     CHECK(count == 1);
-    CHECK(x_sum == 9.f);
+    CHECK(x_sum == 9.F);
   }
 
   // for_each stops early when fn returns false.
   if (true) {
     three_storage_scene_t s;
-    (void)s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 0.f},
+    (void)s.store_new_entity<scene_sid_t{1}>({}, Position{1.F, 0.F},
         Velocity{});
-    (void)s.store_new_entity<scene_sid_t{1}>({}, Position{2.f, 0.f},
+    (void)s.store_new_entity<scene_sid_t{1}>({}, Position{2.F, 0.F},
         Velocity{});
-    (void)s.store_new_entity<scene_sid_t{2}>({}, Position{3.f, 0.f},
+    (void)s.store_new_entity<scene_sid_t{2}>({}, Position{3.F, 0.F},
         Velocity{}, Health{});
     int count = 0;
     s.for_each<Position, Velocity>([&](auto, auto) {
@@ -6618,16 +6620,16 @@ TEST_CASE("ForEach", "[ArchetypeScene]") {
   // for_each on a const scene yields const component references.
   if (true) {
     three_storage_scene_t s;
-    (void)s.store_new_entity<scene_sid_t{1}>({}, Position{7.f, 0.f},
+    (void)s.store_new_entity<scene_sid_t{1}>({}, Position{7.F, 0.F},
         Velocity{});
     const auto& cs = s;
-    float x = 0.f;
+    float x = 0.F;
     cs.for_each<Position, Velocity>([&](auto, auto comps) {
       // std::get<0>(comps) is const Position&
       x = std::get<0>(comps).x;
       return true;
     });
-    CHECK(x == 7.f);
+    CHECK(x == 7.F);
   }
 
   // for_each is a no-op when no storage has all requested components.
@@ -6659,13 +6661,13 @@ TEST_CASE("ForEach", "[ArchetypeScene]") {
   if (true) {
     three_storage_scene_t s;
     auto h =
-        s.store_new_entity<scene_sid_t{1}>({}, Position{0.f, 0.f}, Velocity{});
+        s.store_new_entity<scene_sid_t{1}>({}, Position{0.F, 0.F}, Velocity{});
     s.for_each<Position, Velocity>([](auto, auto comps) {
-      std::get<0>(comps).x = 42.f;
+      std::get<0>(comps).x = 42.F;
       return true;
     });
     CHECK((s.storage<scene_sid_t{1}>()[h.id()].component<Position>().x) ==
-          (42.f));
+          (42.F));
   }
 
   // Component order in the template list is independent of matching but
@@ -6674,20 +6676,20 @@ TEST_CASE("ForEach", "[ArchetypeScene]") {
   // and std::get<1> = Position.
   if (true) {
     three_storage_scene_t s;
-    (void)s.store_new_entity<scene_sid_t{1}>({}, Position{3.f, 0.f},
-        Velocity{5.f, 0.f});
-    (void)s.store_new_entity<scene_sid_t{2}>({}, Position{7.f, 0.f},
-        Velocity{9.f, 0.f}, Health{});
+    (void)s.store_new_entity<scene_sid_t{1}>({}, Position{3.F, 0.F},
+        Velocity{5.F, 0.F});
+    (void)s.store_new_entity<scene_sid_t{2}>({}, Position{7.F, 0.F},
+        Velocity{9.F, 0.F}, Health{});
     (void)s.store_new_entity<scene_sid_t{3}>({}, Health{}); // no Position/Vel
-    float pos_sum = 0.f;
-    float vel_sum = 0.f;
+    float pos_sum = 0.F;
+    float vel_sum = 0.F;
     s.for_each<Velocity, Position>([&](auto, auto comps) {
       vel_sum += std::get<0>(comps).vx; // index 0 = Velocity (first in list)
       pos_sum += std::get<1>(comps).x;  // index 1 = Position (second in list)
       return true;
     });
-    CHECK(pos_sum == 10.f); // 3.f + 7.f
-    CHECK(vel_sum == 14.f); // 5.f + 9.f
+    CHECK(pos_sum == 10.F); // 3.f + 7.f
+    CHECK(vel_sum == 14.F); // 5.f + 9.f
   }
 }
 
@@ -6699,10 +6701,10 @@ TEST_CASE("TryGetComponent", "[ArchetypeScene]") {
   if (true) {
     three_storage_scene_t s;
     auto h =
-        s.store_new_entity<scene_sid_t{1}>({}, Position{3.f, 0.f}, Velocity{});
+        s.store_new_entity<scene_sid_t{1}>({}, Position{3.F, 0.F}, Velocity{});
     auto* pos = s.try_get_component<Position>(h.id());
     REQUIRE(pos != nullptr);
-    CHECK(pos->x == 3.f);
+    CHECK(pos->x == 3.F);
   }
 
   // Returns null for a component the entity's archetype lacks.
@@ -6716,8 +6718,8 @@ TEST_CASE("TryGetComponent", "[ArchetypeScene]") {
   if (true) {
     three_storage_scene_t s;
     auto h1 =
-        s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 0.f}, Velocity{});
-    auto h2 = s.store_new_entity<scene_sid_t{2}>({}, Position{2.f, 0.f},
+        s.store_new_entity<scene_sid_t{1}>({}, Position{1.F, 0.F}, Velocity{});
+    auto h2 = s.store_new_entity<scene_sid_t{2}>({}, Position{2.F, 0.F},
         Velocity{}, Health{});
     auto h3 = s.store_new_entity<scene_sid_t{3}>({}, Health{99});
 
@@ -6747,21 +6749,21 @@ TEST_CASE("TryGetComponent", "[ArchetypeScene]") {
   if (true) {
     three_storage_scene_t s;
     auto h =
-        s.store_new_entity<scene_sid_t{1}>({}, Position{7.f, 0.f}, Velocity{});
+        s.store_new_entity<scene_sid_t{1}>({}, Position{7.F, 0.F}, Velocity{});
     const auto& cs = s;
     const Position* pos = cs.try_get_component<Position>(h.id());
     REQUIRE(pos != nullptr);
-    CHECK(pos->x == 7.f);
+    CHECK(pos->x == 7.F);
   }
 
   // Mutation through the returned pointer is reflected in the stored data.
   if (true) {
     three_storage_scene_t s;
     auto h =
-        s.store_new_entity<scene_sid_t{1}>({}, Position{0.f, 0.f}, Velocity{});
-    s.try_get_component<Position>(h.id())->x = 42.f;
+        s.store_new_entity<scene_sid_t{1}>({}, Position{0.F, 0.F}, Velocity{});
+    s.try_get_component<Position>(h.id())->x = 42.F;
     CHECK((s.storage<scene_sid_t{1}>()[h.id()].component<Position>().x) ==
-          (42.f));
+          (42.F));
   }
 }
 
@@ -6773,15 +6775,15 @@ TEST_CASE("TryGetComponents", "[ArchetypeScene]") {
   // contains them.
   if (true) {
     three_storage_scene_t s;
-    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{2.f, 3.f},
-        Velocity{4.f, 5.f}, Health{77});
+    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{2.F, 3.F},
+        Velocity{4.F, 5.F}, Health{77});
     auto [pos, vel, hp] =
         s.try_get_components<Position, Velocity, Health>(h.id());
     REQUIRE(pos != nullptr);
     REQUIRE(vel != nullptr);
     REQUIRE(hp != nullptr);
-    CHECK(pos->x == 2.f);
-    CHECK(vel->vx == 4.f);
+    CHECK(pos->x == 2.F);
+    CHECK(vel->vx == 4.F);
     CHECK(hp->hp == 77);
   }
 
@@ -6790,7 +6792,7 @@ TEST_CASE("TryGetComponents", "[ArchetypeScene]") {
   if (true) {
     three_storage_scene_t s;
     auto h =
-        s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 0.f}, Velocity{});
+        s.store_new_entity<scene_sid_t{1}>({}, Position{1.F, 0.F}, Velocity{});
     auto [pos, hp] = s.try_get_components<Position, Health>(h.id());
     CHECK(pos == nullptr);
     CHECK(hp == nullptr);
@@ -6814,32 +6816,32 @@ TEST_CASE("TryGetComponents", "[ArchetypeScene]") {
   // On a const scene returns const-qualified pointers.
   if (true) {
     three_storage_scene_t s;
-    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{7.f, 8.f},
-        Velocity{9.f, 10.f}, Health{});
+    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{7.F, 8.F},
+        Velocity{9.F, 10.F}, Health{});
     const auto& cs = s;
     auto [pos, vel] = cs.try_get_components<Position, Velocity>(h.id());
     static_assert(std::is_same_v<decltype(pos), const Position*>);
     static_assert(std::is_same_v<decltype(vel), const Velocity*>);
     REQUIRE(pos != nullptr);
     REQUIRE(vel != nullptr);
-    CHECK(pos->x == 7.f);
-    CHECK(vel->vx == 9.f);
+    CHECK(pos->x == 7.F);
+    CHECK(vel->vx == 9.F);
   }
 
   // Mutation through returned pointers updates stored data.
   if (true) {
     three_storage_scene_t s;
-    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{0.f, 0.f},
-        Velocity{1.f, 2.f}, Health{});
+    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{0.F, 0.F},
+        Velocity{1.F, 2.F}, Health{});
     auto [pos, vel] = s.try_get_components<Position, Velocity>(h.id());
     REQUIRE(pos != nullptr);
     REQUIRE(vel != nullptr);
-    pos->x = 42.f;
-    vel->vx = 24.f;
+    pos->x = 42.F;
+    vel->vx = 24.F;
     CHECK((s.storage<scene_sid_t{2}>()[h.id()].component<Position>().x) ==
-          (42.f));
+          (42.F));
     CHECK((s.storage<scene_sid_t{2}>()[h.id()].component<Velocity>().vx) ==
-          (24.f));
+          (24.F));
   }
 }
 
@@ -6878,20 +6880,20 @@ TEST_CASE("MegaTuple", "[ArchetypeScene]") {
   if (true) {
     two_storage_scene_t s;
     two_storage_scene_t::megatuple_t tpl{};
-    std::get<std::optional<Position>>(tpl) = Position{1.f, 2.f};
-    std::get<std::optional<Velocity>>(tpl) = Velocity{3.f, 4.f};
+    std::get<std::optional<Position>>(tpl) = Position{1.F, 2.F};
+    std::get<std::optional<Velocity>>(tpl) = Velocity{3.F, 4.F};
     auto h = s.store_new_entity_from_mega({}, tpl);
     CHECK(h);
     CHECK(s.storage<scene_sid_t{1}>().contains(h.id()));
     CHECK_FALSE(s.storage<scene_sid_t{2}>().contains(h.id()));
     auto* pos = s.try_get_component<Position>(h.id());
     REQUIRE(pos != nullptr);
-    CHECK(pos->x == 1.f);
-    CHECK(pos->y == 2.f);
+    CHECK(pos->x == 1.F);
+    CHECK(pos->y == 2.F);
     auto* vel = s.try_get_component<Velocity>(h.id());
     REQUIRE(vel != nullptr);
-    CHECK(vel->vx == 3.f);
-    CHECK(vel->vy == 4.f);
+    CHECK(vel->vx == 3.F);
+    CHECK(vel->vy == 4.F);
     // Health is not in arch_pv_t; try_get_component returns null.
     CHECK(s.try_get_component<Health>(h.id()) == nullptr);
   }
@@ -6900,8 +6902,8 @@ TEST_CASE("MegaTuple", "[ArchetypeScene]") {
   if (true) {
     two_storage_scene_t s;
     two_storage_scene_t::megatuple_t tpl{};
-    std::get<std::optional<Position>>(tpl) = Position{5.f, 6.f};
-    std::get<std::optional<Velocity>>(tpl) = Velocity{7.f, 8.f};
+    std::get<std::optional<Position>>(tpl) = Position{5.F, 6.F};
+    std::get<std::optional<Velocity>>(tpl) = Velocity{7.F, 8.F};
     std::get<std::optional<Health>>(tpl) = Health{42};
     auto h = s.store_new_entity_from_mega({}, tpl);
     CHECK(h);
@@ -6912,7 +6914,7 @@ TEST_CASE("MegaTuple", "[ArchetypeScene]") {
     CHECK(hp->hp == 42);
     auto* pos = s.try_get_component<Position>(h.id());
     REQUIRE(pos != nullptr);
-    CHECK(pos->x == 5.f);
+    CHECK(pos->x == 5.F);
   }
 
   // No optionals set: bitmap matches no archetype; returns invalid handle and
@@ -6982,30 +6984,30 @@ TEST_CASE("TryGetSomeComponents", "[ArchetypeScene]") {
   // values.
   if (true) {
     two_storage_scene_t s;
-    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{1.f, 2.f},
-        Velocity{3.f, 4.f}, Health{77});
+    auto h = s.store_new_entity<scene_sid_t{2}>({}, Position{1.F, 2.F},
+        Velocity{3.F, 4.F}, Health{77});
     auto [pos, vel, hp] =
         s.try_get_some_components<Position, Velocity, Health>(h.id());
     REQUIRE(pos != nullptr);
     REQUIRE(vel != nullptr);
     REQUIRE(hp != nullptr);
-    CHECK(pos->x == 1.f);
-    CHECK(vel->vx == 3.f);
+    CHECK(pos->x == 1.F);
+    CHECK(vel->vx == 3.F);
     CHECK(hp->hp == 77);
   }
 
   // Entity in arch_pv_t: Position and Velocity are non-null, Health is null.
   if (true) {
     two_storage_scene_t s;
-    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{5.f, 6.f},
-        Velocity{7.f, 8.f});
+    auto h = s.store_new_entity<scene_sid_t{1}>({}, Position{5.F, 6.F},
+        Velocity{7.F, 8.F});
     auto [pos, vel, hp] =
         s.try_get_some_components<Position, Velocity, Health>(h.id());
     REQUIRE(pos != nullptr);
     REQUIRE(vel != nullptr);
     CHECK(hp == nullptr);
-    CHECK(pos->x == 5.f);
-    CHECK(vel->vx == 7.f);
+    CHECK(pos->x == 5.F);
+    CHECK(vel->vx == 7.F);
   }
 
   // Invalid entity ID: all pointers null.
@@ -7036,10 +7038,10 @@ TEST_CASE("TryGetSomeComponents", "[ArchetypeScene]") {
     auto [pos, hp] = s.try_get_some_components<Position, Health>(h.id());
     REQUIRE(pos != nullptr);
     REQUIRE(hp != nullptr);
-    pos->x = 99.f;
+    pos->x = 99.F;
     hp->hp = 42;
     CHECK((s.storage<scene_sid_t{2}>()[h.id()].component<Position>().x) ==
-          (99.f));
+          (99.F));
     CHECK(s.storage<scene_sid_t{2}>()[h.id()].component<Health>().hp == 42);
   }
 
@@ -7047,13 +7049,13 @@ TEST_CASE("TryGetSomeComponents", "[ArchetypeScene]") {
   if (true) {
     two_storage_scene_t s;
     auto h =
-        s.store_new_entity<scene_sid_t{1}>({}, Position{1.f, 0.f}, Velocity{});
+        s.store_new_entity<scene_sid_t{1}>({}, Position{1.F, 0.F}, Velocity{});
     const auto& cs = s;
     auto [pos, vel] = cs.try_get_some_components<Position, Velocity>(h.id());
     static_assert(std::is_same_v<decltype(pos), const Position*>);
     static_assert(std::is_same_v<decltype(vel), const Velocity*>);
     REQUIRE(pos != nullptr);
-    CHECK(pos->x == 1.f);
+    CHECK(pos->x == 1.F);
   }
 }
 
@@ -7076,9 +7078,9 @@ TEST_CASE("StageNewEntity", "[ComponentScene]") {
   if (true) {
     two_cs_scene_t s;
     auto id = s.stage_new_entity().id();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 7.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 7.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(id, 42));
-    CHECK(s.storage<cs_scene_sid_t{1}>()[id] == 7.0f);
+    CHECK(s.storage<cs_scene_sid_t{1}>()[id] == 7.0F);
     CHECK(s.storage<cs_scene_sid_t{2}>()[id] == 42);
   }
 }
@@ -7093,7 +7095,7 @@ TEST_CASE("RemoveAll", "[ComponentScene]") {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
     auto id = h.id();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 1.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 1.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(id, 42));
     CHECK(s.restage_entity(id));
     CHECK_FALSE(s.storage<cs_scene_sid_t{1}>().contains(id));
@@ -7116,7 +7118,7 @@ TEST_CASE("RemoveAll", "[ComponentScene]") {
   if (true) {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 3.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 3.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(h.id(), 5));
     CHECK(s.restage_entity(h));
     CHECK_FALSE(s.storage<cs_scene_sid_t{1}>().contains(h.id()));
@@ -7136,7 +7138,7 @@ TEST_CASE("RemoveAll", "[ComponentScene]") {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
     auto id = h.id();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 9.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 9.0F));
     CHECK(s.restage_entity(id));
     CHECK(s.erase_staged_entities() == 1U);
     CHECK_FALSE(s.registry().is_valid(h));
@@ -7165,11 +7167,11 @@ TEST_CASE("EntityLifecycle", "[ComponentScene]") {
   CHECK_FALSE(s.storage<cs_scene_sid_t{2}>().contains(id));
 
   // Add to storage 1: entity now carries a float component.
-  CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 3.14f));
+  CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 3.14F));
   CHECK(s.size() == 1U);
   CHECK(s.storage<cs_scene_sid_t{1}>().contains(id));
   CHECK_FALSE(s.storage<cs_scene_sid_t{2}>().contains(id));
-  CHECK(s.storage<cs_scene_sid_t{1}>()[id] == 3.14f);
+  CHECK(s.storage<cs_scene_sid_t{1}>()[id] == 3.14F);
 
   // Add to storage 2 simultaneously: entity now occupies both storages at
   // once. Both components are independently accessible.
@@ -7177,13 +7179,13 @@ TEST_CASE("EntityLifecycle", "[ComponentScene]") {
   CHECK(s.size() == 1U);
   CHECK(s.storage<cs_scene_sid_t{1}>().contains(id));
   CHECK(s.storage<cs_scene_sid_t{2}>().contains(id));
-  CHECK(s.storage<cs_scene_sid_t{1}>()[id] == 3.14f);
+  CHECK(s.storage<cs_scene_sid_t{1}>()[id] == 3.14F);
   CHECK(s.storage<cs_scene_sid_t{2}>()[id] == 42);
 
   // store_entity is idempotent per storage: a second add to storage 1 fails
   // and leaves the existing component unchanged.
-  CHECK_FALSE(s.store_entity<cs_scene_sid_t{1}>(id, 99.0f));
-  CHECK(s.storage<cs_scene_sid_t{1}>()[id] == 3.14f);
+  CHECK_FALSE(s.store_entity<cs_scene_sid_t{1}>(id, 99.0F));
+  CHECK(s.storage<cs_scene_sid_t{1}>()[id] == 3.14F);
 
   // Remove from storage 1 only: entity leaves that storage but remains in
   // storage 2 and in the registry. This is impossible in archetype_scene,
@@ -7196,10 +7198,10 @@ TEST_CASE("EntityLifecycle", "[ComponentScene]") {
 
   // Re-add to storage 1 with a new value while the entity is still in
   // storage 2; both storages are occupied again.
-  CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 2.72f));
+  CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 2.72F));
   CHECK(s.storage<cs_scene_sid_t{1}>().contains(id));
   CHECK(s.storage<cs_scene_sid_t{2}>().contains(id));
-  CHECK(s.storage<cs_scene_sid_t{1}>()[id] == 2.72f);
+  CHECK(s.storage<cs_scene_sid_t{1}>()[id] == 2.72F);
   CHECK(s.storage<cs_scene_sid_t{2}>()[id] == 42);
 
   // Restage: remove from all storages in one call. The entity returns to
@@ -7242,12 +7244,12 @@ TEST_CASE("ForEach", "[ComponentScene]") {
     auto ha = s.stage_new_entity(); // entity A: both storages
     auto hb = s.stage_new_entity(); // entity B: store1 only
     auto hc = s.stage_new_entity(); // entity C: store2 only
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(ha.id(), 10));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 2.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 2.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(hc.id(), 20));
     int count = 0;
-    float fsum = 0.f;
+    float fsum = 0.F;
     int isum = 0;
     s.for_each<float, int>([&](auto, auto comps) {
       ++count;
@@ -7256,7 +7258,7 @@ TEST_CASE("ForEach", "[ComponentScene]") {
       return true;
     });
     CHECK(count == 1); // only entity A
-    CHECK(fsum == 1.0f);
+    CHECK(fsum == 1.0F);
     CHECK(isum == 10);
     (void)hb;
     (void)hc;
@@ -7267,15 +7269,15 @@ TEST_CASE("ForEach", "[ComponentScene]") {
     two_cs_scene_t s;
     auto ha = s.stage_new_entity();
     auto hb = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 3.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 3.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(ha.id(), 0));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 4.0f));
-    float fsum = 0.f;
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 4.0F));
+    float fsum = 0.F;
     s.for_each<float>([&](auto, auto comps) {
       fsum += std::get<0>(comps);
       return true;
     });
-    CHECK(fsum == 7.0f); // 3.0f + 4.0f
+    CHECK(fsum == 7.0F); // 3.0f + 4.0f
     (void)ha;
     (void)hb;
   }
@@ -7283,8 +7285,8 @@ TEST_CASE("ForEach", "[ComponentScene]") {
   // for_each stops early when fn returns false.
   if (true) {
     two_cs_scene_t s;
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(s.stage_new_entity().id(), 1.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(s.stage_new_entity().id(), 2.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(s.stage_new_entity().id(), 1.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(s.stage_new_entity().id(), 2.0F));
     int count = 0;
     s.for_each<float>([&](auto, auto) {
       ++count;
@@ -7297,17 +7299,17 @@ TEST_CASE("ForEach", "[ComponentScene]") {
   if (true) {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 7.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 7.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(h.id(), 42));
     const auto& cs = s;
-    float fval = 0.f;
+    float fval = 0.F;
     int ival = 0;
     cs.for_each<float, int>([&](auto, auto comps) {
       fval = std::get<0>(comps); // const float&
       ival = std::get<1>(comps); // const int&
       return true;
     });
-    CHECK(fval == 7.0f);
+    CHECK(fval == 7.0F);
     CHECK(ival == 42);
     (void)h;
   }
@@ -7327,12 +7329,12 @@ TEST_CASE("ForEach", "[ComponentScene]") {
   if (true) {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 0.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 0.0F));
     s.for_each<float>([](auto, auto comps) {
-      std::get<0>(comps) = 99.0f;
+      std::get<0>(comps) = 99.0F;
       return true;
     });
-    CHECK(s.storage<cs_scene_sid_t{1}>()[h.id()] == 99.0f);
+    CHECK(s.storage<cs_scene_sid_t{1}>()[h.id()] == 99.0F);
     (void)h;
   }
 
@@ -7342,9 +7344,9 @@ TEST_CASE("ForEach", "[ComponentScene]") {
   if (true) {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 5.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 5.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(h.id(), 11));
-    float fval = 0.f;
+    float fval = 0.F;
     int ival = 0;
     s.for_each<int, float>([&](auto, auto comps) {
       ival = std::get<0>(comps); // index 0 = int (first in list)
@@ -7352,7 +7354,7 @@ TEST_CASE("ForEach", "[ComponentScene]") {
       return true;
     });
     CHECK(ival == 11);
-    CHECK(fval == 5.0f);
+    CHECK(fval == 5.0F);
     (void)h;
   }
 
@@ -7361,7 +7363,7 @@ TEST_CASE("ForEach", "[ComponentScene]") {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
     auto id = h.id();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 1.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 1.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(id, 1));
     cs_scene_id_t seen_id{};
     s.for_each<float, int>([&](auto eid, auto) {
@@ -7380,13 +7382,13 @@ TEST_CASE("ForEach", "[ComponentScene]") {
     auto ha = s.stage_new_entity(); // both stores: the match
     auto hb = s.stage_new_entity(); // float only
     auto hc = s.stage_new_entity(); // float only
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(ha.id(), 10));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 2.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hc.id(), 3.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 2.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hc.id(), 3.0F));
     // store1 has 3 entities; store2 has 1 -- primary switches to store2.
     int count = 0;
-    float fval = 0.f;
+    float fval = 0.F;
     int ival = 0;
     s.for_each<float, int>([&](auto, auto comps) {
       ++count;
@@ -7395,7 +7397,7 @@ TEST_CASE("ForEach", "[ComponentScene]") {
       return true;
     });
     CHECK(count == 1); // only ha
-    CHECK(fval == 1.0f);
+    CHECK(fval == 1.0F);
     CHECK(ival == 10);
     (void)hb;
     (void)hc;
@@ -7419,11 +7421,11 @@ TEST_CASE("NonAlignedOwnCount", "[ComponentScene]") {
   scene3_t s;
   auto h = s.stage_new_entity();
   auto id = h.id();
-  CHECK(s.store_entity<reg3_t::store_id_t{1}>(id, 1.0f));
+  CHECK(s.store_entity<reg3_t::store_id_t{1}>(id, 1.0F));
   CHECK(s.store_entity<reg3_t::store_id_t{2}>(id, 42));
   CHECK(s.storage<reg3_t::store_id_t{1}>().contains(id));
   CHECK(s.storage<reg3_t::store_id_t{2}>().contains(id));
-  CHECK(s.storage<reg3_t::store_id_t{1}>()[id] == 1.0f);
+  CHECK(s.storage<reg3_t::store_id_t{1}>()[id] == 1.0F);
   CHECK(s.storage<reg3_t::store_id_t{2}>()[id] == 42);
   CHECK(s.erase_entity(id));
   CHECK(s.size() == 0U);
@@ -7444,12 +7446,12 @@ TEST_CASE("ForAll", "[ComponentScene]") {
     auto ha = s.stage_new_entity(); // both storages
     auto hb = s.stage_new_entity(); // store1 only
     auto hc = s.stage_new_entity(); // store2 only
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(ha.id(), 10));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 2.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 2.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(hc.id(), 20));
     int count = 0;
-    float fsum = 0.f;
+    float fsum = 0.F;
     int isum = 0;
     auto f = s.for_all<float, int>([&](auto, auto comps) {
       ++count;
@@ -7459,7 +7461,7 @@ TEST_CASE("ForAll", "[ComponentScene]") {
     });
     CHECK(f == 0U);
     CHECK(count == 1); // only ha
-    CHECK(fsum == 1.0f);
+    CHECK(fsum == 1.0F);
     CHECK(isum == 10);
     (void)hb;
     (void)hc;
@@ -7480,8 +7482,8 @@ TEST_CASE("ForAll", "[ComponentScene]") {
   // for_all stops early when fn returns false.
   if (true) {
     two_cs_scene_t s;
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(s.stage_new_entity().id(), 1.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(s.stage_new_entity().id(), 2.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(s.stage_new_entity().id(), 1.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(s.stage_new_entity().id(), 2.0F));
     int count = 0;
     auto f = s.for_all<float>([&](auto, auto) {
       ++count;
@@ -7495,10 +7497,10 @@ TEST_CASE("ForAll", "[ComponentScene]") {
   if (true) {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 7.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 7.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(h.id(), 42));
     const auto& cs = s;
-    float fval = 0.f;
+    float fval = 0.F;
     int ival = 0;
     auto f = cs.for_all<float, int>([&](auto, auto comps) {
       fval = std::get<0>(comps);
@@ -7506,7 +7508,7 @@ TEST_CASE("ForAll", "[ComponentScene]") {
       return true;
     });
     CHECK(f == 0U);
-    CHECK(fval == 7.0f);
+    CHECK(fval == 7.0F);
     CHECK(ival == 42);
     (void)h;
   }
@@ -7515,13 +7517,13 @@ TEST_CASE("ForAll", "[ComponentScene]") {
   if (true) {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 0.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 0.0F));
     auto f = s.for_all<float>([](auto, auto comps) {
-      std::get<0>(comps) = 55.0f;
+      std::get<0>(comps) = 55.0F;
       return true;
     });
     CHECK(f == 0U);
-    CHECK(s.storage<cs_scene_sid_t{1}>()[h.id()] == 55.0f);
+    CHECK(s.storage<cs_scene_sid_t{1}>()[h.id()] == 55.0F);
     (void)h;
   }
 
@@ -7530,7 +7532,7 @@ TEST_CASE("ForAll", "[ComponentScene]") {
     two_cs_scene_t s;
     auto h = s.stage_new_entity();
     auto id = h.id();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 1.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(id, 1.0F));
     CHECK(s.store_entity<cs_scene_sid_t{2}>(id, 1));
     cs_scene_id_t seen_id{};
     auto f = s.for_all<float, int>([&](auto eid, auto) {
@@ -7546,9 +7548,9 @@ TEST_CASE("ForAll", "[ComponentScene]") {
     two_cs_scene_t s;
     auto ha = s.stage_new_entity(); // staged only -- must not be visited
     auto hb = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 5.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 5.0F));
     int count = 0;
-    float fsum = 0.f;
+    float fsum = 0.F;
     auto f = s.for_all<float>([&](auto, auto comps) {
       ++count;
       fsum += std::get<0>(comps);
@@ -7556,7 +7558,7 @@ TEST_CASE("ForAll", "[ComponentScene]") {
     });
     CHECK(f == 0U);
     CHECK(count == 1); // only hb
-    CHECK(fsum == 5.0f);
+    CHECK(fsum == 5.0F);
     (void)ha;
     (void)hb;
   }
@@ -7569,12 +7571,12 @@ TEST_CASE("ForAll", "[ComponentScene]") {
     auto ha = s.stage_new_entity();
     auto hb = s.stage_new_entity();
     auto hc = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 99.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hc.id(), 3.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 99.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hc.id(), 3.0F));
     CHECK(s.erase_entity(hb)); // leave a gap at hb's ID
     int count = 0;
-    float fsum = 0.f;
+    float fsum = 0.F;
     auto f = s.for_all<float>([&](auto, auto comps) {
       ++count;
       fsum += std::get<0>(comps);
@@ -7582,7 +7584,7 @@ TEST_CASE("ForAll", "[ComponentScene]") {
     });
     CHECK(f == 0U);
     CHECK(count == 2);   // only ha and hc
-    CHECK(fsum == 4.0f); // 1.0 + 3.0
+    CHECK(fsum == 4.0F); // 1.0 + 3.0
     (void)ha;
     (void)hc;
   }
@@ -7606,13 +7608,13 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
     auto ha = s.stage_new_entity(); // both
     auto hb = s.stage_new_entity(); // TagA only
     auto hc = s.stage_new_entity(); // TagB only
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(ha.id(), 10.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 2.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(hc.id(), 3.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(ha.id(), 10.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 2.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(hc.id(), 3.0F));
     int count = 0;
-    float asum = 0.f;
-    float bsum = 0.f;
+    float asum = 0.F;
+    float bsum = 0.F;
     s.for_each<FloatTagA, FloatTagB>([&](auto, auto comps) {
       ++count;
       asum += std::get<0>(comps); // float from FloatTagA storage
@@ -7620,8 +7622,8 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
       return true;
     });
     CHECK(count == 1); // only ha
-    CHECK(asum == 1.0f);
-    CHECK(bsum == 10.0f);
+    CHECK(asum == 1.0F);
+    CHECK(bsum == 10.0F);
     (void)hb;
     (void)hc;
   }
@@ -7631,14 +7633,14 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
     two_tagged_scene_t s;
     auto ha = s.stage_new_entity();
     auto hb = s.stage_new_entity(); // TagB only, not visited
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 5.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(hb.id(), 6.0f));
-    float asum = 0.f;
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 5.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(hb.id(), 6.0F));
+    float asum = 0.F;
     s.for_each<FloatTagA>([&](auto, auto comps) {
       asum += std::get<0>(comps);
       return true;
     });
-    CHECK(asum == 5.0f);
+    CHECK(asum == 5.0F);
     (void)ha;
     (void)hb;
   }
@@ -7647,12 +7649,12 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
   if (true) {
     two_tagged_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 0.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 0.0F));
     s.for_each<FloatTagA>([](auto, auto comps) {
-      std::get<0>(comps) = 77.0f;
+      std::get<0>(comps) = 77.0F;
       return true;
     });
-    CHECK(s.storage<cs_scene_sid_t{1}>()[h.id()] == 77.0f);
+    CHECK(s.storage<cs_scene_sid_t{1}>()[h.id()] == 77.0F);
     (void)h;
   }
 
@@ -7660,18 +7662,18 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
   if (true) {
     two_tagged_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 3.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(h.id(), 4.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 3.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(h.id(), 4.0F));
     const auto& cs = s;
-    float aval = 0.f;
-    float bval = 0.f;
+    float aval = 0.F;
+    float bval = 0.F;
     cs.for_each<FloatTagA, FloatTagB>([&](auto, auto comps) {
       aval = std::get<0>(comps); // const float&
       bval = std::get<1>(comps); // const float&
       return true;
     });
-    CHECK(aval == 3.0f);
-    CHECK(bval == 4.0f);
+    CHECK(aval == 3.0F);
+    CHECK(bval == 4.0F);
     (void)h;
   }
 
@@ -7680,12 +7682,12 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
     two_tagged_scene_t s;
     auto ha = s.stage_new_entity(); // both
     auto hb = s.stage_new_entity(); // TagA only
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 9.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(ha.id(), 8.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 1.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 9.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(ha.id(), 8.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 1.0F));
     int count = 0;
-    float asum = 0.f;
-    float bsum = 0.f;
+    float asum = 0.F;
+    float bsum = 0.F;
     auto f = s.for_all<FloatTagA, FloatTagB>([&](auto, auto comps) {
       ++count;
       asum += std::get<0>(comps);
@@ -7694,8 +7696,8 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
     });
     CHECK(f == 0U);
     CHECK(count == 1); // only ha
-    CHECK(asum == 9.0f);
-    CHECK(bsum == 8.0f);
+    CHECK(asum == 9.0F);
+    CHECK(bsum == 8.0F);
     (void)hb;
   }
 
@@ -7703,17 +7705,17 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
   if (true) {
     two_tagged_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 11.0f)); // TagA
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(h.id(), 22.0f)); // TagB
-    float aval = 0.f;
-    float bval = 0.f;
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 11.0F)); // TagA
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(h.id(), 22.0F)); // TagB
+    float aval = 0.F;
+    float bval = 0.F;
     s.for_each<FloatTagB, FloatTagA>([&](auto, auto comps) {
       bval = std::get<0>(comps); // index 0 = FloatTagB (first in list)
       aval = std::get<1>(comps); // index 1 = FloatTagA (second in list)
       return true;
     });
-    CHECK(bval == 22.0f);
-    CHECK(aval == 11.0f);
+    CHECK(bval == 22.0F);
+    CHECK(aval == 11.0F);
     (void)h;
   }
 
@@ -7723,8 +7725,8 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
     CHECK(s.storage<tagged_float_a_t>().empty());
     CHECK(s.storage<tagged_float_b_t>().empty());
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 3.0f));
-    CHECK(s.storage<tagged_float_a_t>()[h.id()] == 3.0f);
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 3.0F));
+    CHECK(s.storage<tagged_float_a_t>()[h.id()] == 3.0F);
     CHECK(s.storage<tagged_float_b_t>().empty());
     (void)h;
   }
@@ -7734,10 +7736,10 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
     two_tagged_scene_t s;
     auto ha = s.stage_new_entity(); // TagA only
     auto hb = s.stage_new_entity(); // TagB only, not visited
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 5.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(hb.id(), 6.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 5.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(hb.id(), 6.0F));
     int count = 0;
-    float asum = 0.f;
+    float asum = 0.F;
     auto f = s.for_all<FloatTagA>([&](auto, auto comps) {
       ++count;
       asum += std::get<0>(comps);
@@ -7745,7 +7747,7 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
     });
     CHECK(f == 0U);
     CHECK(count == 1);
-    CHECK(asum == 5.0f);
+    CHECK(asum == 5.0F);
     (void)ha;
     (void)hb;
   }
@@ -7755,8 +7757,8 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
     two_tagged_scene_t s;
     auto ha = s.stage_new_entity();
     auto hb = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 2.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 2.0F));
     int count = 0;
     s.for_each<FloatTagA>([&](auto, auto) {
       ++count;
@@ -7771,19 +7773,19 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
   if (true) {
     two_tagged_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 21.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(h.id(), 42.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 21.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(h.id(), 42.0F));
     const auto& cs = s;
-    float aval = 0.f;
-    float bval = 0.f;
+    float aval = 0.F;
+    float bval = 0.F;
     auto f = cs.for_all<FloatTagA, FloatTagB>([&](auto, auto comps) {
       aval = std::get<0>(comps); // const float&
       bval = std::get<1>(comps); // const float&
       return true;
     });
     CHECK(f == 0U);
-    CHECK(aval == 21.0f);
-    CHECK(bval == 42.0f);
+    CHECK(aval == 21.0F);
+    CHECK(bval == 42.0F);
     (void)h;
   }
 
@@ -7795,12 +7797,12 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
     auto ha = s.stage_new_entity(); // FloatTagA + int: visited
     auto hb = s.stage_new_entity(); // FloatTagA only: skipped
     auto hc = s.stage_new_entity(); // int only: skipped
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0F));
     CHECK(s.store_entity<cs_scene_sid_t{3}>(ha.id(), 10));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 2.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 2.0F));
     CHECK(s.store_entity<cs_scene_sid_t{3}>(hc.id(), 20));
     int count = 0;
-    float fsum = 0.f;
+    float fsum = 0.F;
     int isum = 0;
     s.for_each<FloatTagA, int>([&](auto, auto comps) {
       ++count;
@@ -7809,7 +7811,7 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
       return true;
     });
     CHECK(count == 1); // only ha
-    CHECK(fsum == 1.0f);
+    CHECK(fsum == 1.0F);
     CHECK(isum == 10);
     (void)hb;
     (void)hc;
@@ -7820,11 +7822,11 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
     three_tagged_scene_t s;
     auto ha = s.stage_new_entity(); // FloatTagA + int
     auto hb = s.stage_new_entity(); // FloatTagA only
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 3.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 3.0F));
     CHECK(s.store_entity<cs_scene_sid_t{3}>(ha.id(), 30));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 4.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 4.0F));
     int count = 0;
-    float fsum = 0.f;
+    float fsum = 0.F;
     int isum = 0;
     auto f = s.for_all<FloatTagA, int>([&](auto, auto comps) {
       ++count;
@@ -7834,7 +7836,7 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
     });
     CHECK(f == 0U);
     CHECK(count == 1); // only ha
-    CHECK(fsum == 3.0f);
+    CHECK(fsum == 3.0F);
     CHECK(isum == 30);
     (void)hb;
   }
@@ -7845,16 +7847,16 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
     auto ha = s.stage_new_entity(); // all three: the only match
     auto hb = s.stage_new_entity(); // FloatTagA + FloatTagB only
     auto hc = s.stage_new_entity(); // FloatTagA + int only
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(ha.id(), 2.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(ha.id(), 2.0F));
     CHECK(s.store_entity<cs_scene_sid_t{3}>(ha.id(), 10));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 3.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(hb.id(), 4.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hc.id(), 5.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 3.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(hb.id(), 4.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hc.id(), 5.0F));
     CHECK(s.store_entity<cs_scene_sid_t{3}>(hc.id(), 20));
     int count = 0;
-    float asum = 0.f;
-    float bsum = 0.f;
+    float asum = 0.F;
+    float bsum = 0.F;
     int isum = 0;
     s.for_each<FloatTagA, FloatTagB, int>([&](auto, auto comps) {
       ++count;
@@ -7864,8 +7866,8 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
       return true;
     });
     CHECK(count == 1); // only ha
-    CHECK(asum == 1.0f);
-    CHECK(bsum == 2.0f);
+    CHECK(asum == 1.0F);
+    CHECK(bsum == 2.0F);
     CHECK(isum == 10);
     (void)hb;
     (void)hc;
@@ -7879,15 +7881,15 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
     auto ha = s.stage_new_entity(); // TagA + int: visited (float unambiguous)
     auto hb = s.stage_new_entity(); // TagB + int: visited (float unambiguous)
     auto hc = s.stage_new_entity(); // TagA + TagB + int: ambiguous, counted
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0F));
     CHECK(s.store_entity<cs_scene_sid_t{3}>(ha.id(), 10));
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(hb.id(), 2.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(hb.id(), 2.0F));
     CHECK(s.store_entity<cs_scene_sid_t{3}>(hb.id(), 20));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hc.id(), 99.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(hc.id(), 99.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hc.id(), 99.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(hc.id(), 99.0F));
     CHECK(s.store_entity<cs_scene_sid_t{3}>(hc.id(), 99));
     int count = 0;
-    float fsum = 0.f;
+    float fsum = 0.F;
     int isum = 0;
     auto f = s.for_all<float, int>([&](auto, auto comps) {
       ++count;
@@ -7897,7 +7899,7 @@ TEST_CASE("TagLookup", "[ComponentScene]") {
     });
     CHECK(f == 1U);      // hc is ambiguous
     CHECK(count == 2);   // ha and hb
-    CHECK(fsum == 3.0f); // 1.0 + 2.0
+    CHECK(fsum == 3.0F); // 1.0 + 2.0
     CHECK(isum == 30);   // 10 + 20
     (void)ha;
     (void)hb;
@@ -7919,9 +7921,9 @@ TEST_CASE("ForAllSharedType", "[ComponentScene]") {
   if (true) {
     two_tagged_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 3.0f)); // TagA
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 3.0F)); // TagA
     int count = 0;
-    float fsum = 0.f;
+    float fsum = 0.F;
     auto f1 = s.for_all<float>([&](auto, auto comps) {
       ++count;
       fsum += std::get<0>(comps);
@@ -7929,7 +7931,7 @@ TEST_CASE("ForAllSharedType", "[ComponentScene]") {
     });
     CHECK(f1 == 0U);
     CHECK(count == 1);
-    CHECK(fsum == 3.0f);
+    CHECK(fsum == 3.0F);
     (void)h;
   }
 
@@ -7937,9 +7939,9 @@ TEST_CASE("ForAllSharedType", "[ComponentScene]") {
   if (true) {
     two_tagged_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(h.id(), 7.0f)); // TagB
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(h.id(), 7.0F)); // TagB
     int count = 0;
-    float fsum = 0.f;
+    float fsum = 0.F;
     auto f2 = s.for_all<float>([&](auto, auto comps) {
       ++count;
       fsum += std::get<0>(comps);
@@ -7947,7 +7949,7 @@ TEST_CASE("ForAllSharedType", "[ComponentScene]") {
     });
     CHECK(f2 == 0U);
     CHECK(count == 1);
-    CHECK(fsum == 7.0f);
+    CHECK(fsum == 7.0F);
     (void)h;
   }
 
@@ -7956,10 +7958,10 @@ TEST_CASE("ForAllSharedType", "[ComponentScene]") {
     two_tagged_scene_t s;
     auto ha = s.stage_new_entity();
     auto hb = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0f)); // TagA
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(hb.id(), 2.0f)); // TagB
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0F)); // TagA
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(hb.id(), 2.0F)); // TagB
     int count = 0;
-    float fsum = 0.f;
+    float fsum = 0.F;
     auto f3 = s.for_all<float>([&](auto, auto comps) {
       ++count;
       fsum += std::get<0>(comps);
@@ -7967,7 +7969,7 @@ TEST_CASE("ForAllSharedType", "[ComponentScene]") {
     });
     CHECK(f3 == 0U);
     CHECK(count == 2);
-    CHECK(fsum == 3.0f);
+    CHECK(fsum == 3.0F);
     (void)ha;
     (void)hb;
   }
@@ -7976,8 +7978,8 @@ TEST_CASE("ForAllSharedType", "[ComponentScene]") {
   if (true) {
     two_tagged_scene_t s;
     auto h = s.stage_new_entity();
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 5.0f)); // TagA
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(h.id(), 6.0f)); // TagB
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(h.id(), 5.0F)); // TagA
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(h.id(), 6.0F)); // TagB
     int count = 0;
     auto f4 = s.for_all<float>([&](auto, auto) {
       ++count;
@@ -7993,11 +7995,11 @@ TEST_CASE("ForAllSharedType", "[ComponentScene]") {
     two_tagged_scene_t s;
     auto ha = s.stage_new_entity(); // ambiguous: both storages
     auto hb = s.stage_new_entity(); // TagA only
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 99.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(ha.id(), 99.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 4.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 99.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(ha.id(), 99.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 4.0F));
     int count = 0;
-    float fsum = 0.f;
+    float fsum = 0.F;
     auto f5 = s.for_all<float>([&](auto, auto comps) {
       ++count;
       fsum += std::get<0>(comps);
@@ -8005,7 +8007,7 @@ TEST_CASE("ForAllSharedType", "[ComponentScene]") {
     });
     CHECK(f5 == 1U);   // ha counted as failure
     CHECK(count == 1); // only hb visited
-    CHECK(fsum == 4.0f);
+    CHECK(fsum == 4.0F);
     (void)ha;
     (void)hb;
   }
@@ -8015,8 +8017,8 @@ TEST_CASE("ForAllSharedType", "[ComponentScene]") {
     two_tagged_scene_t s;
     auto ha = s.stage_new_entity(); // TagA only
     auto hb = s.stage_new_entity(); // TagA only
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 2.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 2.0F));
     int count = 0;
     auto f6 = s.for_all<float>([&](auto, auto) {
       ++count;
@@ -8036,9 +8038,9 @@ TEST_CASE("ForAllSharedType", "[ComponentScene]") {
     two_tagged_scene_t s;
     auto ha = s.stage_new_entity(); // ambiguous: in both storages
     auto hb = s.stage_new_entity(); // TagA only
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 99.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(ha.id(), 99.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 4.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 99.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(ha.id(), 99.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hb.id(), 4.0F));
     int count = 0;
     auto f = s.for_all<float>([&](auto, auto) {
       ++count;
@@ -8058,12 +8060,12 @@ TEST_CASE("ForAllSharedType", "[ComponentScene]") {
     auto hb = s.stage_new_entity(); // TagB only, not visited
     auto hc = s.stage_new_entity(); // both storages (ambiguous for float, not
                                     // for FloatTagA)
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(hb.id(), 2.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{1}>(hc.id(), 3.0f));
-    CHECK(s.store_entity<cs_scene_sid_t{2}>(hc.id(), 99.0f));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(ha.id(), 1.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(hb.id(), 2.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{1}>(hc.id(), 3.0F));
+    CHECK(s.store_entity<cs_scene_sid_t{2}>(hc.id(), 99.0F));
     int count = 0;
-    float fsum = 0.f;
+    float fsum = 0.F;
     auto f7 = s.for_all<FloatTagA>([&](auto, auto comps) {
       ++count;
       fsum += std::get<0>(comps);
@@ -8071,7 +8073,7 @@ TEST_CASE("ForAllSharedType", "[ComponentScene]") {
     });
     CHECK(f7 == 0U);     // no ambiguity: tag resolves to exactly one storage
     CHECK(count == 2);   // ha and hc both have the TagA component
-    CHECK(fsum == 4.0f); // 1.0 + 3.0
+    CHECK(fsum == 4.0F); // 1.0 + 3.0
     (void)ha;
     (void)hb;
     (void)hc;
@@ -8090,10 +8092,10 @@ TEST_CASE("SwapMoveReserve", "[ComponentStorage]") {
     cs_store_t s{r, cs_sid_t{1}};
     s.reserve(50);
     auto id0 = r.create_id({}, 0);
-    CHECK(s.add(id0, 1.0f));
+    CHECK(s.add(id0, 1.0F));
     s.shrink_to_fit();
     CHECK(s.size() == 1U);
-    CHECK(s[id0] == 1.0f);
+    CHECK(s[id0] == 1.0F);
   }
 
   // swap() (member) exchanges store_ids and component data.
@@ -8103,15 +8105,15 @@ TEST_CASE("SwapMoveReserve", "[ComponentStorage]") {
     cs_store_t s2{r, cs_sid_t{2}};
     auto id0 = r.create_id({}, 0);
     auto id1 = r.create_id({}, 0);
-    CHECK(s1.add(id0, 1.0f));
-    CHECK(s2.add(id1, 2.0f));
+    CHECK(s1.add(id0, 1.0F));
+    CHECK(s2.add(id1, 2.0F));
     s1.swap(s2);
     CHECK(s1.store_id() == cs_sid_t{2});
     CHECK(s2.store_id() == cs_sid_t{1});
     CHECK(s1.contains(id1));
     CHECK(s2.contains(id0));
-    CHECK(s1[id1] == 2.0f);
-    CHECK(s2[id0] == 1.0f);
+    CHECK(s1[id1] == 2.0F);
+    CHECK(s2[id0] == 1.0F);
   }
 
   // swap() (free function).
@@ -8120,12 +8122,12 @@ TEST_CASE("SwapMoveReserve", "[ComponentStorage]") {
     cs_store_t s1{r, cs_sid_t{1}};
     cs_store_t s2{r, cs_sid_t{2}};
     auto id0 = r.create_id({}, 0);
-    CHECK(s1.add(id0, 5.0f));
+    CHECK(s1.add(id0, 5.0F));
     swap(s1, s2);
     CHECK(s1.store_id() == cs_sid_t{2});
     CHECK(s2.store_id() == cs_sid_t{1});
     CHECK(s2.contains(id0));
-    CHECK(s2[id0] == 5.0f);
+    CHECK(s2[id0] == 5.0F);
     CHECK(s1.empty());
   }
 
@@ -8135,11 +8137,11 @@ TEST_CASE("SwapMoveReserve", "[ComponentStorage]") {
     auto id0 = r.create_id({}, 0);
     {
       cs_store_t s1{r, cs_sid_t{1}};
-      CHECK(s1.add(id0, 3.14f));
+      CHECK(s1.add(id0, 3.14F));
       cs_store_t s2{std::move(s1)};
       CHECK(s2.size() == 1U);
       CHECK(s2.store_id() == cs_sid_t{1});
-      CHECK(s2[id0] == 3.14f);
+      CHECK(s2[id0] == 3.14F);
     } // s2 destructor erases entity
     CHECK_FALSE(r.is_valid(id0));
   }
@@ -8151,10 +8153,10 @@ TEST_CASE("SwapMoveReserve", "[ComponentStorage]") {
     {
       cs_store_t s1{r, cs_sid_t{1}};
       cs_store_t s2;
-      CHECK(s1.add(id0, 7.0f));
+      CHECK(s1.add(id0, 7.0F));
       s2 = std::move(s1);
       CHECK(s2.size() == 1U);
-      CHECK(s2[id0] == 7.0f);
+      CHECK(s2[id0] == 7.0F);
     } // s2 destructor erases entity
     CHECK_FALSE(r.is_valid(id0));
   }
@@ -8170,19 +8172,19 @@ TEST_CASE("AddNew", "[ComponentStorage]") {
   if (true) {
     cs_reg_t r;
     cs_store_t s{r, cs_sid_t{1}};
-    auto h = s.add_new(3.14f);
+    auto h = s.add_new(3.14F);
     CHECK(static_cast<bool>(h));
     CHECK(s.contains(h.id()));
-    CHECK(s[h.id()] == 3.14f);
+    CHECK(s[h.id()] == 3.14F);
   }
 
   // add_new(component, metadata) -- component-first with explicit metadata.
   if (true) {
     cs_reg_t r;
     cs_store_t s{r, cs_sid_t{1}};
-    auto h = s.add_new(9.9f, 42);
+    auto h = s.add_new(9.9F, 42);
     CHECK(static_cast<bool>(h));
-    CHECK(s[h.id()] == 9.9f);
+    CHECK(s[h.id()] == 9.9F);
     CHECK(r[h.id()] == 42);
   }
 
@@ -8192,9 +8194,9 @@ TEST_CASE("AddNew", "[ComponentStorage]") {
     cs_reg_t r;
     cs_store_t s{r, cs_sid_t{1}};
     CHECK(s.set_limit(1));
-    auto h0 = s.add_new(1.0f);
+    auto h0 = s.add_new(1.0F);
     CHECK(static_cast<bool>(h0));
-    auto h1 = s.add_new(2.0f);
+    auto h1 = s.add_new(2.0F);
     CHECK_FALSE(static_cast<bool>(h1));
     CHECK(s.size() == 1U);
     CHECK(r.size() == 1U);
@@ -8208,8 +8210,8 @@ TEST_CASE("AddNew", "[ComponentStorage]") {
     CHECK(s.limit() == *cs_id_t::invalid); // default: unlimited
     auto id0 = r.create_id({}, 0);
     auto id1 = r.create_id({}, 0);
-    CHECK(s.add(id0, 1.0f));
-    CHECK(s.add(id1, 2.0f));
+    CHECK(s.add(id0, 1.0F));
+    CHECK(s.add(id1, 2.0F));
     CHECK_FALSE(s.set_limit(1));           // 2 entities; 1 < 2 -- rejected
     CHECK(s.limit() == *cs_id_t::invalid); // unchanged
     CHECK(s.set_limit(2));                 // exactly current size -- accepted
@@ -8230,10 +8232,10 @@ TEST_CASE("At", "[ComponentStorage]") {
     cs_reg_t r;
     cs_store_t s{r, cs_sid_t{1}};
     auto id0 = r.create_id({}, 0);
-    CHECK(s.add(id0, 2.5f));
+    CHECK(s.add(id0, 2.5F));
     const auto& cs = s;
-    CHECK(cs.at(id0) == 2.5f);
-    CHECK(cs.at(id0).component<float>() == 2.5f);
+    CHECK(cs.at(id0) == 2.5F);
+    CHECK(cs.at(id0).component<float>() == 2.5F);
     CHECK(cs.at(id0).id() == id0);
   }
 
@@ -8250,19 +8252,19 @@ TEST_CASE("At", "[ComponentStorage]") {
   if (true) {
     cs_reg_t r;
     cs_store_t s{r, cs_sid_t{1}};
-    auto h = s.add_new({}, 5.0f);
-    CHECK(s.at(h) == 5.0f);
-    s.at(h) = 99.0f;
-    CHECK(s[h.id()] == 99.0f);
+    auto h = s.add_new({}, 5.0F);
+    CHECK(s.at(h) == 5.0F);
+    s.at(h) = 99.0F;
+    CHECK(s[h.id()] == 99.0F);
   }
 
   // at(handle_t) const: returns `row_view`.
   if (true) {
     cs_reg_t r;
     cs_store_t s{r, cs_sid_t{1}};
-    auto h = s.add_new({}, 7.0f);
+    auto h = s.add_new({}, 7.0F);
     const auto& cs = s;
-    CHECK(cs.at(h).component<float>() == 7.0f);
+    CHECK(cs.at(h).component<float>() == 7.0F);
     CHECK(cs.at(h).id() == h.id());
   }
 
@@ -8281,7 +8283,7 @@ TEST_CASE("At", "[ComponentStorage]") {
     cs_reg_t r;
     cs_store_t s1{r, cs_sid_t{1}};
     cs_store_t s2{r, cs_sid_t{2}};
-    auto h = s2.add_new({}, 3.0f);
+    auto h = s2.add_new({}, 3.0F);
     CHECK_THROWS_AS((void)s1.at(h), std::invalid_argument);
     const auto& cs1 = s1;
     CHECK_THROWS_AS((void)cs1.at(h), std::invalid_argument);
@@ -8290,5 +8292,5 @@ TEST_CASE("At", "[ComponentStorage]") {
 
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/entity_registry_test.cpp
+++ b/tests/portable/entity_registry_test.cpp
@@ -1754,7 +1754,9 @@ TEST_CASE("HandleOwner", "[EntityRegistry]") {
     auto o1 = r.create_owner(staging, 10);
     auto id = o1.id();
     owner_t o2{std::move(o1)};
+    // NOLINTNEXTLINE(bugprone-use-after-move): moved-from is asserted.
     CHECK_FALSE(bool(o1));
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move): same assertion.
     CHECK(o1.id() == id_t::invalid);
     CHECK(bool(o2));
     CHECK(o2.id() == id);
@@ -1769,6 +1771,7 @@ TEST_CASE("HandleOwner", "[EntityRegistry]") {
     auto id1 = o1.id();
     auto id2 = o2.id();
     o2 = std::move(o1);
+    // NOLINTNEXTLINE(bugprone-use-after-move): moved-from is asserted.
     CHECK_FALSE(bool(o1));
     CHECK(bool(o2));
     CHECK(o2.id() == id1);
@@ -1783,6 +1786,7 @@ TEST_CASE("HandleOwner", "[EntityRegistry]") {
     auto id = o1.id();
     owner_t o2;
     o2 = std::move(o1);
+    // NOLINTNEXTLINE(bugprone-use-after-move): moved-from is asserted.
     CHECK_FALSE(bool(o1));
     CHECK(bool(o2));
     CHECK(o2.id() == id);
@@ -2303,6 +2307,7 @@ TEST_CASE("ComponentMode_HandleOwner", "[EntityRegistry]") {
     auto o1 = r.create_owner(10);
     auto id = o1.id();
     owner_t o2{std::move(o1)};
+    // NOLINTNEXTLINE(bugprone-use-after-move): moved-from is asserted.
     CHECK_FALSE(bool(o1));
     CHECK(bool(o2));
     CHECK(o2.id() == id);

--- a/tests/portable/entity_registry_test.cpp
+++ b/tests/portable/entity_registry_test.cpp
@@ -24,8 +24,7 @@
 
 using namespace corvid;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 
 #pragma region Basic
 
@@ -1181,7 +1180,9 @@ TEST_CASE("LocationRecord", "[EntityRegistry]") {
     if (true) {
       reg_t r;
       (void)r.create_id({store_id_t{2}, 0}, 10);
-      bool has_2 = false, has_1 = false, has_invalid = false;
+      bool has_2 = false;
+      bool has_1 = false;
+      bool has_invalid = false;
       r.erase_if([&](auto, auto& rec) {
         has_2 = rec.location.contains(store_id_t{2});
         has_1 = rec.location.contains(store_id_t{1});
@@ -1209,7 +1210,8 @@ TEST_CASE("LocationRecord", "[EntityRegistry]") {
     if (true) {
       creg_t r;
       (void)r.create_id({}, 10);
-      bool has_staging = false, has_1 = false;
+      bool has_staging = false;
+      bool has_1 = false;
       r.erase_if([&](auto, auto& rec) {
         has_staging = rec.location.contains(store_id_t{0});
         has_1 = rec.location.contains(store_id_t{1});
@@ -1224,7 +1226,8 @@ TEST_CASE("LocationRecord", "[EntityRegistry]") {
       creg_t r;
       auto id0 = r.create_id({}, 10);
       r.add_location(id0, store_id_t{5});
-      bool has_5 = false, has_0 = false;
+      bool has_5 = false;
+      bool has_0 = false;
       r.erase_if([&](auto, auto& rec) {
         has_5 = rec.location.contains(store_id_t{5});
         has_0 = rec.location.contains(store_id_t{0}); // staging cleared
@@ -2453,5 +2456,4 @@ TEST_CASE("ComponentMode_Lifo", "[EntityRegistry]") {
 
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/fixed_bitset_test.cpp
+++ b/tests/portable/fixed_bitset_test.cpp
@@ -262,6 +262,7 @@ TEST_CASE("CopyMove", "[FixedBitset]") {
   if (true) {
     fixed_bitset<64> a;
     a.set(5);
+    // NOLINTNEXTLINE(performance-move-const-arg): move is the subject.
     fixed_bitset<64> b{std::move(a)};
     CHECK(b.test(5));
   }
@@ -271,6 +272,7 @@ TEST_CASE("CopyMove", "[FixedBitset]") {
     fixed_bitset<64> a;
     fixed_bitset<64> b;
     a.set(20);
+    // NOLINTNEXTLINE(performance-move-const-arg): move is the subject.
     b = std::move(a);
     CHECK(b.test(20));
   }

--- a/tests/portable/fixed_bitset_test.cpp
+++ b/tests/portable/fixed_bitset_test.cpp
@@ -29,8 +29,7 @@ using namespace corvid;
 // It has no arithmetic operators, which exercises the as_sz/as_pos casts.
 enum class slot_t : size_t {};
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 
 #pragma region Empty
 
@@ -214,7 +213,8 @@ TEST_CASE("Reset", "[FixedBitset]") {
 
 TEST_CASE("Equality", "[FixedBitset]") {
   if (true) {
-    fixed_bitset<64> a, b;
+    fixed_bitset<64> a;
+    fixed_bitset<64> b;
     CHECK(a == b);
 
     a.set(5);
@@ -249,7 +249,8 @@ TEST_CASE("CopyMove", "[FixedBitset]") {
 
   // Copy assignment.
   if (true) {
-    fixed_bitset<64> a, b;
+    fixed_bitset<64> a;
+    fixed_bitset<64> b;
     a.set(10);
     b = a;
     CHECK(a == b);
@@ -267,7 +268,8 @@ TEST_CASE("CopyMove", "[FixedBitset]") {
 
   // Move assignment.
   if (true) {
-    fixed_bitset<64> a, b;
+    fixed_bitset<64> a;
+    fixed_bitset<64> b;
     a.set(20);
     b = std::move(a);
     CHECK(b.test(20));
@@ -651,7 +653,8 @@ TEST_CASE("Reference", "[FixedBitset]") {
 
   // operator=(const reference&) copies the bit value from another reference.
   if (true) {
-    fixed_bitset<64> a, b;
+    fixed_bitset<64> a;
+    fixed_bitset<64> b;
     a.set(2);
     b[5] = a[2]; // b[5] ← true (bit 2 of a)
     CHECK(b.test(5));
@@ -699,7 +702,8 @@ TEST_CASE("Reference", "[FixedBitset]") {
 
 TEST_CASE("BitwiseAnd", "[FixedBitset]") {
   if (true) {
-    fixed_bitset<64> a, b;
+    fixed_bitset<64> a;
+    fixed_bitset<64> b;
     a.set(1).set(3).set(5);
     b.set(3).set(5).set(7);
 
@@ -721,7 +725,8 @@ TEST_CASE("BitwiseAnd", "[FixedBitset]") {
 
   // AND with empty yields empty.
   if (true) {
-    fixed_bitset<64> a, empty;
+    fixed_bitset<64> a;
+    fixed_bitset<64> empty;
     a.set(7);
     auto result = a & empty;
     CHECK(result.none());
@@ -729,7 +734,8 @@ TEST_CASE("BitwiseAnd", "[FixedBitset]") {
 
   // operator&= in-place.
   if (true) {
-    fixed_bitset<64> a, b;
+    fixed_bitset<64> a;
+    fixed_bitset<64> b;
     a.set(2).set(4);
     b.set(4).set(6);
     a &= b;
@@ -744,7 +750,8 @@ TEST_CASE("BitwiseAnd", "[FixedBitset]") {
 
 TEST_CASE("BitwiseOr", "[FixedBitset]") {
   if (true) {
-    fixed_bitset<64> a, b;
+    fixed_bitset<64> a;
+    fixed_bitset<64> b;
     a.set(1).set(3);
     b.set(3).set(5);
 
@@ -757,7 +764,8 @@ TEST_CASE("BitwiseOr", "[FixedBitset]") {
 
   // OR with empty is idempotent.
   if (true) {
-    fixed_bitset<64> a, empty;
+    fixed_bitset<64> a;
+    fixed_bitset<64> empty;
     a.set(7);
     auto result = a | empty;
     CHECK(result == a);
@@ -765,7 +773,8 @@ TEST_CASE("BitwiseOr", "[FixedBitset]") {
 
   // operator|= in-place.
   if (true) {
-    fixed_bitset<64> a, b;
+    fixed_bitset<64> a;
+    fixed_bitset<64> b;
     a.set(1);
     b.set(2);
     a |= b;
@@ -781,7 +790,8 @@ TEST_CASE("BitwiseOr", "[FixedBitset]") {
 TEST_CASE("BitwiseXor", "[FixedBitset]") {
   // Basic XOR: shared bits cancel, unique bits survive.
   if (true) {
-    fixed_bitset<64> a, b;
+    fixed_bitset<64> a;
+    fixed_bitset<64> b;
     a.set(1).set(3).set(5);
     b.set(3).set(5).set(7);
 
@@ -802,14 +812,16 @@ TEST_CASE("BitwiseXor", "[FixedBitset]") {
 
   // XOR with empty is idempotent.
   if (true) {
-    fixed_bitset<64> a, empty;
+    fixed_bitset<64> a;
+    fixed_bitset<64> empty;
     a.set(9);
     CHECK((a ^ empty) == a);
   }
 
   // operator^= in-place.
   if (true) {
-    fixed_bitset<64> a, b;
+    fixed_bitset<64> a;
+    fixed_bitset<64> b;
     a.set(0).set(1);
     b.set(1).set(2);
     a ^= b;
@@ -820,7 +832,8 @@ TEST_CASE("BitwiseXor", "[FixedBitset]") {
 
   // XOR across word boundary (128-bit).
   if (true) {
-    fixed_bitset<128> a, b;
+    fixed_bitset<128> a;
+    fixed_bitset<128> b;
     a.set(63).set(64);
     b.set(63).set(65);
     auto c = a ^ b;
@@ -1192,7 +1205,8 @@ TEST_CASE("MultiWord", "[FixedBitset]") {
 
   // AND across word boundary.
   if (true) {
-    fixed_bitset<128> a, b;
+    fixed_bitset<128> a;
+    fixed_bitset<128> b;
     a.set(63).set(64);
     b.set(63).set(65);
     auto c = a & b;
@@ -1204,7 +1218,8 @@ TEST_CASE("MultiWord", "[FixedBitset]") {
 
   // OR across word boundary.
   if (true) {
-    fixed_bitset<128> a, b;
+    fixed_bitset<128> a;
+    fixed_bitset<128> b;
     a.set(60);
     b.set(68);
     auto c = a | b;
@@ -1243,7 +1258,8 @@ TEST_CASE("MultiWord", "[FixedBitset]") {
 
   // Equality across words.
   if (true) {
-    fixed_bitset<128> a, b;
+    fixed_bitset<128> a;
+    fixed_bitset<128> b;
     a.set(0).set(127);
     b.set(0);
     CHECK(a != b);
@@ -1342,7 +1358,8 @@ TEST_CASE("PosParam", "[FixedBitset]") {
 
   // Bitwise operators preserve pos_t interface.
   if (true) {
-    bs_t a, b;
+    bs_t a;
+    bs_t b;
     a.set(slot_t{2});
     b.set(slot_t{2}).set(slot_t{4});
     auto c = a & b;
@@ -1467,7 +1484,8 @@ TEST_CASE("At", "[FixedBitset]") {
 TEST_CASE("Ordering", "[FixedBitset]") {
   // Reflexive: equal bitsets compare equal.
   if (true) {
-    fixed_bitset<64> a, b;
+    fixed_bitset<64> a;
+    fixed_bitset<64> b;
     CHECK(std::is_eq(a <=> b));
     a.set(5);
     b.set(5);
@@ -1476,7 +1494,8 @@ TEST_CASE("Ordering", "[FixedBitset]") {
 
   // Within one word: a higher-index bit makes the word value larger.
   if (true) {
-    fixed_bitset<64> lo, hi;
+    fixed_bitset<64> lo;
+    fixed_bitset<64> hi;
     lo.set(0); // words_[0] = 1
     hi.set(1); // words_[0] = 2
     CHECK(lo < hi);
@@ -1487,7 +1506,8 @@ TEST_CASE("Ordering", "[FixedBitset]") {
 
   // Empty is less than any set bit.
   if (true) {
-    fixed_bitset<64> empty, b;
+    fixed_bitset<64> empty;
+    fixed_bitset<64> b;
     b.set(0);
     CHECK(empty < b);
     CHECK_FALSE(b < empty);
@@ -1496,7 +1516,8 @@ TEST_CASE("Ordering", "[FixedBitset]") {
   // Multi-word: word 0 dominates word 1, so a single bit in word 0 outweighs
   // any combination of bits in word 1.
   if (true) {
-    fixed_bitset<128> word0, word1;
+    fixed_bitset<128> word0;
+    fixed_bitset<128> word1;
     word0.set(0);  // words_ = {1, 0}
     word1.set(64); // words_ = {0, 1}
     // word0 > word1 because words_[0]=1 > 0
@@ -1506,7 +1527,8 @@ TEST_CASE("Ordering", "[FixedBitset]") {
 
   // A full word 1 is still less than a single bit in word 0.
   if (true) {
-    fixed_bitset<128> w0bit, w1full;
+    fixed_bitset<128> w0bit;
+    fixed_bitset<128> w1full;
     w0bit.set(0);
     for (auto ndx = 64UZ; ndx < 128; ++ndx) w1full.set(ndx);
     // w0bit: words_ = {1, 0}; w1full: words_ = {0, ~0ull}
@@ -1516,7 +1538,8 @@ TEST_CASE("Ordering", "[FixedBitset]") {
 
   // Ordering is consistent with equality.
   if (true) {
-    fixed_bitset<64> a, b;
+    fixed_bitset<64> a;
+    fixed_bitset<64> b;
     a.set(10);
     b.set(10);
     CHECK(a <= b);
@@ -2032,7 +2055,8 @@ TEST_CASE("ArrayConstruct", "[FixedBitset]") {
 TEST_CASE("Intersects", "[FixedBitset]") {
   // intersects: at least one bit set in both.
   if (true) {
-    fixed_bitset<8> a, b;
+    fixed_bitset<8> a;
+    fixed_bitset<8> b;
     a.set(1).set(3);
     b.set(3).set(5);
     CHECK(a.intersects(b)); // bit 3 is in both
@@ -2041,7 +2065,8 @@ TEST_CASE("Intersects", "[FixedBitset]") {
 
   // Non-overlapping sets do not intersect.
   if (true) {
-    fixed_bitset<8> a, b;
+    fixed_bitset<8> a;
+    fixed_bitset<8> b;
     a.set(0).set(2);
     b.set(1).set(3);
     CHECK_FALSE(a.intersects(b));
@@ -2050,7 +2075,8 @@ TEST_CASE("Intersects", "[FixedBitset]") {
 
   // Empty set intersects nothing.
   if (true) {
-    fixed_bitset<8> empty, full;
+    fixed_bitset<8> empty;
+    fixed_bitset<8> full;
     full.set();
     CHECK_FALSE(empty.intersects(full));
     CHECK_FALSE(full.intersects(empty));
@@ -2059,7 +2085,8 @@ TEST_CASE("Intersects", "[FixedBitset]") {
 
   // Full set intersects any non-empty set.
   if (true) {
-    fixed_bitset<8> full, single;
+    fixed_bitset<8> full;
+    fixed_bitset<8> single;
     full.set();
     single.set(4);
     CHECK(full.intersects(single));
@@ -2069,7 +2096,9 @@ TEST_CASE("Intersects", "[FixedBitset]") {
 
   // is_disjoint_from is the complement.
   if (true) {
-    fixed_bitset<8> a, b, c;
+    fixed_bitset<8> a;
+    fixed_bitset<8> b;
+    fixed_bitset<8> c;
     a.set(0);
     b.set(0).set(7);
     c.set(7);
@@ -2080,7 +2109,8 @@ TEST_CASE("Intersects", "[FixedBitset]") {
 
   // Multi-word bitset (128 bits = two 64-bit words, exercises the word loop).
   if (true) {
-    fixed_bitset<128> a, b;
+    fixed_bitset<128> a;
+    fixed_bitset<128> b;
     a.set(0);               // word 0
     a.set(65);              // word 1
     b.set(65);              // word 1 -- shared with a
@@ -2097,7 +2127,9 @@ TEST_CASE("Intersects", "[FixedBitset]") {
   // Constexpr.
   if (true) {
     constexpr auto make = []() {
-      fixed_bitset<8> a, b, c;
+      fixed_bitset<8> a;
+      fixed_bitset<8> b;
+      fixed_bitset<8> c;
       a.set(2);
       b.set(2).set(5);
       c.set(5);
@@ -2118,7 +2150,8 @@ TEST_CASE("Intersects", "[FixedBitset]") {
 TEST_CASE("IsSubset", "[FixedBitset]") {
   // is_subset_of: every set bit in *this is also set in other.
   if (true) {
-    fixed_bitset<8> a, b;
+    fixed_bitset<8> a;
+    fixed_bitset<8> b;
     a.set(1).set(3);
     b.set(1).set(2).set(3);
     CHECK(a.is_subset_of(b));       // {1,3} subset of {1,2,3}
@@ -2127,7 +2160,8 @@ TEST_CASE("IsSubset", "[FixedBitset]") {
 
   // Equal sets are subsets of each other.
   if (true) {
-    fixed_bitset<8> a, b;
+    fixed_bitset<8> a;
+    fixed_bitset<8> b;
     a.set(0).set(7);
     b.set(0).set(7);
     CHECK(a.is_subset_of(b));
@@ -2136,7 +2170,8 @@ TEST_CASE("IsSubset", "[FixedBitset]") {
 
   // Empty set is a subset of everything.
   if (true) {
-    fixed_bitset<8> empty, full;
+    fixed_bitset<8> empty;
+    fixed_bitset<8> full;
     full.set();
     CHECK(empty.is_subset_of(full));
     CHECK(empty.is_subset_of(empty));
@@ -2145,7 +2180,8 @@ TEST_CASE("IsSubset", "[FixedBitset]") {
 
   // Full set is only a subset of itself.
   if (true) {
-    fixed_bitset<8> full, almost;
+    fixed_bitset<8> full;
+    fixed_bitset<8> almost;
     full.set();
     almost = full;
     almost.reset(3);
@@ -2155,7 +2191,8 @@ TEST_CASE("IsSubset", "[FixedBitset]") {
 
   // is_superset_of is the mirror.
   if (true) {
-    fixed_bitset<8> a, b;
+    fixed_bitset<8> a;
+    fixed_bitset<8> b;
     a.set(2);
     b.set(2).set(5);
     CHECK(b.is_superset_of(a));       // {2,5} contains {2}
@@ -2164,7 +2201,8 @@ TEST_CASE("IsSubset", "[FixedBitset]") {
 
   // Multi-word bitset (128 bits = two 64-bit words, exercises the word loop).
   if (true) {
-    fixed_bitset<128> a, b;
+    fixed_bitset<128> a;
+    fixed_bitset<128> b;
     a.set(0);                         // word 0
     a.set(65);                        // word 1
     b.set(0);                         // word 0
@@ -2179,7 +2217,8 @@ TEST_CASE("IsSubset", "[FixedBitset]") {
   // Constexpr.
   if (true) {
     constexpr auto make = []() {
-      fixed_bitset<8> a, b;
+      fixed_bitset<8> a;
+      fixed_bitset<8> b;
       a.set(1);
       b.set(1).set(2);
       return std::pair{a.is_subset_of(b), b.is_subset_of(a)};
@@ -2248,5 +2287,4 @@ TEST_CASE("Formatting", "[FixedBitset]") {
 
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/formatting_test.cpp
+++ b/tests/portable/formatting_test.cpp
@@ -68,11 +68,11 @@ struct closing_handle {
 struct greeter {
   std::string_view who;
   template<typename OutIt>
-  OutIt format_to(OutIt out) const {
+  [[nodiscard]] OutIt format_to(OutIt out) const {
     return std::format_to(out, "hi {}", who);
   }
   template<typename OutIt>
-  OutIt debug_format_to(OutIt out) const {
+  [[nodiscard]] OutIt debug_format_to(OutIt out) const {
     return std::format_to(out, "<{}>", who);
   }
 };
@@ -81,7 +81,8 @@ struct greeter {
 // `format_to_spec` member.
 struct dashes {
   template<CharType CharT, typename OutIt>
-  OutIt format_to_spec(const parsed_spec<CharT>& spec, OutIt out) const {
+  [[nodiscard]] OutIt
+  format_to_spec(const parsed_spec<CharT>& spec, OutIt out) const {
     std::string_view content = "----";
     if (const auto prec = spec.precision) content = content.substr(0, *prec);
     return spec.write_padded(out, content, spec.width);

--- a/tests/portable/formatting_test.cpp
+++ b/tests/portable/formatting_test.cpp
@@ -27,8 +27,7 @@
 using namespace std::literals;
 using namespace corvid;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 
 // These tests exercise the formatter bases in `corvid/meta/formatting.h`
 // directly, with minimal local wrapper types, rather than relying on the
@@ -582,5 +581,4 @@ TEST_CASE("FormatToSpec", "[self_rendering_formatter]") {
 
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/id_container_test.cpp
+++ b/tests/portable/id_container_test.cpp
@@ -29,8 +29,7 @@ using namespace corvid;
 using eid_t = corvid::ecs::id_enums::entity_id_t;
 using container_t = id_container<int, eid_t>;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 
 #pragma region DefaultConstruct
 
@@ -486,5 +485,4 @@ TEST_CASE("NonIntType", "[IdContainer]") {
 
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/id_container_test.cpp
+++ b/tests/portable/id_container_test.cpp
@@ -65,6 +65,8 @@ TEST_CASE("PushBack", "[IdContainer]") {
   if (true) {
     container_t c;
     int val = 42;
+    // Exercising the rvalue overload is the point of this block.
+    // NOLINTNEXTLINE(bugprone-use-after-move,performance-move-const-arg)
     CHECK(c.push_back(std::move(val)));
     CHECK(c[eid_t{0}] == 42);
   }

--- a/tests/portable/intern_table_test.cpp
+++ b/tests/portable/intern_table_test.cpp
@@ -28,8 +28,7 @@ using namespace std::literals;
 using namespace corvid;
 using namespace corvid::internal;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 
 namespace corvid { inline namespace container { inline namespace intern {
 
@@ -377,5 +376,4 @@ TEST_CASE("Concurrency", "[InternTableTest]") {
 }
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/lang_test.cpp
+++ b/tests/portable/lang_test.cpp
@@ -26,8 +26,7 @@
 using namespace std::literals;
 using namespace corvid::lang::ast_pred;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 
 template<operation op, typename... Args>
 [[nodiscard]] node_ptr M(Args&&... args) {
@@ -430,5 +429,4 @@ TEST_CASE("Comprehensive", "[LangTest]") {
 
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/meta_test.cpp
+++ b/tests/portable/meta_test.cpp
@@ -28,8 +28,8 @@
 using namespace std::literals;
 using namespace corvid;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+// NOLINTBEGIN(readability-function-size)
 
 // OStreamDerived
 
@@ -1502,5 +1502,5 @@ TEST_CASE("Swap", "[FixedFunction]") {
 
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/meta_test.cpp
+++ b/tests/portable/meta_test.cpp
@@ -612,8 +612,11 @@ TEST_CASE("Number", "[MetaTest]") {
   CHECK_FALSE(Integer<bool>);
   CHECK(is_bool_v<bool>);
 
+  // The irregular initializers and the width are both deliberate here.
+  // NOLINTBEGIN(performance-enum-size,readability-enum-initial-value)
   enum ColorEnum { red, green = 20, blue };
   enum class ColorClass { red, green = 20, blue };
+  // NOLINTEND(performance-enum-size,readability-enum-initial-value)
 
   CHECK(StdEnum<ColorClass>);
   CHECK(StdEnum<ColorEnum>);
@@ -660,6 +663,7 @@ TEST_CASE("Tuple", "[MetaTest]") {
 TEST_CASE("Detection", "[MetaTest]") {
   // initializer_list detection
   {
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores): decltype only.
     auto il = {1, 2, 3};
     CHECK(is_initializer_list_v<decltype(il)>);
   }
@@ -700,9 +704,12 @@ TEST_CASE("Detection", "[MetaTest]") {
 #pragma region Underlying
 
 TEST_CASE("Underlying", "[MetaTest]") {
+  // The underlying type is the point of these fixtures.
+  // NOLINTBEGIN(performance-enum-size)
   enum class X : size_t { x1 = 1, x2 };
   enum class Y : int64_t { ylow = -1 };
   enum Z { z1 = 1 };
+  // NOLINTEND(performance-enum-size)
 
   // as_underlying converts scoped enum to underlying type
   auto x = as_underlying(X::x1);
@@ -807,6 +814,7 @@ TEST_CASE("MoveConstruct", "[AddressForwarder]") {
   // Move construction updates `ptr` to the new location.
   CHECK(ptr == &b);
   // Source no longer holds the forwarding address slot.
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   CHECK(a.forwarding_address_ptr(Trackable::raw::allow) == nullptr);
 }
 
@@ -823,6 +831,7 @@ TEST_CASE("MoveAssign", "[AddressForwarder]") {
   Trackable b{99};
   b = std::move(a);
   CHECK(ptr == &b);
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   CHECK(a.forwarding_address_ptr(Trackable::raw::allow) == nullptr);
 
   // Clearing the forwarding address on `b` stops future tracking, but does
@@ -892,6 +901,7 @@ TEST_CASE("CustomMoveCtor", "[AddressForwarder]") {
 
   Trackable2 b{std::move(a)};
   CHECK(ptr == &b);
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   CHECK(a.forwarding_address_ptr(Trackable2::raw::allow) == nullptr);
 }
 
@@ -1111,6 +1121,7 @@ TEST_CASE("MoveAcrossSizes", "[FixedFunction]") {
   fixed_function<96, int()> big{std::move(small)};
   CHECK(moves == base + 1);
   CHECK(big() == 42);
+  // NOLINTNEXTLINE(bugprone-use-after-move): moved-from state is the point.
   CHECK_FALSE(static_cast<bool>(small));
   CHECK(small.size() == 0);
   CHECK(big.size() == sizeof(mover));
@@ -1262,6 +1273,7 @@ TEST_CASE("Bool", "[FixedFunction]") {
   fixed_function<64, int()> a{[] { return 1; }};
   CHECK(static_cast<bool>(a));
   fixed_function<64, int()> b{std::move(a)};
+  // NOLINTNEXTLINE(bugprone-use-after-move): moved-from state is the point.
   CHECK_FALSE(static_cast<bool>(a));
   CHECK(static_cast<bool>(b));
 }
@@ -1273,6 +1285,7 @@ TEST_CASE("Move", "[FixedFunction]") {
   fixed_function<64, int()> a{[] { return 7; }};
   CHECK(static_cast<bool>(a));
   fixed_function<64, int()> b{std::move(a)};
+  // NOLINTNEXTLINE(bugprone-use-after-move): moved-from state is the point.
   CHECK_FALSE(static_cast<bool>(a));
   CHECK(static_cast<bool>(b));
   CHECK(b() == 7);
@@ -1285,6 +1298,7 @@ TEST_CASE("MoveAssign", "[FixedFunction]") {
   fixed_function<64, int()> a{[] { return 99; }};
   fixed_function<64, int()> b{[] { return 0; }};
   b = std::move(a);
+  // NOLINTNEXTLINE(bugprone-use-after-move): moved-from state is the point.
   CHECK_FALSE(static_cast<bool>(a));
   CHECK(static_cast<bool>(b));
   CHECK(b() == 99);
@@ -1337,6 +1351,11 @@ static int double_it(int x) { return x * 2; }
 // verifiable.
 #pragma region FixedFunction_CppRef
 
+// This case transcribes the cppreference `std::function` example set to
+// show `fixed_function` accepts the same callables, so the `std::bind`
+// expressions are the subject and the fixture keeps the reference shape.
+// NOLINTBEGIN(modernize-avoid-bind)
+// NOLINTBEGIN(modernize-use-nodiscard)
 TEST_CASE("CppRef", "[FixedFunction]") {
   struct Foo {
     Foo(int num) : num_(num) {}
@@ -1395,6 +1414,8 @@ TEST_CASE("CppRef", "[FixedFunction]") {
   CHECK(factorial(6) == 720);
   CHECK(factorial(7) == 5040);
 }
+// NOLINTEND(modernize-use-nodiscard)
+// NOLINTEND(modernize-avoid-bind)
 
 #pragma endregion
 #pragma region FixedFunction_RefReturn
@@ -1437,7 +1458,9 @@ TEST_CASE("EmptyThrows", "[FixedFunction]") {
   // Moved-from instance is also empty and throws on call.
   fixed_function<64, int()> f{[] { return 1; }};
   fixed_function<64, int()> g{std::move(f)};
+  // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   CHECK(!f);
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.Move): same moved-from check.
   CHECK_THROWS_AS(f(), std::bad_function_call);
 
   // nullptr-assigned instance throws too.

--- a/tests/portable/object_pool_test.cpp
+++ b/tests/portable/object_pool_test.cpp
@@ -152,6 +152,8 @@ TEST_CASE("LIFOOrder", "[ObjectPool]") {
 #pragma endregion
 #pragma region MoveHandle
 
+// Each block checks the moved-from handle, which is the assertion.
+// NOLINTBEGIN(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
 TEST_CASE("MoveHandle", "[ObjectPool]") {
   // Move construction transfers ownership; original becomes empty.
   if (true) {
@@ -160,7 +162,6 @@ TEST_CASE("MoveHandle", "[ObjectPool]") {
     CHECK(h);
 
     auto h2 = std::move(h);
-    // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
     CHECK_FALSE(h);
     CHECK(h2);
   }
@@ -185,11 +186,11 @@ TEST_CASE("MoveHandle", "[ObjectPool]") {
     auto h = pool.borrow();
     object_pool<int, 4>::borrowed h2;
     h2 = std::move(h);
-    // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
     CHECK_FALSE(h);
     CHECK(h2);
   }
 }
+// NOLINTEND(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
 
 #pragma endregion
 #pragma region MultipleSlots
@@ -201,17 +202,18 @@ TEST_CASE("MultipleSlots", "[ObjectPool]") {
     object_pool<int, cap> pool;
 
     std::array<std::optional<object_pool<int, cap>::borrowed>, cap> handles;
+    // Every slot was just filled by borrow(), as the checks above assert.
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     for (auto ndx = 0UZ; ndx < cap; ++ndx) {
       handles[ndx] = pool.borrow();
       CHECK(handles[ndx].has_value());
-      // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
       **handles[ndx] = static_cast<int>(ndx);
     }
     CHECK_FALSE(pool.borrow()); // all slots in use
 
     // Return every other slot.
-    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
     for (auto ndx = 0UZ; ndx < cap; ndx += 2) handles[ndx]->reset();
+    // NOLINTEND(bugprone-unchecked-optional-access)
 
     // Re-borrow the returned slots.
     for (auto ndx = 0UZ; ndx < cap; ndx += 2) {
@@ -308,6 +310,8 @@ TEST_CASE("CreateHelper", "[ObjectPool]") {
 #pragma endregion
 #pragma region DetachAndReattach
 
+// reattach takes its pointer by value; the move spells out the transfer.
+// NOLINTBEGIN(performance-move-const-arg)
 TEST_CASE("DetachAndReattach", "[ObjectPool]") {
   // `detach` releases ownership from the handle without returning the slot.
   if (true) {
@@ -322,7 +326,6 @@ TEST_CASE("DetachAndReattach", "[ObjectPool]") {
     CHECK(detached == item);
     CHECK_FALSE(pool.borrow()); // detached slot is still out of the pool
 
-    // NOLINTNEXTLINE(performance-move-const-arg)
     auto h2 = pool.reattach(std::move(detached));
     CHECK(h2);
     CHECK(h2.get() == item);
@@ -335,7 +338,6 @@ TEST_CASE("DetachAndReattach", "[ObjectPool]") {
   if (true) {
     object_pool<int, 1> pool;
     int outside{};
-    // NOLINTNEXTLINE(performance-move-const-arg)
     auto h = pool.reattach(std::move(&outside));
     CHECK_FALSE(h);
   }
@@ -351,7 +353,6 @@ TEST_CASE("DetachAndReattach", "[ObjectPool]") {
     int* stale = p;
     h.reset(); // slot goes back on the free list; `stale` now dangles
 
-    // NOLINTNEXTLINE(performance-move-const-arg)
     auto squatter = pool.reattach(std::move(stale)); // the misuse "succeeds"
     CHECK(squatter);
     CHECK(squatter.get() == p);
@@ -367,6 +368,7 @@ TEST_CASE("DetachAndReattach", "[ObjectPool]") {
     CHECK(again.get() == p);
   }
 }
+// NOLINTEND(performance-move-const-arg)
 
 #pragma endregion
 #pragma region TokenBasics
@@ -705,13 +707,14 @@ TEST_CASE("Shutdown", "[ObjectPool]") {
   // so the ctor returns the slot on the spot. The handle ends up empty either
   // way, and the token cannot escalate: the seal must not be cleared, or a
   // gen-0 token could reacquire a shut-down slot.
+  // Both blocks check the handle after a detach that had to fail.
+  // NOLINTBEGIN(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   if (true) {
     object_pool<int, 1> pool;
     auto h = pool.borrow();
     CHECK(pool.shutdown());
 
     object_pool<int, 1>::token tok{std::move(h)};
-    // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
     CHECK_FALSE(h); // emptied even though the detach failed
     CHECK(tok);
     CHECK_FALSE(tok.borrow(pool));
@@ -731,10 +734,10 @@ TEST_CASE("Shutdown", "[ObjectPool]") {
     // a dead retry condition, tripping bugprone-use-after-move.
     auto* p = pool.detach(std::move(h));
     CHECK(p == nullptr);
-    // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
     CHECK(h); // detach leaves the handle intact on failure
     CHECK(h.reset());
   }
+  // NOLINTEND(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
 
   // A slot detached before `shutdown` is reclaimed by it: `return_cb_` runs
   // on the detached item, and the later `reattach` fails cleanly.

--- a/tests/portable/opt_string_view_test.cpp
+++ b/tests/portable/opt_string_view_test.cpp
@@ -191,6 +191,7 @@ TEST_CASE("Construction", "[OptStringViewTest]") {
   }
   // Construct string_view on empty string_view.
   if (true) {
+    // NOLINTNEXTLINE(readability-redundant-string-init): non-null empty.
     std::string_view sv("");
     CHECK(sv.data() != nullptr);
     std::string_view v{sv};
@@ -200,6 +201,7 @@ TEST_CASE("Construction", "[OptStringViewTest]") {
   }
   // Construct opt_string_view on empty string_view.
   if (true) {
+    // NOLINTNEXTLINE(readability-redundant-string-init): non-null empty.
     std::string_view sv{""};
     opt_string_view v(sv);
     CHECK(v.empty());
@@ -360,7 +362,7 @@ TEST_CASE("Workalike", "[OptStringViewTest]") {
   // Methods operate correctly on rvalues.
   if (true) {
     opt_string_view osv{"qqq"};
-    // NOLINTNEXTLINE(performance-move-const-arg)
+    // NOLINTNEXTLINE(bugprone-use-after-move,performance-move-const-arg)
     CHECK(std::move(osv).value_or("def") == "qqq");
   }
 }

--- a/tests/portable/opt_string_view_test.cpp
+++ b/tests/portable/opt_string_view_test.cpp
@@ -30,8 +30,8 @@ using namespace std::literals;
 using namespace corvid;
 using namespace corvid::literals;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+// NOLINTBEGIN(readability-function-size)
 
 #pragma region Construction
 
@@ -526,5 +526,5 @@ TEST_CASE("OptStringViewTestEqual", "[OptStringViewTestEqual]") {
 
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/pid_controller_test.cpp
+++ b/tests/portable/pid_controller_test.cpp
@@ -26,8 +26,7 @@
 
 using namespace corvid;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 
 constexpr double eps = 1e-6;
 
@@ -229,8 +228,8 @@ TEST_CASE("plant_test", "[sopdt]") {
         /* Ki = */ 0.5,
         /* Kd = */ 1.0,
         /* alpha = */ 0.1,
-        /* min = */ -10.0,
-        /* max = */ 10.0);
+        /* min_value = */ -10.0,
+        /* max_value = */ 10.0);
 
     const double setpoint = 1.0;
     double measured = 0.0;
@@ -269,5 +268,4 @@ TEST_CASE("FloatInstantiation", "[PidControllerTest]") {
 
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -310,25 +310,26 @@ consteval auto corvid_proxy_spec(hair_trigger*, robber*) {
 // method is noexcept, but a call-site argument needing a throwing conversion
 // (a literal into `std::string`) makes the call expression non-noexcept, in
 // both spellings alike.
+//
+// The by-value parameters below are moved, but only in a dependent call that
+// the check cannot see.
+// NOLINTBEGIN(performance-unnecessary-value-param)
 struct town_crier
     : prox::facade<prox::name<"town_crier">, //
           prox::method<"cry", void(std::string) noexcept>> {
   struct api {
-    // The by-value parameter is moved, but only in a dependent call the
-    // check cannot see.
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     void cry(this auto&& self, std::string words) noexcept {
       self.template call<"cry">(std::move(words));
     }
   };
   template<typename T>
   struct boilerplate: proxy_impl_base {
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     static void on(method_key<"cry">, T& t, std::string words) noexcept {
       t.cry(std::move(words));
     }
   };
 };
+// NOLINTEND(performance-unnecessary-value-param)
 
 struct crier {
   void cry(std::string words) noexcept { last = std::move(words); }

--- a/tests/portable/sequence_enum_test.cpp
+++ b/tests/portable/sequence_enum_test.cpp
@@ -208,7 +208,7 @@ TEST_CASE("MakeSafely", "[SequentialEnumTest]") {
     CHECK(*e == 3);
     e = make_safely<e0_3>(3 + 5);
     CHECK(*e == 0);
-    e = make_safely<e0_3>(3 + 3 * 4);
+    e = make_safely<e0_3>(3 + (3 * 4));
     CHECK(*e == 3);
 
     // Note: All of these casts are strictly unnecessary. They're just to
@@ -224,7 +224,7 @@ TEST_CASE("MakeSafely", "[SequentialEnumTest]") {
     CHECK(*e == 0);
     e = make_safely<e0_3>(int8_t(0 - 5));
     CHECK(*e == 3);
-    e = make_safely<e0_3>(int8_t(0 - 4 * 4));
+    e = make_safely<e0_3>(int8_t(0 - (4 * 4)));
     CHECK(*e == 0);
   }
   if (true) {
@@ -255,7 +255,7 @@ TEST_CASE("MakeSafely", "[SequentialEnumTest]") {
     CHECK(*e == 13);
     e = make_safely<e10_13>(13 + 5);
     CHECK(*e == 10);
-    e = make_safely<e10_13>(13 + 3 * 4);
+    e = make_safely<e10_13>(13 + (3 * 4));
     CHECK(*e == 13);
 
     e = make_safely<e10_13>(10 - 1);
@@ -268,7 +268,7 @@ TEST_CASE("MakeSafely", "[SequentialEnumTest]") {
     CHECK(*e == 10);
     e = make_safely<e10_13>(10 - 5);
     CHECK(*e == 13);
-    e = make_safely<e10_13>(int8_t(10 - 4 * 4));
+    e = make_safely<e10_13>(int8_t(10 - (4 * 4)));
     CHECK(*e == 10);
   }
   if (true) {
@@ -306,7 +306,7 @@ TEST_CASE("MakeSafely", "[SequentialEnumTest]") {
     CHECK(*e == 3);
     e = make_safely<eneg3_3>(3 + 8);
     CHECK(*e == -3);
-    e = make_safely<eneg3_3>(3 + 7 * 4);
+    e = make_safely<eneg3_3>(3 + (7 * 4));
     CHECK(*e == 3);
 
     e = make_safely<eneg3_3>(-3 - 1);
@@ -325,7 +325,7 @@ TEST_CASE("MakeSafely", "[SequentialEnumTest]") {
     CHECK(*e == -3);
     e = make_safely<eneg3_3>(-3 - 8);
     CHECK(*e == 3);
-    e = make_safely<eneg3_3>(-3 - 7 * 4);
+    e = make_safely<eneg3_3>(-3 - (7 * 4));
     CHECK(*e == -3);
   }
   if (true) {
@@ -354,7 +354,7 @@ TEST_CASE("MakeSafely", "[SequentialEnumTest]") {
     CHECK(*e == 254);
     e = make_safely<e0_255>(uint8_t(255 + 3));
     CHECK(*e == 2);
-    e = make_safely<e0_255>(uint8_t(255 + 3 * 256));
+    e = make_safely<e0_255>(uint8_t(255 + (3 * 256)));
     CHECK(*e == 255);
 
     // Safety is meaningless in this case.
@@ -369,7 +369,7 @@ TEST_CASE("MakeSafely", "[SequentialEnumTest]") {
     CHECK(*e == 254);
     e = make<e0_255>(uint8_t(255 + 3));
     CHECK(*e == 2);
-    e = make<e0_255>(uint8_t(255 + 3 * 256));
+    e = make<e0_255>(uint8_t(255 + (3 * 256)));
     CHECK(*e == 255);
   }
   if (true) {
@@ -386,7 +386,7 @@ TEST_CASE("MakeSafely", "[SequentialEnumTest]") {
     CHECK(*e == 126);
     e = make_safely<eneg128_127>(int8_t(127 + 3));
     CHECK(*e == -126);
-    e = make_safely<eneg128_127>(int8_t(127 + 3 * 256));
+    e = make_safely<eneg128_127>(int8_t(127 + (3 * 256)));
     CHECK(*e == 127);
 
     // Safety is meaningless in this case.
@@ -401,7 +401,7 @@ TEST_CASE("MakeSafely", "[SequentialEnumTest]") {
     CHECK(*e == 126);
     e = make<eneg128_127>(int8_t(127 + 3));
     CHECK(*e == -126);
-    e = make<eneg128_127>(int8_t(127 + 3 * 256));
+    e = make<eneg128_127>(int8_t(127 + (3 * 256)));
     CHECK(*e == 127);
   }
 }

--- a/tests/portable/sequence_enum_test.cpp
+++ b/tests/portable/sequence_enum_test.cpp
@@ -566,6 +566,7 @@ TEST_CASE("StreamingOut", "[SequentialEnumTest]") {
 
 #pragma endregion
 
+// NOLINTNEXTLINE(readability-enum-initial-value): the gap is the point.
 enum class tiger_missing : std::uint8_t { eeny, miny = 2, moe };
 consteval auto corvid_enum_spec(tiger_missing*) {
   return make_sequence_enum_spec<tiger_missing, "eeny,,miny,moe">();
@@ -1104,6 +1105,9 @@ TEST_CASE("EnumFindNamed", "[SequentialEnumTest]") {
 
 // Shows that a bare literal or enum value is validated by the parameter type,
 // with no ceremony at the call site.
+// Enum names are interned in static storage, so the returned view
+// outlives the parameter it came from.
+// NOLINTNEXTLINE(bugprone-dangling-handle)
 constexpr std::string_view take_tiger(enum_name<tiger_pick> s) { return s; }
 
 TEST_CASE("EnumStringView", "[SequentialEnumTest]") {
@@ -1266,6 +1270,8 @@ TEST_CASE("StringViewAndValue", "[SequentialEnumTest]") {
 // Sparse enum registered with the segmented syntax: two runs separated by a
 // gap. '|' delimits segments; each segment's first comma-field is its absolute
 // start value, the rest are names.
+// The underlying type is the point of these segment fixtures.
+// NOLINTBEGIN(performance-enum-size)
 enum class seg_basic : int { a = 0, b = 1, x = 10, y = 11, z = 12 };
 consteval auto corvid_enum_spec(seg_basic*) {
   return make_sequence_enum_spec<seg_basic, "0,a,b|10,x,y,z">();
@@ -1293,6 +1299,7 @@ consteval auto corvid_enum_spec(seg_neg*) {
 // * make_sequence_enum_spec<seg_three, "0,a,b|4,c">(); // gap too small; fold
 //   into empty names instead: "0,a,b,,,c"
 enum class seg_three : int { a = 0, b = 1, m = 5, x = 10, y = 11 };
+// NOLINTEND(performance-enum-size)
 consteval auto corvid_enum_spec(seg_three*) {
   return make_sequence_enum_spec<seg_three, "0,a,b|5,m|10,x,y">();
 }

--- a/tests/portable/sequence_enum_test.cpp
+++ b/tests/portable/sequence_enum_test.cpp
@@ -29,8 +29,8 @@ using namespace corvid;
 using namespace corvid::enums;
 using namespace corvid::enums::sequence;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+// NOLINTBEGIN(readability-function-size)
 
 enum class tiger_pick : std::int8_t { eeny, meany, miny, moe };
 consteval auto corvid_enum_spec(tiger_pick*) {
@@ -610,7 +610,8 @@ TEST_CASE("Missing", "[SequentialEnumTest]") {
 
 TEST_CASE("Intervals", "[SequentialEnumTest]") {
   if (true) {
-    int c{}, s{};
+    int c{};
+    int s{};
     for (auto e : make_interval<e0_3>()) {
       ++c;
       s += *e;
@@ -619,7 +620,8 @@ TEST_CASE("Intervals", "[SequentialEnumTest]") {
     CHECK(s == (0 + 1 + 2 + 3));
   }
   if (true) {
-    int c{}, s{};
+    int c{};
+    int s{};
     for (auto e : make_interval<e10_13>()) {
       ++c;
       s += *e;
@@ -628,7 +630,8 @@ TEST_CASE("Intervals", "[SequentialEnumTest]") {
     CHECK(s == (10 + 11 + 12 + 13));
   }
   if (true) {
-    int c{}, s{};
+    int c{};
+    int s{};
     // This fails with an assertion.
     // * auto bad = make_interval<e0_255>();
     for (auto e : make_interval<e0_255, uint16_t>()) {
@@ -639,7 +642,8 @@ TEST_CASE("Intervals", "[SequentialEnumTest]") {
     CHECK(s == 32640);
   }
   if (true) {
-    int c{}, s{};
+    int c{};
+    int s{};
     // This fails with an assertion.
     // * auto bad = make_interval<eneg128_127>();
     for (auto e : make_interval<eneg128_127, int16_t>()) {
@@ -1373,5 +1377,5 @@ TEST_CASE("Segmented", "[SequentialEnumTest]") {
 
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/strings_test.cpp
+++ b/tests/portable/strings_test.cpp
@@ -44,8 +44,8 @@ using namespace corvid::enums::sequence;
 using namespace corvid::enums::bitmask;
 using namespace corvid::strings::delimiting;
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
+// NOLINTBEGIN(readability-function-size)
 
 // Test extract_piece.
 #pragma region ExtractPiece
@@ -73,7 +73,8 @@ TEST_CASE("ExtractPiece", "[StringUtilsTest]") {
 #pragma region MorePieces
 
 TEST_CASE("MorePieces", "[StringUtilsTest]") {
-  std::string_view w, part;
+  std::string_view w;
+  std::string_view part;
   w = "1,2";
   CHECK_FALSE(w.empty());
   CHECK(strings::more_pieces(part, w, ","));
@@ -420,7 +421,8 @@ TEST_CASE("WideSplit", "[StringUtilsTest]") {
   CHECK(strings::extract_piece<std::u16string>(sv, u",") == u"1");
 
   // more_pieces threads the same code unit.
-  std::u16string_view w = u"a;b", part;
+  std::u16string_view w = u"a;b";
+  std::u16string_view part;
   CHECK(strings::more_pieces(part, w, u";"));
   CHECK(part == u"a");
   CHECK_FALSE(strings::more_pieces(part, w, u";"));
@@ -2586,64 +2588,64 @@ TEST_CASE("StdFromChars", "[StringUtilsTest]") {
     sv = "3.14";
     auto result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     CHECK(result.ec == std::errc{});
-    CHECK((value > 3.13f && value < 3.15f));
+    CHECK((value > 3.13F && value < 3.15F));
     CHECK(result.ptr == (sv.data() + sv.size()));
 
     // Basic negative float.
     sv = "-2.5";
     result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     CHECK(result.ec == std::errc{});
-    CHECK(value == -2.5f);
+    CHECK(value == -2.5F);
     CHECK(result.ptr == (sv.data() + sv.size()));
 
     // Integer parsed as float.
     sv = "42";
     result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     CHECK(result.ec == std::errc{});
-    CHECK(value == 42.0f);
+    CHECK(value == 42.0F);
 
     // Zero.
     sv = "0.0";
     result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     CHECK(result.ec == std::errc{});
-    CHECK(value == 0.0f);
+    CHECK(value == 0.0F);
 
     // Negative zero.
     sv = "-0.0";
     result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     CHECK(result.ec == std::errc{});
     // Negative zero should be equal to positive zero.
-    CHECK(value == 0.0f);
+    CHECK(value == 0.0F);
 
     // Scientific notation.
     sv = "1.5e3";
     result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     CHECK(result.ec == std::errc{});
-    CHECK(value == 1500.0f);
+    CHECK(value == 1500.0F);
 
     // Negative exponent.
     sv = "1.5e-2";
     result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     CHECK(result.ec == std::errc{});
-    CHECK((value > 0.014f && value < 0.016f));
+    CHECK((value > 0.014F && value < 0.016F));
 
     // Large positive exponent.
     sv = "1e30";
     result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     CHECK(result.ec == std::errc{});
-    CHECK(value > 9e29f);
+    CHECK(value > 9e29F);
 
     // Very small positive number.
     sv = "1e-30";
     result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     CHECK(result.ec == std::errc{});
-    CHECK((value > 0.0f && value < 1e-29f));
+    CHECK((value > 0.0F && value < 1e-29F));
 
     // Partial parse (stops at non-numeric).
     sv = "3.14abc";
     result = std::from_chars(sv.data(), sv.data() + sv.size(), value);
     CHECK(result.ec == std::errc{});
-    CHECK((value > 3.13f && value < 3.15f));
+    CHECK((value > 3.13F && value < 3.15F));
     CHECK(result.ptr == (sv.data() + 4)); // Stops at 'a'.
   }
   // Test std::from_chars directly for double.
@@ -2696,7 +2698,7 @@ TEST_CASE("StdFromChars", "[StringUtilsTest]") {
   }
   // Test error handling.
   if (true) {
-    float fvalue{42.0f};
+    float fvalue{42.0F};
     std::string_view sv;
 
     // Empty string - properly returns error.
@@ -2717,13 +2719,13 @@ TEST_CASE("StdFromChars", "[StringUtilsTest]") {
     // Basic extraction.
     sv = "  3.14  ";
     CHECK(strings::extract_num(f, sv));
-    CHECK((f > 3.13f && f < 3.15f));
+    CHECK((f > 3.13F && f < 3.15F));
     CHECK(sv == "  "); // Whitespace trimmed from left, remaining on right.
 
     // Scientific notation.
     sv = "6.022e23";
     CHECK(strings::extract_num(f, sv));
-    CHECK(f > 6e23f);
+    CHECK(f > 6e23F);
     CHECK(sv.empty());
   }
   // Test parse_num float wrappers.
@@ -2731,7 +2733,7 @@ TEST_CASE("StdFromChars", "[StringUtilsTest]") {
     // Successful parse.
     auto opt = strings::parse_num<float>("2.5"sv);
     CHECK(opt.has_value());
-    CHECK(opt.value() == 2.5f);
+    CHECK(opt.value() == 2.5F);
 
     // Failure - trailing garbage.
     opt = strings::parse_num<float>("2.5abc"sv);
@@ -2742,14 +2744,14 @@ TEST_CASE("StdFromChars", "[StringUtilsTest]") {
     CHECK_FALSE(opt.has_value());
 
     // With default value.
-    float val = strings::parse_num<float>("1.5"sv, -1.0f);
-    CHECK(val == 1.5f);
+    float val = strings::parse_num<float>("1.5"sv, -1.0F);
+    CHECK(val == 1.5F);
 
-    val = strings::parse_num<float>("bad"sv, -1.0f);
-    CHECK(val == -1.0f);
+    val = strings::parse_num<float>("bad"sv, -1.0F);
+    CHECK(val == -1.0F);
 
-    val = strings::parse_num<float>("1.5 "sv, -1.0f);
-    CHECK(val == -1.0f); // Trailing space causes failure.
+    val = strings::parse_num<float>("1.5 "sv, -1.0F);
+    CHECK(val == -1.0F); // Trailing space causes failure.
   }
   // Test parse_num double wrappers.
   if (true) {
@@ -2781,19 +2783,19 @@ TEST_CASE("NoZero", "[StringUtilsTest]") {
   if (true) {
     std::string s;
     s.resize(50);
-    CHECK(s.capacity() >= 50u);
+    CHECK(s.capacity() >= 50U);
     s.clear();
-    CHECK(s.capacity() >= 50u);
+    CHECK(s.capacity() >= 50U);
     s.shrink_to_fit();
-    CHECK((s.capacity()) < (50u));
-    CHECK((s.capacity()) > (0u));
+    CHECK((s.capacity()) < (50U));
+    CHECK((s.capacity()) > (0U));
   }
 
   // Capture the SSO capacity (typically 15 on libc++ 64-bit).
   const auto sso_cap = std::string{}.capacity();
 
   // Ensure that the small values we use below are within SSO capacity.
-  CHECK((sso_cap) > (10u));
+  CHECK((sso_cap) > (10U));
 
   using corvid::strings::no_zero;
 
@@ -2805,41 +2807,41 @@ TEST_CASE("NoZero", "[StringUtilsTest]") {
 
     // Zero.
     no_zero{s}.resize_to(0);
-    CHECK(s.size() == 0u);
+    CHECK(s.size() == 0U);
 
     // Tiny (SSO range).
     no_zero{s}.resize_to(2);
-    CHECK(s.size() == 2u);
-    CHECK(s.capacity() >= 2u);
+    CHECK(s.size() == 2U);
+    CHECK(s.capacity() >= 2U);
 
     no_zero{s}.resize_to(4);
-    CHECK(s.size() == 4u);
-    CHECK(s.capacity() >= 4u);
+    CHECK(s.size() == 4U);
+    CHECK(s.capacity() >= 4U);
 
     // Shrink within SSO: capacity must not change.
     auto cap = s.capacity();
     no_zero{s}.resize_to(2);
-    CHECK(s.size() == 2u);
+    CHECK(s.size() == 2U);
     CHECK(s.capacity() == cap);
 
     // Small (heap range).
     no_zero{s}.resize_to(50);
-    CHECK(s.size() == 50u);
-    CHECK(s.capacity() >= 50u);
+    CHECK(s.size() == 50U);
+    CHECK(s.capacity() >= 50U);
 
     no_zero{s}.resize_to(100);
-    CHECK(s.size() == 100u);
-    CHECK(s.capacity() >= 100u);
+    CHECK(s.size() == 100U);
+    CHECK(s.capacity() >= 100U);
 
     // Shrink on heap: capacity must not change.
     cap = s.capacity();
     no_zero{s}.resize_to(50);
-    CHECK(s.size() == 50u);
+    CHECK(s.size() == 50U);
     CHECK(s.capacity() == cap);
 
     // Same size (no-op).
     no_zero{s}.resize_to(50);
-    CHECK(s.size() == 50u);
+    CHECK(s.size() == 50U);
     CHECK(s.capacity() == cap);
   }
 
@@ -2880,45 +2882,45 @@ TEST_CASE("NoZero", "[StringUtilsTest]") {
 
     // Shrink within current size.
     no_zero{s}.trim_to(20);
-    CHECK(s.size() == 20u);
+    CHECK(s.size() == 20U);
     CHECK(s.capacity() == cap);
 
     // Same size is a no-op.
     no_zero{s}.trim_to(20);
-    CHECK(s.size() == 20u);
+    CHECK(s.size() == 20U);
     CHECK(s.capacity() == cap);
 
     // Larger size request must not enlarge.
     no_zero{s}.trim_to(40);
-    CHECK(s.size() == 20u);
+    CHECK(s.size() == 20U);
     CHECK(s.capacity() == cap);
 
     // Trimming to zero works and still preserves capacity.
     no_zero{s}.trim_to(0);
-    CHECK(s.size() == 0u);
+    CHECK(s.size() == 0U);
     CHECK(s.capacity() == cap);
 
     // Negative signed values clamp to zero.
     no_zero{s}.resize_to(30);
     no_zero{s}.trim_to(-1);
-    CHECK(s.size() == 0u);
+    CHECK(s.size() == 0U);
     CHECK(s.capacity() == cap);
 
     // Positive signed values trim normally after the signed check.
     no_zero{s}.resize_to(30);
     no_zero{s}.trim_to(int16_t{6});
-    CHECK(s.size() == 6u);
+    CHECK(s.size() == 6U);
     CHECK(s.capacity() == cap);
 
     // Any integer type is accepted, including unsigned non-size_t.
     no_zero{s}.resize_to(30);
-    no_zero{s}.trim_to(7u);
-    CHECK(s.size() == 7u);
+    no_zero{s}.trim_to(7U);
+    CHECK(s.size() == 7U);
     CHECK(s.capacity() == cap);
 
     // Returns a reference to the same string.
     CHECK(&*no_zero{s}.trim_to(10) == &s);
-    CHECK(s.size() == 7u);
+    CHECK(s.size() == 7U);
     CHECK(s.capacity() == cap);
   }
 
@@ -2929,7 +2931,7 @@ TEST_CASE("NoZero", "[StringUtilsTest]") {
     // full SSO capacity.
     std::string s;
     no_zero{s}.enlarge_to(3);
-    CHECK(s.size() >= 3u);
+    CHECK(s.size() >= 3U);
     CHECK(s.size() == sso_cap);
     CHECK(s.size() == s.capacity());
 
@@ -2942,7 +2944,7 @@ TEST_CASE("NoZero", "[StringUtilsTest]") {
 
     // Small request beyond current capacity: reallocates, then fills capacity.
     no_zero{s}.enlarge_to(50);
-    CHECK(s.size() >= 50u);
+    CHECK(s.size() >= 50U);
     CHECK(s.size() == s.capacity());
 
     // Request within the new capacity: no reallocation.
@@ -2967,10 +2969,10 @@ TEST_CASE("NoZero", "[StringUtilsTest]") {
     // Heap-allocated string: buffer is released.
     std::string s;
     no_zero{s}.enlarge_to(100);
-    CHECK(s.capacity() >= 100u);
+    CHECK(s.capacity() >= 100U);
     no_zero{s}.clear_out();
-    CHECK(s.size() == 0u);
-    CHECK((s.capacity()) < (100u));
+    CHECK(s.size() == 0U);
+    CHECK((s.capacity()) < (100U));
     CHECK(s.capacity() >= sso_cap);
 
     // SSO-sized string: capacity is unchanged (nothing to release).
@@ -2978,7 +2980,7 @@ TEST_CASE("NoZero", "[StringUtilsTest]") {
     no_zero{t}.resize_to(4);
     auto cap = t.capacity();
     no_zero{t}.clear_out();
-    CHECK(t.size() == 0u);
+    CHECK(t.size() == 0U);
     CHECK(t.capacity() == cap);
 
     // Returns a reference to the same string.
@@ -2993,27 +2995,27 @@ TEST_CASE("NoZero", "[StringUtilsTest]") {
     // Tiny: SSO capacity within bounds -> enlarge_to path.
     std::string s;
     no_zero{s}.rightsize_to(3, 100);
-    CHECK(s.size() >= 3u);
+    CHECK(s.size() >= 3U);
     CHECK(s.size() == s.capacity());
 
     // Tiny: SSO capacity above maximum -> shrink to minimum_size.
     std::string t;
     no_zero{t}.resize_to(4); // capacity == sso_cap
     no_zero{t}.rightsize_to(2, sso_cap - 1);
-    CHECK(t.size() == 2u);
+    CHECK(t.size() == 2U);
 
     // Small: capacity within bounds -> enlarge_to path.
     std::string u;
     no_zero{u}.rightsize_to(50, 500);
-    CHECK(u.size() >= 50u);
+    CHECK(u.size() >= 50U);
     CHECK(u.size() == u.capacity());
 
     // Small: capacity above maximum -> shrinks to minimum_size.
     no_zero{u}.enlarge_to(200);
-    CHECK(u.capacity() >= 200u);
+    CHECK(u.capacity() >= 200U);
     no_zero{u}.rightsize_to(50, 100);
-    CHECK(u.size() == 50u);
-    CHECK((u.capacity()) < (200u));
+    CHECK(u.size() == 50U);
+    CHECK((u.capacity()) < (200U));
 
     // Returns a reference to the same string.
     CHECK(&*no_zero{u}.rightsize_to(50, 500) == &u);
@@ -3024,13 +3026,13 @@ TEST_CASE("NoZero", "[StringUtilsTest]") {
   if (true) {
     std::wstring w;
     no_zero{w}.enlarge_to(50);
-    CHECK(w.size() >= 50u);
+    CHECK(w.size() >= 50U);
     CHECK(w.size() == w.capacity());
-    CHECK(no_zero{w}.trim_to(3)->size() == 3u);
+    CHECK(no_zero{w}.trim_to(3)->size() == 3U);
 
     std::u16string u16;
     CHECK(&*no_zero{u16}.resize_to(20).clear_out() == &u16);
-    CHECK(u16.size() == 0u);
+    CHECK(u16.size() == 0U);
   }
 }
 
@@ -3154,12 +3156,12 @@ TEST_CASE("AnyStrings", "[StringUtilsTest]") {
   CHECK(v0.empty());
 
   auto v1 = strings::as_vector(std::string{"hello"});
-  REQUIRE(v1.size() == 1u);
+  REQUIRE(v1.size() == 1U);
   CHECK(v1[0] == "hello");
 
   auto v2 =
       strings::as_vector(std::string{"a"}, std::string{"b"}, std::string{"c"});
-  REQUIRE(v2.size() == 3u);
+  REQUIRE(v2.size() == 3U);
   CHECK(v2[0] == "a");
   CHECK(v2[1] == "b");
   CHECK(v2[2] == "c");
@@ -3177,7 +3179,7 @@ TEST_CASE("AnyStrings", "[StringUtilsTest]") {
   auto a2 = strings::as_any(std::string{"x"}, std::string{"y"});
   REQUIRE(std::holds_alternative<std::vector<std::string>>(a2));
   const auto& sv = std::get<std::vector<std::string>>(a2);
-  REQUIRE(sv.size() == 2u);
+  REQUIRE(sv.size() == 2U);
   CHECK(sv[0] == "x");
   CHECK(sv[1] == "y");
 }
@@ -3191,5 +3193,5 @@ TEST_CASE("DelimFormats", "[StringUtilsTest]") {
 
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/strings_test.cpp
+++ b/tests/portable/strings_test.cpp
@@ -140,6 +140,7 @@ TEST_CASE("Split", "[StringUtilsTest]") {
     std::string s{w};
     CHECK(strings::split(w, ",") == V{"1", "2", "3", "4"});
     CHECK(strings::split(s, ",") == V{"1", "2", "3", "4"});
+    // NOLINTNEXTLINE(bugprone-use-after-move): moved-from is asserted.
     CHECK(strings::split(std::move(s), ",") == S{"1", "2", "3", "4"});
   }
   if (true) {
@@ -175,6 +176,8 @@ TEST_CASE("WhitespaceDelim", "[StringUtilsTest]") {
     for (auto ndx = 0; ndx < 256; ++ndx) {
       const auto c = static_cast<char>(ndx);
       CHECK(strings::is_space(c) ==
+            // find/npos is the oracle that is_space is checked against.
+            // NOLINTNEXTLINE(readability-container-contains)
             (strings::whitespace.find(c) != strings::npos));
     }
     CHECK(strings::is_space(strings::wwhitespace));
@@ -1092,6 +1095,8 @@ TEST_CASE("RLocate", "[StringUtilsTest]") {
     CHECK(strings::rlocate(s, "a") == 10U);
     CHECK(strings::rlocate(s, "a", 10U) == 10U);
     CHECK(strings::rlocate(s, "a", 1U) == 0U);
+    // Mirrors the corvid call it is compared against.
+    // NOLINTNEXTLINE(performance-faster-string-find)
     CHECK(s.rfind("a", 0U) == 0U);
     CHECK(strings::rlocate(s, "a", 0U) == 0U);
     CHECK(strings::rlocate(s, {'i', 'j'}) == location{19U, 1U});
@@ -1176,6 +1181,8 @@ TEST_CASE("LocateEdges", "[StringUtilsTest]") {
   // Confirm the correctness of infinite loops.
   if (true) {
     constexpr auto s = "abcdefghijabcdefghij"sv;
+    // Mirrors the corvid call it is compared against.
+    // NOLINTNEXTLINE(performance-faster-string-find)
     CHECK(s.find("a") == 0U);
     CHECK(strings::locate(s, "a") == 0U);
     CHECK(s.find("") == 0U);
@@ -2357,7 +2364,7 @@ TEST_CASE("ParseNum", "[StringUtilsTest]") {
   if (true) {
     std::string_view sv;
     sv = "123";
-    int64_t t;
+    int64_t t{};
     CHECK(strings::extract_num(t, sv));
     CHECK(t == 123);
     CHECK(sv.empty());
@@ -2558,7 +2565,7 @@ TEST_CASE("WideConversion", "[StringUtilsTest]") {
   strings::append_num<10, 5>(s, 7); // width and pad
   CHECK(s == u"    7");
   s.clear();
-  strings::append_num(s, double(0.25));
+  strings::append_num(s, 0.25);
   CHECK(s == u"0.25");
 
   // num_as_string can return a wide string (code unit as the trailing arg).
@@ -2744,7 +2751,7 @@ TEST_CASE("StdFromChars", "[StringUtilsTest]") {
     CHECK_FALSE(opt.has_value());
 
     // With default value.
-    float val = strings::parse_num<float>("1.5"sv, -1.0F);
+    auto val = strings::parse_num<float>("1.5"sv, -1.0F);
     CHECK(val == 1.5F);
 
     val = strings::parse_num<float>("bad"sv, -1.0F);
@@ -2766,7 +2773,7 @@ TEST_CASE("StdFromChars", "[StringUtilsTest]") {
     CHECK((opt.value() > 0.0 && opt.value() < 1e-99));
 
     // With default value.
-    double val = strings::parse_num<double>("2.718281828"sv, 0.0);
+    auto val = strings::parse_num<double>("2.718281828"sv, 0.0);
     CHECK((val > 2.71828182 && val < 2.71828183));
 
     val = strings::parse_num<double>("xyz"sv, -999.0);
@@ -2865,9 +2872,7 @@ TEST_CASE("NoZero", "[StringUtilsTest]") {
   // `trim_to`: shrinks when `new_size` is smaller, but never enlarges and
   // never changes capacity.
   if (true) {
-    static_assert(requires(std::string& value) {
-      no_zero{value}.trim_to(int{1});
-    });
+    static_assert(requires(std::string& value) { no_zero{value}.trim_to(1); });
     static_assert(requires(std::string& value) {
       no_zero{value}.trim_to(unsigned{1});
     });

--- a/tests/portable/tagged_string_view_test.cpp
+++ b/tests/portable/tagged_string_view_test.cpp
@@ -50,8 +50,7 @@ consteval beta operator""_beta(const char* s, size_t n) {
 }
 } // namespace
 
-// NOLINTBEGIN(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTBEGIN(readability-function-cognitive-complexity)
 
 #pragma region TypeSafety
 
@@ -317,5 +316,4 @@ TEST_CASE("TaggedComparison", "[tagged_string_view]") {
 
 #pragma endregion
 
-// NOLINTEND(readability-function-cognitive-complexity,
-// readability-function-size)
+// NOLINTEND(readability-function-cognitive-complexity)


### PR DESCRIPTION
Seventeen test files carried a `NOLINTBEGIN` whose check list was split across
two comment lines:

```cpp
// NOLINTBEGIN(readability-function-cognitive-complexity,
// readability-function-size)
```

clang-tidy requires the list to close on the same line. Split like this it is
malformed, and clang-tidy falls back to suppressing **every** check through to
the matching `NOLINTEND`. Each of those files was running under a silent
file-wide suppression rather than the two checks it named.

The split is not arbitrary: a single line naming both checks is 84 characters,
so clang-format wraps it. Naming one check per line, or one directive per
check, stays under the limit and survives the formatter.

With the directives repaired, 1088 warnings became visible. This branch clears
all of them, and the whole suite is now clang-tidy clean.

## The directives

Every affected file now names `readability-function-cognitive-complexity` on
one line. The seven files that genuinely trip `readability-function-size`
(`containers`, `cstring_view`, `ecs`, `meta`, `opt_string_view`,
`sequence_enum`, `strings`) carry it as a second stacked directive, the form
already used in `netsocket_tests.cpp` and `proto_test.cpp`. The other ten do
not trip it, so they do not name it.

## Mechanical fixes

1001 warnings across seven files, applied with `clang-tidy --fix` restricted to
the two checks and with headers excluded from the fixer:

- `readability-uppercase-literal-suffix`: `0u` becomes `0U`. 866 of these are
  in `ecs_test.cpp`.
- `readability-isolate-declaration`: `int a = 0, b = 0;` becomes two
  statements.

## Parenthesization

- `containers_test.cpp`: nine `<=>` subexpressions, `CHECK(fn <=> fn2 == ...)`
  to `CHECK((fn <=> fn2) == ...)`. `<=>` already binds tighter than `==`, so
  the parse is unchanged and Catch2 decomposes at the same `==`.
- `sequence_enum_test.cpp`: ten precedence sites, `3 + 3 * 4` to `3 + (3 * 4)`.
  These are deliberate wraparound inputs to `make_safely` and their values are
  unchanged.

## Fixed rather than suppressed

- `formatting_test.cpp`: `[[nodiscard]]` on the three fixture methods that
  return an output iterator the caller must use.
- `strings_test.cpp`: `int64_t t;` to `int64_t t{}`, which is what the
  analyzer's garbage-value report was pointing at and what the initialization
  policy asks for.
- `ecs_test.cpp` and `strings_test.cpp`: `std::find` to `std::ranges::find`, a
  `reserve` ahead of a push_back loop, two redundant casts dropped, and two
  declarations moved to `auto` where the right-hand side names the type.

## Suppressions

The rest are cases where the check contradicts what the test exists to prove,
each with a stated reason. Ranges cover a group that shares one reason, and
line directives cover isolated sites.

- Moved-from state is the assertion: `bugprone-use-after-move` and its
  path-sensitive companion `clang-analyzer-cplusplus.Move`, in the move
  semantics tests.
- The fixture's shape is the subject: enums whose underlying type is what is
  being exercised (`X` is `size_t`, `Y` is `int64_t`), `tiger_missing`'s
  deliberate gap, and `throwing_scoped_value_test`, whose move constructor
  throws on purpose.
- The suggested rewrite would weaken the test: `std::string_view sv("")` is
  non-null and empty, which the next line asserts; the `data()` and `c_str()`
  checks exercise two distinct accessors; `s.rfind("a", 0U)` is the std oracle
  that the neighboring `strings::rlocate` assertions are compared against.
- False positives: `enum_name` returns a view into interned static storage, so
  it outlives the parameter; the `pi`-like literals in the charconv test are
  test data for float formatting, not uses of a constant.

One library header is included. `component_scene.h`'s `get_component_dyn` ends
`assert(result); return *result;` in both branches, which is the narrow
contract that "error-handling-policy.md" prescribes, so the range names the
analyzer check and points at the caller guarantee the function already
documents.

## Verification

Full suite green at 73/73. `cleanbuild.sh tidy` over all 75 translation units
reports no warnings at all. Because a wrapped or orphaned directive fails
silently, three properties are also checked directly: no directive exceeds 79
characters, none has an unclosed check list, and no `NOLINTNEXTLINE` is
followed by a comment line rather than the code it covers.

This is a C++23 codebase.
