### PR TITLE
Normalize #pragma region style across tests; region every test case

### DIFF
--- a/corvid/lang/coreb/value.h
+++ b/corvid/lang/coreb/value.h
@@ -62,6 +62,10 @@ namespace corvid { inline namespace lang { namespace coreb {
 //   auto v = rt.cons(value{rt.intern("x")}, rt.cons(value{42}, value{}));
 //   v.print();  // "(x 42)"
 
+// Declared up front: a friend declaration alone does not make the name
+// visible (MSVC injects it as an extension; conforming compilers do not).
+class runtime;
+
 #pragma region symbol
 
 // Interned symbol.

--- a/tests/cuda/avatar_body_test.cu
+++ b/tests/cuda/avatar_body_test.cu
@@ -41,6 +41,8 @@ vec3 slope_normal(float degrees) {
 
 } // namespace
 
+#pragma region Gravity and contact
+
 TEST_CASE("avatar_body falls under gravity", "[cuda][physics][avatar_body]") {
   avatar_body b;
   b.params = test_params();
@@ -84,6 +86,9 @@ TEST_CASE("avatar_body is pushed out of an overlap",
   CHECK(b.center.v.y > 0.99F); // lifted ~0.3 back to resting
   CHECK(b.grounded);
 }
+
+#pragma endregion
+#pragma region Seating
 
 TEST_CASE("avatar_body seats a ball hovering within the ground tolerance",
     "[cuda][physics][avatar_body]") {
@@ -143,6 +148,9 @@ TEST_CASE("avatar_body holds still when seated, no vertical sawtooth",
   CHECK(b.grounded);
 }
 
+#pragma endregion
+#pragma region Jumping
+
 TEST_CASE("avatar_body jump apex matches v^2 / 2g",
     "[cuda][physics][avatar_body]") {
   avatar_body b;
@@ -195,6 +203,9 @@ TEST_CASE("avatar_body defers a held jump while rising to the next contact",
   CHECK(b.velocity.y > 5.0F);
 }
 
+#pragma endregion
+#pragma region Slopes
+
 TEST_CASE("avatar_body holds on a slope below the friction angle",
     "[cuda][physics][avatar_body]") {
   avatar_body b;
@@ -229,6 +240,9 @@ TEST_CASE("avatar_body slides down a slope above the friction angle",
   const vec3 downhill = normalize(gravity - (normal * dot(gravity, normal)));
   CHECK(dot(normalize(b.velocity), downhill) > 0.9F);
 }
+
+#pragma endregion
+#pragma region Wheel spin
 
 TEST_CASE("avatar_body spins a slipping ball up to rolling without slipping",
     "[cuda][physics][avatar_body]") {
@@ -297,6 +311,9 @@ TEST_CASE("avatar_body revs the wheel in the air toward the command",
   CHECK(length(b.angular_velocity - omega) < 1e-6F);
 }
 
+#pragma endregion
+#pragma region Terminal speed
+
 TEST_CASE("avatar_body reaches a drag-limited terminal speed",
     "[cuda][physics][avatar_body]") {
   avatar_body b;
@@ -318,5 +335,7 @@ TEST_CASE("avatar_body reaches a drag-limited terminal speed",
   const vec3 vt = b.velocity - (up * dot(b.velocity, up));
   CHECK(std::fabs(length(vt) - terminal) < 0.25F);
 }
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/cuda/cuda_device_test.cu
+++ b/tests/cuda/cuda_device_test.cu
@@ -86,6 +86,8 @@ constexpr attr_case attr_cases[]{
 
 } // namespace
 
+#pragma region cuda_device_attr
+
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 TEST_CASE("cuda_device_attr derived range", "[cuda][enums]") {
   static_assert(*min_value<cuda_device_attr>() == 1);
@@ -149,4 +151,6 @@ TEST_CASE("cuda_device_attr gap and unknown handling", "[cuda][enums]") {
   cuda_device_attr unused{};
   CHECK_FALSE(convert_enum(unused, "not_a_real_attr"));
 }
+
+#pragma endregion
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/cuda/cuda_saxpy_test.cu
+++ b/tests/cuda/cuda_saxpy_test.cu
@@ -38,6 +38,8 @@ __global__ void saxpy_kernel(float a, float x, float y, float* out) {
 
 using namespace corvid::cuda;
 
+#pragma region Saxpy
+
 TEST_CASE("cuda saxpy kernel runs on the device", "[cuda]") {
   float h_out = 0.0F;
   if (cuda_ptr<float> d_out; true) {
@@ -57,3 +59,5 @@ TEST_CASE("cuda saxpy kernel runs on the device", "[cuda]") {
   // 2*3 + 4 == 10, exactly representable in float.
   CHECK(h_out == 10.0F);
 }
+
+#pragma endregion

--- a/tests/cuda/cuda_status_test.cu
+++ b/tests/cuda/cuda_status_test.cu
@@ -48,6 +48,8 @@ constexpr status_case status_cases[]{
 
 } // namespace
 
+#pragma region cuda_status
+
 TEST_CASE("cuda_status values and string round-trip", "[cuda][enums]") {
   for (const auto& c : status_cases) {
     CAPTURE(c.name);
@@ -78,3 +80,5 @@ TEST_CASE("cuda_status gap and unknown handling", "[cuda][enums]") {
   cuda_status unused{};
   CHECK_FALSE(convert_enum(unused, "not_a_real_status"));
 }
+
+#pragma endregion

--- a/tests/cuda/raycast_test.cu
+++ b/tests/cuda/raycast_test.cu
@@ -65,6 +65,8 @@ __global__ void to_byte_kernel(unsigned char* out) {
 
 } // namespace
 
+#pragma region surface_normal
+
 TEST_CASE("surface_normal points outward from the sphere", "[cuda][raycast]") {
   vec3 normal{};
   if (cuda_ptr<vec3> d_out; true) {
@@ -78,6 +80,9 @@ TEST_CASE("surface_normal points outward from the sphere", "[cuda][raycast]") {
   CHECK(std::fabs(normal.z) < 1e-3F);
 }
 
+#pragma endregion
+#pragma region soft_shadow
+
 TEST_CASE("soft_shadow blocks light through the sphere", "[cuda][raycast]") {
   float shadow[2]{-1.0F, -1.0F};
   if (cuda_ptr<float> d_out{2}; true) {
@@ -90,6 +95,9 @@ TEST_CASE("soft_shadow blocks light through the sphere", "[cuda][raycast]") {
   CHECK(shadow[1] == 1.0F); // unobstructed
 }
 
+#pragma endregion
+#pragma region ambient_occlusion
+
 TEST_CASE("ambient_occlusion is open on a convex surface", "[cuda][raycast]") {
   float ao = -1.0F;
   if (cuda_ptr<float> d_out; true) {
@@ -101,6 +109,9 @@ TEST_CASE("ambient_occlusion is open on a convex surface", "[cuda][raycast]") {
   CHECK(ao > 0.99F);
   CHECK(ao <= 1.0F);
 }
+
+#pragma endregion
+#pragma region shade_ray
 
 TEST_CASE("shade_ray shades a hit and returns sky on a miss",
     "[cuda][raycast]") {
@@ -123,6 +134,9 @@ TEST_CASE("shade_ray shades a hit and returns sky on a miss",
   CHECK(std::fabs(color[1].z - 0.5F) < 1e-4F);
 }
 
+#pragma endregion
+#pragma region to_byte
+
 TEST_CASE("to_byte gamma-encodes and clamps", "[cuda][raycast]") {
   unsigned char bytes[5]{};
   if (cuda_ptr<unsigned char> d_out{5}; true) {
@@ -137,5 +151,7 @@ TEST_CASE("to_byte gamma-encodes and clamps", "[cuda][raycast]") {
   CHECK(bytes[3] == 255); // above one clamps to 255
   CHECK(bytes[4] == 186); // 0.5 ^ (1/2.2) * 255, rounded
 }
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/cuda/windows/cuda_d3d11_interop_test.cu
+++ b/tests/cuda/windows/cuda_d3d11_interop_test.cu
@@ -31,6 +31,8 @@ constexpr flag_case flag_cases[]{
 
 } // namespace
 
+#pragma region cuda_graphics_register_flags
+
 TEST_CASE("cuda_graphics_register_flags single-flag round-trip",
     "[cuda][enums]") {
   for (const auto& c : flag_cases) {
@@ -59,6 +61,9 @@ TEST_CASE("cuda_graphics_register_flags combined and unknown",
   CHECK_FALSE(convert_enum(unused, "not_a_flag"));
 }
 
+#pragma endregion
+#pragma region cuda_interop_adapter
+
 TEST_CASE("cuda_interop_adapter picks the CUDA device's adapter",
     "[cuda][interop]") {
   // These CUDA tests already target a discrete GPU, so an adapter must be
@@ -79,3 +84,5 @@ TEST_CASE("cuda_interop_adapter picks the CUDA device's adapter",
   CHECK(std::memcmp(&desc.AdapterLuid, prop.luid, sizeof(desc.AdapterLuid)) ==
         0);
 }
+
+#pragma endregion

--- a/tests/linux/epoll_tests.cpp
+++ b/tests/linux/epoll_tests.cpp
@@ -85,7 +85,6 @@ TEST_CASE("Lifecycle", "[Epoll]") {
 }
 
 #pragma endregion
-
 #pragma region Create
 
 TEST_CASE("Create", "[Epoll]") {
@@ -120,7 +119,6 @@ TEST_CASE("Create", "[Epoll]") {
 }
 
 #pragma endregion
-
 #pragma region Move
 
 // The moved-from source going invalid is what these blocks assert.
@@ -160,7 +158,6 @@ TEST_CASE("Move", "[Epoll]") {
 // NOLINTEND(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
 
 #pragma endregion
-
 #pragma region Release
 
 TEST_CASE("Release", "[Epoll]") {
@@ -175,7 +172,6 @@ TEST_CASE("Release", "[Epoll]") {
 }
 
 #pragma endregion
-
 #pragma region ControlWait
 
 TEST_CASE("ControlWait", "[Epoll]") {
@@ -205,7 +201,6 @@ TEST_CASE("ControlWait", "[Epoll]") {
 }
 
 #pragma endregion
-
 #pragma region WaitArray
 
 TEST_CASE("WaitArray", "[Epoll]") {
@@ -234,7 +229,6 @@ TEST_CASE("WaitArray", "[Epoll]") {
 }
 
 #pragma endregion
-
 #pragma region EventFd_Lifecycle
 
 TEST_CASE("Lifecycle", "[EventFd]") {
@@ -263,7 +257,6 @@ TEST_CASE("Lifecycle", "[EventFd]") {
 }
 
 #pragma endregion
-
 #pragma region EventFd_Move
 
 // The moved-from source going invalid is what these blocks assert.
@@ -303,7 +296,6 @@ TEST_CASE("Move", "[EventFd]") {
 // NOLINTEND(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
 
 #pragma endregion
-
 #pragma region EventFd_Release
 
 TEST_CASE("Release", "[EventFd]") {
@@ -318,7 +310,6 @@ TEST_CASE("Release", "[EventFd]") {
 }
 
 #pragma endregion
-
 #pragma region EventFd_NotifyRead
 
 TEST_CASE("NotifyRead", "[EventFd]") {
@@ -343,7 +334,6 @@ TEST_CASE("NotifyRead", "[EventFd]") {
 }
 
 #pragma endregion
-
 #pragma region EventFd_Create
 
 TEST_CASE("Create", "[EventFd]") {
@@ -378,7 +368,6 @@ TEST_CASE("Create", "[EventFd]") {
 }
 
 #pragma endregion
-
 #pragma region EventFd_SemaphoreMode
 
 TEST_CASE("SemaphoreMode", "[EventFd]") {
@@ -424,7 +413,6 @@ TEST_CASE("SemaphoreMode", "[EventFd]") {
 }
 
 #pragma endregion
-
 #pragma region EventFd_NonblockingEmptyRead
 
 TEST_CASE("NonblockingEmptyRead", "[EventFd]") {

--- a/tests/linux/http3_conn_test.cpp
+++ b/tests/linux/http3_conn_test.cpp
@@ -25,6 +25,8 @@ using namespace corvid::proto::quic::http3_literals;
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region h3_error_code
+
 TEST_CASE("h3_error_code names round-trip across the gap", "[http3]") {
   using namespace corvid;
   using E = h3_error_code;
@@ -46,6 +48,8 @@ TEST_CASE("h3_error_code names round-trip across the gap", "[http3]") {
         E::qpack_encoder_stream_error);
   CHECK(!parse_enum<E>("nonexistent"));
 }
+
+#pragma endregion
 
 namespace {
 
@@ -142,6 +146,8 @@ int pump(http3_conn& from, http3_conn& to) {
 }
 
 } // namespace
+
+#pragma region http3_conn
 
 TEST_CASE("http3_conn links nghttp3 control streams end to end", "[http3]") {
   recording_handlers client_handlers;
@@ -312,4 +318,6 @@ TEST_CASE("http3_conn set_stream_user_data round-trips to upcalls",
   REQUIRE_FALSE(client_handlers.headers.empty());
   CHECK(client_handlers.last_user_data == &marker);
 }
+
+#pragma endregion
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/linux/http3_header_test.cpp
+++ b/tests/linux/http3_header_test.cpp
@@ -26,6 +26,8 @@ using namespace corvid::proto::quic::http3_literals;
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region Http3HeaderLiterals
+
 TEST_CASE("Http3HeaderLiterals", "[http3]") {
   // The `_header` literal validates the field name at compile time. It stores
   // only the name; `as_enum` resolves the token by lookup, not from a stored
@@ -44,6 +46,9 @@ TEST_CASE("Http3HeaderLiterals", "[http3]") {
   // Underscored enumerators spell as hyphenated names on the wire.
   CHECK(("VERSION-CONTROL"_method).as_enum() == http3_method::VERSION_CONTROL);
 }
+
+#pragma endregion
+#pragma region Http3FieldMake
 
 TEST_CASE("Http3FieldMake", "[http3]") {
   SECTION("make derives the token from a known name") {
@@ -64,6 +69,9 @@ TEST_CASE("Http3FieldMake", "[http3]") {
     CHECK(f.flags == nv_flags::never_index);
   }
 }
+
+#pragma endregion
+#pragma region Http3HeadersAdd
 
 TEST_CASE("Http3HeadersAdd", "[http3]") {
   http3_headers h;
@@ -109,6 +117,9 @@ TEST_CASE("Http3HeadersAdd", "[http3]") {
     CHECK(h[0].value == "abc");
   }
 }
+
+#pragma endregion
+#pragma region Http3HeadersSet
 
 TEST_CASE("Http3HeadersSet", "[http3]") {
   http3_headers h;
@@ -167,6 +178,9 @@ TEST_CASE("Http3HeadersSet", "[http3]") {
     CHECK(h[1].value == "b"); // later duplicate left untouched
   }
 }
+
+#pragma endregion
+#pragma region Http3HeadersFind
 
 TEST_CASE("Http3HeadersFind", "[http3]") {
   http3_headers h;
@@ -236,6 +250,9 @@ TEST_CASE("Http3HeadersFind", "[http3]") {
   }
 }
 
+#pragma endregion
+#pragma region Http3HeadersIteration
+
 TEST_CASE("Http3HeadersIteration", "[http3]") {
   http3_headers h;
   h.add(":method", "GET"_method);
@@ -272,6 +289,9 @@ TEST_CASE("Http3HeadersIteration", "[http3]") {
   }
 }
 
+#pragma endregion
+#pragma region Http3HeadersEraseAndClear
+
 TEST_CASE("Http3HeadersEraseAndClear", "[http3]") {
   http3_headers h;
   h.add(":method", "GET"_method);
@@ -298,6 +318,9 @@ TEST_CASE("Http3HeadersEraseAndClear", "[http3]") {
   }
 }
 
+#pragma endregion
+#pragma region Http3HeadersChunkFin
+
 TEST_CASE("Http3HeadersChunkFin", "[http3]") {
   http3_headers h;
 
@@ -317,6 +340,9 @@ TEST_CASE("Http3HeadersChunkFin", "[http3]") {
   }
 }
 
+#pragma endregion
+#pragma region Http3HeadersSpanConversion
+
 TEST_CASE("Http3HeadersSpanConversion", "[http3]") {
   http3_headers h;
   h.add(":status", "200");
@@ -331,6 +357,9 @@ TEST_CASE("Http3HeadersSpanConversion", "[http3]") {
   CHECK(fields[1].name == "content-length");
   CHECK(fields.data() == &h[0]);
 }
+
+#pragma endregion
+#pragma region NvFlagsString
 
 TEST_CASE("NvFlagsString", "[http3]") {
   // Each named bit round-trips through `enum_as_string` / `parse_enum`.
@@ -357,6 +386,9 @@ TEST_CASE("NvFlagsString", "[http3]") {
   }
 }
 
+#pragma endregion
+#pragma region StreamChunkString
+
 TEST_CASE("StreamChunkString", "[http3]") {
   // Both sequence values round-trip through `enum_as_string` / `parse_enum`.
   using namespace corvid;
@@ -372,6 +404,9 @@ TEST_CASE("StreamChunkString", "[http3]") {
     CHECK(parse_enum("fin", bad) == C::fin);
   }
 }
+
+#pragma endregion
+#pragma region HttpMethodString
 
 TEST_CASE("HttpMethodString", "[http3]") {
   // Method names round-trip through `enum_as_string` / `parse_enum`.
@@ -394,4 +429,6 @@ TEST_CASE("HttpMethodString", "[http3]") {
     CHECK(parse_enum("VERSION-CONTROL", bad) == M::VERSION_CONTROL);
   }
 }
+
+#pragma endregion
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/linux/http3_server_stream_test.cpp
+++ b/tests/linux/http3_server_stream_test.cpp
@@ -44,6 +44,8 @@ std::string_view gate(std::optional<std::string_view> authority,
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region Http3ServerStreamAuthorityGate
+
 TEST_CASE("Http3ServerStreamAuthorityGate", "[http3]") {
   SECTION("no configured authority is a server misconfiguration") {
     CHECK(gate("example.com", std::nullopt, ""sv) == "500");
@@ -85,5 +87,7 @@ TEST_CASE("Http3ServerStreamAuthorityGate", "[http3]") {
     CHECK(gate("evil.com", "example.com") == "421");
   }
 }
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/linux/http3_stream_test.cpp
+++ b/tests/linux/http3_stream_test.cpp
@@ -57,6 +57,8 @@ struct capture_stream: http3_stream {
 
 } // namespace
 
+#pragma region Http3StreamHeaders
+
 TEST_CASE("Http3StreamHeaders", "[http3]") {
   capture_stream s{};
   s.attach(nullptr, a_stream_id);
@@ -108,6 +110,9 @@ TEST_CASE("Http3StreamHeaders", "[http3]") {
   }
 }
 
+#pragma endregion
+#pragma region Http3StreamTrailers
+
 TEST_CASE("Http3StreamTrailers", "[http3]") {
   capture_stream s;
   s.attach(nullptr, a_stream_id);
@@ -157,6 +162,9 @@ TEST_CASE("Http3StreamTrailers", "[http3]") {
   }
 }
 
+#pragma endregion
+#pragma region Http3StreamDefaults
+
 TEST_CASE("Http3StreamDefaults", "[http3]") {
   // The base class is concrete; its unoverridden hooks are no-op `true`.
   http3_stream s;
@@ -172,4 +180,6 @@ TEST_CASE("Http3StreamDefaults", "[http3]") {
   CHECK(s.on_end_stream());
   CHECK(s.on_close(h3_error_code::no_error));
 }
+
+#pragma endregion
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/linux/http_header_block_tests.cpp
+++ b/tests/linux/http_header_block_tests.cpp
@@ -91,6 +91,7 @@ TEST_CASE("ParseHttp11", "[HttpHeaderBlock]") {
   REQUIRE(accept);
   CHECK(*accept == "text/html");
 }
+
 #pragma endregion
 #pragma region ParseHttp10
 
@@ -102,6 +103,7 @@ TEST_CASE("ParseHttp10", "[HttpHeaderBlock]") {
   CHECK(req.method == http_method::POST);
   CHECK(req.target == "/submit");
 }
+
 #pragma endregion
 #pragma region UnknownMethod
 
@@ -110,6 +112,7 @@ TEST_CASE("UnknownMethod", "[HttpHeaderBlock]") {
   request_head req;
   CHECK_FALSE(req.parse("BREW /coffee HTTP/1.1\r\n"));
 }
+
 #pragma endregion
 #pragma region InvalidVersion
 
@@ -118,6 +121,7 @@ TEST_CASE("InvalidVersion", "[HttpHeaderBlock]") {
   request_head req;
   CHECK_FALSE(req.parse("GET / HTTP/2.0\r\n"));
 }
+
 #pragma endregion
 #pragma region Http09Style
 
@@ -129,6 +133,7 @@ TEST_CASE("Http09Style", "[HttpHeaderBlock]") {
   CHECK(req.version == http_version::http_0_9);
   CHECK(req.target == "/");
 }
+
 #pragma endregion
 #pragma region NoSp
 
@@ -137,6 +142,7 @@ TEST_CASE("NoSp", "[HttpHeaderBlock]") {
   request_head req;
   CHECK_FALSE(req.parse("GETNOSPC\r\n"));
 }
+
 #pragma endregion
 #pragma region HeaderLookupCanonical
 
@@ -152,6 +158,7 @@ TEST_CASE("HeaderLookupCanonical", "[HttpHeaderBlock]") {
   REQUIRE(content_type);
   CHECK(*content_type == "text/plain");
 }
+
 #pragma endregion
 #pragma region HeaderGet
 
@@ -165,6 +172,7 @@ TEST_CASE("HeaderGet", "[HttpHeaderBlock]") {
   CHECK_FALSE(h.get("Heist"));
   CHECK_FALSE(h.get("Content-Type"));
 }
+
 #pragma endregion
 #pragma region HeaderGetEmptyValue
 
@@ -177,6 +185,7 @@ TEST_CASE("HeaderGetEmptyValue", "[HttpHeaderBlock]") {
   CHECK(empty_value->empty());
   CHECK_FALSE(h.get("Missing"));
 }
+
 #pragma endregion
 #pragma region HeaderCombine
 
@@ -188,6 +197,7 @@ TEST_CASE("HeaderCombine", "[HttpHeaderBlock]") {
   CHECK(h.get_combined("Accept") == "text/html, application/json");
   CHECK(h.get_combined("Missing") == "");
 }
+
 #pragma endregion
 #pragma region KeepAlive
 
@@ -214,6 +224,7 @@ TEST_CASE("KeepAlive", "[HttpHeaderBlock]") {
     CHECK(req.options.keep_alive(req.version) == after_response::keep_alive);
   }
 }
+
 #pragma endregion
 #pragma region KeepAliveTokenList
 
@@ -248,6 +259,7 @@ TEST_CASE("KeepAliveTokenList", "[HttpHeaderBlock]") {
     CHECK(req.options.keep_alive(req.version) == after_response::close);
   }
 }
+
 #pragma endregion
 #pragma region ResponseSerialize
 
@@ -269,6 +281,7 @@ TEST_CASE("ResponseSerialize", "[HttpHeaderBlock]") {
   // Wire format ends with the blank line; body is not included.
   CHECK(wire.ends_with("\r\n\r\n"));
 }
+
 #pragma endregion
 #pragma region ExtractLeadingCrlf
 
@@ -291,6 +304,7 @@ TEST_CASE("ExtractLeadingCrlf", "[HttpHeaderBlock]") {
     CHECK_FALSE(req.parse("\r\n\r\n"));
   }
 }
+
 #pragma endregion
 #pragma region ExtractHeaderErrors
 
@@ -319,6 +333,7 @@ TEST_CASE("ExtractHeaderErrors", "[HttpHeaderBlock]") {
     CHECK_FALSE(req.parse("GET / HTTP/1.1\r\nBad Name: value\r\n"));
   }
 }
+
 #pragma endregion
 #pragma region RequestSerialize
 
@@ -373,6 +388,7 @@ TEST_CASE("RequestSerialize", "[HttpHeaderBlock]") {
     CHECK(req.serialize().empty());
   }
 }
+
 #pragma endregion
 #pragma region ResponseExtract
 
@@ -436,6 +452,7 @@ TEST_CASE("ResponseExtract", "[HttpHeaderBlock]") {
     CHECK(*location == "/new/resource");
   }
 }
+
 #pragma endregion
 #pragma region NormalizeCasing
 
@@ -534,6 +551,7 @@ TEST_CASE("NormalizeCasing", "[HttpHeaderBlock]") {
     CHECK(name == "X-Forwarded-For");
   }
 }
+
 #pragma endregion
 #pragma region NormalizeSpecialChars
 
@@ -566,6 +584,7 @@ TEST_CASE("NormalizeSpecialChars", "[HttpHeaderBlock]") {
     CHECK(name == "-Foo");
   }
 }
+
 #pragma endregion
 #pragma region NormalizeInvalidChars
 
@@ -591,6 +610,7 @@ TEST_CASE("NormalizeInvalidChars", "[HttpHeaderBlock]") {
   CHECK(bad("bad<name"));  // less-than
   CHECK(bad("bad>name"));  // greater-than
 }
+
 #pragma endregion
 #pragma region NormalizeEdgeCases
 
@@ -632,6 +652,7 @@ TEST_CASE("NormalizeEdgeCases", "[HttpHeaderBlock]") {
     CHECK(name == "Content Type");
   }
 }
+
 #pragma endregion
 #pragma region IsValidFieldValue
 
@@ -654,6 +675,7 @@ TEST_CASE("IsValidFieldValue", "[HttpHeaderBlock]") {
   // Other control chars (< 0x20, not HTAB): invalid.
   CHECK_FALSE(http_headers::is_valid_field_value("bad\x01value"));
 }
+
 #pragma endregion
 #pragma region ContentLength
 
@@ -693,6 +715,7 @@ TEST_CASE("ContentLength", "[HttpHeaderBlock]") {
     CHECK(*opts.content_length == 0ULL);
   }
 }
+
 #pragma endregion
 #pragma region IsChunked
 
@@ -761,6 +784,7 @@ TEST_CASE("IsChunked", "[HttpHeaderBlock]") {
     CHECK_FALSE(opts.transfer_encoding);
   }
 }
+
 #pragma endregion
 #pragma region SizeAndEmpty
 
@@ -785,6 +809,7 @@ TEST_CASE("SizeAndEmpty", "[HttpHeaderBlock]") {
   ++it;
   CHECK(it == h.end());
 }
+
 #pragma endregion
 #pragma region AddRawWithRawName
 
@@ -806,6 +831,7 @@ TEST_CASE("AddRawWithRawName", "[HttpHeaderBlock]") {
   CHECK(out.contains("content-type: text/html\r\n"));
   CHECK_FALSE(out.contains("Content-Type"));
 }
+
 #pragma endregion
 #pragma region GetReturnsFirst
 
@@ -825,6 +851,7 @@ TEST_CASE("GetReturnsFirst", "[HttpHeaderBlock]") {
   CHECK((h.get_combined("Accept")) ==
         ("text/html, application/json, image/webp"));
 }
+
 #pragma endregion
 #pragma region KeepAliveHttp09
 
@@ -844,6 +871,7 @@ TEST_CASE("KeepAliveHttp09", "[HttpHeaderBlock]") {
   opts.extract(h);
   CHECK(opts.keep_alive(http_version::http_0_9) == after_response::close);
 }
+
 #pragma endregion
 #pragma region Http09WithHeaders
 
@@ -853,6 +881,7 @@ TEST_CASE("Http09WithHeaders", "[HttpHeaderBlock]") {
   request_head req;
   CHECK_FALSE(req.parse("GET /\r\nHost: example.com\r\n"));
 }
+
 #pragma endregion
 #pragma region TooManyLeadingCrlfs
 
@@ -871,6 +900,7 @@ TEST_CASE("TooManyLeadingCrlfs", "[HttpHeaderBlock]") {
     CHECK_FALSE(req.parse("\r\n\r\n\r\n\r\n\r\n\r\nGET / HTTP/1.1\r\n"));
   }
 }
+
 #pragma endregion
 #pragma region TargetNotPath
 
@@ -887,6 +917,7 @@ TEST_CASE("TargetNotPath", "[HttpHeaderBlock]") {
     CHECK_FALSE(req.parse("CONNECT example.com:443 HTTP/1.1\r\n"));
   }
 }
+
 #pragma endregion
 #pragma region ClearRequest
 
@@ -905,6 +936,7 @@ TEST_CASE("ClearRequest", "[HttpHeaderBlock]") {
   CHECK(req.target.empty());
   CHECK(req.headers.empty());
 }
+
 #pragma endregion
 #pragma region ClearResponse
 
@@ -922,6 +954,7 @@ TEST_CASE("ClearResponse", "[HttpHeaderBlock]") {
   CHECK(resp.reason.empty());
   CHECK(resp.headers.empty());
 }
+
 #pragma endregion
 #pragma region ResponseSerializeInvalid
 
@@ -938,6 +971,7 @@ TEST_CASE("ResponseSerializeInvalid", "[HttpHeaderBlock]") {
   resp.reason = "OK";
   CHECK(resp.serialize().empty());
 }
+
 #pragma endregion
 #pragma region MakeErrorResponse
 
@@ -963,6 +997,7 @@ TEST_CASE("MakeErrorResponse", "[HttpHeaderBlock]") {
     CHECK(wire.contains("Connection: keep-alive"));
   }
 }
+
 #pragma endregion
 #pragma region ResponseParseEdgeCases
 
@@ -994,6 +1029,7 @@ TEST_CASE("ResponseParseEdgeCases", "[HttpHeaderBlock]") {
     CHECK_FALSE(resp.parse("HTTP/1.1 1000 Too High\r\n"));
   }
 }
+
 #pragma endregion
 #pragma region HttpOptionsExtractApply
 
@@ -1092,6 +1128,7 @@ TEST_CASE("HttpOptionsExtractApply", "[HttpHeaderBlock]") {
     CHECK_FALSE(h.get("Content-Type"));
   }
 }
+
 #pragma endregion
 #pragma region GetValues
 
@@ -1147,6 +1184,7 @@ TEST_CASE("GetValues", "[HttpHeaderBlock]") {
     CHECK(*it == "application/json");
   }
 }
+
 #pragma endregion
 #pragma region SetRawAndRemove
 
@@ -1249,6 +1287,7 @@ TEST_CASE("SetRawAndRemove", "[HttpHeaderBlock]") {
     CHECK(*host == "example.com");
   }
 }
+
 #pragma endregion
 
 // NOLINTEND(bugprone-unchecked-optional-access)

--- a/tests/linux/http_server_tests.cpp
+++ b/tests/linux/http_server_tests.cpp
@@ -149,6 +149,7 @@ TEST_CASE("Http09", "[HttpServer]") {
   // HTTP/0.9 never keep-alive; server should close after the response.
   CHECK(client.recv_sync_drain_to_eof());
 }
+
 #pragma endregion
 #pragma region LeadingCrlf
 
@@ -168,6 +169,7 @@ TEST_CASE("LeadingCrlf", "[HttpServer]") {
   const auto response = client.recv_sync_until(buf, "\r\n\r\n");
   CHECK(response.contains("200"));
 }
+
 #pragma endregion
 #pragma region TooManyLeadingCrls
 
@@ -188,6 +190,7 @@ TEST_CASE("TooManyLeadingCrls", "[HttpServer]") {
   const auto response = client.recv_sync_until(buf, "\r\n\r\n");
   CHECK(response.empty());
 }
+
 #pragma endregion
 #pragma region OwnLoop
 
@@ -199,6 +202,7 @@ TEST_CASE("OwnLoop", "[HttpServer]") {
   REQUIRE(server);
   CHECK(server->local_endpoint());
 }
+
 #pragma endregion
 #pragma region SharedLoop
 
@@ -212,6 +216,7 @@ TEST_CASE("SharedLoop", "[HttpServer]") {
   REQUIRE(server);
   CHECK(server->local_endpoint());
 }
+
 #pragma endregion
 #pragma region Create_BadEndpoint
 
@@ -221,6 +226,7 @@ TEST_CASE("Create_BadEndpoint", "[HttpServer]") {
   auto server = make_test_server(net_endpoint{});
   CHECK_FALSE(server);
 }
+
 #pragma endregion
 #pragma region GetRoot
 
@@ -239,6 +245,7 @@ TEST_CASE("GetRoot", "[HttpServer]") {
   const auto response = client.recv_sync_until(buf, "\r\n\r\n");
   CHECK(response.contains("200"));
 }
+
 #pragma endregion
 #pragma region GetPath
 
@@ -259,6 +266,7 @@ TEST_CASE("GetPath", "[HttpServer]") {
   const auto body = client.recv_sync_until(buf, "</html>");
   CHECK(body.contains("123"));
 }
+
 #pragma endregion
 #pragma region RouteBasePath
 
@@ -278,6 +286,7 @@ TEST_CASE("RouteBasePath", "[HttpServer]") {
   for (const auto& tc : cases)
     CHECK(epoll_http_server::route_base_path(tc.target) == tc.base_path);
 }
+
 #pragma endregion
 #pragma region InvalidRequest
 
@@ -295,6 +304,7 @@ TEST_CASE("InvalidRequest", "[HttpServer]") {
   const auto response = client.recv_sync_until(buf, "\r\n\r\n");
   CHECK(response.contains("405"));
 }
+
 #pragma endregion
 #pragma region TooLongRequest
 
@@ -315,6 +325,7 @@ TEST_CASE("TooLongRequest", "[HttpServer]") {
   const auto response = client.recv_sync_until(buf, "\r\n\r\n");
   CHECK(response.size() == 0ULL);
 }
+
 #pragma endregion
 #pragma region PartialRequest
 
@@ -337,6 +348,7 @@ TEST_CASE("PartialRequest", "[HttpServer]") {
   const auto body = client.recv_sync_until(buf, "</html>");
   CHECK(body.contains("42"));
 }
+
 #pragma endregion
 #pragma region ANS
 
@@ -362,6 +374,7 @@ TEST_CASE("ANS", "[HttpServer]") {
   const auto body = client.recv_sync_until(buf, "</html>");
   CHECK(body.contains("42"));
 }
+
 #pragma endregion
 #pragma region SharedWheel
 
@@ -375,6 +388,7 @@ TEST_CASE("SharedWheel", "[HttpServer]") {
   REQUIRE(server);
   CHECK(server->local_endpoint());
 }
+
 #pragma endregion
 #pragma region RequestWithinTimeout
 
@@ -393,6 +407,7 @@ TEST_CASE("RequestWithinTimeout", "[HttpServer]") {
   const auto response = client.recv_sync_until(buf, "\r\n\r\n");
   CHECK(response.contains("200"));
 }
+
 #pragma endregion
 #pragma region IdleTimeout
 
@@ -425,6 +440,7 @@ TEST_CASE("IdleTimeout", "[HttpServer]") {
   no_zero{buf}.enlarge_to(4096);
   CHECK_FALSE(client.recv(buf));
 }
+
 #pragma endregion
 #pragma region WriteTimeout
 
@@ -495,6 +511,7 @@ TEST_CASE("WriteTimeout", "[HttpServer]") {
   // (e.g., the response drained before backpressure engaged).
   CHECK((std::chrono::steady_clock::now() - start) >= (kWriteTimeout / 2));
 }
+
 #pragma endregion
 #pragma region MissingHost
 
@@ -515,6 +532,7 @@ TEST_CASE("MissingHost", "[HttpServer]") {
   // Server closes after the error response.
   CHECK(client.recv_sync_drain_to_eof());
 }
+
 #pragma endregion
 #pragma region KeepAlive
 
@@ -540,6 +558,7 @@ TEST_CASE("KeepAlive", "[HttpServer]") {
   CHECK(r2.contains("200"));
   (void)client.recv_sync_until(buf, "</html>");
 }
+
 #pragma endregion
 #pragma region Pipeline
 
@@ -568,6 +587,7 @@ TEST_CASE("Pipeline", "[HttpServer]") {
   CHECK(r2.contains("200"));
   (void)client.recv_sync_until(buf, "</html>");
 }
+
 #pragma endregion
 #pragma region ConnectionClose
 
@@ -591,6 +611,7 @@ TEST_CASE("ConnectionClose", "[HttpServer]") {
   // Server should close after the response.
   CHECK(client.recv_sync_drain_to_eof());
 }
+
 #pragma endregion
 #pragma region Http10NoKeepAlive
 
@@ -612,6 +633,7 @@ TEST_CASE("Http10NoKeepAlive", "[HttpServer]") {
   // HTTP/1.0 default is close; server should close after the response.
   CHECK(client.recv_sync_drain_to_eof());
 }
+
 #pragma endregion
 #pragma region BodyTooLarge
 
@@ -632,6 +654,7 @@ TEST_CASE("BodyTooLarge", "[HttpServer]") {
   const auto response = client.recv_sync_until(buf, "\r\n\r\n");
   CHECK(response.contains("400"));
 }
+
 #pragma endregion
 #pragma region TooLongHeaders
 
@@ -655,6 +678,7 @@ TEST_CASE("TooLongHeaders", "[HttpServer]") {
   CHECK(response.contains("400"));
   CHECK(client.recv_sync_drain_to_eof()); // server closes after error
 }
+
 #pragma endregion
 #pragma region MalformedRequestLine
 
@@ -675,6 +699,7 @@ TEST_CASE("MalformedRequestLine", "[HttpServer]") {
   CHECK(response.contains("400"));
   CHECK(client.recv_sync_drain_to_eof()); // server closes after error
 }
+
 #pragma endregion
 #pragma region Http10KeepAlive
 
@@ -705,6 +730,7 @@ TEST_CASE("Http10KeepAlive", "[HttpServer]") {
   CHECK(r2.contains("200"));
   (void)client.recv_sync_until(buf, "</html>");
 }
+
 #pragma endregion
 
 // NOLINTEND(bugprone-unchecked-optional-access)

--- a/tests/linux/iou_buf_pool_test.cpp
+++ b/tests/linux/iou_buf_pool_test.cpp
@@ -42,6 +42,7 @@ static size_t sim_read(iou_buf_pool::buffer& buf, std::string_view data) {
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
 #pragma region ReadInitialState
+
 TEST_CASE("ReadInitialState", "[IouBufPool]") {
   // Freshly allocated read buffer: empty payload, active = entire block.
   if (true) {
@@ -63,9 +64,10 @@ TEST_CASE("ReadInitialState", "[IouBufPool]") {
 #endif
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ReadAfterUpdate
+
 TEST_CASE("ReadAfterUpdate", "[IouBufPool]") {
   // After a simulated read, payload grows and active shrinks to the tail.
   if (true) {
@@ -82,9 +84,10 @@ TEST_CASE("ReadAfterUpdate", "[IouBufPool]") {
     CHECK(buf.payload_view().substr(0, 5) == "hello");
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ReadMultipleUpdates
+
 TEST_CASE("ReadMultipleUpdates", "[IouBufPool]") {
   // Two successive reads concatenate into a single growing payload.
   if (true) {
@@ -101,9 +104,10 @@ TEST_CASE("ReadMultipleUpdates", "[IouBufPool]") {
     CHECK(buf.active_span().size() == (buf.size() - 11));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ReadConsumePartial
+
 TEST_CASE("ReadConsumePartial", "[IouBufPool]") {
   // consume_read(n) with n < payload returns n bytes and advances the front.
   if (true) {
@@ -124,9 +128,10 @@ TEST_CASE("ReadConsumePartial", "[IouBufPool]") {
     CHECK(buf.active_span().size() == (buf.size() - 8));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ReadConsumeFullReset
+
 TEST_CASE("ReadConsumeFullReset", "[IouBufPool]") {
   // Consuming all payload bytes resets the buffer to its initial state.
   if (true) {
@@ -146,9 +151,10 @@ TEST_CASE("ReadConsumeFullReset", "[IouBufPool]") {
     CHECK(buf.active_span().data() == base);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ReadConsumeOverRequest
+
 TEST_CASE("ReadConsumeOverRequest", "[IouBufPool]") {
   // Requesting more bytes than available returns only what's present.
   if (true) {
@@ -164,9 +170,10 @@ TEST_CASE("ReadConsumeOverRequest", "[IouBufPool]") {
     CHECK(buf.active_span().size() == buf.size());
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ReadUpdateError
+
 TEST_CASE("ReadUpdateError", "[IouBufPool]") {
   // An error result leaves spans unchanged.
   if (true) {
@@ -184,9 +191,10 @@ TEST_CASE("ReadUpdateError", "[IouBufPool]") {
     CHECK(buf.active_span().size() == active_before);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region WriteInitialState
+
 TEST_CASE("WriteInitialState", "[IouBufPool]") {
   // Freshly allocated write buffer: both payload and active are empty.
   if (true) {
@@ -200,9 +208,10 @@ TEST_CASE("WriteInitialState", "[IouBufPool]") {
     CHECK(buf.payload_span().data() == buf.active_span().data());
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region WriteViaAppend
+
 TEST_CASE("WriteViaAppend", "[IouBufPool]") {
   // append fills payload and active_span covers the same bytes.
   if (true) {
@@ -223,9 +232,10 @@ TEST_CASE("WriteViaAppend", "[IouBufPool]") {
     CHECK(buf.payload_view() == "hello, world");
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region WriteAppendOverflow
+
 TEST_CASE("WriteAppendOverflow", "[IouBufPool]") {
   // append returns false without modifying anything when data would not fit.
   if (true) {
@@ -242,9 +252,10 @@ TEST_CASE("WriteAppendOverflow", "[IouBufPool]") {
     CHECK(buf.payload_span().size() == cap); // unchanged
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region WriteViaTailAndUpdatePayload
+
 TEST_CASE("WriteViaTailAndUpdatePayload", "[IouBufPool]") {
   // Manual fill: get tail_span, memcpy, then update_payload.
   if (true) {
@@ -263,9 +274,10 @@ TEST_CASE("WriteViaTailAndUpdatePayload", "[IouBufPool]") {
     CHECK(buf.payload_view() == msg);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region WriteUpdatePayloadBadStart
+
 TEST_CASE("WriteUpdatePayloadBadStart", "[IouBufPool]") {
   // update_payload rejects a span that does not start at payload_span's end.
   if (true) {
@@ -281,9 +293,10 @@ TEST_CASE("WriteUpdatePayloadBadStart", "[IouBufPool]") {
     CHECK(buf.payload_span().size() == 3ULL); // unchanged
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region WriteUpdatePayloadOverflow
+
 TEST_CASE("WriteUpdatePayloadOverflow", "[IouBufPool]") {
   // update_payload rejects a span whose end exceeds full_span.
   if (true) {
@@ -298,9 +311,10 @@ TEST_CASE("WriteUpdatePayloadOverflow", "[IouBufPool]") {
     CHECK(buf.payload_span().size() == 0ULL); // unchanged
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region WriteUpdatePartialSend
+
 TEST_CASE("WriteUpdatePartialSend", "[IouBufPool]") {
   // Partial send advances active_span front while payload_span stays fixed.
   if (true) {
@@ -322,9 +336,10 @@ TEST_CASE("WriteUpdatePartialSend", "[IouBufPool]") {
           ("6789"));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region WriteFullyConsumedThenAppend
+
 TEST_CASE("WriteFullyConsumedThenAppend", "[IouBufPool]") {
   // After a complete send, the next append resets from the block base.
   if (true) {
@@ -349,9 +364,10 @@ TEST_CASE("WriteFullyConsumedThenAppend", "[IouBufPool]") {
     CHECK(buf.payload_view() == "new");
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region WriteFullyConsumedThenTailSpan
+
 TEST_CASE("WriteFullyConsumedThenTailSpan", "[IouBufPool]") {
   // After a complete send, tail_span() triggers an implicit reset.
   if (true) {
@@ -370,9 +386,10 @@ TEST_CASE("WriteFullyConsumedThenTailSpan", "[IouBufPool]") {
     CHECK(tail.data() == base);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region WriteUpdateError
+
 TEST_CASE("WriteUpdateError", "[IouBufPool]") {
   // An error result leaves spans unchanged.
   if (true) {
@@ -392,9 +409,10 @@ TEST_CASE("WriteUpdateError", "[IouBufPool]") {
     CHECK(buf.active_span().size() == active_before);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region AppendToPartiallySentBuffer
+
 TEST_CASE("AppendToPartiallySentBuffer", "[IouBufPool]") {
   // After a partial send, appending more extends both payload and active.
   if (true) {
@@ -420,9 +438,10 @@ TEST_CASE("AppendToPartiallySentBuffer", "[IouBufPool]") {
           ("lo world"));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region PromoteToWrite
+
 TEST_CASE("PromoteToWrite", "[IouBufPool]") {
   // Promoting a read buffer keeps payload; active_span = payload_span.
   if (true) {
@@ -443,9 +462,10 @@ TEST_CASE("PromoteToWrite", "[IouBufPool]") {
     CHECK(buf.payload_view() == "proxy data");
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region DemoteToRead
+
 TEST_CASE("DemoteToRead", "[IouBufPool]") {
   // Demoting a write buffer keeps payload; active_span = tail after payload.
   if (true) {
@@ -464,9 +484,10 @@ TEST_CASE("DemoteToRead", "[IouBufPool]") {
           buf.payload_span().data() + buf.payload_span().size());
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region PromoteDemoteRoundtrip
+
 TEST_CASE("PromoteDemoteRoundtrip", "[IouBufPool]") {
   // promote_to_write then demote_to_read preserves payload throughout.
   if (true) {
@@ -486,9 +507,10 @@ TEST_CASE("PromoteDemoteRoundtrip", "[IouBufPool]") {
     CHECK(buf.active_span().size() == (buf.size() - 9ULL));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region AvailableTracking
+
 TEST_CASE("AvailableTracking", "[IouBufPool]") {
   // Allocating reduces available bytes; reset restores them.
   if (true) {
@@ -510,9 +532,10 @@ TEST_CASE("AvailableTracking", "[IouBufPool]") {
     CHECK(pool->available() == initial);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region MoveBuffer
+
 TEST_CASE("MoveBuffer", "[IouBufPool]") {
   // Moving a buffer transfers ownership; source becomes empty.
   if (true) {
@@ -527,9 +550,10 @@ TEST_CASE("MoveBuffer", "[IouBufPool]") {
     CHECK(b.payload_view() == "move me");
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region CoalesceSmallToMedium
+
 TEST_CASE("CoalesceSmallToMedium", "[IouBufPool]") {
   // Four smalls from the same medium coalesce back to one medium.
   // The three sibling mediums are held, so the large does NOT coalesce.
@@ -568,9 +592,10 @@ TEST_CASE("CoalesceSmallToMedium", "[IouBufPool]") {
     CHECK(pool->available() == (2ULL * 1024 * 1024));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region CoalesceMediumToLarge
+
 TEST_CASE("CoalesceMediumToLarge", "[IouBufPool]") {
   // Four mediums from the same large coalesce back to one large.
   if (true) {
@@ -596,9 +621,10 @@ TEST_CASE("CoalesceMediumToLarge", "[IouBufPool]") {
     CHECK(pool->available() == initial);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region CoalesceChain
+
 TEST_CASE("CoalesceChain", "[IouBufPool]") {
   // Allocate all 512 smalls, free all 512: cascading coalesce must rebuild
   // all 32 large blocks.
@@ -626,9 +652,10 @@ TEST_CASE("CoalesceChain", "[IouBufPool]") {
     CHECK(pool->available() == (2ULL * 1024 * 1024));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region UdpTierAlloc
+
 TEST_CASE("UdpTierAlloc", "[IouBufPool]") {
   // Allocate all 1024 x 2 KB slots (2 MB / 2 KB), verify each succeeds and
   // has the right size, then confirm full pool recovery after freeing all.
@@ -648,9 +675,10 @@ TEST_CASE("UdpTierAlloc", "[IouBufPool]") {
     CHECK(pool->available() == (2ULL * 1024 * 1024));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region UpdateRecvmsgMsgFlagsDefault
+
 TEST_CASE("UpdateRecvmsgMsgFlagsDefault", "[IouBufPool]") {
   // A freshly borrowed buffer has msg_flags() == 0.
   if (true) {
@@ -660,9 +688,10 @@ TEST_CASE("UpdateRecvmsgMsgFlagsDefault", "[IouBufPool]") {
     CHECK(buf.msghdr_flags() == msg_flags{});
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region UpdateRecvmsgValid
+
 TEST_CASE("UpdateRecvmsgValid", "[IouBufPool]") {
   if (true) {
     auto pool = iou_buf_pool::create();
@@ -706,9 +735,10 @@ TEST_CASE("UpdateRecvmsgValid", "[IouBufPool]") {
     CHECK(buf.peer_addr().port() == peer_port);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region UpdateRecvmsgTruncated
+
 TEST_CASE("UpdateRecvmsgTruncated", "[IouBufPool]") {
   // When the kernel sets MSG_TRUNC in out->flags, msg_flags() reflects it.
   if (true) {
@@ -742,9 +772,10 @@ TEST_CASE("UpdateRecvmsgTruncated", "[IouBufPool]") {
     CHECK(bitmask::has(buf.msghdr_flags(), msg_flags::trunc));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SyntheticPrefilled
+
 TEST_CASE("SyntheticPrefilled", "[IouBufPool]") {
   // `make_synthetic` produces a non-owning read buffer whose payload covers
   // the input span and whose active tail is empty.
@@ -763,9 +794,10 @@ TEST_CASE("SyntheticPrefilled", "[IouBufPool]") {
         buf.payload_span().data() + buf.payload_span().size());
   CHECK(buf.result().bytes() == data.size());
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SyntheticDestructionHarmless
+
 TEST_CASE("SyntheticDestructionHarmless", "[IouBufPool]") {
   // The buffer holds no real allocation, so going out of scope must not
   // touch the data the caller owns.
@@ -778,9 +810,10 @@ TEST_CASE("SyntheticDestructionHarmless", "[IouBufPool]") {
   }
   CHECK(data == "keepalive");
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SyntheticConsumeRead
+
 TEST_CASE("SyntheticConsumeRead", "[IouBufPool]") {
   // A synthetic buffer behaves like a freshly completed read: the consumer
   // can drain it via `consume_read`.
@@ -799,9 +832,10 @@ TEST_CASE("SyntheticConsumeRead", "[IouBufPool]") {
   CHECK(rest.size() == 3ULL);
   CHECK(buf.payload_span().size() == 0ULL);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SyntheticMove
+
 TEST_CASE("SyntheticMove", "[IouBufPool]") {
   // Moving a synthetic buffer transfers the view; the source ends up empty.
   std::string data{"transferable"};
@@ -816,6 +850,7 @@ TEST_CASE("SyntheticMove", "[IouBufPool]") {
   // NOLINTNEXTLINE(bugprone-use-after-move,clang-analyzer-cplusplus.Move)
   CHECK(src.payload_span().size() == 0ULL);
 }
+
 #pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/linux/iou_dgram_router_test.cpp
+++ b/tests/linux/iou_dgram_router_test.cpp
@@ -135,6 +135,8 @@ using capture_handle =
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region BasicSendRecv
+
 TEST_CASE("BasicSendRecv", "[IouDgramRouter]") {
   // First packet hits create_session; payload arrives via the buffer.
   if (true) {
@@ -173,6 +175,9 @@ TEST_CASE("BasicSendRecv", "[IouDgramRouter]") {
     CHECK(payload == "buf-udp");
   }
 }
+
+#pragma endregion
+#pragma region OnSentReturnsBuffer
 
 TEST_CASE("OnSentReturnsBuffer", "[IouDgramRouter]") {
   // `handle_sent` fires with the buffer in success state after a send
@@ -215,6 +220,9 @@ TEST_CASE("OnSentReturnsBuffer", "[IouDgramRouter]") {
     CHECK(sent_bytes.load(std::memory_order::acquire) == 4);
   }
 }
+
+#pragma endregion
+#pragma region LazySession
 
 TEST_CASE("LazySession", "[IouDgramRouter]") {
   // create_session fires once per unknown key; subsequent packets bypass it
@@ -262,6 +270,9 @@ TEST_CASE("LazySession", "[IouDgramRouter]") {
   }
 }
 
+#pragma endregion
+#pragma region DropOnNullFactory
+
 TEST_CASE("DropOnNullFactory", "[IouDgramRouter]") {
   // `create_session` returns false (no session installed); every arriving
   // packet re-invokes it.
@@ -297,6 +308,8 @@ TEST_CASE("DropOnNullFactory", "[IouDgramRouter]") {
         1s));
   }
 }
+
+#pragma endregion
 
 namespace {
 
@@ -368,6 +381,8 @@ public:
 
 } // namespace
 
+#pragma region CustomKey
+
 TEST_CASE("CustomKey", "[IouDgramRouter]") {
   // Routing by a 32-bit ID extracted from the first 4 payload bytes,
   // independent of peer_addr.
@@ -422,6 +437,8 @@ TEST_CASE("CustomKey", "[IouDgramRouter]") {
     }));
   }
 }
+
+#pragma endregion
 
 namespace {
 
@@ -492,6 +509,8 @@ public:
 
 } // namespace
 
+#pragma region WithPluginState
+
 TEST_CASE("WithPluginState", "[IouDgramRouter]") {
   // SessionPlugin is the per-session state container.
   if (true) {
@@ -525,6 +544,9 @@ TEST_CASE("WithPluginState", "[IouDgramRouter]") {
     }));
   }
 }
+
+#pragma endregion
+#pragma region Multishot
 
 TEST_CASE("Multishot", "[IouDgramRouter]") {
   // Multishot recvmsg path: a burst of datagrams all arrive.
@@ -564,6 +586,9 @@ TEST_CASE("Multishot", "[IouDgramRouter]") {
         2s));
   }
 }
+
+#pragma endregion
+#pragma region OnClose
 
 TEST_CASE("OnClose", "[IouDgramRouter]") {
   // Closing the router fires `unregister_self` on registered sessions
@@ -607,6 +632,9 @@ TEST_CASE("OnClose", "[IouDgramRouter]") {
   }
 }
 
+#pragma endregion
+#pragma region RoundTrip
+
 TEST_CASE("RoundTrip", "[IouDgramEchoProtocol]") {
   // `iou_dgram_echo_server` bounces each datagram back to its sender.
   if (true) {
@@ -643,5 +671,7 @@ TEST_CASE("RoundTrip", "[IouDgramEchoProtocol]") {
     CHECK(echoed == "hello-echo");
   }
 }
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/linux/iou_loop_test.cpp
+++ b/tests/linux/iou_loop_test.cpp
@@ -58,6 +58,7 @@ bool WaitFor(const auto& pred, std::chrono::milliseconds timeout = 500ms) {
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 #pragma region NopCompletion
+
 TEST_CASE("NopCompletion", "[IouLoop]") {
   // Verify that a submitted NOP fires its completion callback on the runner.
   if (true) {
@@ -80,9 +81,10 @@ TEST_CASE("NopCompletion", "[IouLoop]") {
     CHECK(result.load() == 0);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region MultipleNops
+
 TEST_CASE("MultipleNops", "[IouLoop]") {
   // Submit several NOPs and confirm all complete on the runner thread.
   if (true) {
@@ -104,9 +106,10 @@ TEST_CASE("MultipleNops", "[IouLoop]") {
     CHECK(count.load() == 4);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region StopFromThread
+
 TEST_CASE("StopFromThread", "[IouLoop]") {
   // Stop the runner from another thread and let destruction join cleanly.
   if (true) {
@@ -122,9 +125,10 @@ TEST_CASE("StopFromThread", "[IouLoop]") {
     CHECK(stopped.load(std::memory_order::acquire));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SelfDestroyOnLoopThread
+
 // A loop-thread callback that holds the last `unique_ptr<iou_loop_runner>`
 // destroys the runner from inside the worker thread. The destructor detaches
 // the jthread and returns; the worker then unwinds out of `loop_t::run`
@@ -151,9 +155,10 @@ TEST_CASE("SelfDestroyOnLoopThread", "[IouLoop]") {
 
   REQUIRE(finished->wait_for_value(1s, true));
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region PostFromThread
+
 TEST_CASE("PostFromThread", "[IouLoop]") {
   // Post a callback from an external thread; verify the loop executes it.
   if (true) {
@@ -170,9 +175,10 @@ TEST_CASE("PostFromThread", "[IouLoop]") {
     CHECK(WaitFor([&] { return fired.load(std::memory_order::acquire); }));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region PostAndWait
+
 TEST_CASE("PostAndWait", "[IouLoop]") {
   // `post_and_wait` blocks until the callback runs, then returns.
   if (true) {
@@ -188,9 +194,10 @@ TEST_CASE("PostAndWait", "[IouLoop]") {
     CHECK(ran.load());
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region RecvSend
+
 TEST_CASE("RecvSend", "[IouLoop]") {
   // Submit a recv and a send over a Unix socket pair; confirm the payload
   // arrives and the byte counts are correct.
@@ -232,9 +239,10 @@ TEST_CASE("RecvSend", "[IouLoop]") {
               msg.size()) == msg);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region RecvWriteFixed
+
 TEST_CASE("RecvWriteFixed", "[IouLoop]") {
   // Submit a recv_fixed and a send_fixed over a Unix socket pair using
   // registered buffers; confirm the payload arrives and byte counts match.
@@ -281,9 +289,10 @@ TEST_CASE("RecvWriteFixed", "[IouLoop]") {
     CHECK(payload == msg);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SendBuffer
+
 TEST_CASE("SendBuffer", "[IouLoop]") {
   // `submit_send_buffer` uses `IORING_OP_SEND_ZC` over connected UDP sockets
   // on loopback. ZC send requires IP sockets; Unix domain sockets return
@@ -347,9 +356,10 @@ TEST_CASE("SendBuffer", "[IouLoop]") {
     CHECK(payload == std::string{msg});
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region IsLoopThread
+
 TEST_CASE("IsLoopThread", "[IouLoop]") {
   // `is_loop_thread` returns false on the test thread and true inside a
   // callback executing on the loop thread.
@@ -366,9 +376,10 @@ TEST_CASE("IsLoopThread", "[IouLoop]") {
     CHECK(confirmed.load(std::memory_order::acquire));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ExecuteOrPost
+
 TEST_CASE("ExecuteOrPost", "[IouLoop]") {
   // `execute_or_post` from an off-thread posts; the callback still runs.
   if (true) {
@@ -384,9 +395,10 @@ TEST_CASE("ExecuteOrPost", "[IouLoop]") {
     CHECK(WaitFor([&] { return executed.load(std::memory_order::acquire); }));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region NopTokenVariant
+
 TEST_CASE("NopTokenVariant", "[IouLoop]") {
   // `tokenize` + `submit_nop(token)` exercises the token-based submission
   // path.
@@ -410,9 +422,10 @@ TEST_CASE("NopTokenVariant", "[IouLoop]") {
     CHECK(result.load() == 0);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region TokenIsReleased
+
 TEST_CASE("TokenIsReleased", "[IouLoop]") {
   // `tokenize` produces a valid token; `is_released` returns false while the
   // slot is live, true after explicit release.
@@ -433,9 +446,10 @@ TEST_CASE("TokenIsReleased", "[IouLoop]") {
     CHECK_FALSE(token.is_valid());
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SubmitClose
+
 TEST_CASE("SubmitClose", "[IouLoop]") {
   // `submit_close` fires its callback with `res == 0` after the fd is closed.
   if (true) {
@@ -457,9 +471,10 @@ TEST_CASE("SubmitClose", "[IouLoop]") {
     CHECK(result.load() == 0);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SubmitTimeout
+
 TEST_CASE("SubmitTimeout", "[IouLoop]") {
   // A single-shot timeout fires with `-ETIME` after the specified duration.
   if (true) {
@@ -482,9 +497,10 @@ TEST_CASE("SubmitTimeout", "[IouLoop]") {
     CHECK(result.load() == -ETIME);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SubmitTimeoutMultishot
+
 TEST_CASE("SubmitTimeoutMultishot", "[IouLoop]") {
   // A multishot timeout with `cqe_count`=3 fires exactly 3 times then stops.
   if (true) {
@@ -508,9 +524,10 @@ TEST_CASE("SubmitTimeoutMultishot", "[IouLoop]") {
     CHECK(count.load() == 3);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SubmitCancelFile
+
 TEST_CASE("SubmitCancelFile", "[IouLoop]") {
   // Canceling a file's pending ops delivers a negative result to the recv
   // callback (typically `ECANCELED`).
@@ -545,9 +562,10 @@ TEST_CASE("SubmitCancelFile", "[IouLoop]") {
     CHECK((recv_res.load()) < (0));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SubmitCancelToken
+
 TEST_CASE("SubmitCancelToken", "[IouLoop]") {
   // Canceling via `completion_token` delivers a negative result to the
   // matching recv callback (typically `ECANCELED`).
@@ -583,9 +601,10 @@ TEST_CASE("SubmitCancelToken", "[IouLoop]") {
     CHECK((recv_res.load()) < (0));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region AcceptConnect
+
 TEST_CASE("AcceptConnect", "[IouLoop]") {
   // `submit_accept` and `submit_connect` complete successfully over a Unix ANS
   // socket. The accepted socket fd (>= 0) is immediately closed to avoid
@@ -635,9 +654,10 @@ TEST_CASE("AcceptConnect", "[IouLoop]") {
     if (accept_res.load() >= 0) ::close(accept_res.load());
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region RecvSendMsg
+
 TEST_CASE("RecvSendMsg", "[IouLoop]") {
   // `submit_recvmsg_buffer` and `submit_sendmsg_buffer` exchange a datagram
   // between two UDP sockets. On completion, the received payload and sender
@@ -695,9 +715,10 @@ TEST_CASE("RecvSendMsg", "[IouLoop]") {
     CHECK(recv_result == std::string{payload});
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region BorrowBufferSizes
+
 TEST_CASE("BorrowBufferSizes", "[IouLoop]") {
   // `borrow_read_buffer` and `borrow_write_buffer` succeed for all three block
   // sizes, and the buffers are returned to the pool on destruction.
@@ -722,9 +743,10 @@ TEST_CASE("BorrowBufferSizes", "[IouLoop]") {
     }
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SlotRetentionRetain
+
 TEST_CASE("SlotRetentionRetain", "[IouLoop]") {
   // A callback returning `slot_retention::retain` keeps the pool slot live.
   // Re-submitting a NOP with the same token fires the callback a second time,
@@ -753,9 +775,10 @@ TEST_CASE("SlotRetentionRetain", "[IouLoop]") {
     CHECK(count.load() == 2);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region TimespecDurationRoundTrip
+
 TEST_CASE("TimespecDurationRoundTrip", "[IouWrap]") {
   // Construct from durations and verify `as_duration` recovers the original.
   if (true) {
@@ -777,9 +800,10 @@ TEST_CASE("TimespecDurationRoundTrip", "[IouWrap]") {
     CHECK(ts.as_duration<std::chrono::nanoseconds>().count() == 0);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region TimespecTimePointRoundTrip
+
 TEST_CASE("TimespecTimePointRoundTrip", "[IouWrap]") {
   // Construct from a `steady_clock` time_point and verify `as_time_point`
   // recovers the exact same value.
@@ -792,9 +816,10 @@ TEST_CASE("TimespecTimePointRoundTrip", "[IouWrap]") {
     CHECK(recovered == now);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region TimespecStaticHelpers
+
 TEST_CASE("TimespecStaticHelpers", "[IouWrap]") {
   // `from_duration` splits seconds and nanosecond remainder correctly.
   if (true) {
@@ -822,9 +847,10 @@ TEST_CASE("TimespecStaticHelpers", "[IouWrap]") {
     CHECK(recovered == now);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region TimespecAsPointer
+
 TEST_CASE("TimespecAsPointer", "[IouWrap]") {
   // `as_pointer(nullptr)` is null; `as_pointer(&ts)` is non-null.
   if (true) {
@@ -840,9 +866,10 @@ TEST_CASE("TimespecAsPointer", "[IouWrap]") {
     CHECK(iou_timespec::to_pointer(&cts) != nullptr);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ItimerspecConstruct
+
 TEST_CASE("ItimerspecConstruct", "[IouWrap]") {
   // Default construction zeros both fields; explicit construction stores the
   // correct interval and value.
@@ -861,9 +888,10 @@ TEST_CASE("ItimerspecConstruct", "[IouWrap]") {
     CHECK(its.it_value().tv_nsec == 500'000'000LL);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ResStatus
+
 TEST_CASE("ResStatus", "[IouWrap]") {
   // `ok`, `bool`, and `!` reflect the sign of the raw result.
   if (true) {
@@ -896,9 +924,10 @@ TEST_CASE("ResStatus", "[IouWrap]") {
     CHECK_FALSE(iou_res{-EINVAL}.is_soft_error());
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region CqeFlagsString
+
 TEST_CASE("CqeFlagsString", "[IouWrap]") {
   // Each named bit round-trips through `enum_as_string` / `parse_enum`.
   using namespace corvid::strings;
@@ -922,9 +951,10 @@ TEST_CASE("CqeFlagsString", "[IouWrap]") {
     CHECK(parse_enum("more + buffer", bad) == (F::more | F::buffer));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SqeFlagsString
+
 TEST_CASE("SqeFlagsString", "[IouWrap]") {
   // Each named bit round-trips through `enum_as_string` / `parse_enum`.
   using namespace corvid::strings;
@@ -949,9 +979,10 @@ TEST_CASE("SqeFlagsString", "[IouWrap]") {
     CHECK(parse_enum("async + io_link", bad) == (F::async | F::io_link));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SetupFlagsString
+
 TEST_CASE("SetupFlagsString", "[IouWrap]") {
   // Each named bit round-trips through `enum_as_string` / `parse_enum`.
   using namespace corvid::strings;
@@ -989,9 +1020,10 @@ TEST_CASE("SetupFlagsString", "[IouWrap]") {
           (F::setup_sqpoll | F::setup_iopoll));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region TimeoutFlagsString
+
 TEST_CASE("TimeoutFlagsString", "[IouWrap]") {
   // Each named bit round-trips through `enum_as_string` / `parse_enum`.
   // `rel` (value 0) has no bit name and prints as "0x00".
@@ -1018,9 +1050,10 @@ TEST_CASE("TimeoutFlagsString", "[IouWrap]") {
     CHECK(parse_enum("multishot + abs", bad) == (F::multishot | F::abs));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region RecvBufferMulti
+
 TEST_CASE("RecvBufferMulti", "[IouLoop]") {
   // `submit_recv_buffer_multi` fires the callback for each message received.
   // Send three messages over a SEQPACKET socket pair (which preserves message
@@ -1065,9 +1098,10 @@ TEST_CASE("RecvBufferMulti", "[IouLoop]") {
       CHECK(payloads[ndx] == std::string{msgs[ndx]});
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region RecvMsgBufferMulti
+
 TEST_CASE("RecvMsgBufferMulti", "[IouLoop]") {
   // `submit_recvmsg_buffer_multi` fires the callback for each datagram.
   // Send three UDP datagrams; confirm all three arrive with correct payloads.
@@ -1122,9 +1156,10 @@ TEST_CASE("RecvMsgBufferMulti", "[IouLoop]") {
       CHECK(payloads[ndx] == std::string{msgs[ndx]});
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region RecvMsgBufferMultiTruncated
+
 TEST_CASE("RecvMsgBufferMultiTruncated", "[IouLoop]") {
   // An 8 KiB datagram exceeds the 2 KiB UDP provided-buffer size. The
   // multishot recvmsg callback should fire once with:
@@ -1180,9 +1215,10 @@ TEST_CASE("RecvMsgBufferMultiTruncated", "[IouLoop]") {
     CHECK(len == datagram_size);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region RecvMsgBufferMultiStress
+
 TEST_CASE("RecvMsgBufferMultiStress", "[IouLoop]") {
   // Stress test for multishot recvmsg with provided buffers.
   //
@@ -1276,9 +1312,10 @@ TEST_CASE("RecvMsgBufferMultiStress", "[IouLoop]") {
     CHECK(c_count == 1024);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region FnSizeProbe
+
 TEST_CASE("CompletionFnSizeProbe", "[IouLoop]") {
   // Probe the storage each (cb, ep) combination would need if `completion_fn`
   // were replaced with `fixed_function<SZ, slot_retention(completion_id,
@@ -1371,9 +1408,10 @@ TEST_CASE("CompletionFnSizeProbe", "[IouLoop]") {
       sz_direct_fn, sz_raw_bt, sz_raw_bewt, sz_raw_buf, max_sz);
 #endif
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SubmitPoll
+
 TEST_CASE("SubmitPoll", "[IouLoop]") {
   // Single-shot `submit_poll` fires once when the polled file becomes
   // readable; `res` contains the triggered events mask (POLLIN bit set).
@@ -1407,9 +1445,10 @@ TEST_CASE("SubmitPoll", "[IouLoop]") {
     CHECK(poll_res.load() >= 0);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SubmitShutdown
+
 TEST_CASE("SubmitShutdown", "[IouLoop]") {
   // `submit_shutdown(SHUT_WR)` causes the peer recv to see EOF (0 bytes).
   if (true) {
@@ -1452,9 +1491,10 @@ TEST_CASE("SubmitShutdown", "[IouLoop]") {
     CHECK(shutdown_res.load() == 0); // success
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SubmitTimeoutRemove
+
 TEST_CASE("SubmitTimeoutRemove", "[IouLoop]") {
   // `submit_timeout_remove(completion_token&&)` (auto-release variant)
   // cancels a pending timeout. The returned remove token is valid; its slot
@@ -1480,9 +1520,10 @@ TEST_CASE("SubmitTimeoutRemove", "[IouLoop]") {
     CHECK(ok);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SubmitTimeoutRemoveExplicit
+
 TEST_CASE("SubmitTimeoutRemoveExplicit", "[IouLoop]") {
   // Two-arg `submit_timeout_remove` allows an explicit callback for the
   // remove operation itself; verify it fires with `res == 0`.
@@ -1520,9 +1561,10 @@ TEST_CASE("SubmitTimeoutRemoveExplicit", "[IouLoop]") {
     CHECK(remove_res.load() == 0);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SubmitCancelTokenAutoRelease
+
 TEST_CASE("SubmitCancelTokenAutoRelease", "[IouLoop]") {
   if (true) {
     auto [send_sock, recv_sock] = net_socket::create_pair();
@@ -1550,9 +1592,10 @@ TEST_CASE("SubmitCancelTokenAutoRelease", "[IouLoop]") {
     CHECK((recv_res.load()) < (0));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SubmitTimeoutUpdate
+
 TEST_CASE("SubmitTimeoutUpdate", "[IouLoop]") {
   // `submit_timeout_update` changes the expiry of a pending timeout. Submit a
   // 2s timeout, update it to 50ms, then wait for two CQEs on the same token:
@@ -1593,6 +1636,7 @@ TEST_CASE("SubmitTimeoutUpdate", "[IouLoop]") {
     CHECK(last_res.load(std::memory_order::acquire) == -ETIME);
   }
 }
+
 #pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/linux/iou_provided_buf_pool_test.cpp
+++ b/tests/linux/iou_provided_buf_pool_test.cpp
@@ -29,6 +29,7 @@ using namespace std::string_view_literals;
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
 #pragma region NoOpZeroSlab
+
 TEST_CASE("NoOpZeroSlab", "[IouProvidedBufPool]") {
   // slab_size=0 produces a no-op pool with no allocation.
   iou_provided_buf_pool::dispatcher_t dispatcher;
@@ -48,9 +49,10 @@ TEST_CASE("NoOpZeroSlab", "[IouProvidedBufPool]") {
     CHECK_FALSE(buf);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ConstructValid
+
 TEST_CASE("ConstructValid", "[IouProvidedBufPool]") {
   // Valid construction: sizes, buf_count, slab_size, and bgid are correct.
   iou_provided_buf_pool::dispatcher_t dispatcher;
@@ -69,9 +71,10 @@ TEST_CASE("ConstructValid", "[IouProvidedBufPool]") {
     CHECK(pool->buf_data(512) == nullptr); // out of range
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region BufCountFromDivision
+
 TEST_CASE("BufCountFromDivision", "[IouProvidedBufPool]") {
   // buf_count is derived as slab_size / buf_size.
   iou_provided_buf_pool::dispatcher_t dispatcher;
@@ -96,9 +99,10 @@ TEST_CASE("BufCountFromDivision", "[IouProvidedBufPool]") {
     CHECK(pool->register_with(ring));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region BufDataOffsets
+
 TEST_CASE("BufDataOffsets", "[IouProvidedBufPool]") {
   // buf_data(bid) returns pointers that are exactly buf_size apart.
   iou_provided_buf_pool::dispatcher_t dispatcher;
@@ -114,9 +118,10 @@ TEST_CASE("BufDataOffsets", "[IouProvidedBufPool]") {
     }
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region RegisterWithRing
+
 TEST_CASE("RegisterWithRing", "[IouProvidedBufPool]") {
   // register_with succeeds, and a second call on the same pool fails.
   iou_provided_buf_pool::dispatcher_t dispatcher;
@@ -130,9 +135,10 @@ TEST_CASE("RegisterWithRing", "[IouProvidedBufPool]") {
     CHECK_FALSE(pool->register_with(ring));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ReconstructBeforeRegister
+
 TEST_CASE("ReconstructBeforeRegister", "[IouProvidedBufPool]") {
   // reconstruct before register_with returns an empty buffer.
   iou_provided_buf_pool::dispatcher_t dispatcher;
@@ -146,9 +152,10 @@ TEST_CASE("ReconstructBeforeRegister", "[IouProvidedBufPool]") {
     CHECK_FALSE(buf);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ReconstructPayload
+
 TEST_CASE("ReconstructPayload", "[IouProvidedBufPool]") {
   // After register_with, reconstruct creates a read buffer with the correct
   // payload span.
@@ -184,9 +191,10 @@ TEST_CASE("ReconstructPayload", "[IouProvidedBufPool]") {
     CHECK(buf.pending_releases() == 0ULL);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ReconstructErrorResult
+
 TEST_CASE("ReconstructErrorResult", "[IouProvidedBufPool]") {
   // A CQE with buffer flag set but an error result yields an empty payload.
   iou_provided_buf_pool::dispatcher_t dispatcher;
@@ -205,9 +213,10 @@ TEST_CASE("ReconstructErrorResult", "[IouProvidedBufPool]") {
     CHECK(buf.payload_span().size() == 0ULL); // no data
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ReconstructNoBufferFlag
+
 TEST_CASE("ReconstructNoBufferFlag", "[IouProvidedBufPool]") {
   // A CQE without the buffer flag returns a synthetic stub: no payload, but
   // the CQE `res` is preserved so callers can distinguish EOF (`res=0`)
@@ -227,9 +236,10 @@ TEST_CASE("ReconstructNoBufferFlag", "[IouProvidedBufPool]") {
     CHECK(buf.payload_view().empty());
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ReconstructOutOfRangeBid
+
 TEST_CASE("ReconstructOutOfRangeBid", "[IouProvidedBufPool]") {
   // A buffer ID >= buf_count returns an empty buffer.
   iou_provided_buf_pool::dispatcher_t dispatcher;
@@ -247,9 +257,10 @@ TEST_CASE("ReconstructOutOfRangeBid", "[IouProvidedBufPool]") {
     CHECK_FALSE(buf);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ReturnReplenishes
+
 TEST_CASE("ReturnReplenishes", "[IouProvidedBufPool]") {
   // Destroying the reconstructed buffer returns the slot to the ring.
   // We verify indirectly: reconstruct the same slot twice (once after the
@@ -277,6 +288,7 @@ TEST_CASE("ReturnReplenishes", "[IouProvidedBufPool]") {
     CHECK(buf2.payload_span().size() == 3ULL);
   }
 }
+
 #pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/linux/iov_queue_test.cpp
+++ b/tests/linux/iov_queue_test.cpp
@@ -68,6 +68,8 @@ size_t fill(iov_queue<>& q, std::span<const uint8_t> src) {
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region basics
+
 TEST_CASE("empty queue is empty", "[iov_queue]") {
   iov_queue<> q;
   CHECK(q.size() == 0);
@@ -80,6 +82,7 @@ TEST_CASE("empty queue is empty", "[iov_queue]") {
   CHECK(q.slack() == 0);
 }
 
+#pragma endregion
 #pragma region send-style use
 
 TEST_CASE("append takes ownership and drops empties", "[iov_queue]") {

--- a/tests/linux/netsocket_tests.cpp
+++ b/tests/linux/netsocket_tests.cpp
@@ -87,7 +87,6 @@ TEST_CASE("Lifecycle", "[NetSocket]") {
 }
 
 #pragma endregion
-
 #pragma region Move
 
 TEST_CASE("Move", "[NetSocket]") {
@@ -130,7 +129,6 @@ TEST_CASE("Move", "[NetSocket]") {
 }
 
 #pragma endregion
-
 #pragma region Release
 
 TEST_CASE("Release", "[NetSocket]") {
@@ -147,7 +145,6 @@ TEST_CASE("Release", "[NetSocket]") {
 }
 
 #pragma endregion
-
 #pragma region Options
 
 TEST_CASE("Options", "[NetSocket]") {
@@ -187,7 +184,6 @@ TEST_CASE("Options", "[NetSocket]") {
 }
 
 #pragma endregion
-
 #pragma region Nonblocking
 
 TEST_CASE("Nonblocking", "[NetSocket]") {
@@ -206,7 +202,6 @@ TEST_CASE("Nonblocking", "[NetSocket]") {
 }
 
 #pragma endregion
-
 #pragma region SendRecv
 
 TEST_CASE("SendRecv", "[NetSocket]") {
@@ -234,7 +229,6 @@ TEST_CASE("SendRecv", "[NetSocket]") {
 }
 
 #pragma endregion
-
 #pragma region RecvAtContract
 
 TEST_CASE("RecvAtContract", "[NetSocket]") {
@@ -271,7 +265,6 @@ TEST_CASE("RecvAtContract", "[NetSocket]") {
 }
 
 #pragma endregion
-
 #pragma region BindListenAccept
 
 TEST_CASE("BindListenAccept", "[NetSocket]") {
@@ -308,7 +301,6 @@ TEST_CASE("BindListenAccept", "[NetSocket]") {
 }
 
 #pragma endregion
-
 #pragma region FactoryMethods
 
 TEST_CASE("FactoryMethods", "[NetSocket]") {
@@ -387,7 +379,6 @@ TEST_CASE("FactoryMethods", "[NetSocket]") {
 }
 
 #pragma endregion
-
 #pragma region SocketTypeString
 
 TEST_CASE("SocketTypeString", "[NetSocket]") {
@@ -410,7 +401,6 @@ TEST_CASE("SocketTypeString", "[NetSocket]") {
 }
 
 #pragma endregion
-
 #pragma region AddressFamilyString
 
 TEST_CASE("AddressFamilyString", "[NetSocket]") {
@@ -434,7 +424,6 @@ TEST_CASE("AddressFamilyString", "[NetSocket]") {
 }
 
 #pragma endregion
-
 #pragma region ProtocolTypeString
 
 TEST_CASE("ProtocolTypeString", "[NetSocket]") {
@@ -485,7 +474,6 @@ TEST_CASE("ProtocolTypeString", "[NetSocket]") {
 }
 
 #pragma endregion
-
 #pragma region SocketOptionString
 
 TEST_CASE("SocketOptionString", "[NetSocket]") {
@@ -534,7 +522,6 @@ TEST_CASE("SocketOptionString", "[NetSocket]") {
 }
 
 #pragma endregion
-
 #pragma region TcpOptionString
 
 TEST_CASE("TcpOptionString", "[NetSocket]") {

--- a/tests/linux/nghttp3_smoke_test.cpp
+++ b/tests/linux/nghttp3_smoke_test.cpp
@@ -26,6 +26,8 @@
 // functional test of HTTP/3 itself; that arrives with the http3_router
 // wrapping nghttp3_conn.
 
+#pragma region Smoke
+
 TEST_CASE("HTTP/3 dependency links and reports version", "[http3]") {
   SECTION("nghttp3 returns a valid version struct") {
     const nghttp3_info* info = nghttp3_version(0);
@@ -45,4 +47,6 @@ TEST_CASE("HTTP/3 dependency links and reports version", "[http3]") {
     SUCCEED("nghttp3_settings_default linked and ran");
   }
 }
+
+#pragma endregion
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/linux/quic_conn_test.cpp
+++ b/tests/linux/quic_conn_test.cpp
@@ -102,6 +102,8 @@ struct bound_loopback {
 
 } // namespace
 
+#pragma region Construction
+
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 TEST_CASE("quic_conn constructs as server", "[quic][conn]") {
   self_signed_cert ck;
@@ -174,6 +176,9 @@ TEST_CASE("quic_conn expiry is queryable on a fresh conn", "[quic][conn]") {
   // Any non-default value is fine; the API just needs to round-trip.
   (void)deadline;
 }
+
+#pragma endregion
+#pragma region Handshake
 
 TEST_CASE("quic_conn handshake completes in-process", "[quic][conn]") {
   // Drive a real TLS 1.3 handshake between a client and server conn, in
@@ -444,6 +449,9 @@ TEST_CASE("quic_conn handler returning false aborts read_pkt",
   CHECK(saw_error);
   CHECK_FALSE(server_trace.saw("handshake_completed"));
 }
+
+#pragma endregion
+#pragma region Close and I/O
 
 TEST_CASE("quic_conn request_close + write_connection_close ships a packet",
     "[quic][conn]") {
@@ -735,7 +743,9 @@ TEST_CASE(
         quic_status::ok);
 }
 
+#pragma endregion
 #pragma region CloseKindString
+
 TEST_CASE("CloseKindString", "[quic]") {
   // Each named value round-trips through `enum_as_string` / `parse_enum`.
   // Values are the on-wire CONNECTION_CLOSE frame type codes (0x1c, 0x1d).
@@ -751,9 +761,10 @@ TEST_CASE("CloseKindString", "[quic]") {
     CHECK(parse_enum("application", bad) == F::application);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region WriteStreamFlagsString
+
 TEST_CASE("WriteStreamFlagsString", "[quic]") {
   // Each named bit round-trips through `enum_as_string` / `parse_enum`.
   using namespace corvid::strings;
@@ -777,6 +788,7 @@ TEST_CASE("WriteStreamFlagsString", "[quic]") {
           (F::padding | F::fin | F::more));
   }
 }
+
 #pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/linux/quic_dgram_echo_test.cpp
+++ b/tests/linux/quic_dgram_echo_test.cpp
@@ -171,6 +171,8 @@ using client_protocol_t = quic_dgram_protocol<echo_client_plugin>;
 
 } // namespace
 
+#pragma region Echo
+
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 TEST_CASE(
     "quic_echo_plugin echoes stream bytes (+ FIN) back to a client running "
@@ -244,4 +246,6 @@ TEST_CASE(
     return client_plugin.received_for(sid) == payload;
   }));
 }
+
+#pragma endregion
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/linux/quic_dgram_http3_test.cpp
+++ b/tests/linux/quic_dgram_http3_test.cpp
@@ -153,6 +153,8 @@ run_get(std::string server_name, std::string client_authority) {
 
 } // namespace
 
+#pragma region http3_router
+
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 TEST_CASE(
     "http3_router establishes a connection and exchanges SETTINGS over the "
@@ -205,6 +207,9 @@ TEST_CASE(
   }));
 }
 
+#pragma endregion
+#pragma region http3_server_router
+
 TEST_CASE(
     "http3_server_router serves a GET and enforces the request authority over "
     "the live iou_dgram_router",
@@ -225,4 +230,6 @@ TEST_CASE(
     CHECK(r.body.empty());
   }
 }
+
+#pragma endregion
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/linux/quic_dgram_router_test.cpp
+++ b/tests/linux/quic_dgram_router_test.cpp
@@ -99,6 +99,8 @@ constexpr std::array<uint8_t, 16> sample_scid{0x11, 0x22, 0x33, 0x44, 0x55,
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region Extract
+
 TEST_CASE("quic_dgram_protocol::router_plugin::extract", "[quic][router]") {
   // `router_plugin` requires a server SSL context for `create_session`, but
   // we only exercise `extract` here, which doesn't consult it. A client-side
@@ -151,6 +153,8 @@ TEST_CASE("quic_dgram_protocol::router_plugin::extract", "[quic][router]") {
   }
 }
 
+#pragma endregion
+
 namespace {
 
 constexpr std::string_view handshake_alpn = "corvid-test";
@@ -166,6 +170,8 @@ constexpr std::array<uint8_t, 16> client_scid_bytes{0x11, 0x22, 0x33, 0x44,
 }
 
 } // namespace
+
+#pragma region Handshake
 
 TEST_CASE(
     "quic_dgram_protocol drives a server-side TLS 1.3 handshake "
@@ -336,6 +342,8 @@ TEST_CASE(
   }));
 }
 
+#pragma endregion
+
 // Counts live server-side upper plugins, and counts server handshake
 // completions. A server session constructs its plugin on creation and destroys
 // it on reap (when the router drops its last reference), so
@@ -359,6 +367,8 @@ struct reap_probe_plugin: quic_no_op_plugin {
   }
 };
 } // namespace
+
+#pragma region Draining
 
 TEST_CASE(
     "quic_dgram_protocol reaps a draining server session after a "
@@ -484,4 +494,6 @@ TEST_CASE(
       },
       5000ms));
 }
+
+#pragma endregion
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/linux/quic_header_test.cpp
+++ b/tests/linux/quic_header_test.cpp
@@ -26,6 +26,8 @@
 
 namespace quic = corvid::proto::quic;
 
+#pragma region quic_connection_id
+
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 TEST_CASE("quic_connection_id basics", "[quic]") {
   SECTION("value-initialized is empty") {
@@ -81,7 +83,9 @@ TEST_CASE("quic_connection_id basics", "[quic]") {
   }
 }
 
+#pragma endregion
 #pragma region StreamIdString
+
 TEST_CASE("StreamIdString", "[quic]") {
   // Each named bit round-trips through `enum_as_string` / `parse_enum`.
   using namespace corvid;
@@ -104,9 +108,10 @@ TEST_CASE("StreamIdString", "[quic]") {
           (F::unidirectional | F::server_initiated));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region StreamSideString
+
 TEST_CASE("StreamSideString", "[quic]") {
   // Each named bit round-trips through `enum_as_string` / `parse_enum`.
   using namespace corvid;
@@ -127,9 +132,10 @@ TEST_CASE("StreamSideString", "[quic]") {
     CHECK(parse_enum("write + read", bad) == F::both);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region StreamDataFlagsString
+
 TEST_CASE("StreamDataFlagsString", "[quic]") {
   // Each named bit round-trips through `enum_as_string` / `parse_enum`.
   using namespace corvid;
@@ -150,9 +156,10 @@ TEST_CASE("StreamDataFlagsString", "[quic]") {
     CHECK(parse_enum("zero_rtt + fin", bad) == (F::zero_rtt | F::fin));
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region DatagramFlagsString
+
 TEST_CASE("DatagramFlagsString", "[quic]") {
   // Single named bit round-trips through `enum_as_string` / `parse_enum`.
   using namespace corvid;
@@ -186,6 +193,7 @@ TEST_CASE("QuicStatusString", "[quic]") {
     CHECK(parse_enum("nonexistent", bad) == bad); // unknown -> default
   }
 }
+
 #pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/linux/quic_smoke_test.cpp
+++ b/tests/linux/quic_smoke_test.cpp
@@ -30,6 +30,8 @@
 // test of the libraries themselves; that comes with the wrappers.
 // nghttp3's matching link/version check lives in nghttp3_smoke_test.cpp.
 
+#pragma region Smoke
+
 TEST_CASE("QUIC dependencies link and report versions", "[quic]") {
   SECTION("OpenSSL is 3.5 or newer (native QUIC API)") {
     // 0x30500000L == 3.5.0. We need the QUIC API that landed in 3.5.
@@ -56,4 +58,6 @@ TEST_CASE("QUIC dependencies link and report versions", "[quic]") {
     ngtcp2_crypto_ossl_ctx_del(ctx);
   }
 }
+
+#pragma endregion
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/bitmask_enum_test.cpp
+++ b/tests/portable/bitmask_enum_test.cpp
@@ -116,8 +116,8 @@ TEST_CASE("Ops", "[BitMaskTest]") {
     CHECK(c == rgb::green);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region NamedFunctions
 
 TEST_CASE("NamedFunctions", "[BitMaskTest]") {
@@ -183,8 +183,8 @@ TEST_CASE("NamedFunctions", "[BitMaskTest]") {
     CHECK(enum_as_string(rgb(7 + 0x40)) == "red + green + blue + 0x40");
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SafeOps
 
 TEST_CASE("SafeOps", "[BitMaskTest]") {
@@ -224,8 +224,8 @@ TEST_CASE("SafeOps", "[BitMaskTest]") {
     CHECK(c == safe_rgb::green);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SafeNamedFunctions
 
 TEST_CASE("SafeNamedFunctions", "[BitMaskTest]") {
@@ -271,6 +271,7 @@ TEST_CASE("SafeNamedFunctions", "[BitMaskTest]") {
     CHECK(enum_as_string(safe_rgb(7 + 0x40)) == "white + 0x40");
   }
 }
+
 #pragma endregion
 
 enum class rgb_unnamed : std::uint8_t {
@@ -344,8 +345,8 @@ TEST_CASE("MoreNamingTests", "[BitMaskTest]") {
     CHECK(enum_as_string(patchy_rgb(7 + 0x40)) == "white + 0x40");
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region StreamingOut
 
 TEST_CASE("StreamingOut", "[BitMaskTest]") {
@@ -362,6 +363,7 @@ TEST_CASE("StreamingOut", "[BitMaskTest]") {
     CHECK(ss.str() == "red");
   }
 }
+
 #pragma endregion
 
 // RGB, but without the G.
@@ -398,6 +400,7 @@ TEST_CASE("NoGreen", "[BitMaskTest]") {
     CHECK(enum_as_string(rb(0x7 + 0x40)) == "red + blue + 0x42");
   }
 }
+
 #pragma endregion
 
 // RGB, but without the B.
@@ -434,6 +437,7 @@ TEST_CASE("NoBlue", "[BitMaskTest]") {
     CHECK(enum_as_string(rg(0x7 + 0x40)) == "red + green + 0x41");
   }
 }
+
 #pragma endregion
 
 // RGB, but without the R.
@@ -474,6 +478,7 @@ TEST_CASE("NoRed", "[BitMaskTest]") {
     CHECK(enum_as_string(gb(0x7 + 0x40)) == "green + blue + 0x44");
   }
 }
+
 #pragma endregion
 
 // Same thing, but safe due to clipping.
@@ -511,6 +516,7 @@ TEST_CASE("SafeNoGreen", "[BitMaskTest]") {
     CHECK(enum_as_string(safe_rb(0x7 + 0x40)) == "purple + 0x42");
   }
 }
+
 #pragma endregion
 
 // Same thing, but safe due to clipping.
@@ -548,6 +554,7 @@ TEST_CASE("SafeNoBlue", "[BitMaskTest]") {
     CHECK(enum_as_string(safe_rg(0x7 + 0x40)) == "yellow + 0x41");
   }
 }
+
 #pragma endregion
 
 // Same thing, but safe due to clipping.
@@ -585,6 +592,7 @@ TEST_CASE("SafeNoRed", "[BitMaskTest]") {
     CHECK(enum_as_string(safe_gb(0x7 + 0x40)) == "cyan + 0x44");
   }
 }
+
 #pragma endregion
 
 // All three bits are valid, but we have no name for green, so we use a
@@ -682,8 +690,8 @@ TEST_CASE("Placeholders", "[BitMaskTest]") {
     CHECK(enum_as_string(safe_rb_h(0x07)) == "purple + 0x02");
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region SkipBlue
 
 TEST_CASE("SkipBlue", "[BitMaskTest]") {
@@ -725,6 +733,7 @@ TEST_CASE("SkipBlue", "[BitMaskTest]") {
     CHECK(enum_as_string(safe_rskipb(0x7 + 0x40)) == "purple + 0x42");
   }
 }
+
 #pragma endregion
 
 // Note: safe_b is impossible because we need at least one valid bit.
@@ -759,6 +768,7 @@ TEST_CASE("SafeBlackWhite", "[BitMaskTest]") {
     CHECK(enum_as_string(safe_bw(0x7 + 0x40)) == "color::white + 0x46");
   }
 }
+
 #pragma endregion
 
 // Same thing, but safe due to clipping.
@@ -791,6 +801,7 @@ TEST_CASE("SafeWhite", "[BitMaskTest]") {
     CHECK(enum_as_string(safe_w(0x7 + 0x40)) == "color::white + 0x46");
   }
 }
+
 #pragma endregion
 
 template<meta::fixed_string W>
@@ -815,6 +826,7 @@ TEST_CASE("EnumCalcBitNames", "[BitMaskTest]") {
              "az,ba,bb,bc,bd,be,bf,bg,bh,bi,bj,bk,bl">() ==
       18446744073709551615ULL);
 }
+
 #pragma endregion
 
 template<meta::fixed_string W>
@@ -838,8 +850,8 @@ TEST_CASE("EnumCalcValueNames", "[BitMaskTest]") {
   static_assert(cvbfvn<"black,blue,,,red,purple,,,">() == 5);
   static_assert(cvbfvn<"black,,green,,red,,yellow,">() == 6);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ExtractEnum
 
 TEST_CASE("ExtractEnum", "[BitMaskTest]") {
@@ -934,6 +946,7 @@ TEST_CASE("ExtractEnum", "[BitMaskTest]") {
     CHECK_FALSE(extract_enum(e, sv));
   }
 }
+
 #pragma endregion
 
 // Valid bits with a hole (0b101): legal to register and use, but
@@ -1023,8 +1036,8 @@ TEST_CASE("HoleyOps", "[BitMaskTest]") {
     CHECK(~safe_rb::purple == safe_rb::black);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region MakeAt
 
 TEST_CASE("MakeAt", "[BitMaskTest]") {
@@ -1044,6 +1057,7 @@ TEST_CASE("MakeAt", "[BitMaskTest]") {
     CHECK(clear_at(rgb::white, 3) == rgb::cyan);
   }
 }
+
 #pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/circular_buffer_test.cpp
+++ b/tests/portable/circular_buffer_test.cpp
@@ -69,8 +69,8 @@ TEST_CASE("Construction", "[CircularBufferTest]") {
     cb2.push_back(2);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region Ops
 
 TEST_CASE("Ops", "[CircularBufferTest]") {
@@ -196,8 +196,8 @@ TEST_CASE("Ops", "[CircularBufferTest]") {
   CHECK(cb.front() == 2);
   CHECK(cb.back() == 1);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region WrapIndex
 
 TEST_CASE("WrapIndex", "[CircularBufferTest]") {
@@ -222,8 +222,8 @@ TEST_CASE("WrapIndex", "[CircularBufferTest]") {
   CHECK(cb[4] == 2);
   CHECK(cb[5] == 3);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region At
 
 TEST_CASE("At", "[CircularBufferTest]") {
@@ -242,8 +242,8 @@ TEST_CASE("At", "[CircularBufferTest]") {
   CHECK(cb.at(1) == 2);
   CHECK_THROWS_AS((void)cb.at(2), std::out_of_range);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ZeroCapacity
 
 TEST_CASE("ZeroCapacity", "[CircularBufferTest]") {
@@ -288,8 +288,8 @@ TEST_CASE("ZeroCapacity", "[CircularBufferTest]") {
     CHECK(cb2.size() == 1U);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region PushPop
 
 TEST_CASE("PushPop", "[CircularBufferTest]") {
@@ -338,8 +338,8 @@ TEST_CASE("PushPop", "[CircularBufferTest]") {
   CHECK(cb[1] == 3);
   CHECK(cb[2] == 4);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region Iterate
 
 TEST_CASE("Iterate", "[CircularBufferTest]") {
@@ -392,6 +392,7 @@ TEST_CASE("Iterate", "[CircularBufferTest]") {
     // *c = 5;
   }
 }
+
 #pragma endregion
 
 class MoveOnlyInt {
@@ -624,6 +625,7 @@ TEST_CASE("Smoke", "[CircularBufferTest]") {
     //*ccb[0] = 43;
   }
 }
+
 #pragma endregion
 #pragma region Format
 

--- a/tests/portable/containers_test.cpp
+++ b/tests/portable/containers_test.cpp
@@ -97,6 +97,7 @@ TEST_CASE("General", "[TransparentTest]") {
     CHECK(tss.contains(ksv));
   }
 }
+
 #pragma endregion
 
 // Hashers with explicit exception specs, to pin the adapters' conditional
@@ -139,6 +140,7 @@ TEST_CASE("Basic", "[IndirectKey]") {
   CHECK(std::format("{}", IMK{key}) == "abc");
   CHECK(std::format("{:>5}", IMK{key}) == "  abc");
 }
+
 #pragma endregion
 
 template<typename T, typename D = std::default_delete<T>>
@@ -166,8 +168,8 @@ TEST_CASE("Experimental", "[DeductionTest]") {
   //  Holder h1{&i};
   //  Holder h2{42.0};
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region NoInitResize_Basic
 
 TEST_CASE("Basic", "[NoInitResize]") {
@@ -177,8 +179,8 @@ TEST_CASE("Basic", "[NoInitResize]") {
   // s.resize_and_overwrite(2);
   (void)s;
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region Arena_Basic
 
 TEST_CASE("Basic", "[ArenaTest]") {
@@ -276,6 +278,7 @@ TEST_CASE("Basic", "[ArenaTest]") {
         std::bad_array_new_length);
   }
 }
+
 #pragma endregion
 
 using FirstName = strong_type<std::string, struct FirstNameTag>;
@@ -324,8 +327,8 @@ TEST_CASE("Basic", "[StrongType]") {
   CHECK(age == 43);
   age = age << 1;
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region StrongType_Heterogeneous
 
 TEST_CASE("Heterogeneous", "[StrongType]") {
@@ -368,8 +371,8 @@ TEST_CASE("Heterogeneous", "[StrongType]") {
     CHECK(target == 9);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region StrongType_Extended
 
 TEST_CASE("Extended", "[StrongType]") {
@@ -730,6 +733,7 @@ TEST_CASE("Extended", "[StrongType]") {
   using Tags = strong_type<std::vector<int>, struct TagsTag>;
   CHECK(std::format("{}", Tags{std::vector<int>{1, 2, 3}}) == "[1, 2, 3]");
 }
+
 #pragma endregion
 
 struct RetrievalKey {
@@ -911,6 +915,7 @@ TEST_CASE("Basic", "[EnumVariant]") {
     CHECK(moved == "status");
   }
 }
+
 #pragma endregion
 
 enum class ThrowKind : std::uint8_t { value, thrower };
@@ -966,8 +971,8 @@ TEST_CASE("BadIndex", "[EnumVariant]") {
     CHECK_THROWS_AS(tv.visit(overloads), std::bad_variant_access);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region EnumVector_Basic
 
 TEST_CASE("Basic", "[EnumVector]") {
@@ -1058,6 +1063,7 @@ TEST_CASE("Basic", "[EnumVector]") {
   v.clear();
   CHECK(v.empty());
 }
+
 #pragma endregion
 
 struct throwing_scoped_value_test {
@@ -1188,8 +1194,8 @@ TEST_CASE("Basic", "[ScopedValue]") {
     CHECK(x == 10);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region HashCombiner_Basic
 
 TEST_CASE("Basic", "[HashCombiner]") {
@@ -1262,6 +1268,7 @@ TEST_CASE("Basic", "[HashCombiner]") {
     CHECK(combined_hash(1, 2) != combined_hash(1, 3));
   }
 }
+
 #pragma endregion
 
 // NOLINTEND(readability-function-size)

--- a/tests/portable/enable_format_test.cpp
+++ b/tests/portable/enable_format_test.cpp
@@ -30,6 +30,8 @@ using namespace corvid::strings::format_wrapping;
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region EnableFormat
+
 TEST_CASE("EnableFormat", "[EnableFormat]") {
   const std::map<std::string, std::string> cities{{"NYC", "New York City"},
       {"LA", "Los Angeles"}};
@@ -151,5 +153,7 @@ TEST_CASE("EnableFormat", "[EnableFormat]") {
         std::format_error);
   }
 }
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/entity_registry_test.cpp
+++ b/tests/portable/entity_registry_test.cpp
@@ -263,7 +263,6 @@ TEST_CASE("Basic", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region Handle
 
 TEST_CASE("Handle", "[EntityRegistry]") {
@@ -460,7 +459,6 @@ TEST_CASE("Handle", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region Fifo
 
 TEST_CASE("Fifo", "[EntityRegistry]") {
@@ -484,7 +482,6 @@ TEST_CASE("Fifo", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region Clear
 
 TEST_CASE("Clear", "[EntityRegistry]") {
@@ -520,7 +517,6 @@ TEST_CASE("Clear", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region Reserve
 
 TEST_CASE("Reserve", "[EntityRegistry]") {
@@ -585,7 +581,6 @@ TEST_CASE("Reserve", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region IdLimit
 
 TEST_CASE("IdLimit", "[EntityRegistry]") {
@@ -618,7 +613,6 @@ TEST_CASE("IdLimit", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region NoGen
 
 TEST_CASE("NoGen", "[EntityRegistry]") {
@@ -765,7 +759,6 @@ TEST_CASE("NoGen", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region VoidMeta
 
 TEST_CASE("VoidMeta", "[EntityRegistry]") {
@@ -888,7 +881,6 @@ TEST_CASE("VoidMeta", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region VoidNoGen
 
 TEST_CASE("VoidNoGen", "[EntityRegistry]") {
@@ -934,7 +926,6 @@ TEST_CASE("VoidNoGen", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region IdLimitAdvanced
 
 TEST_CASE("IdLimitAdvanced", "[EntityRegistry]") {
@@ -1020,7 +1011,6 @@ TEST_CASE("IdLimitAdvanced", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region FifoAdvanced
 
 TEST_CASE("FifoAdvanced", "[EntityRegistry]") {
@@ -1092,7 +1082,6 @@ TEST_CASE("FifoAdvanced", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region LifoAdvanced
 
 TEST_CASE("LifoAdvanced", "[EntityRegistry]") {
@@ -1183,7 +1172,6 @@ TEST_CASE("LifoAdvanced", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region LocationRecord
 
 TEST_CASE("LocationRecord", "[EntityRegistry]") {
@@ -1275,7 +1263,6 @@ TEST_CASE("LocationRecord", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region EdgeCases
 
 TEST_CASE("EdgeCases", "[EntityRegistry]") {
@@ -1508,7 +1495,6 @@ TEST_CASE("EdgeCases", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region MetadataCleanup
 
 TEST_CASE("MetadataCleanup", "[EntityRegistry]") {
@@ -1563,7 +1549,6 @@ TEST_CASE("MetadataCleanup", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region EraseIfPredicate
 
 TEST_CASE("EraseIfPredicate", "[EntityRegistry]") {
@@ -1626,7 +1611,6 @@ TEST_CASE("EraseIfPredicate", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region IdLimitFreeList
 
 TEST_CASE("IdLimitFreeList", "[EntityRegistry]") {
@@ -1659,7 +1643,6 @@ TEST_CASE("IdLimitFreeList", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region SwapMoveFreeList
 
 TEST_CASE("SwapMoveFreeList", "[EntityRegistry]") {
@@ -1723,7 +1706,6 @@ TEST_CASE("SwapMoveFreeList", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region ReservePrefillExisting
 
 TEST_CASE("ReservePrefillExisting", "[EntityRegistry]") {
@@ -1767,7 +1749,6 @@ TEST_CASE("ReservePrefillExisting", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region HandleOwner
 
 TEST_CASE("HandleOwner", "[EntityRegistry]") {
@@ -1998,7 +1979,6 @@ TEST_CASE("HandleOwner", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region GetAllocator
 
 TEST_CASE("GetAllocator", "[EntityRegistry]") {
@@ -2181,7 +2161,6 @@ TEST_CASE("ComponentMode_Basic", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region ComponentMode_Bitmap
 
 TEST_CASE("ComponentMode_Bitmap", "[EntityRegistry]") {
@@ -2299,7 +2278,6 @@ TEST_CASE("ComponentMode_Bitmap", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region ComponentMode_Fifo
 
 TEST_CASE("ComponentMode_Fifo", "[EntityRegistry]") {
@@ -2364,7 +2342,6 @@ TEST_CASE("ComponentMode_Fifo", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region ComponentMode_HandleOwner
 
 TEST_CASE("ComponentMode_HandleOwner", "[EntityRegistry]") {
@@ -2447,7 +2424,6 @@ TEST_CASE("ComponentMode_HandleOwner", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region ComponentMode_NoGen
 
 TEST_CASE("ComponentMode_NoGen", "[EntityRegistry]") {
@@ -2496,7 +2472,6 @@ TEST_CASE("ComponentMode_NoGen", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region ComponentMode_VoidMeta
 
 TEST_CASE("ComponentMode_VoidMeta", "[EntityRegistry]") {
@@ -2552,7 +2527,6 @@ TEST_CASE("ComponentMode_VoidMeta", "[EntityRegistry]") {
 }
 
 #pragma endregion
-
 #pragma region ComponentMode_Lifo
 
 TEST_CASE("ComponentMode_Lifo", "[EntityRegistry]") {

--- a/tests/portable/enum_formatter_test.cpp
+++ b/tests/portable/enum_formatter_test.cpp
@@ -67,6 +67,8 @@ consteval auto corvid_enum_spec(dial*) {
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region Rendering
+
 TEST_CASE("Sequence enum formats by name", "[EnumFormatterTest]") {
   if (true) {
     CHECK(std::format("{}", hue::red) == "red");
@@ -108,6 +110,9 @@ TEST_CASE("Unregistered scoped enums are not formattable",
   }
 }
 
+#pragma endregion
+#pragma region Wide and debug
+
 TEST_CASE("Wide formatting widens the name", "[EnumFormatterTest]") {
   if (true) {
     CHECK(std::format(L"{}", hue::green) == L"green");
@@ -131,6 +136,9 @@ TEST_CASE("Debug spec escapes special characters", "[EnumFormatterTest]") {
     CHECK(std::format(L"{:?}", weird::quote) == LR"("q\"x")");
   }
 }
+
+#pragma endregion
+#pragma region Spec handling
 
 TEST_CASE("Honors width, align, fill, and precision", "[EnumFormatterTest]") {
   if (true) {
@@ -176,6 +184,9 @@ TEST_CASE("Rejects specs that don't apply to a name", "[EnumFormatterTest]") {
   }
 }
 
+#pragma endregion
+#pragma region Composition
+
 TEST_CASE("Composes inside std range and map", "[EnumFormatterTest]") {
   if (true) {
     // The range and map formatters auto-enable debug on elements that have
@@ -187,5 +198,7 @@ TEST_CASE("Composes inside std range and map", "[EnumFormatterTest]") {
     CHECK(std::format("{}", m) == R"({1: "red", 2: "blue"})");
   }
 }
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/find_opt_test.cpp
+++ b/tests/portable/find_opt_test.cpp
@@ -28,6 +28,8 @@ using namespace corvid;
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region FindOptTest_Maps
+
 TEST_CASE("FindOptTest_Maps", "[find_opt][maps]") {
   SECTION("std::map of string to string") {
     const auto key = "key"s;
@@ -63,6 +65,9 @@ TEST_CASE("FindOptTest_Maps", "[find_opt][maps]") {
   }
 }
 
+#pragma endregion
+#pragma region FindOptTest_Sets
+
 TEST_CASE("FindOptTest_Sets", "[find_opt][sets]") {
   const auto value = "value"s;
   using C = std::set<std::string>;
@@ -72,6 +77,9 @@ TEST_CASE("FindOptTest_Sets", "[find_opt][sets]") {
   CHECK(KeyFindable<C>);
   CHECK_FALSE(RangeWithoutFind<C>);
 }
+
+#pragma endregion
+#pragma region FindOptTest_Vectors
 
 TEST_CASE("FindOptTest_Vectors", "[find_opt][vectors]") {
   const auto value = "value"s;
@@ -83,6 +91,9 @@ TEST_CASE("FindOptTest_Vectors", "[find_opt][vectors]") {
   CHECK(RangeWithoutFind<C>);
 }
 
+#pragma endregion
+#pragma region FindOptTest_Arrays
+
 TEST_CASE("FindOptTest_Arrays", "[find_opt][arrays]") {
   int s[]{1, 2, 3, 4};
   using C = decltype(s);
@@ -91,6 +102,9 @@ TEST_CASE("FindOptTest_Arrays", "[find_opt][arrays]") {
   CHECK_FALSE(KeyFindable<C>);
   CHECK(RangeWithoutFind<C>);
 }
+
+#pragma endregion
+#pragma region FindOptTest_Strings
 
 TEST_CASE("FindOptTest_Strings", "[find_opt][strings]") {
   SECTION("std::string") {
@@ -118,5 +132,7 @@ TEST_CASE("FindOptTest_Strings", "[find_opt][strings]") {
     CHECK(RangeWithoutFind<C>);
   }
 }
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/infra_clocks_test.cpp
+++ b/tests/portable/infra_clocks_test.cpp
@@ -43,6 +43,8 @@ using coarse_now_clock = now_clock<coarse_clock, 100>;
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region Fake clock injection
+
 TEST_CASE("set_now_fn installs a custom function", "[infra][clocks]") {
   custom_now_calls = 0;
   const auto sentinel =
@@ -125,6 +127,9 @@ TEST_CASE(
         high_resolution_now_clock::time_point_t{2ms});
 }
 
+#pragma endregion
+#pragma region Nanosecond conversion
+
 TEST_CASE("as_nanoseconds and from_nanoseconds round-trip",
     "[infra][clocks]") {
   const auto tp = steady_now_clock::time_point_t{1234ms};
@@ -185,6 +190,9 @@ TEST_CASE("as_nanoseconds saturates for clocks with a coarser tick",
         coarse_now_clock::time_point_t::max());
 }
 
+#pragma endregion
+#pragma region Calendar clocks
+
 TEST_CASE("utc_clock supports fake injection", "[infra][clocks]") {
   auto guard = utc_now_clock::fake_now_scope();
   utc_now_clock::set_fake_now(utc_now_clock::time_point_t{42ms});
@@ -236,5 +244,7 @@ TEST_CASE("libc++ experimental tzdb / utc_now_clock are available",
   const auto utc = std::chrono::utc_clock::now();
   CHECK(utc.time_since_epoch().count() > 0);
 }
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/infra_log_test.cpp
+++ b/tests/portable/infra_log_test.cpp
@@ -50,6 +50,8 @@ struct std::formatter<move_only_arg>: std::formatter<std::string_view> {
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region Logger
+
 TEST_CASE("logger threshold gates output", "[infra][log]") {
   logger lg;
   CHECK(lg.threshold() == log_level::info);
@@ -152,6 +154,9 @@ TEST_CASE("logger prefixes output with a UTC ISO-8601 timestamp",
   CHECK(out.contains("] [I "));
 }
 
+#pragma endregion
+#pragma region Log facade
+
 TEST_CASE("log singleton can be redirected via set_stream", "[infra][log]") {
   std::stringstream sink;
   log::singleton().set_stream(sink);
@@ -236,6 +241,9 @@ TEST_CASE("loggers sharing a stream do not interleave lines", "[infra][log]") {
   }
   CHECK(cnt == 2 * n_lines);
 }
+
+#pragma endregion
+#pragma region Exception firewalls
 
 TEST_CASE("try_or_log swallows and substitutes failure_value",
     "[infra][exception]") {
@@ -393,5 +401,7 @@ TEST_CASE("try_or_log with attempt swallows mid-unwind",
   log::singleton().set_stream(std::cerr);
   CHECK(sink.str().contains("inner"));
 }
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/infra_relaxed_atomic_test.cpp
+++ b/tests/portable/infra_relaxed_atomic_test.cpp
@@ -26,6 +26,8 @@ using namespace corvid;
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region relaxed_atomic
+
 TEST_CASE("relaxed_atomic converts and assigns", "[infra][relaxed_atomic]") {
   relaxed_atomic_int a{5};
   int copied = a;
@@ -112,5 +114,7 @@ TEST_CASE("relaxed_atomic is not copyable", "[infra][relaxed_atomic]") {
   STATIC_CHECK_FALSE(std::is_copy_constructible_v<relaxed_atomic_int>);
   STATIC_CHECK_FALSE(std::is_copy_assignable_v<relaxed_atomic_int>);
 }
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/infra_scope_exit_test.cpp
+++ b/tests/portable/infra_scope_exit_test.cpp
@@ -93,6 +93,7 @@ TEST_CASE("Basic", "[ScopeExit]") {
     CHECK(value == 7);
   }
 }
+
 #pragma endregion
 #pragma region ScopeFail_Basic
 
@@ -164,6 +165,7 @@ TEST_CASE("Basic", "[ScopeFail]") {
     CHECK(calls == 1);
   }
 }
+
 #pragma endregion
 #pragma region ScopeSuccess_Basic
 
@@ -217,6 +219,7 @@ TEST_CASE("Basic", "[ScopeSuccess]") {
     CHECK_THROWS_AS(fire(), std::runtime_error);
   }
 }
+
 #pragma endregion
 #pragma region ThrowingConstruction
 
@@ -256,6 +259,7 @@ TEST_CASE("Throwing construction", "[ScopeExit][ScopeFail][ScopeSuccess]") {
     CHECK(calls == 0);
   }
 }
+
 #pragma endregion
 #pragma region CopyRefused
 
@@ -317,6 +321,7 @@ TEST_CASE("Copy refused", "[ScopeExit]") {
   }
   CHECK(moved_calls == 1);
 }
+
 #pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/intern_table_test.cpp
+++ b/tests/portable/intern_table_test.cpp
@@ -209,8 +209,8 @@ TEST_CASE("Basic", "[InternTableTest]") {
     CHECK(iv.value() == "abc");
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region Comparison
 
 TEST_CASE("Comparison", "[InternTableTest]") {
@@ -289,8 +289,8 @@ TEST_CASE("Comparison", "[InternTableTest]") {
     CHECK(""sv > empty);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region Chaining
 
 TEST_CASE("Chaining", "[InternTableTest]") {
@@ -347,8 +347,8 @@ TEST_CASE("Chaining", "[InternTableTest]") {
     CHECK(&through.value() == &alpha.value());
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region Concurrency
 
 TEST_CASE("Concurrency", "[InternTableTest]") {
@@ -373,6 +373,7 @@ TEST_CASE("Concurrency", "[InternTableTest]") {
   reader.join();
   CHECK(ok.load());
 }
+
 #pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/interval_test.cpp
+++ b/tests/portable/interval_test.cpp
@@ -106,8 +106,8 @@ TEST_CASE("Ctors", "[Intervals]") {
     static_assert(interval<hue>::max_size() == 256UZ);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region Insert
 
 TEST_CASE("Insert", "[IntervalTest]") {
@@ -206,8 +206,8 @@ TEST_CASE("Insert", "[IntervalTest]") {
     CHECK(i.empty());
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region ForEach
 
 TEST_CASE("ForEach", "[IntervalTest]") {
@@ -228,8 +228,8 @@ TEST_CASE("ForEach", "[IntervalTest]") {
   for ([[maybe_unused]] auto e : interval{}) ++n;
   CHECK(n == 0);
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region Reverse
 
 TEST_CASE("Reverse", "[IntervalTest]") {
@@ -305,8 +305,8 @@ TEST_CASE("Reverse", "[IntervalTest]") {
     CHECK(l == 1);
   }
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region MinMax
 
 TEST_CASE("MinMax", "[IntervalTest]") {
@@ -326,8 +326,8 @@ TEST_CASE("MinMax", "[IntervalTest]") {
   i.max(std::numeric_limits<int>::max());
   CHECK(i.back() == std::numeric_limits<int>::max());
 }
-#pragma endregion
 
+#pragma endregion
 #pragma region CompareAndSwap
 
 TEST_CASE("CompareAndSwap", "[IntervalTest]") {
@@ -343,6 +343,7 @@ TEST_CASE("CompareAndSwap", "[IntervalTest]") {
   i.swap(j);
   CHECK(i.back() == 4);
 }
+
 #pragma endregion
 #pragma region Formatting
 
@@ -377,7 +378,6 @@ TEST_CASE("Formatting", "[Intervals]") {
 }
 
 #pragma endregion
-
 #pragma region Int128
 
 #ifdef __SIZEOF_INT128__
@@ -422,6 +422,7 @@ TEST_CASE("Int128", "[IntervalTest]") {
   SUCCEED("__int128 is not available on this compiler");
 #endif
 }
+
 #pragma endregion
 
 // NOLINTEND(readability-function-size)

--- a/tests/portable/lang_test.cpp
+++ b/tests/portable/lang_test.cpp
@@ -34,6 +34,7 @@ template<operation op, typename... Args>
 }
 
 #pragma region Constants
+
 TEST_CASE("Constants", "[LangTest]") {
   using enum operation;
   node_ptr root;

--- a/tests/portable/math_test.cpp
+++ b/tests/portable/math_test.cpp
@@ -30,6 +30,8 @@ using namespace corvid;
 // magnitudes.
 constexpr double eps = 1e-15;
 
+#pragma region TwoPi
+
 TEST_CASE("TwoPi", "[MathTest]") {
   // Defaults to `float` and follows the argument otherwise, in the same
   // variable-template form as <numbers>.
@@ -44,6 +46,9 @@ TEST_CASE("TwoPi", "[MathTest]") {
   CHECK(std::abs(two_pi_v<double> - 6.283185307179586) <= eps);
   CHECK(std::abs(std::sin(two_pi_v<double>)) <= eps);
 }
+
+#pragma endregion
+#pragma region Cos30
 
 TEST_CASE("Cos30", "[MathTest]") {
   // Defaults to `float` and follows the argument otherwise.
@@ -60,12 +65,18 @@ TEST_CASE("Cos30", "[MathTest]") {
                  std::cos(std::numbers::pi_v<double> / 6.0)) <= eps);
 }
 
+#pragma endregion
+#pragma region CeilDivExact
+
 TEST_CASE("CeilDivExact", "[MathTest]") {
   // Exact division has no remainder to round up.
   CHECK(ceil_div(0, 3) == 0);
   CHECK(ceil_div(6, 3) == 2);
   CHECK(ceil_div(4096, 16) == 256);
 }
+
+#pragma endregion
+#pragma region CeilDivRoundsUp
 
 TEST_CASE("CeilDivRoundsUp", "[MathTest]") {
   // Any remainder rounds up to the next bucket.
@@ -74,11 +85,17 @@ TEST_CASE("CeilDivRoundsUp", "[MathTest]") {
   CHECK(ceil_div(4090, 16) == 256);
 }
 
+#pragma endregion
+#pragma region CeilDivByOne
+
 TEST_CASE("CeilDivByOne", "[MathTest]") {
   // A divisor of one returns the dividend unchanged.
   CHECK(ceil_div(0, 1) == 0);
   CHECK(ceil_div(7, 1) == 7);
 }
+
+#pragma endregion
+#pragma region CeilDivMixedSign
 
 TEST_CASE("CeilDivMixedSign", "[MathTest]") {
   // Mixed operands resolve to the common type. The matmul grid case is an
@@ -87,17 +104,26 @@ TEST_CASE("CeilDivMixedSign", "[MathTest]") {
   CHECK(ceil_div(size_t{1000}, 256) == 4U);
 }
 
+#pragma endregion
+#pragma region CeilDivNoOverflow
+
 TEST_CASE("CeilDivNoOverflow", "[MathTest]") {
   // The `(n + d - 1)` idiom would wrap uint32_t here; ceil_div must not.
   constexpr auto max32 = std::numeric_limits<std::uint32_t>::max();
   CHECK(ceil_div(max32, std::uint32_t{2}) == (max32 / 2) + 1);
 }
 
+#pragma endregion
+#pragma region CeilDivConstexpr
+
 TEST_CASE("CeilDivConstexpr", "[MathTest]") {
   // Usable in constant expressions.
   static_assert(ceil_div(7, 3) == 3);
   static_assert(ceil_div(16'777'216, 4096) == 4096);
 }
+
+#pragma endregion
+#pragma region RoundUpAlreadyMultiple
 
 TEST_CASE("RoundUpAlreadyMultiple", "[MathTest]") {
   // A value already on a boundary is returned unchanged.
@@ -106,6 +132,9 @@ TEST_CASE("RoundUpAlreadyMultiple", "[MathTest]") {
   CHECK(round_up_to_multiple(512, 256) == 512);
 }
 
+#pragma endregion
+#pragma region RoundUpRoundsUp
+
 TEST_CASE("RoundUpRoundsUp", "[MathTest]") {
   // A value off a boundary rounds up to the next multiple.
   CHECK(round_up_to_multiple(1, 256) == 256);
@@ -113,10 +142,16 @@ TEST_CASE("RoundUpRoundsUp", "[MathTest]") {
   CHECK(round_up_to_multiple(257, 256) == 512);
 }
 
+#pragma endregion
+#pragma region RoundUpByOne
+
 TEST_CASE("RoundUpByOne", "[MathTest]") {
   // Every integer is a multiple of one, so the value is unchanged.
   CHECK(round_up_to_multiple(7, 1) == 7);
 }
+
+#pragma endregion
+#pragma region RoundUpMixedSign
 
 TEST_CASE("RoundUpMixedSign", "[MathTest]") {
   // Mixed operands resolve to the common type. The viewer rounds a pixel
@@ -124,6 +159,9 @@ TEST_CASE("RoundUpMixedSign", "[MathTest]") {
   CHECK(round_up_to_multiple(100, 256U) == 256U);
   CHECK(round_up_to_multiple(513U, 256) == 768U);
 }
+
+#pragma endregion
+#pragma region RoundUpNoDivisionOverflow
 
 TEST_CASE("RoundUpNoDivisionOverflow", "[MathTest]") {
   // The underlying ceil_div avoids the (n + m - 1) wraparound, so rounding the
@@ -133,11 +171,17 @@ TEST_CASE("RoundUpNoDivisionOverflow", "[MathTest]") {
   CHECK(round_up_to_multiple(max32, std::uint32_t{1}) == max32);
 }
 
+#pragma endregion
+#pragma region RoundUpConstexpr
+
 TEST_CASE("RoundUpConstexpr", "[MathTest]") {
   // Usable in constant expressions.
   static_assert(round_up_to_multiple(1, 256) == 256);
   static_assert(round_up_to_multiple(4096, 256) == 4096);
 }
+
+#pragma endregion
+#pragma region SaturateCast
 
 TEST_CASE("SaturateCast", "[MathTest]") {
   // In-range values pass through; out-of-range values clamp to the
@@ -151,6 +195,9 @@ TEST_CASE("SaturateCast", "[MathTest]") {
   static_assert(saturate_cast<uint16_t>(1000U) == 1000);
 }
 
+#pragma endregion
+#pragma region ExtractByte
+
 TEST_CASE("ExtractByte", "[MathTest]") {
   // Index 0 is the low byte, counting up from there.
   CHECK(extract_byte<0>(std::uint16_t{0x2001}) == 0x01);
@@ -158,6 +205,9 @@ TEST_CASE("ExtractByte", "[MathTest]") {
   CHECK(extract_byte<0>(std::uint16_t{}) == 0);
   CHECK(extract_byte<1>(std::uint16_t{}) == 0);
 }
+
+#pragma endregion
+#pragma region ExtractByteAddressesEveryByte
 
 TEST_CASE("ExtractByteAddressesEveryByte", "[MathTest]") {
   // Every byte of a wider value is reachable by its own index, most
@@ -171,18 +221,29 @@ TEST_CASE("ExtractByteAddressesEveryByte", "[MathTest]") {
   CHECK(extract_byte<0>(std::uint8_t{0x42}) == 0x42);
 }
 
+#pragma endregion
+#pragma region ExtractByteConstexpr
+
 TEST_CASE("ExtractByteConstexpr", "[MathTest]") {
   // Usable in constant expressions.
   static_assert(extract_byte<1>(std::uint16_t{0xbeef}) == 0xbe);
   static_assert(extract_byte<0>(std::uint16_t{0xbeef}) == 0xef);
 }
 
+#pragma endregion
+
 #ifdef NOT_SUPPOSED_TO_COMPILE
+#pragma region ExtractByteOutOfRange
+
 TEST_CASE("ExtractByteOutOfRange", "[MathTest]") {
   // A byte the type does not have is a compile error, not a zero.
   CHECK(extract_byte<2>(std::uint16_t{0x2001}) == 0);
 }
+
+#pragma endregion
 #endif
+
+#pragma region CombineBytes
 
 TEST_CASE("CombineBytes", "[MathTest]") {
   // Least significant first, so the first argument is the low byte.
@@ -192,6 +253,9 @@ TEST_CASE("CombineBytes", "[MathTest]") {
             std::uint8_t{0xa8}, std::uint8_t{0xc0}) == 0xc0a80101);
 }
 
+#pragma endregion
+#pragma region CombineBytesRoundTrips
+
 TEST_CASE("CombineBytesRoundTrips", "[MathTest]") {
   // The inverse of `extract_byte`.
   constexpr auto addr = std::uint32_t{0xc0a80101};
@@ -199,6 +263,9 @@ TEST_CASE("CombineBytesRoundTrips", "[MathTest]") {
             extract_byte<1>(addr), extract_byte<2>(addr),
             extract_byte<3>(addr)) == addr);
 }
+
+#pragma endregion
+#pragma region CombineBytesSpellsItsZeros
 
 TEST_CASE("CombineBytesSpellsItsZeros", "[MathTest]") {
   // Every byte is supplied, so a mostly-empty value states the zeros rather
@@ -209,11 +276,17 @@ TEST_CASE("CombineBytesSpellsItsZeros", "[MathTest]") {
       combine_bytes<std::uint32_t>(z, z, z, std::uint8_t{0xff}) == 0xff000000);
 }
 
+#pragma endregion
+#pragma region CombineBytesUsesOnlyTheLowByte
+
 TEST_CASE("CombineBytesUsesOnlyTheLowByte", "[MathTest]") {
   // A wider argument contributes its low byte and nothing else.
   CHECK(combine_bytes<std::uint16_t>(std::uint16_t{0xbeef}, std::uint8_t{}) ==
         0x00ef);
 }
+
+#pragma endregion
+#pragma region CombineBytesDeducesItsWidth
 
 TEST_CASE("CombineBytesDeducesItsWidth", "[MathTest]") {
   // With no type named, the byte count picks the result type.
@@ -230,7 +303,11 @@ TEST_CASE("CombineBytesDeducesItsWidth", "[MathTest]") {
             std::uint8_t{0xfe}) == 0xfe00'0000'0000'0010);
 }
 
+#pragma endregion
+
 #ifdef __SIZEOF_INT128__
+#pragma region ExtractAndCombine128
+
 TEST_CASE("ExtractAndCombine128", "[MathTest]") {
   // Where the compiler has a 128-bit type, the pair reaches it too. Note that
   // libstdc++ outside GNU mode does not report `__uint128_t` as integral, so
@@ -243,7 +320,11 @@ TEST_CASE("ExtractAndCombine128", "[MathTest]") {
   CHECK(extract_byte<15>(v) == 0xfe);
   CHECK(extract_byte<7>(v) == 0);
 }
+
+#pragma endregion
 #endif
+
+#pragma region CombineBytesDeducedMatchesSpelled
 
 TEST_CASE("CombineBytesDeducedMatchesSpelled", "[MathTest]") {
   // Naming the type is allowed and must agree with the count.
@@ -252,6 +333,9 @@ TEST_CASE("CombineBytesDeducedMatchesSpelled", "[MathTest]") {
   CHECK(combine_bytes<std::uint16_t>(lo, hi) == combine_bytes(lo, hi));
 }
 
+#pragma endregion
+#pragma region CombineBytesConstexpr
+
 TEST_CASE("CombineBytesConstexpr", "[MathTest]") {
   // Usable in constant expressions.
   static_assert(
@@ -259,7 +343,11 @@ TEST_CASE("CombineBytesConstexpr", "[MathTest]") {
       0xbeef);
 }
 
+#pragma endregion
+
 #ifdef NOT_SUPPOSED_TO_COMPILE
+#pragma region CombineBytesWrongCount
+
 TEST_CASE("CombineBytesWrongCount", "[MathTest]") {
   // A named type must match the count exactly, in both directions.
   CHECK(combine_bytes<std::uint16_t>(std::uint8_t{1}, std::uint8_t{2},
@@ -268,4 +356,6 @@ TEST_CASE("CombineBytesWrongCount", "[MathTest]") {
   // Deducing needs a count some standard width matches.
   CHECK(combine_bytes(std::uint8_t{1}, std::uint8_t{2}, std::uint8_t{3}) == 0);
 }
+
+#pragma endregion
 #endif

--- a/tests/portable/notifiable_test.cpp
+++ b/tests/portable/notifiable_test.cpp
@@ -373,6 +373,7 @@ TEST_CASE("RelaxedAtomic", "[Notifiable]") {
     CHECK_FALSE(n.wait_for_changed(1ms));
   }
 }
+
 #pragma endregion
 #pragma region LedeExample
 

--- a/tests/portable/one_euro_filter_test.cpp
+++ b/tests/portable/one_euro_filter_test.cpp
@@ -29,6 +29,8 @@ namespace {
 constexpr float dt = 1.0F / 60.0F;
 } // namespace
 
+#pragma region OneEuroFirstSamplePassesThrough
+
 TEST_CASE("OneEuroFirstSamplePassesThrough", "[OneEuroFilter]") {
   // The first sample has no history to smooth against, so it seeds the state
   // and is returned unchanged.
@@ -39,6 +41,9 @@ TEST_CASE("OneEuroFirstSamplePassesThrough", "[OneEuroFilter]") {
   CHECK(dx == 5.0F);
   CHECK(dy == -3.0F);
 }
+
+#pragma endregion
+#pragma region OneEuroConstantInputIsFixed
 
 TEST_CASE("OneEuroConstantInputIsFixed", "[OneEuroFilter]") {
   // A steady input has nothing to converge toward: once seeded, the same value
@@ -53,6 +58,9 @@ TEST_CASE("OneEuroConstantInputIsFixed", "[OneEuroFilter]") {
   CHECK(dx == 2.0F);
   CHECK(dy == 2.0F);
 }
+
+#pragma endregion
+#pragma region OneEuroNonPositiveDtIsNoOp
 
 TEST_CASE("OneEuroNonPositiveDtIsNoOp", "[OneEuroFilter]") {
   // A zero or negative elapsed time cannot define a speed, so the sample is
@@ -71,6 +79,9 @@ TEST_CASE("OneEuroNonPositiveDtIsNoOp", "[OneEuroFilter]") {
   CHECK(dx == 4.0F);
   CHECK(dy == 4.0F);
 }
+
+#pragma endregion
+#pragma region OneEuroResetForgetsState
 
 TEST_CASE("OneEuroResetForgetsState", "[OneEuroFilter]") {
   // After reset, the filter behaves as if freshly constructed: the next sample
@@ -91,6 +102,9 @@ TEST_CASE("OneEuroResetForgetsState", "[OneEuroFilter]") {
   filter.smooth(dt, dx, dy);
   CHECK(dx == 7.0F);
 }
+
+#pragma endregion
+#pragma region OneEuroStepResponseConverges
 
 TEST_CASE("OneEuroStepResponseConverges", "[OneEuroFilter]") {
   // Seeded at zero, a constant unit input is approached from below without
@@ -113,6 +127,9 @@ TEST_CASE("OneEuroStepResponseConverges", "[OneEuroFilter]") {
   }
   CHECK(previous > 0.99F);
 }
+
+#pragma endregion
+#pragma region OneEuroSpeedRelaxesSmoothing
 
 TEST_CASE("OneEuroSpeedRelaxesSmoothing", "[OneEuroFilter]") {
   // The adaptive cutoff is the point of the filter: for the same input, a
@@ -137,6 +154,9 @@ TEST_CASE("OneEuroSpeedRelaxesSmoothing", "[OneEuroFilter]") {
 
   CHECK(ax > px);
 }
+
+#pragma endregion
+#pragma region OneEuroSetParamsRetunesInPlace
 
 TEST_CASE("OneEuroSetParamsRetunesInPlace", "[OneEuroFilter]") {
   // Retuning keeps the carried state, so the next sample smooths from it
@@ -171,6 +191,9 @@ TEST_CASE("OneEuroSetParamsRetunesInPlace", "[OneEuroFilter]") {
   CHECK(rx < px);
 }
 
+#pragma endregion
+#pragma region OneEuroInstantiation
+
 TEST_CASE("OneEuroInstantiation", "[OneEuroFilter]") {
   // The default is `float`, and deduction follows the constructor arguments.
   one_euro_filter<> filter{50.0F, 1.0F};
@@ -187,5 +210,7 @@ TEST_CASE("OneEuroInstantiation", "[OneEuroFilter]") {
   CHECK(dx == 5.0);
   CHECK(dy == -3.0);
 }
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/proxy_test.cpp
+++ b/tests/portable/proxy_test.cpp
@@ -1710,6 +1710,8 @@ static_assert(prox::validate_api<ranger>());
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region Registration and dispatch
+
 TEST_CASE("Boilerplate impl through registration", "[proxy]") {
   lawman l;
   proxy_view<gunslinger> pv{l};
@@ -1809,6 +1811,9 @@ TEST_CASE("Heterogeneous dispatch", "[proxy]") {
   pv2.fire(1);
   CHECK(l.rounds_fired == 3);
 }
+
+#pragma endregion
+#pragma region Views and emptiness
 
 TEST_CASE("Views rebind by assignment", "[proxy]") {
   lawman l;
@@ -1947,6 +1952,9 @@ TEST_CASE("Generic code accepts concrete and erased alike", "[proxy]") {
   CHECK(fire_twice(p) == 2);
 }
 
+#pragma endregion
+#pragma region Owning proxies
+
 TEST_CASE("Owning proxy, inline target", "[proxy]") {
   life_stats stats;
   if (true) {
@@ -2037,6 +2045,9 @@ TEST_CASE("Noexcept facade methods", "[proxy]") {
   tv.cry(std::move(words));
   CHECK(c.last == "oyez");
 }
+
+#pragma endregion
+#pragma region Facade composition and overloads
 
 TEST_CASE("Member-call sugar via the api mixin", "[proxy]") {
   lawman l;
@@ -2328,6 +2339,9 @@ TEST_CASE("Diamond composition", "[proxy]") {
   p.rally();
 }
 
+#pragma endregion
+#pragma region Upcasts
+
 TEST_CASE("Upcasting views", "[proxy]") {
   texas_ranger tr;
   proxy_view<ranger> rv{tr};
@@ -2476,6 +2490,9 @@ TEST_CASE("Owning upcast lifetimes", "[proxy]") {
   }
   CHECK(heap_stats.destroyed == heap_stats.constructed);
 }
+
+#pragma endregion
+#pragma region Storage and downcasts
 
 // Diagnostics on record: constructing an sbo_only proxy over an ineligible
 // target, e.g. `make_proxy<lockbox, big_box, policies::sbo_only>(stats)`,
@@ -2839,6 +2856,9 @@ TEST_CASE("Downcasting a shared_proxy", "[proxy]") {
   CHECK(!sm.try_downcast<ranger>());
 }
 
+#pragma endregion
+#pragma region Cloning
+
 TEST_CASE("Cloning", "[proxy]") {
   // Cloneability is a runtime property of the erased target: `strongbox` is
   // move-only, so its proxy answers no. Cloning it anyway is graceful: the
@@ -2954,6 +2974,9 @@ TEST_CASE("Clone exception safety", "[proxy]") {
   }
   CHECK(stats.destroyed == stats.constructed);
 }
+
+#pragma endregion
+#pragma region Ownership interop
 
 TEST_CASE("unique_ptr interop", "[proxy]") {
   life_stats stats;
@@ -3100,6 +3123,9 @@ TEST_CASE("Shared ownership interop with std", "[proxy]") {
   }
   CHECK(stats.destroyed == stats.constructed);
 }
+
+#pragma endregion
+#pragma region Codegen
 
 TEST_CASE("Codegen", "[proxy]") {
   // `prox::codegen<F>(os)` writes the canonical `api` and `boilerplate` for
@@ -3321,5 +3347,7 @@ TEST_CASE("Codegen", "[proxy]") {
   prox::codegen<vault>(oss);
   CHECK(oss.str() == vault_golden);
 }
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/sequence_enum_test.cpp
+++ b/tests/portable/sequence_enum_test.cpp
@@ -480,7 +480,6 @@ TEST_CASE("WrapExtremes", "[SequentialEnumTest]") {
 }
 
 #pragma endregion
-
 #pragma region NamedConcept
 
 // `NamedSequentialEnum` refines `SequentialEnum` to enums registered with a

--- a/tests/portable/string_partition_test.cpp
+++ b/tests/portable/string_partition_test.cpp
@@ -27,6 +27,8 @@ using namespace corvid::strings::partitioning;
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region Partition
+
 TEST_CASE("Partition", "[StringPartition]") {
   // The common case: split a key from a value.
   if (true) {
@@ -93,6 +95,9 @@ TEST_CASE("Partition", "[StringPartition]") {
   }
 }
 
+#pragma endregion
+#pragma region Rpartition
+
 TEST_CASE("Rpartition", "[StringPartition]") {
   // Split around the last separator instead of the first.
   if (true) {
@@ -131,6 +136,9 @@ TEST_CASE("Rpartition", "[StringPartition]") {
   }
 }
 
+#pragma endregion
+#pragma region PartitionAnchoring
+
 TEST_CASE("PartitionAnchoring", "[StringPartition]") {
   // Probe the anchoring contract: the three views tile the input exactly, so
   // their concatenation reconstructs it, even when empty.
@@ -157,6 +165,9 @@ TEST_CASE("PartitionAnchoring", "[StringPartition]") {
   }
 }
 
+#pragma endregion
+#pragma region WidePartition
+
 TEST_CASE("WidePartition", "[StringPartition]") {
   // Wide strings come along for free, deduced through CTAD.
   if (true) {
@@ -171,5 +182,7 @@ TEST_CASE("WidePartition", "[StringPartition]") {
     CHECK(p.tail == L"c"sv);
   }
 }
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/string_view_wrapper_test.cpp
+++ b/tests/portable/string_view_wrapper_test.cpp
@@ -30,6 +30,8 @@ using namespace std::string_view_literals;
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region Basic formatting
+
 TEST_CASE("Wrapper formats like its string view", "[StringViewWrapperTest]") {
   if (true) {
     CHECK(std::format("{}", "hi"_czsv) == "hi");
@@ -55,6 +57,9 @@ TEST_CASE("Wrapper honors fill, align, and width", "[StringViewWrapperTest]") {
   }
 }
 
+#pragma endregion
+#pragma region Null handling
+
 TEST_CASE("Null is transparent under {} and marked under {:?}",
     "[StringViewWrapperTest]") {
   if (true) {
@@ -73,6 +78,9 @@ TEST_CASE("Null marker honors fill, align, and width",
     CHECK(std::format("{:*^10?}", 0_optsv) == "**(null)**");
   }
 }
+
+#pragma endregion
+#pragma region Dynamic width and composition
 
 TEST_CASE("Dynamic width works with and without the debug spec",
     "[StringViewWrapperTest]") {
@@ -126,6 +134,8 @@ TEST_CASE("Wide formatting widens the content", "[StringViewWrapperTest]") {
   }
 }
 
+#pragma endregion
+
 // The blocks below frame the subject between other fields that consume their
 // own (sometimes dynamic) width/precision args, so a miscounted arg id on the
 // subject would shift the trailing field and show up in the output. Each
@@ -133,6 +143,8 @@ TEST_CASE("Wide formatting widens the content", "[StringViewWrapperTest]") {
 // `std::string_view`, which must agree; only the null cases are wrapper-only.
 // Surrounding fields use strings and ints, not floats, to keep expected output
 // exact.
+
+#pragma region Framed comparisons
 
 TEST_CASE("Static width and precision, framed, match std::string_view",
     "[StringViewWrapperTest]") {
@@ -246,6 +258,9 @@ TEST_CASE("Null marker honors fill, align, and static width, framed",
   }
 }
 
+#pragma endregion
+#pragma region Null vs empty
+
 TEST_CASE("Empty-present differs from null under the debug spec",
     "[StringViewWrapperTest]") {
   if (true) {
@@ -295,5 +310,7 @@ TEST_CASE("Null marker honors DYNAMIC width under the debug spec",
     CHECK(std::format(L"{:{}?}", wnul, 10) == L"(null)    ");
   }
 }
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/portable/timers_test.cpp
+++ b/tests/portable/timers_test.cpp
@@ -107,7 +107,6 @@ TEST_CASE("ReturnPastTimeCancels", "[TimersTest]") {
 }
 
 #pragma endregion
-
 #pragma region OneShot
 
 TEST_CASE("OneShot", "[TimersTest]") {

--- a/tests/windows/d3d11_swapchain_test.cpp
+++ b/tests/windows/d3d11_swapchain_test.cpp
@@ -35,6 +35,8 @@ constexpr flag_case flag_cases[]{
 
 } // namespace
 
+#pragma region d3d11_bind_flag
+
 TEST_CASE("d3d11_bind_flag string round-trip and valid-bit set",
     "[d3d][enums]") {
   // Convert each named flag both ways, then confirm the named flags are
@@ -68,3 +70,5 @@ TEST_CASE("d3d11_bind_flag combined and unknown handling", "[d3d][enums]") {
   d3d11_bind_flag unused{};
   CHECK_FALSE(convert_enum(unused, "not_a_flag"));
 }
+
+#pragma endregion

--- a/tests/windows/sdl_event_test.cpp
+++ b/tests/windows/sdl_event_test.cpp
@@ -35,6 +35,8 @@ void check_data_type(SDL_EventType type, sdl_event_data_type expected) {
 
 // NOLINTBEGIN(readability-function-cognitive-complexity)
 
+#pragma region Classification and enums
+
 TEST_CASE("sdl_event classifies every union member", "[sdl][event]") {
   using dt = sdl_event_data_type;
   check_data_type(SDL_EVENT_DISPLAY_ORIENTATION, dt::display);
@@ -105,6 +107,9 @@ TEST_CASE("sdl_event exposes the shared header", "[sdl][event]") {
   CHECK(ev.raw().type == SDL_EVENT_KEY_DOWN); // escape hatch sees the union
 }
 
+#pragma endregion
+#pragma region Display and polling
+
 TEST_CASE("sdl_event get_display copies the cleaned payload", "[sdl][event]") {
   SDL_Event raw{};
   raw.type = SDL_EVENT_DISPLAY_MOVED;
@@ -139,6 +144,9 @@ TEST_CASE("sdl_event::poll drains the queue through the wrapper",
 
   SDL_Quit();
 }
+
+#pragma endregion
+#pragma region sdl_keycode
 
 TEST_CASE("sdl_keycode string round-trip", "[sdl][event][enums]") {
   struct keycode_case {
@@ -415,6 +423,9 @@ TEST_CASE("sdl_keycode string round-trip", "[sdl][event][enums]") {
   }
 }
 
+#pragma endregion
+#pragma region Payload accessors
+
 TEST_CASE("sdl_event get_wheel copies the cleaned payload", "[sdl][event]") {
   SDL_Event raw{};
   raw.type = SDL_EVENT_MOUSE_WHEEL;
@@ -479,5 +490,7 @@ TEST_CASE("sdl_event get_window copies the cleaned payload", "[sdl][event]") {
   CHECK(window.data1 == 1280);
   CHECK(window.data2 == 720);
 }
+
+#pragma endregion
 
 // NOLINTEND(readability-function-cognitive-complexity)

--- a/tests/windows/sdl_event_type_test.cpp
+++ b/tests/windows/sdl_event_type_test.cpp
@@ -70,6 +70,8 @@ constexpr event_case event_cases[]{
 
 } // namespace
 
+#pragma region sdl_event_type
+
 TEST_CASE("sdl_event_type values and string round-trip", "[sdl][enums]") {
   for (const auto& c : event_cases) {
     CAPTURE(c.name);
@@ -89,3 +91,5 @@ TEST_CASE("sdl_event_type unnamed and unknown handling", "[sdl][enums]") {
   sdl_event_type unused{};
   CHECK_FALSE(convert_enum(unused, "not_a_real_event"));
 }
+
+#pragma endregion

--- a/tests/windows/sdl_window_test.cpp
+++ b/tests/windows/sdl_window_test.cpp
@@ -51,6 +51,8 @@ constexpr flag_case flag_cases[]{
 
 } // namespace
 
+#pragma region sdl_window_flags
+
 TEST_CASE("sdl_window_flags single-flag string round-trip", "[sdl][enums]") {
   for (const auto& c : flag_cases) {
     CAPTURE(c.name);
@@ -75,3 +77,5 @@ TEST_CASE("sdl_window_flags combined and unknown handling", "[sdl][enums]") {
   sdl_window_flags unused{};
   CHECK_FALSE(convert_enum(unused, "not_a_flag"));
 }
+
+#pragma endregion


### PR DESCRIPTION
Mechanical normalization of `#pragma region` style across `tests/`, plus a one-line compile fix for the CoreB headers. Every changed line under `tests/` is a pragma or a blank line; no test content changed.

## Region style

The convention (matching the `corvid/` headers): a blank line above `#pragma endregion`, no blank between an `endregion` and a following `region`, a blank after each region opener, and every `TEST_CASE` inside a region.

- **Spacing**: 20 files normalized (218 missing-blank-above, 170 blank-between, and 95 missing-blank-after-opener violations, all now zero).
- **Per-case regions**: 71 identifier-named cases wrapped in same-named regions across 9 files (e.g. `math_test.cpp`, `find_opt_test.cpp`, the http3/iou tests).
- **Thematic regions**: 170 sentence-named cases grouped under 58 new regions across 25 files (e.g. `proxy_test.cpp` gains nine groups from "Registration and dispatch" through "Codegen"; `avatar_body_test.cu` groups by physics behavior). Existing thematic groupings were preserved rather than split.

All 1,257 test cases across the 96 tracked test files now sit inside regions. `coreb_test.cpp` and `notest_coreb_repl.cpp` were excluded because the active CoreB branch touches them.

## CoreB compile fix

`corvid/lang/coreb/value.h` now forward-declares `class runtime;` before first use. A friend declaration alone does not make the name visible to ordinary lookup (MSVC injects it as an extension, which is why this compiled on the Windows side), so the CoreB headers failed to build under clang.

## Verification

- The diff under `tests/` was mechanically verified to contain only pragma and blank-line changes.
- Survey scripts report zero spacing violations and zero uncovered test cases post-sweep.
- Full suite green on Linux (clang/libc++): 75/75, including the `tests/cuda/*.cu` files via nvcc.
- The four `tests/windows/` files carry pragma-only edits; they get compile confirmation on the next Windows build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
